### PR TITLE
streaming: allow to receive RTP multicast streams

### DIFF
--- a/conf/janus.plugin.streaming.cfg.sample.in
+++ b/conf/janus.plugin.streaming.cfg.sample.in
@@ -66,7 +66,7 @@ secret = adminpwd
 [gstreamer-multicast]
 type = rtp
 id = 4
-description = Opus/VP8 live stream coming from gstreamer
+description = Opus/VP8 live multicast stream coming from gstreamer 
 audio = yes
 video = yes
 audioport = 5002

--- a/conf/janus.plugin.streaming.cfg.sample.in
+++ b/conf/janus.plugin.streaming.cfg.sample.in
@@ -17,9 +17,11 @@
 ; video = yes|no (do/don't stream video)
 ;    The following options are only valid for the 'rtp' type:
 ; audioport = local port for receiving audio frames
+; audiomcast = multicast group port for receiving audio frames (only for rtp)
 ; audiocodec = <audio RTP payload type> (e.g., 111)
 ; audiortpmap = RTP map of the audio codec (e.g., opus/48000/2)
 ; videoport = local port for receiving video frames (only for rtp)
+; videomcast = multicast group port for receiving video frames (only for rtp)
 ; videocodec = <video RTP payload type> (e.g., 100)
 ; videortpmap = RTP map of the video codec (e.g., VP8/90000)
 ;
@@ -59,6 +61,22 @@ description = mu-law file source (music)
 filename = @streamdir@/music.mulaw	; See install.sh
 audio = yes
 video = no
+secret = adminpwd
+
+[gstreamer-multicast]
+type = rtp
+id = 4
+description = Opus/VP8 live stream coming from gstreamer
+audio = yes
+video = yes
+audioport = 5002
+audiomcast = 232.3.4.5
+audiopt = 111
+audiortpmap = opus/48000/2
+videoport = 5004
+videomcast = 232.3.4.5
+videopt = 100
+videortpmap = VP8/90000
 secret = adminpwd
 
 ;

--- a/conf/janus.plugin.streaming.cfg.sample.in
+++ b/conf/janus.plugin.streaming.cfg.sample.in
@@ -63,22 +63,6 @@ audio = yes
 video = no
 secret = adminpwd
 
-[gstreamer-multicast]
-type = rtp
-id = 4
-description = Opus/VP8 live multicast stream coming from gstreamer 
-audio = yes
-video = yes
-audioport = 5002
-audiomcast = 232.3.4.5
-audiopt = 111
-audiortpmap = opus/48000/2
-videoport = 5004
-videomcast = 232.3.4.5
-videopt = 100
-videortpmap = VP8/90000
-secret = adminpwd
-
 ;
 ; Firefox Nightly supports H.264 through Cisco's OpenH264 plugin. The only
 ; supported profile is the baseline one. This is an example of how to create
@@ -95,4 +79,22 @@ secret = adminpwd
 ;videopt = 126
 ;videortpmap = H264/90000
 ;videofmtp = profile-level-id=42e01f\;packetization-mode=1
+
+;
+; This is a sample configuration for Opus/VP8 multicast streams
+;
+;[gstreamer-multicast]
+;type = rtp
+;id = 20
+;description = Opus/VP8 live multicast stream coming from gstreamer 
+;audio = yes
+;video = yes
+;audioport = 5002
+;audiomcast = 232.3.4.5
+;audiopt = 111
+;audiortpmap = opus/48000/2
+;videoport = 5004
+;videomcast = 232.3.4.5
+;videopt = 100
+;videortpmap = VP8/90000
 

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2629,7 +2629,7 @@ static void *janus_streaming_relay_thread(void *data) {
 	if(video_port >= 0) {
 		video_fd = socket(AF_INET, SOCK_DGRAM, 0);
 		int yes = 1;	/* For setsockopt() SO_REUSEADDR */
-		setsockopt(audio_fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
+		setsockopt(video_fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
 		if (IN_MULTICAST(source->video_mcast))
 		{
 			struct ip_mreq mreq;

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2612,6 +2612,8 @@ static void *janus_streaming_relay_thread(void *data) {
 			mreq.imr_multiaddr.s_addr = source->audio_mcast;
 			if (setsockopt(audio_fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(struct ip_mreq)) == -1) {
 				JANUS_LOG(LOG_ERR, "[%s] Audio listener IP_ADD_MEMBERSHIP fail\n", mountpoint->name);
+				g_thread_unref(g_thread_self());
+				return NULL;
 			}
 		}
 
@@ -2636,6 +2638,8 @@ static void *janus_streaming_relay_thread(void *data) {
 			mreq.imr_multiaddr.s_addr = source->video_mcast;
 			if (setsockopt(video_fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(struct ip_mreq)) == -1) {
 				JANUS_LOG(LOG_ERR, "[%s] Video listener IP_ADD_MEMBERSHIP fail\n", mountpoint->name);
+				g_thread_unref(g_thread_self());
+				return NULL;
 			}
 		}
 		

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -101,6 +101,7 @@ videofmtp = Codec specific parameters, if any
  * \ingroup plugins
  * \ref plugins
  */
+ 
 #include "plugin.h"
 
 #include <jansson.h>

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -101,7 +101,7 @@ videofmtp = Codec specific parameters, if any
  * \ingroup plugins
  * \ref plugins
  */
- 
+
 #include "plugin.h"
 
 #include <jansson.h>

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2629,7 +2629,7 @@ static void *janus_streaming_relay_thread(void *data) {
 	if(video_port >= 0) {
 		video_fd = socket(AF_INET, SOCK_DGRAM, 0);
 		int yes = 1;	/* For setsockopt() SO_REUSEADDR */
-		setsockopt(video_fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));		
+		setsockopt(audio_fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
 		if (IN_MULTICAST(source->video_mcast))
 		{
 			struct ip_mreq mreq;

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -101,7 +101,6 @@ videofmtp = Codec specific parameters, if any
  * \ingroup plugins
  * \ref plugins
  */
-
 #include "plugin.h"
 
 #include <jansson.h>
@@ -793,7 +792,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		g_snprintf(error_cause, 512, "%s", "No message??");
 		goto error;
 	}
-	JANUS_LOG(LOG_ERR, "Handling message: %s\n", message);
+	JANUS_LOG(LOG_VERB, "Handling message: %s\n", message);
 
 	janus_streaming_session *session = (janus_streaming_session *)handle->plugin_handle;	
 	if(!session) {


### PR DESCRIPTION
This modification allow to use RTP multicast listeners for audio and video streams.
In configuration file janus.plugin.streaming.cfg the new properties **audiomcast** and **videomcast** allow to ask for multicast membership of rtp stream :

    [gstreamer-multicast]
    type = rtp
    id = 4
    description = Opus/VP8 live multicast stream coming from gstreamer 
    audio = yes
    video = yes
    audioport = 5002
    audiomcast = 232.3.4.5
    audiopt = 111
    audiortpmap = opus/48000/2
    videoport = 5004
    videomcast = 232.3.4.5
    videopt = 100
    videortpmap = VP8/90000

gstreamer can easily generate input test streams that will be relayed : 

    gst-launch-1.0 -v videotestsrc ! vp8enc deadline=1 ! rtpvp8pay ! udpsink host=232.3.4.5 port=5004
    gst-launch-1.0  audiotestsrc ! audioconvert ! opusenc ! rtpopuspay ! udpsink host=232.3.4.5 port=5002