### PR TITLE
recordplay: avoid stopping if already stopped

### DIFF
--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -903,6 +903,7 @@ void janus_recordplay_hangup_media(janus_plugin_session *handle) {
 	g_free(event_text);
 
 	/* FIXME Simulate a "stop" coming from the browser */
+	if(!session->recorder) { return; }
 	janus_recordplay_message *msg = calloc(1, sizeof(janus_recordplay_message));
 	msg->handle = handle;
 	msg->message = json_loads("{\"request\":\"stop\"}", 0, NULL);


### PR DESCRIPTION
If the client has already requested a ‘stop’ of 
the recording before, the ‘hangup’ procedure 
would try to stop it again resulting in duplicate 
‘stopped’ event sent to the client.