### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ HTTP REST API, you'll have to install it manually:
 	cd libwebsockets
 	mkdir build
 	cd build
-	cmake ..
+	cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
 	make && sudo make install
 	
 Finally, the same can be said for rabbitmq-c as well, which is needed


### PR DESCRIPTION
Update README.md to change the install path of libwebsockets.
This fixes not found error when executing janus server.