### PR TITLE
Changing name for new "private" configuration attribute to "is_private"

### DIFF
--- a/conf/janus.plugin.audiobridge.cfg.sample
+++ b/conf/janus.plugin.audiobridge.cfg.sample
@@ -1,6 +1,6 @@
 ; [<unique room ID>]
 ; description = This is my awesome room
-; private = yes|no (whether this room should be in the public list, default=yes)
+; is_private = yes|no (whether this room should be in the public list, default=yes)
 ; secret = <password needed for manipulating (e.g. destroying) the room>
 ; sampling_rate = <sampling rate> (e.g., 16000 for wideband mixing)
 ; record = true|false (whether this room should be recorded, default=false)

--- a/conf/janus.plugin.streaming.cfg.sample.in
+++ b/conf/janus.plugin.streaming.cfg.sample.in
@@ -8,7 +8,7 @@
 ;                   (multiple listeners = different streaming contexts)
 ; id = <unique numeric ID> (if missing, a random one will be generated)
 ; description = This is my awesome stream
-; private = yes|no (private streams don't appear when you do a 'list'
+; is_private = yes|no (private streams don't appear when you do a 'list'
 ;			request)
 ; secret = <optional password needed for manipulating (e.g., destroying
 ;			or enabling/disabling) the stream>

--- a/conf/janus.plugin.videoroom.cfg.sample
+++ b/conf/janus.plugin.videoroom.cfg.sample
@@ -1,6 +1,6 @@
 ; [<unique room ID>]
 ; description = This is my awesome room
-; private = yes|no (whether this room should be in the public list, default=yes)
+; is_private = yes|no (whether this room should be in the public list, default=yes)
 ; secret = <password needed for manipulating (e.g. destroying) the room>
 ; publishers = <max number of concurrent senders> (e.g., 6 for a video
 ;              conference or 1 for a webinar)

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -48,7 +48,7 @@ type = rtp|live|ondemand
                   (multiple listeners = different streaming contexts)
 id = <unique numeric ID>
 description = This is my awesome stream
-private = yes|no (private streams don't appear when you do a 'list' request)
+is_private = yes|no (private streams don't appear when you do a 'list' request)
 filename = path to the local file to stream (only for live/ondemand)
 secret = <optional password needed for manipulating (e.g., destroying
 		or enabling/disabling) the stream>
@@ -184,7 +184,7 @@ typedef struct janus_streaming_mountpoint {
 	gint64 id;
 	char *name;
 	char *description;
-	gboolean private;
+	gboolean is_private;
 	char *secret;
 	gboolean enabled;
 	gboolean active;
@@ -353,7 +353,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				/* RTP live source (e.g., from gstreamer/ffmpeg/vlc/etc.) */
 				janus_config_item *id = janus_config_get_item(cat, "id");
 				janus_config_item *desc = janus_config_get_item(cat, "description");
-				janus_config_item *priv = janus_config_get_item(cat, "private");
+				janus_config_item *priv = janus_config_get_item(cat, "is_private");
 				janus_config_item *secret = janus_config_get_item(cat, "secret");
 				janus_config_item *audio = janus_config_get_item(cat, "audio");
 				janus_config_item *video = janus_config_get_item(cat, "video");
@@ -365,7 +365,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				janus_config_item *vcodec = janus_config_get_item(cat, "videopt");
 				janus_config_item *vrtpmap = janus_config_get_item(cat, "videortpmap");
 				janus_config_item *vfmtp = janus_config_get_item(cat, "videofmtp");
-				gboolean private = priv && priv->value && janus_is_true(priv->value);
+				gboolean is_private = priv && priv->value && janus_is_true(priv->value);
 				gboolean doaudio = audio && audio->value && janus_is_true(audio->value);
 				gboolean dovideo = video && video->value && janus_is_true(video->value);
 				if(!doaudio && !dovideo) {
@@ -420,14 +420,14 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					JANUS_LOG(LOG_ERR, "Error creating 'rtp' stream '%s'...\n", cat->name);
 					continue;
 				}
-				mp->private = private;
+				mp->is_private = is_private;
 				if(secret && secret->value)
 					mp->secret = g_strdup(secret->value);
 			} else if(!strcasecmp(type->value, "live")) {
 				/* File live source */
 				janus_config_item *id = janus_config_get_item(cat, "id");
 				janus_config_item *desc = janus_config_get_item(cat, "description");
-				janus_config_item *priv = janus_config_get_item(cat, "private");
+				janus_config_item *priv = janus_config_get_item(cat, "is_private");
 				janus_config_item *secret = janus_config_get_item(cat, "secret");
 				janus_config_item *file = janus_config_get_item(cat, "filename");
 				janus_config_item *audio = janus_config_get_item(cat, "audio");
@@ -437,7 +437,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					cat = cat->next;
 					continue;
 				}
-				gboolean private = priv && priv->value && janus_is_true(priv->value);
+				gboolean is_private = priv && priv->value && janus_is_true(priv->value);
 				gboolean doaudio = audio && audio->value && janus_is_true(audio->value);
 				gboolean dovideo = video && video->value && janus_is_true(video->value);
 				/* TODO We should support something more than raw a-Law and mu-Law streams... */
@@ -473,14 +473,14 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					JANUS_LOG(LOG_ERR, "Error creating 'live' stream '%s'...\n", cat->name);
 					continue;
 				}
-				mp->private = private;
+				mp->is_private = is_private;
 				if(secret && secret->value)
 					mp->secret = g_strdup(secret->value);
 			} else if(!strcasecmp(type->value, "ondemand")) {
 				/* mu-Law file on demand source */
 				janus_config_item *id = janus_config_get_item(cat, "id");
 				janus_config_item *desc = janus_config_get_item(cat, "description");
-				janus_config_item *priv = janus_config_get_item(cat, "private");
+				janus_config_item *priv = janus_config_get_item(cat, "is_private");
 				janus_config_item *secret = janus_config_get_item(cat, "secret");
 				janus_config_item *file = janus_config_get_item(cat, "filename");
 				janus_config_item *audio = janus_config_get_item(cat, "audio");
@@ -490,7 +490,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					cat = cat->next;
 					continue;
 				}
-				gboolean private = priv && priv->value && janus_is_true(priv->value);
+				gboolean is_private = priv && priv->value && janus_is_true(priv->value);
 				gboolean doaudio = audio && audio->value && janus_is_true(audio->value);
 				gboolean dovideo = video && video->value && janus_is_true(video->value);
 				/* TODO We should support something more than raw a-Law and mu-Law streams... */
@@ -526,7 +526,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					JANUS_LOG(LOG_ERR, "Error creating 'ondemand' stream '%s'...\n", cat->name);
 					continue;
 				}
