### PR TITLE
Modify build to output header files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,11 @@ CLEANFILES = $(NULL)
 
 bin_PROGRAMS = janus
 
+headerdir = $(includedir)/janus
+header_HEADERS = \
+	plugins/plugin.h apierror.h config.h debug.h dtls.h ice.h mutex.h record.h \
+	rtcp.h rtp.h sctp.h sdp.h utils.h
+
 confdir = $(sysconfdir)/janus
 conf_DATA = conf/janus.cfg.sample
 

--- a/configure.ac
+++ b/configure.ac
@@ -86,8 +86,11 @@ AC_CHECK_LIB([srtp],
 AC_CHECK_LIB([websock],
              [libwebsock_init],
              [
-               AC_DEFINE(HAVE_WEBSOCKETS)
-               JANUS_MANUAL_LIBS+=" -lwebsock"
+               AS_IF([test "x$enable_websockets" = "xyes"],
+               [
+                  AC_DEFINE(HAVE_WEBSOCKETS)
+                  JANUS_MANUAL_LIBS+=" -lwebsock"
+               ])
              ],
              [
                AS_IF([test "x$enable_websockets" = "xyes"],
@@ -97,8 +100,11 @@ AC_CHECK_LIB([websock],
 AC_CHECK_LIB([usrsctp],
              [usrsctp_finish],
              [
-               AC_DEFINE(HAVE_SCTP)
-               JANUS_MANUAL_LIBS+=" -lusrsctp"
+               AS_IF([test "x$enable_data_channels" = "xyes"],
+               [
+                  AC_DEFINE(HAVE_SCTP)
+                  JANUS_MANUAL_LIBS+=" -lusrsctp"
+               ])
              ],
              [
                AS_IF([test "x$enable_data_channels" = "xyes"],
@@ -108,8 +114,11 @@ AC_CHECK_LIB([usrsctp],
 AC_CHECK_LIB([rabbitmq],
              [amqp_error_string2],
              [
-               AC_DEFINE(HAVE_RABBITMQ)
-               JANUS_MANUAL_LIBS+=" -lrabbitmq"
+               AS_IF([test "x$enable_data_channels" = "xyes"],
+               [
+                  AC_DEFINE(HAVE_RABBITMQ)
+                  JANUS_MANUAL_LIBS+=" -lrabbitmq"
+               ])
              ],
              [
                AS_IF([test "x$enable_rabbitmq" = "xyes"],


### PR DESCRIPTION
This causes `make install` to put the header files in `$(prefix)/include/janus` so that plugin code can `#include <janus/plugin.h>` (as long as` $(prefix)/include` is in the `C_INCLUDE_PATH`)