### PR TITLE
exit cleanly on SIGTERM

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -3851,8 +3851,9 @@ gint main(int argc, char *argv[])
 	JANUS_PRINT("  Starting Meetecho Janus (WebRTC Gateway) v%s\n", JANUS_VERSION_STRING);
 	JANUS_PRINT("---------------------------------------------------\n\n");
 	
-	/* Handle SIGINT */
+	/* Handle SIGINT (CTRL-C), SIGTERM (from service managers) */
 	signal(SIGINT, janus_handle_signal);
+	signal(SIGTERM, janus_handle_signal);
 
 	/* Setup Glib */
 #if !GLIB_CHECK_VERSION(2, 36, 0)


### PR DESCRIPTION
... in addition to SIGINT which is already handled. SIGTERM is the signal typically used by docker and other service/process managers.