-				private = private;
+				mp->is_private = is_private;
 				if(secret && secret->value)
 					mp->secret = g_strdup(secret->value);
 			} else {
@@ -548,7 +548,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 		JANUS_LOG(LOG_VERB, "  ::: [%"SCNu64"][%s] %s (%s, %s, %s)\n", mp->id, mp->name, mp->description,
 			mp->streaming_type == janus_streaming_type_live ? "live" : "on demand",
 			mp->streaming_source == janus_streaming_source_rtp ? "RTP source" : "file source",
-			mp->private ? "private" : "public");
+			mp->is_private ? "private" : "public");
 	}
 	janus_mutex_unlock(&mountpoints_mutex);
 
@@ -750,7 +750,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		g_hash_table_iter_init(&iter, mountpoints);
 		while (g_hash_table_iter_next(&iter, NULL, &value)) {
 			janus_streaming_mountpoint *mp = value;
-			if(mp->private) {
+			if(mp->is_private) {
 				/* Skip private stream */
 				JANUS_LOG(LOG_VERB, "Skipping private mountpoint '%s'\n", mp->description);
 				continue;
@@ -818,11 +818,11 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				g_snprintf(error_cause, 512, "Invalid element (desc should be a string)");
 				goto error;
 			}
-			json_t *private = json_object_get(root, "private");
-			if(private && !json_is_boolean(private)) {
-				JANUS_LOG(LOG_ERR, "Invalid element (private should be a boolean)\n");
+			json_t *is_private = json_object_get(root, "is_private");
+			if(is_private && !json_is_boolean(is_private)) {
+				JANUS_LOG(LOG_ERR, "Invalid element (is_private should be a boolean)\n");
 				error_code = JANUS_STREAMING_ERROR_INVALID_ELEMENT;
-				g_snprintf(error_cause, 512, "Invalid value (private should be a boolean)");
+				g_snprintf(error_cause, 512, "Invalid value (is_private should be a boolean)");
 				goto error;
 			}
 			json_t *audio = json_object_get(root, "audio");
@@ -983,7 +983,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				g_snprintf(error_cause, 512, "Error creating 'rtp' stream");
 				goto error;
 			}
-			mp->private = private ? json_is_true(private) : FALSE;
+			mp->is_private = is_private ? json_is_true(is_private) : FALSE;
 		} else if(!strcasecmp(type_text, "live")) {
 			/* File live source */
 			json_t *id = json_object_get(root, "id");
@@ -1007,11 +1007,11 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				g_snprintf(error_cause, 512, "Invalid element (desc should be a string)");
 				goto error;
 			}
-			json_t *private = json_object_get(root, "private");
-			if(private && !json_is_boolean(private)) {
-				JANUS_LOG(LOG_ERR, "Invalid element (private should be a boolean)\n");
+			json_t *is_private = json_object_get(root, "is_private");
+			if(is_private && !json_is_boolean(is_private)) {
+				JANUS_LOG(LOG_ERR, "Invalid element (is_private should be a boolean)\n");
 				error_code = JANUS_STREAMING_ERROR_INVALID_ELEMENT;
-				g_snprintf(error_cause, 512, "Invalid value (private should be a boolean)");
+				g_snprintf(error_cause, 512, "Invalid value (is_private should be a boolean)");
 				goto error;
 			}
 			json_t *file = json_object_get(root, "file");
@@ -1076,7 +1076,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				g_snprintf(error_cause, 512, "Error creating 'live' stream");
 				goto error;
 			}
-			mp->private = private ? json_is_true(private) : FALSE;
+			mp->is_private = is_private ? json_is_true(is_private) : FALSE;
 		} else if(!strcasecmp(type_text, "ondemand")) {
 			/* mu-Law file on demand source */
 			json_t *id = json_object_get(root, "id");
@@ -1100,11 +1100,11 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				g_snprintf(error_cause, 512, "Invalid element (desc should be a string)");
 				goto error;
 			}
