### PR TITLE
Fixing bug when video room is destroyed right when participant is leaving the room

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -923,12 +923,12 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		/* Show updated rooms list */
 		GHashTableIter iter;
 		gpointer value;
+		g_hash_table_insert(rooms, GUINT_TO_POINTER(videoroom->room_id), videoroom);
 		g_hash_table_iter_init(&iter, rooms);
 		while (g_hash_table_iter_next(&iter, NULL, &value)) {
 			janus_videoroom *vr = value;
 			JANUS_LOG(LOG_VERB, "  ::: [%"SCNu64"][%s] %"SCNu64", max %d publishers, FIR frequency of %d seconds\n", vr->room_id, vr->room_name, vr->bitrate, vr->max_publishers, vr->fir_freq);
 		}
-		g_hash_table_insert(rooms, GUINT_TO_POINTER(videoroom->room_id), videoroom);
 		janus_mutex_unlock(&rooms_mutex);
 		/* Send info back */
 		json_t *response = json_object();


### PR DESCRIPTION
This bug happens when a participant is leaving the room(their session closing) at the same time as a rooms destruction. This causes issues with the hash table and the destruction logic of notifying the participants. 

The main changes are these:
- Make room destruction lazy so that participants have time to clean up if they are wanting to leave at just about the same time. 
- Added mutex logic to protect the participant hash table so that participants are not removed when another thread is iterating over them
- Checked for room destruction when iterating over participants so that mutex can be freed ASAP if the room is destroyed

This has been tested in my environment(though not with numerous rooms being created, joined, destroyed, and left all rapidly).
