### PR TITLE
Adding synchronous API request for the videoroom plugin

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -744,7 +744,7 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		g_snprintf(error_cause, 512, "Invalid element (request should be a string)");
 		goto error;
 	}
-	/* Some requests ('create', 'destroy', 'exists', 'list', 'details') can be handled synchronously */
+	/* Some requests ('create', 'destroy', 'exists', 'list') can be handled synchronously */
 	const char *request_text = json_string_value(request);
 	if(!strcasecmp(request_text, "create")) {
 		/* Create a new videoroom */


### PR DESCRIPTION
Added a API request handler that will return a list of the current videorooms. Also, added a todo, to determine if we want to list participant details in this request or add a new room details request that will do that(if that is something desired).

Added a API request handler that will tell if a room exists or not(does not list any details). This is for a quick and small check against the gateway for room existence so that the client API caller does not have to worry about error handling(say, when trying to create a room or add itself to a room).
