### PR TITLE
echotest: fix Start button being disabled after stopping

### DIFF
--- a/html/echotest.html
+++ b/html/echotest.html
@@ -66,7 +66,7 @@
 		<div class="col-md-12">
 			<div class="page-header">
 				<h1>Plugin Demo: Echo Test
-					<button class="btn btn-default" id="start">Start</button>
+					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
 			<div class="container" id="details">


### PR DESCRIPTION
echotest page start button needs autocomplete off for button to be re-enabled on reload in firefox

strange but true
http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing
