### PR TITLE
Moved some includes for easier plugin building

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -25,6 +25,7 @@
 #include "cmdline.h"
 #include "config.h"
 #include "apierror.h"
+#include "debug.h"
 #include "rtcp.h"
 #include "sdp.h"
 #include "utils.h"

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -41,6 +41,7 @@ record_file =	/path/to/recording.wav (where to save the recording)
 #include <opus/opus.h>
 #include <sys/time.h>
 
+#include "../debug.h"
 #include "../apierror.h"
 #include "../config.h"
 #include "../mutex.h"

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -26,6 +26,7 @@
 
 #include <jansson.h>
 
+#include "../debug.h"
 #include "../apierror.h"
 #include "../config.h"
 #include "../mutex.h"

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -44,6 +44,7 @@
 #include <sys/time.h>
 #include <jansson.h>
 
+#include "../debug.h"
 #include "../apierror.h"
 #include "../config.h"
 #include "../mutex.h"

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -43,6 +43,7 @@
 #include <sofia-sip/sdp.h>
 #include <sofia-sip/sip_status.h>
 
+#include "../debug.h"
 #include "../apierror.h"
 #include "../config.h"
 #include "../mutex.h"

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -74,6 +74,7 @@ videofmtp = Codec specific parameters, if any
 #include <jansson.h>
 #include <sys/time.h>
 
+#include "../debug.h"
 #include "../apierror.h"
 #include "../config.h"
 #include "../mutex.h"

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -28,6 +28,7 @@
 
 #include <jansson.h>
 
+#include "../debug.h"
 #include "../apierror.h"
 #include "../config.h"
 #include "../mutex.h"

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -73,6 +73,7 @@ rec_dir = <folder where recordings should be stored, when enabled>
 #include <jansson.h>
 #include <sofia-sip/sdp.h>
 
+#include "../debug.h"
 #include "../apierror.h"
 #include "../config.h"
 #include "../mutex.h"

--- a/plugins/janus_voicemail.c
+++ b/plugins/janus_voicemail.c
@@ -30,6 +30,7 @@
 
 #include <ogg/ogg.h>
 
+#include "../debug.h"
 #include "../apierror.h"
 #include "../config.h"
 #include "../mutex.h"

--- a/plugins/plugin.c
+++ b/plugins/plugin.c
@@ -11,6 +11,9 @@
 
 #include "plugin.h"
 
+#include "../apierror.h"
+#include "../debug.h"
+
 janus_plugin_result *janus_plugin_result_new(janus_plugin_result_type type, const char *content) {
 	JANUS_LOG(LOG_HUGE, "Creating plugin result...\n");
 	janus_plugin_result *result = (janus_plugin_result *)calloc(1, sizeof(janus_plugin_result));

--- a/plugins/plugin.h
+++ b/plugins/plugin.h
@@ -140,9 +140,6 @@ janus_plugin *create(void) {
 #include <unistd.h>
 #include <inttypes.h>
 
-#include "../apierror.h"
-#include "../debug.h"
-
 
 /*! \brief Version of the API, to match the one plugins were compiled against
  * 

--- a/sdp.c
+++ b/sdp.c
@@ -19,6 +19,7 @@
 #include "dtls.h"
 #include "sdp.h"
 #include "utils.h"
+#include "debug.h"
 
 
 static su_home_t *home = NULL;


### PR DESCRIPTION
Moved headers around to make it easier to build plugins outside of the Janus source tree.

Plugins can then be built with `gcc -o <plugin>.so <plugin>.c -fpic -shared -l<libs>` without having to recompile the entire source tree.

For example, the audiobridge demo can be built with ``gcc -o janus_audiobridge.so janus_audiobridge.c -fpic -shared `pkg-config --cflags glib-2.0 sofia-sip-ua` -lopus``