### PR TITLE
fix message memory leak in plugins which process some messages synchronously

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -1408,8 +1408,11 @@ int janus_process_incoming_request(janus_request_source *source, json_t *root) {
 			sdp = NULL;
 			janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_PROCESSING_OFFER);
 		}
+
+		/* Send the message to the plugin.
+		 * Plugin must eventually free transaction_text, body_text, jsep_type, sdp.
+		 */
 		char *body_text = json_dumps(body, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
-		/* Send the message to the plugin */
 		janus_plugin_result *result = plugin_t->handle_message(handle->app_handle, g_strdup((char *)transaction_text), body_text, jsep_type, jsep_sdp_stripped);
 		if(result == NULL) {
 			/* Something went horribly wrong! */


### PR DESCRIPTION
The plugin handler function arguments, which become the responsibility of the plugin to free, are not always freed. I've fixed this for the `videoroom` plugin as an example.

Plugins like echotest, which process all their messages asynchronously, don't suffer from this as much, since they almost always free their own internal queued message struct which wraps all the arguments (using a `janus_*_message_free()` function). Plugins like videoroom, which process some message synchronously, forget to free the arguments for those synchronously processed messages (and for synchronous-case error responses).

Other items:

I did not free arguments in the first return case, where the plugin handle_message() checks if the plugin is not initialized or is shutting down. I think that case won't happen often :)

I moved checking if `message` is NULL to before logging out `message`. In fact, it was logged out twice, before.

I changed a couple of places that immediately returned if allocation failed, to also `goto error`. Which I suppose is silly, because they'll probably fail to allocate the json objects used to create the response. Really, if a small memory allocation fails, it's probably best to abort, for this kind of codebase. In fact, glib2 allocation functions do that: "If any call to allocate memory fails, the application is terminated. This also means that there is no need to check if the call succeeded." https://developer.gnome.org/glib/unstable/glib-Memory-Allocation.html (more support for this philosophy, in high-level application cases, is that on most systems, which use "overcommit", the out-of-memory killer will kick in before malloc() fails).

Let me know what you think... not that I'm too excited to tackle the rest of the plugins which may benefit from this treatment...