### PR TITLE
Fix Fedora package name for pkgconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ instance, is very simple:
 
     yum install libmicrohttpd-devel jansson-devel libnice-devel \
        openssl-devel libsrtp-devel sofia-sip-devel glib-devel \
-       opus-devel libogg-devel libini_config-devel pkg-config gengetopt \
+       opus-devel libogg-devel libini_config-devel pkgconfig gengetopt \
        libtool autoconf automake
 
 On Ubuntu or Debian, it would require something like this:


### PR DESCRIPTION
Checked on F20 and F21 just to be sure.

```
$ sudo yum provides "*/bin/pkg-config"

1:pkgconfig-0.28-3.fc20.x86_64 : A tool for determining compilation options
Repo        : fedora
Matched from:
Filename    : /usr/bin/pkg-config
```