### PR TITLE
a couple tiny cleanups

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -3857,7 +3857,6 @@ gint main(int argc, char *argv[])
 					!janus_plugin->get_description ||
 					!janus_plugin->get_package ||
 					!janus_plugin->get_name ||
-					!janus_plugin->get_name ||
 					!janus_plugin->create_session ||
 					!janus_plugin->handle_message ||
 					!janus_plugin->setup_media ||

--- a/record.c
+++ b/record.c
@@ -29,7 +29,7 @@
 static const char *header = "MEETECHO";
 
 
-janus_recorder *janus_recorder_create(char *dir, int video, char *filename) {
+janus_recorder *janus_recorder_create(const char *dir, int video, const char *filename) {
 	janus_recorder *rc = calloc(1, sizeof(janus_recorder));
 	if(rc == NULL) {
 		JANUS_LOG(LOG_FATAL, "Memory error!\n");

--- a/record.h
+++ b/record.h
@@ -51,7 +51,7 @@ typedef struct janus_recorder {
  * @param[in] video If this recorder is for video or audio
  * @param[in] filename Filename to use for the recording
  * @returns A valid janus_recorder instance in case of success, NULL otherwise */
-janus_recorder *janus_recorder_create(char *dir, int video, char *filename);
+janus_recorder *janus_recorder_create(const char *dir, int video, const char *filename);
 /*! \brief Save an RTP frame in the recorder
  * @param[in] recorder The janus_recorder instance to save the frame to
  * @param[in] buffer The frame data to save


### PR DESCRIPTION
- make some janus_recorder_create() args const - enables me to fix compiler warnings in a plugin I'm working on (literal strings should be const)
- remove duplicate condition in plugin loading - harmless, just something I noticed in passing
