### PR TITLE
slow_link callback refactor: count NACKs over full second

### DIFF
--- a/ice.h
+++ b/ice.h
@@ -309,8 +309,12 @@ struct janus_ice_component {
 	GList *last_seqs;
 	/*! \brief Time when the last NACK was sent */
 	gint64 last_nack_time;
-	/*! \brief Time when we last notified the plugin about a slow link (too many received NACKs) */
+	/*! \brief last time the slow_link callback (of the plugin) was called */
 	gint64 last_slowlink_time;
+	/*! \brief start time of recent NACKs (for slow_link) */
+	gint64 sl_nack_period_ts;
+	/*! \brief count of recent NACKs (for slow_link) */
+	guint sl_nack_recent_cnt;
 	/*! \brief Stats for incoming data (audio/video/data) */
 	janus_ice_stats in_stats;
 	/*! \brief Stats for outgoing data (audio/video/data) */


### PR DESCRIPTION
... instead of only counting over a compound RTCP packet, to see if the threshold of NACKs is exceeded.

This mostly affects outgoing streams, since peers usually send NACKs to janus one-per-packet under reasonable-loss circumstances (for latency reasons). I would typically see many separate RTCP packets, with 1 to 4 NACKs each, when testing with 2% packet loss.

Janus batches up NACKs to send for incoming streams over 0.5 seconds, so was already much more likely to reach the threshold per-packet.