### PR TITLE
New timer for NACKs to avoid retransmitting the same packet over and over

### DIFF
--- a/rtp.h
+++ b/rtp.h
@@ -48,6 +48,7 @@ typedef struct rtp_header
 typedef struct janus_rtp_packet {
 	char *data;
 	gint length;
+	gint64 last_retransmit;
 } janus_rtp_packet;
 
 #endif


### PR DESCRIPTION
Attempt to improve the patch provided by @gatecrasher777 in pull request #101 with a time-based check.
