### PR TITLE
Added gstreamer 1.0 command variant for generating gstreamer test stream

### DIFF
--- a/plugins/streams/test_gstreamer_1.sh
+++ b/plugins/streams/test_gstreamer_1.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+gst-launch-1.0 \
+  audiotestsrc ! \
+    audioresample ! audio/x-raw,channels=1,rate=16000 ! \
+    opusenc bitrate=20000 ! \
+      rtpopuspay ! udpsink host=127.0.0.1 port=5002 \
+  videotestsrc ! \
+    video/x-raw,width=320,height=240,framerate=15/1 ! \
+    videoscale ! videorate ! videoconvert ! timeoverlay ! \
+    vp8enc error-resilient=true ! \
+      rtpvp8pay ! udpsink host=127.0.0.1 port=5004


### PR DESCRIPTION
I'm not sure if this will be helpful to people or not, but I've got 1.0 gstreamer compiled on my dev machine and needed to change the pipeline to make it 1.0 compatible.  I know almost nothing about gstreamer though so I'm not sure if this is right - but it worked for me :)
