### PR TITLE
sip: Add setting for local IP address

### DIFF
--- a/conf/janus.plugin.sip.cfg.sample
+++ b/conf/janus.plugin.sip.cfg.sample
@@ -1,17 +1,19 @@
 
 [general]
 ; Specify which local IP address to use. If not set it will be automatically
-; guessed from the system, ignoring the interfaces in autodetect_ignore
+; guessed from the system
 ; local_ip = 1.2.3.4
-autodetect_ignore = vmnet
+
 ; Enable local keep-alives to keep the registration open. Keep-alives are
 ; sent in the form of OPTIONS requests, at the given interval inseconds.
 ; (0 to disable)
 keepalive_interval = 120
+
 ; Indicate if the server is behind NAT. If so, the server will use STUN
 ; to guess its own public IP address and use it in the Contat header of
 ; outgoing requests
 behind_nat = no
+
 ; User-Agent string to be used
 ; user_agent = Cool WebRTC Gateway
 ; Expiration time for registrations

--- a/conf/janus.plugin.sip.cfg.sample
+++ b/conf/janus.plugin.sip.cfg.sample
@@ -1,12 +1,8 @@
-; The only information the SIP Gateway plugin requires is related to the
-; IP address to put in the c-lines of the SIP messages SDPs. You can either
-; specify it (e.g., c_address = 1.2.3.4) or let the plugin autodetect
-; the address to use. If autodetecting, though, you'd better fill in the
-; autodetect_ignore list (e.g., to skip interfaces like VMware ones),
-; which works the same way as the ice_ignore_list setting in the main
-; configuration
+
 [general]
-; c_address = 1.2.3.4
+; Specify which local IP address to use. If not set it will be automatically
+; guessed from the system, ignoring the interfaces in autodetect_ignore
+; local_ip = 1.2.3.4
 autodetect_ignore = vmnet
 ; Enable local keep-alives to keep the registration open. Keep-alives are
 ; sent in the form of OPTIONS requests, at the given interval inseconds.

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1862,7 +1862,7 @@ static int janus_sip_allocate_local_ports(janus_sip_session *session) {
 				rtp_port++;	/* Pick an even port for RTP */
 			audio_rtp_address.sin_family = AF_INET;
 			audio_rtp_address.sin_port = htons(rtp_port);
-			audio_rtp_address.sin_addr.s_addr = INADDR_ANY;
+			inet_pton(AF_INET, local_ip, &audio_rtp_address.sin_addr.s_addr);
 			if(bind(session->media.audio_rtp_fd, (struct sockaddr *)(&audio_rtp_address), sizeof(struct sockaddr)) < 0) {
 				JANUS_LOG(LOG_ERR, "Bind failed for audio RTP (port %d), trying a different one...\n", rtp_port);
 				attempts--;
@@ -1872,7 +1872,7 @@ static int janus_sip_allocate_local_ports(janus_sip_session *session) {
 			int rtcp_port = rtp_port+1;
 			audio_rtcp_address.sin_family = AF_INET;
 			audio_rtcp_address.sin_port = htons(rtcp_port);
-			audio_rtcp_address.sin_addr.s_addr = INADDR_ANY;
+			inet_pton(AF_INET, local_ip, &audio_rtcp_address.sin_addr.s_addr);
 			if(bind(session->media.audio_rtcp_fd, (struct sockaddr *)(&audio_rtcp_address), sizeof(struct sockaddr)) < 0) {
 				JANUS_LOG(LOG_ERR, "Bind failed for audio RTCP (port %d), trying a different one...\n", rtcp_port);
 				/* RTP socket is not valid anymore, reset it */
@@ -1908,17 +1908,17 @@ static int janus_sip_allocate_local_ports(janus_sip_session *session) {
 				rtp_port++;	/* Pick an even port for RTP */
 			video_rtp_address.sin_family = AF_INET;
 			video_rtp_address.sin_port = htons(rtp_port);
-			video_rtp_address.sin_addr.s_addr = INADDR_ANY;
+			inet_pton(AF_INET, local_ip, &video_rtp_address.sin_addr.s_addr);
 			if(bind(session->media.video_rtp_fd, (struct sockaddr *)(&video_rtp_address), sizeof(struct sockaddr)) < 0) {
 				JANUS_LOG(LOG_ERR, "Bind failed for video RTP (port %d), trying a different one...\n", rtp_port);
 				attempts--;
 				continue;
 			}
-			JANUS_LOG(LOG_VERB, "Audio RTP listener bound to port %d\n", rtp_port);
+			JANUS_LOG(LOG_VERB, "Video RTP listener bound to port %d\n", rtp_port);
 			int rtcp_port = rtp_port+1;
 			video_rtcp_address.sin_family = AF_INET;
 			video_rtcp_address.sin_port = htons(rtcp_port);
-			video_rtcp_address.sin_addr.s_addr = INADDR_ANY;
+			inet_pton(AF_INET, local_ip, &video_rtcp_address.sin_addr.s_addr);
 			if(bind(session->media.video_rtcp_fd, (struct sockaddr *)(&video_rtcp_address), sizeof(struct sockaddr)) < 0) {
 				JANUS_LOG(LOG_ERR, "Bind failed for video RTCP (port %d), trying a different one...\n", rtcp_port);
 				/* RTP socket is not valid anymore, reset it */
@@ -1927,7 +1927,7 @@ static int janus_sip_allocate_local_ports(janus_sip_session *session) {
 				attempts--;
 				continue;
 			}
-			JANUS_LOG(LOG_VERB, "Audio RTCP listener bound to port %d\n", rtcp_port);
+			JANUS_LOG(LOG_VERB, "Video RTCP listener bound to port %d\n", rtcp_port);
 			session->media.local_video_rtp_port = rtp_port;
 			session->media.local_video_rtcp_port = rtcp_port;
 		}


### PR DESCRIPTION
This does away with the c_address setting, effectively replacing it. Now the local_ip (which is either set or autodetected) is used for SIP signaling and media.

I also simplified the local IP detection code, it now takes the IP of the default (IPv4) route, instead of the IP of the first interface. While one could think both approaches are "correct", this one is simpler, allows us to remove the autodetect_ignore setting and it's also portable.