### PR TITLE
only log once when "Still cleaning up from previous media session"

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -1224,11 +1224,6 @@ int janus_process_incoming_request(janus_request_source *source, json_t *root) {
 				goto jsondone;
 			}
 			jsep_type = g_strdup(json_string_value(type));
-			if(jsep_type == NULL) {
-				JANUS_LOG(LOG_FATAL, "Memory error!\n");
-				ret = janus_process_error(source, session_id, transaction_text, JANUS_ERROR_UNKNOWN, "Memory error");
-				goto jsondone;
-			}
 			type = NULL;
 			/* Are we still cleaning up from a previous media session? */
 			if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_CLEANING)) {

--- a/janus.c
+++ b/janus.c
@@ -1235,7 +1235,6 @@ int janus_process_incoming_request(janus_request_source *source, json_t *root) {
 				JANUS_LOG(LOG_INFO, "[%"SCNu64"] Still cleaning up from a previous media session, let's wait a bit...\n", handle->handle_id);
 				gint64 waited = 0;
 				while(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_CLEANING)) {
-					JANUS_LOG(LOG_VERB, "[%"SCNu64"] Still cleaning up from a previous media session, let's wait a bit...\n", handle->handle_id);
 					g_usleep(100000);
 					waited += 100000;
 					if(waited >= 3*G_USEC_PER_SEC) {


### PR DESCRIPTION
same type of logging cleanup as in #225 

I also threw in a commit to remove a check for g_strdup() failing. Like most glib2 functions, it will abort the process if it fails.