### PR TITLE
quiet logging: ice candidate added, looping ice thread

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -1432,7 +1432,7 @@ void *janus_ice_thread(void *data) {
 		return NULL;
 	}
 	g_usleep (100000);
-	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Looping (ICE)...\n", handle->handle_id);
+	JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Looping (ICE)...\n", handle->handle_id);
 	g_main_loop_run (loop);
 	janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_CLEANING);
 	if(handle->cdone == 0)

--- a/sdp.c
+++ b/sdp.c
@@ -500,7 +500,7 @@ int janus_sdp_parse_candidate(janus_ice_stream *stream, const char *candidate, i
 					nice_address_set_port(&c->base_addr, rrelport);
 				}
 				component->candidates = g_slist_append(component->candidates, c);
-				JANUS_LOG(LOG_VERB, "[%"SCNu64"]    Candidate added to the list! (%u elements for %d/%d)\n", handle->handle_id,
+				JANUS_LOG(LOG_HUGE, "[%"SCNu64"]    Candidate added to the list! (%u elements for %d/%d)\n", handle->handle_id,
 					g_slist_length(component->candidates), stream->stream_id, component->component_id);
 				/* Save for the summary, in case we need it */
 				component->remote_candidates = g_slist_append(component->remote_candidates, g_strdup(candidate));
@@ -517,7 +517,7 @@ int janus_sdp_parse_candidate(janus_ice_stream *stream, const char *candidate, i
 							if(nice_agent_set_remote_candidates(handle->agent, stream->stream_id, component->component_id, candidates) < 1) {
 								JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to add trickle candidate :-(\n", handle->handle_id);
 							} else {
-								JANUS_LOG(LOG_VERB, "[%"SCNu64"] Trickle candidate added!\n", handle->handle_id);
+								JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Trickle candidate added!\n", handle->handle_id);
 							}
 							g_slist_free(candidates);
 						}


### PR DESCRIPTION
quieter logging of final "ice candidate added" message
  * an earlier log message says it is being added
  * if there is some error adding it, that will show

The "Looping (ICE)" message is almost debug-level information, IMHO.

(Again, this is subjective, so I understand if you reject.)