-			json_t *private = json_object_get(root, "private");
-			if(private && !json_is_boolean(private)) {
-				JANUS_LOG(LOG_ERR, "Invalid element (private should be a boolean)\n");
+			json_t *is_private = json_object_get(root, "is_private");
+			if(is_private && !json_is_boolean(is_private)) {
+				JANUS_LOG(LOG_ERR, "Invalid element (is_private should be a boolean)\n");
 				error_code = JANUS_STREAMING_ERROR_INVALID_ELEMENT;
-				g_snprintf(error_cause, 512, "Invalid value (private should be a boolean)");
+				g_snprintf(error_cause, 512, "Invalid value (is_private should be a boolean)");
 				goto error;
 			}
 			json_t *file = json_object_get(root, "file");
@@ -1169,7 +1169,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				g_snprintf(error_cause, 512, "Error creating 'ondemand' stream");
 				goto error;
 			}
-			mp->private = private ? json_is_true(private) : FALSE;
+			mp->is_private = is_private ? json_is_true(is_private) : FALSE;
 		} else {
 			JANUS_LOG(LOG_ERR, "Unknown stream type '%s'...\n", type_text);
 			error_code = JANUS_STREAMING_ERROR_INVALID_ELEMENT;
@@ -1187,7 +1187,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		json_object_set_new(ml, "id", json_integer(mp->id));
 		json_object_set_new(ml, "description", json_string(mp->description));
 		json_object_set_new(ml, "type", json_string(mp->streaming_type == janus_streaming_type_live ? "live" : "on demand"));
-		json_object_set_new(ml, "private", json_boolean(mp->private));
+		json_object_set_new(ml, "is_private", json_boolean(mp->is_private));
 		json_object_set_new(response, "stream", ml);
 		char *response_text = json_dumps(response, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
 		json_decref(response);


### PR DESCRIPTION
This allows for better integration with other api clients that may be using a language in which "private" is a key word. Keeping it has "private" will obviously cause serialization and deserialization errors into and from object in other languages.

Also, setting the mountpoint to private on line 529 in the janus streaming plugin was missing(did not reference the moutpoint and only set private equal to itself...which does nothing...)

The other commits seen in this pull request are stupid merge pushes I made over time that github is not smart enough(or I am not) to not care about, but there are no code changes there.
