### PR TITLE
make JANUS_LOG macro less redundant

### DIFF
--- a/debug.h
+++ b/debug.h
@@ -74,38 +74,26 @@ static const char *log_prefix[] = {
  * or not according to the configuration of the gateway.
  * The format must be a string literal. */
 #define JANUS_LOG(level, format, ...) \
-{ \
-	if (!log_timestamps) { \
-		if (level > LOG_NONE && level <= LOG_MAX && level <= log_level) { \
-			if (level == LOG_FATAL || level == LOG_ERR || level == LOG_DBG) { \
-				g_print("%s[%s:%s:%d:] " format, log_prefix[level], \
-						__FILE__, __FUNCTION__, __LINE__, \
-						##__VA_ARGS__); \
-			} else { \
-				g_print("%s" format, log_prefix[level], \
-						##__VA_ARGS__); \
-			} \
+do { \
+	if (level > LOG_NONE && level <= LOG_MAX && level <= log_level) { \
+		char janus_log_ts[32] = ""; \
+		char janus_log_src[64] = ""; \
+		if (log_timestamps) { \
+			struct tm janustmresult; \
+			time_t janusltime = time(NULL); \
+			localtime_r(&janusltime, &janustmresult); \
+			strftime(janus_log_ts, sizeof(janus_log_ts), \
+			         "[%a %b %e %T %Y] ", &janustmresult); \
 		} \
-	} else { \
-		time_t janusltime; \
-		struct tm janustmresult; \
-		char janusstime[32]; \
-		janusltime = time(NULL); \
-		localtime_r(&janusltime, &janustmresult); \
-		asctime_r(&janustmresult, janusstime); \
-		janusstime[strlen(janusstime)-1] = '\0'; \
-		if (level > LOG_NONE && level <= LOG_MAX && level <= log_level) { \
-			if (level == LOG_FATAL || level == LOG_ERR || level == LOG_DBG) { \
-				g_print("[%s] %s[%s:%s:%d:] " format, janusstime, log_prefix[level], \
-						__FILE__, __FUNCTION__, __LINE__, \
-						##__VA_ARGS__); \
-			} else { \
-				g_print("[%s] %s" format, janusstime, log_prefix[level], \
-						##__VA_ARGS__); \
-			} \
+		if (level == LOG_FATAL || level == LOG_ERR || level == LOG_DBG) { \
+			snprintf(janus_log_src, sizeof(janus_log_src), \
+			         "[%s:%s:%d] ", __FILE__, __FUNCTION__, __LINE__); \
 		} \
+		g_print("%s%s%s" format, \
+		        janus_log_ts, log_prefix[level], janus_log_src, \
+		        ##__VA_ARGS__); \
 	} \
-}
+} while (0)
 ///@}
 
 #endif


### PR DESCRIPTION
This revised version should have the exact same output as the old version. But it's shorter, and IMHO simpler.

Notice that the old version prepared the `janusstime` time string even if it didn't end up logging for that level (if debug-timestamps were enabled).