### PR TITLE
Use bower for front end dependency management

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,39 @@
+{
+  "name": "janus-gateway",
+  "version": "0.0.7",
+  "homepage": "https://github.com/meetecho/janus-gateway",
+  "authors": [
+    "Lorenzo Miniero <lorenzo@meetecho.com>",
+    "Philip Withnall <philip@tecnocode.co.uk>",
+    "Jack Leigh",
+    "Pierce Lopez <pierce.lopez@gmail.com>",
+    "Benjamin Trent <ben.w.trent@gmail.com>",
+    "Dustin Oprea <dustin@randomingenuity.com>",
+    "Maurizio Porrato",
+    "Giacomo Vacca",
+    "mrauhu",
+    "Min Wang",
+    "leonuh",
+    "Nicholas Wylie",
+    "Graeme Yeates <yeatesgraeme@gmail.com>",
+    "gatecrasher777",
+    "Damon Oehlman <damon.oehlman@gmail.com>",
+    "Scott <scottmortonashton@gmail.com>"
+  ],
+  "description": "A javascript library for interacting with the C based Janus WebRTC Gateway",
+  "main": "./html/janus.js",
+  "license": "GPLv3",
+  "ignore": [
+    "**/.*",
+    "**/*.alaw",
+    "**/*.mjr",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "adapter.js": "*",
+    "jquery": "*"    
+  }
+}


### PR DESCRIPTION
Hooked up janus gateway with the Bower package manger system. This enables two thing:

1. Cleans up the project source code by not having to commit external libraries. Now, when we want to build the HTML website, we simply need to have bower installed via node, then do the shell command "bower install" to download and extract dependencies to the "html/bower_components" folder.

2. Potentially exposes the Janus javascript library as a bower package, so that it's easier for developers to integrate the Janus front end library with their code base. If we register with bower, then all that a developer would need to do in order to get janus.js (and it's dependencies like "adapter.js", etc), will be to type "bower install --save janus". If this pull goes through, then we would need to register janus with Bower, by typing "bower register janus git://github.com/meetecho/janus-gateway.git"

