### PR TITLE
support proxy_auth 407 and disable 100rel in sip module

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -2163,6 +2163,7 @@ static void *janus_sip_relay_thread(void *data) {
 	return NULL;
 }
 
+
 /* Sofia Event thread */
 gpointer janus_sip_sofia_thread(gpointer user_data) {
 	janus_sip_session *session = (janus_sip_session *)user_data;
@@ -2182,6 +2183,9 @@ gpointer janus_sip_sofia_thread(gpointer user_data) {
 				SIPTAG_FROM_STR(g_strdup(tag_url)),
 				NUTAG_URL("sip:0.0.0.0:*;transport=udp"),
 				//~ NUTAG_OUTBOUND("outbound natify use-rport"),	/* To use the same port used in Contact */
+				// sofia-sip default supported: timer and 100rel
+				// disable 100rel, There are known issues (asserts and segfaults) when 100rel is enabled from freeswitch config comments
+				SIPTAG_SUPPORTED_STR("timer"),
 				TAG_NULL());
 	nua_set_params(session->stack->s_nua, TAG_NULL());
 	su_root_run(session->stack->s_root);


### PR DESCRIPTION
Hi

two patches here:
(1) Add support for sip proxy-auth 407,  as we know most sip proxies will use 407 to auth the sip invite.
(2) disable 100rel in the support header
    100rel in the supported sip header will cause janus-gateway (maybe due to sofia-sip) to segfault.
it also observed on the freeswitch project as well.
     There are known issues (asserts and segfaults) when 100rel is enabled.  It is not recommended to enable 100rel at this time. 

see: https://freeswitch.org/stash/projects/FS/repos/freeswitch/browse/src/mod/endpoints/mod_sofia/conf/sofia.conf.xml
