### PR TITLE
Fix videoremote id for spinner

### DIFF
--- a/html/videomcutest.js
+++ b/html/videomcutest.js
@@ -396,7 +396,7 @@ function newRemoteFeed(id, display) {
 						remoteFeed.rfid = msg["id"];
 						remoteFeed.rfdisplay = msg["display"];
 						if(remoteFeed.spinner === undefined || remoteFeed.spinner === null) {
-							var target = document.getElementById('#videoremote'+remoteFeed.rfindex);
+							var target = document.getElementById('videoremote'+remoteFeed.rfindex);
 							remoteFeed.spinner = new Spinner({top:100}).spin(target);
 						} else {
 							remoteFeed.spinner.spin();


### PR DESCRIPTION
The spinner wasn't working because the getElementById selecter included #

I also included anoteher change in my own UI which you might want to utilize or maybe there's a better way of getting a callback to disable this spinner?

At the moment the spinner is stopped whenever the video element is created, but when it is it could still take a while for the connection to be established and until that time the video element will be black.

To keep the spinner going until the video actually shows video I changed the code which adds the bitrate label to the following;
```javascript
					if(webrtcDetectedBrowser == "chrome") {
						spinstopTimer[remoteFeed.rfindex] = setInterval(function() {
						if(remoteFeed.webrtcStuff==undefined){
							//if the remotefeed was cleared before it reached bitr > 0 clear it so it doesn't overlay another cam
							remoteFeed.spinner.stop();
							spinStopped[remoteFeed.rfindex]=true;
							clearInterval(spinstopTimer[remoteFeed.rfindex]);
							spinstopTimer[remoteFeed.rfindex] = null;
						} else {
						var bitrate = remoteFeed.getBitrate();
						var bitr = parseInt(bitrate);
							if(spinStopped[remoteFeed.rfindex]==false){
								if(bitr>0){
									//Stop the spinner when the bitrate gets over 0
									if(remoteFeed.spinner !== undefined && remoteFeed.spinner !== null){
										remoteFeed.spinner.stop();
										spinStopped[remoteFeed.rfindex]=true;
										clearInterval(spinstopTimer[remoteFeed.rfindex]);
										spinstopTimer[remoteFeed.rfindex] = null;
									}
								}
							}
						}
						}, 250);

						$('#curbitrate'+remoteFeed.rfindex).removeClass('hide').show();
							bitrateTimer[remoteFeed.rfindex] = setInterval(function() {
							// Display updated bitrate, if supported
							var bitrate = remoteFeed.getBitrate();
							$('#curbitrate'+remoteFeed.rfindex).text(bitrate);
						}, 1000);
					} else {
					//Stop the spinner in non-chrome browsers which don't support getBitrate();
					remoteFeed.spinner.stop();
					}
```

And I commented out 
```javascript
				if(remoteFeed.spinner !== undefined && remoteFeed.spinner !== null)
					remoteFeed.spinner.stop();
```

Now as this is using a counter to check the bitrate label and only works in Chrome it's not the most efficient, is there a callback that is received when the video actually starts?

Thanks
