### PR TITLE
janus.js: make "lowres" "hires" hints affect capture resolution on firefox 35

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1016,24 +1016,39 @@ function Janus(gatewayCallbacks) {
 			pluginHandle.consentDialog(true);
 			var videoSupport = isVideoSendEnabled(media);
 			if(videoSupport === true && media != undefined && media != null) {
-				if(media.video === 'lowres') {
-					// Add a video constraint (320x240)
-					if(!navigator.mozGetUserMedia) {
-						videoSupport = {"mandatory": {"maxHeight": "240", "maxWidth": "320"}, "optional": []};
-						Janus.log("Adding media constraint (low-res video)");
-						Janus.log(videoSupport);
+				if(media.video && media.video != 'screen') {
+					var width = 0;
+					var height = 0;
+					if       (media.video === 'lowres') {
+						height = 240;
+						width  = 320;
+					} else if(media.video === 'hires' ) {
+						height = 720;
+						width  = 1280;
 					} else {
-						Janus.log("Firefox doesn't support media constraints at the moment, ignoring low-res video");
+						janus.log("unrecognized video setting " + media.video);
+						height = 480;
+						width  = 640;
 					}
-				} else if(media.video === 'hires') {
-					// Add a video constraint (1280x720)
-					if(!navigator.mozGetUserMedia) {
-						videoSupport = {"mandatory": {"minHeight": "720", "minWidth": "1280"}, "optional": []};
-						Janus.log("Adding media constraint (hi-res video)");
-						Janus.log(videoSupport);
+					Janus.log("Adding media constraint " + media.video);
+					if(navigator.mozGetUserMedia) {
+						videoSupport = {
+						    'require': ['height', 'width'],
+						    'height': {'max': height, 'min': height},
+						    'width':  {'max': width,  'min': width}
+						};
 					} else {
-						Janus.log("Firefox doesn't support media constraints at the moment, ignoring hi-res video");
+						videoSupport = {
+						    'mandatory': {
+						        'maxHeight': height,
+						        'minHeight': height,
+						        'maxWidth':  width,
+						        'minWidth':  width
+						    },
+						    'optional': []
+						};
 					}
+					Janus.log(videoSupport);
 				} else if(media.video === 'screen') {
 					// Not a webcam, but screen capture
 					if(window.location.protocol !== 'https:') {


### PR DESCRIPTION
I was trying to get 16/9 capture on firefox, and found this technique of controlling the capture resolution to work with current firefox. I got the tip from https://groups.google.com/forum/#!topic/mozilla.dev.media/OxgXMRStD8Q

It's arguable whether you want to constrain min and max so strictly, and maybe cause a video capture to fail. I think that, generally, the browser never treats the constraints strictly, and picks the closest resolution from a limited list of supported resolutions. see https://webrtchacks.com/video-constraints-2/

Another "to taste" part of this is, which resolutions to use. For my application, I used 16/9 resolutions of 320/180, 640/360, 1280/720. (I also added a "stdres" name for the middle resolution.) For this PR I figured I would keep it close to the existing behavior, and just show how to get firefox to work with it.