### PR TITLE
setting pointer to NULL to match other plugins

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -354,6 +354,7 @@ static void session_free(gpointer data) {
 		}
 		session->handle = NULL;
 		g_free(session);
+		session = NULL;
 	}
 }
 


### PR DESCRIPTION
The convenience function for freeing video room sessions did not set pointer to NULL after freeing the memory...which could cause corrupted memory issues(not sure if related to #117 will continue to test to see if the issue is corrected after this patch). If so, I will close the issue. 
