### PR TITLE
Example Matrix Integration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,9 @@ AM_CFLAGS = \
 	-Warray-bounds -Wold-style-definition -Wsign-compare -Wlarger-than=65537
 AM_CFLAGS += -Wno-undef  # sophiasip is not -Wundef--safe
 AM_CFLAGS += -Wno-redundant-decls  # sophiasip also contains redundant declarations
-AM_CFLAGS += -Wno-override-init  # we need this for JANUS_PLUGIN_INIT
+AM_CFLAGS += -Wno-override-init -Wno-initializer-overrides  # we need this for JANUS_PLUGIN_INIT
+# make clang stop whining:
+AM_CFLAGS += -Wno-format
 # FIXME: These should be enabled once the code is safe for them. That requires
 # some fairly big refactoring though, which can wait.
 # AM_CFLAGS += -Wshadow -Wstrict-aliasing=2
@@ -182,9 +184,13 @@ endif
 
 if ENABLE_PLUGIN_STREAMING
 plugin_LTLIBRARIES += plugins/libjanus_streaming.la
-plugins_libjanus_streaming_la_SOURCES = plugins/janus_streaming.c
-plugins_libjanus_streaming_la_CFLAGS = $(plugins_cflags)
-plugins_libjanus_streaming_la_LDFLAGS = $(plugins_ldflags)
+ARSDK_DIR=$(HOME)/workspace/ARDrone3SDK/ARSDKBuildUtils
+plugins_libjanus_streaming_la_SOURCES = plugins/janus_streaming.c plugins/BebopDroneReceiveStream.c
+plugins_libjanus_streaming_la_CFLAGS = $(plugins_cflags) -I$(ARSDK_DIR)/Targets/Unix/Install/include
+plugins_libjanus_streaming_la_LDFLAGS = $(plugins_ldflags) -L$(ARSDK_DIR)/Targets/Unix/Install/lib -larsal -larcommands -larnetwork -larnetworkal -lardiscovery -larstream
+#plugins_libjanus_streaming_la_SOURCES = plugins/janus_streaming.c
+#plugins_libjanus_streaming_la_CFLAGS = $(plugins_cflags)
+#plugins_libjanus_streaming_la_LDFLAGS = $(plugins_ldflags)
 plugins_libjanus_streaming_la_LIBADD = $(plugins_libadd)
 conf_DATA += conf/janus.plugin.streaming.cfg.sample
 stream_DATA += \

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -141,7 +141,7 @@ $(document).ready(function() {
 									console.log(" ::: Got a remote stream :::");
 									console.log(JSON.stringify(stream));
 									if($('#remotevideo').length === 0)
-										$('#stream').append('<video class="rounded centered hide" id="remotevideo" width=320 height=240 autoplay/>');
+										$('#stream').append('<video class="rounded centered hide" id="remotevideo" width=640 height=368 autoplay/>');
 									// Show the stream and hide the spinner when we get a playing event
 									$("#remotevideo").bind("playing", function () {
 										$('#waitingvideo').remove();
@@ -218,7 +218,7 @@ function startStream() {
 	var body = { "request": "watch", id: parseInt(selectedStream) };
 	streaming.send({"message": body});
 	// No remote video yet
-	$('#stream').append('<video class="rounded centered" id="waitingvideo" width=320 height=240 />');
+	$('#stream').append('<video class="rounded centered" id="waitingvideo" width=640 height=368 />');
 	if(spinner == null) {
 		var target = document.getElementById('stream');
 		spinner = new Spinner({top:100}).spin(target);

--- a/ice.c
+++ b/ice.c
@@ -2569,6 +2569,7 @@ void *janus_ice_send_thread(void *data) {
 				} else {
 					/* FIXME Copy in a buffer and fix SSRC */
 					char sbuf[BUFSIZE];
+					JANUS_LOG(LOG_VERB, "ICE: Trying to send a packet %p with data %p of length %d\n", pkt, pkt->data, pkt->length);
 					memcpy(&sbuf, pkt->data, pkt->length);
 					if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_PLAN_B)) {
 						/* Overwrite SSRC */

--- a/janus.c
+++ b/janus.c
@@ -5322,7 +5322,7 @@ void janus_matrix_handle_event(matrix_event *ev, json_t *rawevent) {
 
         json_t *body = json_object();
         json_object_set_new(body, "request", json_string("watch"));
-        json_object_set_new(body, "id", json_integer(2));
+        json_object_set_new(body, "id", json_integer(1));
 
         json_object_set_new(root, "body", body);
         //json_object_set(root, "jsep", offer);

--- a/janus.c
+++ b/janus.c
@@ -5401,26 +5401,22 @@ void janus_matrix_handle_event(matrix_event *ev, json_t *rawevent) {
             return;
         }
         JANUS_LOG(LOG_INFO, "\tcall_id %s is handle ID %llu\n", call_id, handle->handle_id);
-        size_t i;
-        for (i = 0; i < json_array_size(cands); ++i) {
-            json_t *cand = json_array_get(cands, i);
 
-            json_t *root = json_object();
-            json_object_set_new(root, "janus", json_string("trickle"));
+        json_t *root = json_object();
+        json_object_set_new(root, "janus", json_string("trickle"));
 
-            json_object_set_new(root, "session_id", json_integer(jan_session->session_id));
-            json_object_set_new(root, "handle_id", json_integer(handle->handle_id));
+        json_object_set_new(root, "session_id", json_integer(jan_session->session_id));
+        json_object_set_new(root, "handle_id", json_integer(handle->handle_id));
 
-            json_object_set(root, "candidate", cand);
-            char trstr[128];
-            sprintf(trstr, "%lu", g_random_int());
-            json_object_set_new(root, "transaction", json_string(trstr));
-            json_object_set_new(root, "apisecret", json_string(ws_api_secret));
+        json_object_set(root, "candidates", cands);
+        char trstr[128];
+        sprintf(trstr, "%lu", g_random_int());
+        json_object_set_new(root, "transaction", json_string(trstr));
+        json_object_set_new(root, "apisecret", json_string(ws_api_secret));
 
-            JANUS_LOG(LOG_INFO, "\tSending on a candidate to handle ID %llu, call ID %s...\n", handle->handle_id, call_id);
-            janus_process_incoming_request(&source, root);
-            json_decref(root);
-        }
+        JANUS_LOG(LOG_INFO, "\tSending on candidates to handle ID %llu, call ID %s...\n", handle->handle_id, call_id);
+        janus_process_incoming_request(&source, root);
+        json_decref(root);
     } else {
         // pass other events through unfettered
         

--- a/janus.c
+++ b/janus.c
@@ -4914,10 +4914,10 @@ gint main(int argc, char *argv[])
 	matrix_call_id_to_handle = g_hash_table_new(g_str_hash, g_str_equal);
 	matrix_handle_to_call_id = g_hash_table_new(g_str_hash, g_str_equal);
     matrix_room_id_to_handle = g_hash_table_new(g_str_hash, g_str_equal);
-    mxsess.hs_url = strdup("https://matrix.org");
-    mxsess.access_token = strdup("QHBvbGx5Om1hdHJpeC5vcmc..LIbiJzQUCbwKylrasG");
+    mxsess.hs_url = strdup("http://localhost:8008");
+    mxsess.access_token = strdup("QHBvbGx5OmVjaG8tbWF0cml4.eozjERVjtQrdeVxCbC");
     mxsess.run_event_stream = 1;
-    mxsess.matrix_id = "@polly:matrix.org";
+    mxsess.matrix_id = "@polly:echo-matrix";
 
     GError *error = NULL;
     JANUS_LOG(LOG_INFO, "Starting matrix event stream thread\n");

--- a/janus.h
+++ b/janus.h
@@ -42,7 +42,7 @@
 #include "plugins/plugin.h"
 
 
-#define BUFSIZE	65536
+#define BUFSIZE	4096
 
 
 /*! \brief Incoming HTTP message */

--- a/janus.h
+++ b/janus.h
@@ -42,7 +42,7 @@
 #include "plugins/plugin.h"
 
 
-#define BUFSIZE	4096
+#define BUFSIZE	65536
 
 
 /*! \brief Incoming HTTP message */

--- a/janus.h
+++ b/janus.h
@@ -422,7 +422,7 @@ size_t curl_data_cb(void *contents, size_t size, size_t nmemb, void *userp);
 typedef struct matrix_session {
     char *hs_url;
     char *matrix_id;
-    pthread_t event_stream_thread;
+    GThread *event_stream_thread;
     char *access_token;
     int run_event_stream;
 } matrix_session;

--- a/janus.h
+++ b/janus.h
@@ -438,7 +438,7 @@ typedef struct matrix_event {
     const char *state_key;
     json_t *content;
 } matrix_event;
-void janus_matrix_handle_event(matrix_event *ev);
+void janus_matrix_handle_event(matrix_event *ev, json_t *rawevent);
 int matrix_join_room(matrix_session *sess, const char *room_id);
 int matrix_send_event(matrix_session *sess, const char *room_id, const char *type, json_t *content);
 #endif

--- a/plugins/BebopDroneReceiveStream.c
+++ b/plugins/BebopDroneReceiveStream.c
@@ -1231,6 +1231,12 @@ void onMatrixMessage (char *message, BD_MANAGER_t *deviceManager)
 		deviceManager->dataPCMD.flag = 1;
 	    deviceManager->dataPCMD.pitch = -param1;
 	}
+	else if (sscanf(message, "turn left %d", &param1) == 1) {
+        deviceManager->dataPCMD.yaw = -param1;
+	}
+	else if (sscanf(message, "turn right %d", &param1) == 1) {
+        deviceManager->dataPCMD.yaw = param1;
+	}
 	else if (sscanf(message, "look %d,%d", &param1, &param2) == 2) {
 		deviceManager->dataCam.pan = param1;
 		deviceManager->dataCam.tilt = param2;

--- a/plugins/BebopDroneReceiveStream.c
+++ b/plugins/BebopDroneReceiveStream.c
@@ -614,6 +614,18 @@ uint8_t *frameCompleteCallback (eARSTREAM_READER_CAUSE cause, uint8_t *frame, ui
 			f = calloc(1, sizeof(janus_streaming_ardrone3_frame));
 			f->data = frame;
 			f->length = frameSize;
+			
+			struct timeval now;
+			time_t d_s, d_us;
+			gettimeofday(&now, NULL);
+			d_s = now.tv_sec;
+			d_us = now.tv_usec;
+			if(d_us < 0) {
+				d_us += 1000000;
+				--d_s;
+			}
+		 	f->ts = (uint64_t)d_s*1000000 + d_us;
+
 			g_async_queue_push(ardrone3_frames, f);
 			
             //ret = deviceManager->videoFrame;

--- a/plugins/BebopDroneReceiveStream.c
+++ b/plugins/BebopDroneReceiveStream.c
@@ -237,11 +237,16 @@ void *looperRun (void* data)
             sendPCMD(deviceManager);
 
 			// reset state after each command
-            deviceManager->dataPCMD.flag = 0;
-            deviceManager->dataPCMD.roll = 0;
-            deviceManager->dataPCMD.pitch = 0;
-            deviceManager->dataPCMD.yaw = 0;
-            deviceManager->dataPCMD.gaz = 0;
+			if (deviceManager->dataPCMD.lifetime == 0) {
+	            deviceManager->dataPCMD.flag = 0;
+	            deviceManager->dataPCMD.roll = 0;
+	            deviceManager->dataPCMD.pitch = 0;
+	            deviceManager->dataPCMD.yaw = 0;
+				deviceManager->dataPCMD.gaz = 0;
+			}
+			else {
+				deviceManager->dataPCMD.lifetime--;
+			}
             
             sendCameraOrientation(deviceManager);
             
@@ -295,6 +300,7 @@ BD_MANAGER_t * bebop_start()
         deviceManager->dataPCMD.pitch = 0;
         deviceManager->dataPCMD.yaw = 0;
         deviceManager->dataPCMD.gaz = 0;
+        deviceManager->dataPCMD.lifetime = 0;
         
         deviceManager->dataCam.tilt = 0;
         deviceManager->dataCam.pan = 0;
@@ -1176,6 +1182,9 @@ void onMatrixMessage (char *message, BD_MANAGER_t *deviceManager)
 	int param1, param2;
 	char arg[16];
 	
+	int amount = 50;
+	int lifetime = 10;
+	
 	if (!strcasecmp(message, "launch")) {
         sendTakeoff(deviceManager);		
 	}
@@ -1189,61 +1198,77 @@ void onMatrixMessage (char *message, BD_MANAGER_t *deviceManager)
 		sendEmergency(deviceManager);
 	}
 	else if (!strcasecmp(message, "up")) {
-		deviceManager->dataPCMD.gaz = 50;
+		deviceManager->dataPCMD.gaz = amount;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (!strcasecmp(message, "down")) {
-		deviceManager->dataPCMD.gaz = -50;
+		deviceManager->dataPCMD.gaz = -amount;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (!strcasecmp(message, "left")) {
         deviceManager->dataPCMD.flag = 1;
-        deviceManager->dataPCMD.roll = -50;
+        deviceManager->dataPCMD.roll = -amount;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (!strcasecmp(message, "right")) {
         deviceManager->dataPCMD.flag = 1;
-        deviceManager->dataPCMD.roll = 50;
+        deviceManager->dataPCMD.roll = amount;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (!strcasecmp(message, "forward")) {
 		deviceManager->dataPCMD.flag = 1;
-	    deviceManager->dataPCMD.pitch = 50;
+	    deviceManager->dataPCMD.pitch = amount;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (!strcasecmp(message, "back") || !strcasecmp(message, "backward")) {
 		deviceManager->dataPCMD.flag = 1;
-	    deviceManager->dataPCMD.pitch = -50;
+	    deviceManager->dataPCMD.pitch = -amount;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (!strcasecmp(message, "turn left")) {
-        deviceManager->dataPCMD.yaw = -50;
+        deviceManager->dataPCMD.yaw = -amount;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (!strcasecmp(message, "turn right")) {
-        deviceManager->dataPCMD.yaw = 50;
+        deviceManager->dataPCMD.yaw = amount;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (sscanf(message, "up %d", &param1) == 1) {
 		deviceManager->dataPCMD.gaz = param1;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (sscanf(message, "down %d", &param1) == 1) {
 		deviceManager->dataPCMD.gaz = -param1;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (sscanf(message, "left %d", &param1) == 1) {
         deviceManager->dataPCMD.flag = 1;
         deviceManager->dataPCMD.roll = -param1;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (sscanf(message, "right %d", &param1) == 1) {
         deviceManager->dataPCMD.flag = 1;
         deviceManager->dataPCMD.roll = param1;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (sscanf(message, "forward %d", &param1) == 1) {
 		deviceManager->dataPCMD.flag = 1;
 	    deviceManager->dataPCMD.pitch = param1;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (sscanf(message, "back %d", &param1) == 1 ||
 			 sscanf(message, "backward %d", &param1) == 1) {
 		deviceManager->dataPCMD.flag = 1;
 	    deviceManager->dataPCMD.pitch = -param1;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (sscanf(message, "turn left %d", &param1) == 1) {
         deviceManager->dataPCMD.yaw = -param1;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (sscanf(message, "turn right %d", &param1) == 1) {
         deviceManager->dataPCMD.yaw = param1;
+		deviceManager->dataPCMD.lifetime = lifetime;
 	}
 	else if (sscanf(message, "look %d,%d", &param1, &param2) == 2) {
 		deviceManager->dataCam.pan = param1;

--- a/plugins/BebopDroneReceiveStream.c
+++ b/plugins/BebopDroneReceiveStream.c
@@ -1,0 +1,728 @@
+/*
+    Copyright (C) 2014 Parrot SA
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Parrot nor the names
+      of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written
+      permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+    OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED 
+    AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+    OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.
+*/
+/**
+ * @file BebopDroneReceiveStream.c
+ * @brief Modified from original Parrot source
+ * @date 08/01/2015
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "BebopDroneReceiveStream.h"
+
+#define TAG "BebopDroneReceiveStream"
+#define BD_IP_ADDRESS "192.168.42.1"
+#define BD_DISCOVERY_PORT 44444
+#define BD_C2D_PORT 54321 // should be read from Json
+#define BD_D2C_PORT 43210
+
+#define BD_NET_CD_NONACK_ID 10
+#define BD_NET_CD_ACK_ID 11
+#define BD_NET_CD_EMERGENCY_ID 12
+#define BD_NET_CD_VIDEO_ACK_ID 13
+#define BD_NET_DC_NAVDATA_ID 127
+#define BD_NET_DC_EVENT_ID 126
+#define BD_NET_DC_VIDEO_DATA_ID 125
+
+#define BD_NET_DC_VIDEO_FRAG_SIZE 1000
+#define BD_NET_DC_VIDEO_MAX_NUMBER_OF_FRAG 128
+
+GAsyncQueue *ardrone3_frames = NULL;
+
+static ARNETWORK_IOBufferParam_t c2dParams[] = {
+    /* Non-acknowledged commands. */
+    {
+        .ID = BD_NET_CD_NONACK_ID,
+        .dataType = ARNETWORKAL_FRAME_TYPE_DATA,
+        .sendingWaitTimeMs = 20,
+        .ackTimeoutMs = ARNETWORK_IOBUFFERPARAM_INFINITE_NUMBER,
+        .numberOfRetry = ARNETWORK_IOBUFFERPARAM_INFINITE_NUMBER,
+        .numberOfCell = 2,
+        .dataCopyMaxSize = 128,
+        .isOverwriting = 1,
+    },
+    /* Acknowledged commands. */
+    {
+        .ID = BD_NET_CD_ACK_ID,
+        .dataType = ARNETWORKAL_FRAME_TYPE_DATA_WITH_ACK,
+        .sendingWaitTimeMs = 20,
+        .ackTimeoutMs = 500,
+        .numberOfRetry = 3,
+        .numberOfCell = 20,
+        .dataCopyMaxSize = 128,
+        .isOverwriting = 0,
+    },
+    /* Emergency commands. */
+    {
+        .ID = BD_NET_CD_EMERGENCY_ID,
+        .dataType = ARNETWORKAL_FRAME_TYPE_DATA_WITH_ACK,
+        .sendingWaitTimeMs = 10,
+        .ackTimeoutMs = 100,
+        .numberOfRetry = ARNETWORK_IOBUFFERPARAM_INFINITE_NUMBER,
+        .numberOfCell = 1,
+        .dataCopyMaxSize = 128,
+        .isOverwriting = 0,
+    },
+    /* Video ACK (Initialized later) */
+    {
+        .ID = BD_NET_CD_VIDEO_ACK_ID,
+        .dataType = ARNETWORKAL_FRAME_TYPE_UNINITIALIZED,
+        .sendingWaitTimeMs = 0,
+        .ackTimeoutMs = 0,
+        .numberOfRetry = 0,
+        .numberOfCell = 0,
+        .dataCopyMaxSize = 0,
+        .isOverwriting = 0,
+    },
+};
+static const size_t numC2dParams = sizeof(c2dParams) / sizeof(ARNETWORK_IOBufferParam_t);
+
+static ARNETWORK_IOBufferParam_t d2cParams[] = {
+    {
+        .ID = BD_NET_DC_NAVDATA_ID,
+        .dataType = ARNETWORKAL_FRAME_TYPE_DATA,
+        .sendingWaitTimeMs = 20,
+        .ackTimeoutMs = ARNETWORK_IOBUFFERPARAM_INFINITE_NUMBER,
+        .numberOfRetry = ARNETWORK_IOBUFFERPARAM_INFINITE_NUMBER,
+        .numberOfCell = 20,
+        .dataCopyMaxSize = 128,
+        .isOverwriting = 0,
+    },
+    {
+        .ID = BD_NET_DC_EVENT_ID,
+        .dataType = ARNETWORKAL_FRAME_TYPE_DATA_WITH_ACK,
+        .sendingWaitTimeMs = 20,
+        .ackTimeoutMs = 500,
+        .numberOfRetry = 3,
+        .numberOfCell = 20,
+        .dataCopyMaxSize = 128,
+        .isOverwriting = 0,
+    },
+    /* Video data (Initialized later) */
+    {
+        .ID = BD_NET_DC_VIDEO_DATA_ID,
+        .dataType = ARNETWORKAL_FRAME_TYPE_UNINITIALIZED,
+        .sendingWaitTimeMs = 0,
+        .ackTimeoutMs = 0,
+        .numberOfRetry = 0,
+        .numberOfCell = 0,
+        .dataCopyMaxSize = 0,
+        .isOverwriting = 0,
+    },
+};
+static const size_t numD2cParams = sizeof(d2cParams) / sizeof(ARNETWORK_IOBufferParam_t);
+
+static int commandBufferIds[] = {
+    BD_NET_DC_NAVDATA_ID,
+    BD_NET_DC_EVENT_ID,
+};
+static const size_t numOfCommandBufferIds = sizeof(commandBufferIds) / sizeof(int);
+
+void *readerRun (void* data)
+{
+    BD_MANAGER_t *deviceManager = NULL;
+    int bufferId = 0;
+    int failed = 0;
+    
+    // Allocate some space for incoming data.
+    const size_t maxLength = 128 * 1024;
+    void *readData = malloc (maxLength);
+    if (readData == NULL)
+    {
+        failed = 1;
+    }
+    
+    if (!failed)
+    {
+        // get thread data.
+        if (data != NULL)
+        {
+            bufferId = ((READER_THREAD_DATA_t *)data)->readerBufferId;
+            deviceManager = ((READER_THREAD_DATA_t *)data)->deviceManager;
+            
+            if (deviceManager == NULL)
+            {
+                failed = 1;
+            }
+        }
+        else
+        {
+            failed = 1;
+        }
+    }
+    
+    if (!failed)
+    {
+        while (deviceManager->run)
+        {
+            eARNETWORK_ERROR netError = ARNETWORK_OK;
+            int length = 0;
+            int skip = 0;
+            
+            // read data
+            netError = ARNETWORK_Manager_ReadDataWithTimeout (deviceManager->netManager, bufferId, readData, maxLength, &length, 1000);
+            if (netError != ARNETWORK_OK)
+            {
+                if (netError != ARNETWORK_ERROR_BUFFER_EMPTY)
+                {
+                    ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "ARNETWORK_Manager_ReadDataWithTimeout () failed : %s", ARNETWORK_Error_ToString(netError));
+                }
+                skip = 1;
+            }
+            
+            if (!skip)
+            {
+                // Forward data to the CommandsManager
+                eARCOMMANDS_DECODER_ERROR cmdError = ARCOMMANDS_DECODER_OK;
+                cmdError = ARCOMMANDS_Decoder_DecodeBuffer ((uint8_t *)readData, length);
+                if ((cmdError != ARCOMMANDS_DECODER_OK) && (cmdError != ARCOMMANDS_DECODER_ERROR_NO_CALLBACK))
+                {
+                    char msg[128];
+                    ARCOMMANDS_Decoder_DescribeBuffer ((uint8_t *)readData, length, msg, sizeof(msg));
+                    ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "ARCOMMANDS_Decoder_DecodeBuffer () failed : %d %s", cmdError, msg);
+                }
+            }
+        }
+    }
+    
+    if (readData != NULL)
+    {
+        free (readData);
+        readData = NULL;
+    }
+    
+    return NULL;
+}
+
+void bebop_start()
+{
+    /* local declarations */
+    int failed = 0;
+    BD_MANAGER_t *deviceManager = malloc(sizeof(BD_MANAGER_t));
+
+    ARSAL_PRINT(ARSAL_PRINT_INFO, TAG, "-- Bebop Drone Receive Video Stream --");
+    
+    ARSAL_PRINT (ARSAL_PRINT_INFO, TAG, "-- Starting --");
+
+    if (deviceManager != NULL)
+    {
+        // initialize jsMnager
+        deviceManager->alManager = NULL;
+        deviceManager->netManager = NULL;
+        deviceManager->streamReader = NULL;
+        deviceManager->rxThread = NULL;
+        deviceManager->txThread = NULL;
+        deviceManager->videoRxThread = NULL;
+        deviceManager->videoTxThread = NULL;
+        deviceManager->d2cPort = BD_D2C_PORT;
+        deviceManager->c2dPort = BD_C2D_PORT; //deviceManager->c2dPort = 0; // Should be read from json
+        deviceManager->arstreamAckDelay = 0; // Should be read from json
+        deviceManager->arstreamFragSize = BD_NET_DC_VIDEO_FRAG_SIZE; // Should be read from json
+        deviceManager->arstreamFragNb   = BD_NET_DC_VIDEO_MAX_NUMBER_OF_FRAG; // Should be read from json
+        //deviceManager->video_out = fopen("./video_fifo", "w");
+        deviceManager->run = 1;
+    }
+    else
+    {
+        failed = 1;
+        ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "deviceManager alloc error !");
+    }
+
+    if (!failed)
+    {
+        failed = ardiscoveryConnect (deviceManager);
+    }
+
+    if (!failed)
+    {
+        ARSTREAM_Reader_InitStreamDataBuffer (&d2cParams[2], BD_NET_DC_VIDEO_DATA_ID, deviceManager->arstreamFragSize, deviceManager->arstreamFragNb);
+        ARSTREAM_Reader_InitStreamAckBuffer (&c2dParams[3], BD_NET_CD_VIDEO_ACK_ID);
+    }
+
+    if (!failed)
+    {
+        /* start */
+        failed = startNetwork (deviceManager);
+    }
+
+    if (!failed)
+    {
+        failed = startVideo (deviceManager);
+    }
+
+    if (!failed)
+    {
+        int cmdSend = 0;
+
+        cmdSend = sendBeginStream(deviceManager);
+    }
+
+    if (!failed)
+    {
+        // allocate reader thread array.
+        deviceManager->readerThreads = calloc(numOfCommandBufferIds, sizeof(ARSAL_Thread_t));
+        
+        if (deviceManager->readerThreads == NULL)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Allocation of reader threads failed.");
+            failed = 1;
+        }
+    }
+    
+    if (!failed)
+    {
+        // allocate reader thread data array.
+        deviceManager->readerThreadsData = calloc(numOfCommandBufferIds, sizeof(READER_THREAD_DATA_t));
+        
+        if (deviceManager->readerThreadsData == NULL)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Allocation of reader threads data failed.");
+            failed = 1;
+        }
+    }
+    
+    if (!failed)
+    {
+        // Create and start reader threads.
+        int readerThreadIndex = 0;
+        for (readerThreadIndex = 0 ; readerThreadIndex < numOfCommandBufferIds ; readerThreadIndex++)
+        {
+            // initialize reader thread data
+            deviceManager->readerThreadsData[readerThreadIndex].deviceManager = deviceManager;
+            deviceManager->readerThreadsData[readerThreadIndex].readerBufferId = commandBufferIds[readerThreadIndex];
+            
+            if (ARSAL_Thread_Create(&(deviceManager->readerThreads[readerThreadIndex]), readerRun, &(deviceManager->readerThreadsData[readerThreadIndex])) != 0)
+            {
+                ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Creation of reader thread failed.");
+                failed = 1;
+            }
+        }
+    }
+}
+
+//void bebop_stop(BD_MANAGER_t *deviceManager) {
+//    if (deviceManager != NULL)
+//    {
+//        deviceManager->run = 0; // break threads loops
+//
+//        /* stop */
+//        if (deviceManager->readerThreads != NULL)
+//        {
+//            // Stop reader Threads
+//            int readerThreadIndex = 0;
+//            for (readerThreadIndex = 0 ; readerThreadIndex < numOfCommandBufferIds ; readerThreadIndex++)
+//            {
+//                if (deviceManager->readerThreads[readerThreadIndex] != NULL)
+//                {
+//                    ARSAL_Thread_Join(deviceManager->readerThreads[readerThreadIndex], NULL);
+//                    ARSAL_Thread_Destroy(&(deviceManager->readerThreads[readerThreadIndex]));
+//                    deviceManager->readerThreads[readerThreadIndex] = NULL;
+//                }
+//            }
+//            
+//            // free reader thread array
+//            free (deviceManager->readerThreads);
+//            deviceManager->readerThreads = NULL;
+//        }
+//        
+//        if (deviceManager->readerThreadsData != NULL)
+//        {
+//            // free reader thread data array
+//            free (deviceManager->readerThreadsData);
+//            deviceManager->readerThreadsData = NULL;
+//        }
+//
+//        stopVideo (deviceManager);
+//        stopNetwork (deviceManager);
+//        //fclose (deviceManager->video_out);
+//        free (deviceManager);
+//    }
+//
+//    ARSAL_PRINT(ARSAL_PRINT_INFO, TAG, "-- END --");
+//}
+
+int ardiscoveryConnect (BD_MANAGER_t *deviceManager)
+{
+    int failed = 0;
+
+    ARSAL_PRINT(ARSAL_PRINT_INFO, TAG, "- ARDiscovery Connection");
+
+    eARDISCOVERY_ERROR err = ARDISCOVERY_OK;
+    ARDISCOVERY_Connection_ConnectionData_t *discoveryData = ARDISCOVERY_Connection_New (ARDISCOVERY_Connection_SendJsonCallback, ARDISCOVERY_Connection_ReceiveJsonCallback, deviceManager, &err);
+    if (discoveryData == NULL || err != ARDISCOVERY_OK)
+    {
+        ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Error while creating discoveryData : %s", ARDISCOVERY_Error_ToString(err));
+        failed = 1;
+    }
+
+    if (!failed)
+    {
+        eARDISCOVERY_ERROR err = ARDISCOVERY_Connection_ControllerConnection(discoveryData, BD_DISCOVERY_PORT, BD_IP_ADDRESS);
+        if (err != ARDISCOVERY_OK)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Error while opening discovery connection : %s", ARDISCOVERY_Error_ToString(err));
+            failed = 1;
+        }
+    }
+
+    ARDISCOVERY_Connection_Delete(&discoveryData);
+
+    return failed;
+}
+
+int startNetwork (BD_MANAGER_t *deviceManager)
+{
+    int failed = 0;
+    eARNETWORK_ERROR netError = ARNETWORK_OK;
+    eARNETWORKAL_ERROR netAlError = ARNETWORKAL_OK;
+    int pingDelay = 0; // 0 means default, -1 means no ping
+
+    ARSAL_PRINT(ARSAL_PRINT_INFO, TAG, "- Start ARNetwork");
+
+    // Create the ARNetworkALManager
+    deviceManager->alManager = ARNETWORKAL_Manager_New(&netAlError);
+    if (netAlError != ARNETWORKAL_OK)
+    {
+        failed = 1;
+    }
+
+    if (!failed)
+    {
+        // Initilize the ARNetworkALManager
+        netAlError = ARNETWORKAL_Manager_InitWifiNetwork(deviceManager->alManager, BD_IP_ADDRESS, BD_C2D_PORT, BD_D2C_PORT, 1);
+        if (netAlError != ARNETWORKAL_OK)
+        {
+            failed = 1;
+        }
+    }
+
+    if (!failed)
+    {
+        // Create the ARNetworkManager.
+        deviceManager->netManager = ARNETWORK_Manager_New(deviceManager->alManager, numC2dParams, c2dParams, numD2cParams, d2cParams, pingDelay, onDisconnectNetwork, deviceManager, &netError);
+        if (netError != ARNETWORK_OK)
+        {
+            failed = 1;
+        }
+    }
+
+    if (!failed)
+    {
+        // Create and start Tx and Rx threads.
+        if (ARSAL_Thread_Create(&(deviceManager->rxThread), ARNETWORK_Manager_ReceivingThreadRun, deviceManager->netManager) != 0)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Creation of Rx thread failed.");
+            failed = 1;
+        }
+
+        if (ARSAL_Thread_Create(&(deviceManager->txThread), ARNETWORK_Manager_SendingThreadRun, deviceManager->netManager) != 0)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Creation of Tx thread failed.");
+            failed = 1;
+        }
+    }
+
+    // Print net error
+    if (failed)
+    {
+        if (netAlError != ARNETWORKAL_OK)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "ARNetWorkAL Error : %s", ARNETWORKAL_Error_ToString(netAlError));
+        }
+
+        if (netError != ARNETWORK_OK)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "ARNetWork Error : %s", ARNETWORK_Error_ToString(netError));
+        }
+    }
+
+    return failed;
+}
+
+//void stopNetwork (BD_MANAGER_t *deviceManager)
+//{
+//    int failed = 0;
+//    eARNETWORK_ERROR netError = ARNETWORK_OK;
+//    eARNETWORKAL_ERROR netAlError = ARNETWORKAL_OK;
+//    int pingDelay = 0; // 0 means default, -1 means no ping
+//
+//    ARSAL_PRINT(ARSAL_PRINT_INFO, TAG, "- Stop ARNetwork");
+//
+//    // ARNetwork cleanup
+//    if (deviceManager->netManager != NULL)
+//    {
+//        ARNETWORK_Manager_Stop(deviceManager->netManager);
+//        if (deviceManager->rxThread != NULL)
+//        {
+//            ARSAL_Thread_Join(deviceManager->rxThread, NULL);
+//            ARSAL_Thread_Destroy(&(deviceManager->rxThread));
+//            deviceManager->rxThread = NULL;
+//        }
+//
+//        if (deviceManager->txThread != NULL)
+//        {
+//            ARSAL_Thread_Join(deviceManager->txThread, NULL);
+//            ARSAL_Thread_Destroy(&(deviceManager->txThread));
+//            deviceManager->txThread = NULL;
+//        }
+//    }
+//
+//    if (deviceManager->alManager != NULL)
+//    {
+//        ARNETWORKAL_Manager_Unlock(deviceManager->alManager);
+//
+//        ARNETWORKAL_Manager_CloseWifiNetwork(deviceManager->alManager);
+//    }
+//
+//    ARNETWORK_Manager_Delete(&(deviceManager->netManager));
+//    ARNETWORKAL_Manager_Delete(&(deviceManager->alManager));
+//}
+
+void onDisconnectNetwork (ARNETWORK_Manager_t *manager, ARNETWORKAL_Manager_t *alManager, void *customData)
+{
+    ARSAL_PRINT(ARSAL_PRINT_DEBUG, TAG, "onDisconnectNetwork ...");
+}
+
+int startVideo(BD_MANAGER_t *deviceManager)
+{
+    int failed = 0;
+    eARSTREAM_ERROR err = ARSTREAM_OK;
+
+    ARSAL_PRINT(ARSAL_PRINT_INFO, TAG, "- Start ARStream");
+
+    deviceManager->videoFrameSize = deviceManager->arstreamFragSize * deviceManager->arstreamFragNb;
+    deviceManager->videoFrame = malloc (deviceManager->videoFrameSize);
+    if (deviceManager->videoFrame == NULL)
+    {
+        failed = 1;
+    }
+
+    if (!failed)
+    {
+        deviceManager->streamReader = ARSTREAM_Reader_New (deviceManager->netManager, BD_NET_DC_VIDEO_DATA_ID, BD_NET_CD_VIDEO_ACK_ID, frameCompleteCallback, deviceManager->videoFrame, deviceManager->videoFrameSize, deviceManager->arstreamFragSize, deviceManager->arstreamAckDelay, deviceManager, &err);
+        if (err != ARSTREAM_OK)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Error during ARStream creation : %s", ARSTREAM_Error_ToString(err));
+            failed = 1;
+        }
+    }
+
+    if (!failed)
+    {
+        // Create and start Tx and Rx threads.
+        if (ARSAL_Thread_Create(&(deviceManager->videoRxThread), ARSTREAM_Reader_RunDataThread, deviceManager->streamReader) != 0)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Creation of video Rx thread failed.");
+            failed = 1;
+        }
+
+        if (ARSAL_Thread_Create(&(deviceManager->videoTxThread), ARSTREAM_Reader_RunAckThread, deviceManager->streamReader) != 0)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Creation of video Tx thread failed.");
+            failed = 1;
+        }
+    }
+
+    return failed;
+}
+
+void stopVideo(BD_MANAGER_t *deviceManager)
+{
+    //int failed = 0;
+    //eARSTREAM_ERROR err = ARSTREAM_OK;
+
+    ARSAL_PRINT(ARSAL_PRINT_INFO, TAG, "- Stop ARStream");
+
+    if (deviceManager->streamReader)
+    {
+        ARSTREAM_Reader_StopReader(deviceManager->streamReader);
+
+        // Optionnal, but better for speed:
+        ARNETWORKAL_Manager_Unlock(deviceManager->alManager);
+
+        if (deviceManager->videoRxThread != NULL)
+        {
+            ARSAL_Thread_Join(deviceManager->videoRxThread, NULL);
+            ARSAL_Thread_Destroy(&(deviceManager->videoRxThread));
+            deviceManager->videoRxThread = NULL;
+        }
+        if (deviceManager->videoTxThread != NULL)
+        {
+            ARSAL_Thread_Join(deviceManager->videoTxThread, NULL);
+            ARSAL_Thread_Destroy(&(deviceManager->videoTxThread));
+            deviceManager->videoTxThread = NULL;
+        }
+
+        ARSTREAM_Reader_Delete (&(deviceManager->streamReader));
+    }
+
+    if (deviceManager->videoFrame)
+    {
+        free (deviceManager->videoFrame);
+        deviceManager->videoFrame = NULL;
+    }
+}
+
+uint8_t *frameCompleteCallback (eARSTREAM_READER_CAUSE cause, uint8_t *frame, uint32_t frameSize, int numberOfSkippedFrames, int isFlushFrame, uint32_t *newBufferCapacity, void *custom)
+{
+    uint8_t *ret = NULL;
+    BD_MANAGER_t *deviceManager = (BD_MANAGER_t *)custom;
+	janus_streaming_ardrone3_frame *f;
+	
+    switch(cause)
+    {
+        case ARSTREAM_READER_CAUSE_FRAME_COMPLETE:
+            /* Here, the mjpeg video frame is in the "frame" pointer, with size "frameSize" bytes
+             You can do what you want, but keep it as short as possible, as the video is blocked until you return from this callback.
+             Typically, you will either copy the frame and return the same buffer to the library, or store the buffer
+             in a fifo for pending operations, and provide a new one.
+             In this sample, we do nothing and just pass the buffer back*/
+			
+			// shove the frame onto the right asyncqueue
+			f = calloc(1, sizeof(janus_streaming_ardrone3_frame));
+			f->data = frame;
+			f->length = frameSize;
+			g_async_queue_push(ardrone3_frames, f);
+			
+            //ret = deviceManager->videoFrame;
+		    ret = malloc (deviceManager->videoFrameSize);
+            *newBufferCapacity = deviceManager->videoFrameSize;
+
+            /* Again, don't write files in this thread, that is just for the example :) */
+            //fwrite(frame, frameSize, 1, deviceManager->video_out);
+            //fflush (deviceManager->video_out);
+            break;
+        case ARSTREAM_READER_CAUSE_FRAME_TOO_SMALL:
+            /* This case should not happen, as we've allocated a frame pointer to the maximum possible size. */
+            ret = deviceManager->videoFrame;
+            *newBufferCapacity = deviceManager->videoFrameSize;
+            break;
+        case ARSTREAM_READER_CAUSE_COPY_COMPLETE:
+            /* Same as before ... but return value are ignored, so we just do nothing */
+            break;
+        case ARSTREAM_READER_CAUSE_CANCEL:
+            /* Called when the library closes, return values ignored, so do nothing here */
+            break;
+        default:
+            break;
+    }
+
+    return ret;
+}
+
+int sendBeginStream(BD_MANAGER_t *deviceManager)
+{
+    int sentStatus = 1;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    ARSAL_PRINT(ARSAL_PRINT_INFO, TAG, "- Send Streaming Begin");
+    
+    // Send Streaming begin command
+    cmdError = ARCOMMANDS_Generator_GenerateARDrone3MediaStreamingVideoEnable(cmdBuffer, sizeof(cmdBuffer), &cmdSize, 1);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        netError = ARNETWORK_Manager_SendData(deviceManager->netManager, BD_NET_CD_ACK_ID, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        ARSAL_PRINT(ARSAL_PRINT_WARNING, TAG, "Failed to send Streaming command. cmdError:%d netError:%s", cmdError, ARNETWORK_Error_ToString(netError));
+        sentStatus = 0;
+    }
+    
+    return sentStatus;
+}
+
+eARNETWORK_MANAGER_CALLBACK_RETURN arnetworkCmdCallback(int buffer_id, uint8_t *data, void *custom, eARNETWORK_MANAGER_CALLBACK_STATUS cause)
+{
+    eARNETWORK_MANAGER_CALLBACK_RETURN retval = ARNETWORK_MANAGER_CALLBACK_RETURN_DEFAULT;
+
+    ARSAL_PRINT(ARSAL_PRINT_DEBUG, TAG, "    - arnetworkCmdCallback %d, cause:%d ", buffer_id, cause);
+
+    if (cause == ARNETWORK_MANAGER_CALLBACK_STATUS_TIMEOUT)
+    {
+        retval = ARNETWORK_MANAGER_CALLBACK_RETURN_DATA_POP;
+    }
+
+    return retval;
+}
+
+eARDISCOVERY_ERROR ARDISCOVERY_Connection_SendJsonCallback (uint8_t *dataTx, uint32_t *dataTxSize, void *customData)
+{
+    BD_MANAGER_t *deviceManager = (BD_MANAGER_t *)customData;
+    eARDISCOVERY_ERROR err = ARDISCOVERY_OK;
+
+    if ((dataTx != NULL) && (dataTxSize != NULL) && (deviceManager != NULL))
+    {
+        *dataTxSize = sprintf((char *)dataTx, "{ \"%s\": %d,\n \"%s\": \"%s\",\n \"%s\": \"%s\" }",
+                              ARDISCOVERY_CONNECTION_JSON_D2CPORT_KEY, deviceManager->d2cPort,
+                              ARDISCOVERY_CONNECTION_JSON_CONTROLLER_NAME_KEY, "toto",
+                              ARDISCOVERY_CONNECTION_JSON_CONTROLLER_TYPE_KEY, "tata") + 1;
+    }
+    else
+    {
+        err = ARDISCOVERY_ERROR;
+    }
+
+    return err;
+}
+
+eARDISCOVERY_ERROR ARDISCOVERY_Connection_ReceiveJsonCallback (uint8_t *dataRx, uint32_t dataRxSize, char *ip, void *customData)
+{
+    BD_MANAGER_t *deviceManager = (BD_MANAGER_t *)customData;
+    eARDISCOVERY_ERROR err = ARDISCOVERY_OK;
+
+    if ((dataRx != NULL) && (dataRxSize != 0) && (deviceManager != NULL))
+    {
+        char *json = malloc(dataRxSize + 1);
+        strncpy(json, (char *)dataRx, dataRxSize);
+        json[dataRxSize] = '\0';
+
+        //read c2dPort ...
+
+        ARSAL_PRINT(ARSAL_PRINT_DEBUG, TAG, "    - ReceiveJson:%s ", json);
+
+        free(json);
+    }
+    else
+    {
+        err = ARDISCOVERY_ERROR;
+    }
+
+    return err;
+}

--- a/plugins/BebopDroneReceiveStream.c
+++ b/plugins/BebopDroneReceiveStream.c
@@ -1161,6 +1161,7 @@ void onMatrixMessage (char *message, BD_MANAGER_t *deviceManager)
 	// for now, just operate using text messages for simplicity:
 	// {launch, land, home, die}
 	// {up, down, left, right, forward, back} [<amount>]
+	// turn {left,right}
 	// flip [{front, back, left, right}]
 	// look <pan>,<tilt>
 	
@@ -1200,6 +1201,12 @@ void onMatrixMessage (char *message, BD_MANAGER_t *deviceManager)
 	else if (!strcasecmp(message, "back") || !strcasecmp(message, "backward")) {
 		deviceManager->dataPCMD.flag = 1;
 	    deviceManager->dataPCMD.pitch = -50;
+	}
+	else if (!strcasecmp(message, "turn left")) {
+        deviceManager->dataPCMD.yaw = -50;
+	}
+	else if (!strcasecmp(message, "turn right")) {
+        deviceManager->dataPCMD.yaw = 50;
 	}
 	else if (sscanf(message, "up %d", &param1) == 1) {
 		deviceManager->dataPCMD.gaz = param1;

--- a/plugins/BebopDroneReceiveStream.c
+++ b/plugins/BebopDroneReceiveStream.c
@@ -246,6 +246,15 @@ void *looperRun (void* data)
             sendCameraOrientation(deviceManager);
             
             usleep(50*1000);
+/*
+		    ARSAL_PRINT(ARSAL_PRINT_INFO, TAG, "%d,%d,%d,%d,%d\n",
+		        deviceManager->dataPCMD.flag,
+	            deviceManager->dataPCMD.roll,
+	            deviceManager->dataPCMD.pitch,
+	            deviceManager->dataPCMD.yaw,
+	            deviceManager->dataPCMD.gaz
+	    	);
+*/
         }
     }
     

--- a/plugins/BebopDroneReceiveStream.c
+++ b/plugins/BebopDroneReceiveStream.c
@@ -41,6 +41,7 @@
 #include <signal.h>
 
 #include "BebopDroneReceiveStream.h"
+#include "janus_streaming.h"
 
 #define TAG "BebopDroneReceiveStream"
 #define BD_IP_ADDRESS "192.168.42.1"
@@ -58,8 +59,6 @@
 
 #define BD_NET_DC_VIDEO_FRAG_SIZE 1000
 #define BD_NET_DC_VIDEO_MAX_NUMBER_OF_FRAG 128
-
-GAsyncQueue *ardrone3_frames = NULL;
 
 static ARNETWORK_IOBufferParam_t c2dParams[] = {
     /* Non-acknowledged commands. */
@@ -686,9 +685,9 @@ uint8_t *frameCompleteCallback (eARSTREAM_READER_CAUSE cause, uint8_t *frame, ui
                 d_us += 1000000;
                 --d_s;
             }
-             f->ts = (uint64_t)d_s*1000000 + d_us;
+            f->ts = (uint64_t)d_s*1000000 + d_us;
 
-            g_async_queue_push(ardrone3_frames, f);
+            g_async_queue_push(deviceManager->source->frames, f);
             
             //ret = deviceManager->videoFrame;
             ret = malloc (deviceManager->videoFrameSize);

--- a/plugins/BebopDroneReceiveStream.c
+++ b/plugins/BebopDroneReceiveStream.c
@@ -599,8 +599,8 @@ uint8_t *frameCompleteCallback (eARSTREAM_READER_CAUSE cause, uint8_t *frame, ui
 {
     uint8_t *ret = NULL;
     BD_MANAGER_t *deviceManager = (BD_MANAGER_t *)custom;
-	janus_streaming_ardrone3_frame *f;
-	
+    janus_streaming_ardrone3_frame *f;
+    
     switch(cause)
     {
         case ARSTREAM_READER_CAUSE_FRAME_COMPLETE:
@@ -609,27 +609,27 @@ uint8_t *frameCompleteCallback (eARSTREAM_READER_CAUSE cause, uint8_t *frame, ui
              Typically, you will either copy the frame and return the same buffer to the library, or store the buffer
              in a fifo for pending operations, and provide a new one.
              In this sample, we do nothing and just pass the buffer back*/
-			
-			// shove the frame onto the right asyncqueue
-			f = calloc(1, sizeof(janus_streaming_ardrone3_frame));
-			f->data = frame;
-			f->length = frameSize;
-			
-			struct timeval now;
-			time_t d_s, d_us;
-			gettimeofday(&now, NULL);
-			d_s = now.tv_sec;
-			d_us = now.tv_usec;
-			if(d_us < 0) {
-				d_us += 1000000;
-				--d_s;
-			}
-		 	f->ts = (uint64_t)d_s*1000000 + d_us;
+            
+            // shove the frame onto the right asyncqueue
+            f = calloc(1, sizeof(janus_streaming_ardrone3_frame));
+            f->data = frame;
+            f->length = frameSize;
+            
+            struct timeval now;
+            time_t d_s, d_us;
+            gettimeofday(&now, NULL);
+            d_s = now.tv_sec;
+            d_us = now.tv_usec;
+            if(d_us < 0) {
+                d_us += 1000000;
+                --d_s;
+            }
+             f->ts = (uint64_t)d_s*1000000 + d_us;
 
-			g_async_queue_push(ardrone3_frames, f);
-			
+            g_async_queue_push(ardrone3_frames, f);
+            
             //ret = deviceManager->videoFrame;
-		    ret = malloc (deviceManager->videoFrameSize);
+            ret = malloc (deviceManager->videoFrameSize);
             *newBufferCapacity = deviceManager->videoFrameSize;
 
             /* Again, don't write files in this thread, that is just for the example :) */

--- a/plugins/BebopDroneReceiveStream.h
+++ b/plugins/BebopDroneReceiveStream.h
@@ -42,15 +42,6 @@
 #include <libARDiscovery/ARDiscovery.h>
 #include <libARStream/ARStream.h>
 
-// XXX: these would go in janus_streaming.h if one existed...
-typedef struct janus_streaming_ardrone3_frame {
-	uint8_t *data;
-	gint length;
-	uint64_t ts;
-} janus_streaming_ardrone3_frame;
-
-struct janus_streaming_ardrone3_source;
-
 typedef struct READER_THREAD_DATA_t READER_THREAD_DATA_t;
 
 typedef struct

--- a/plugins/BebopDroneReceiveStream.h
+++ b/plugins/BebopDroneReceiveStream.h
@@ -1,0 +1,103 @@
+/*
+    Copyright (C) 2014 Parrot SA
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Parrot nor the names
+      of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written
+      permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+    OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED 
+    AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+    OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.
+*/
+#ifndef _SDK_EXAMPLE_BD_H_
+#define _SDK_EXAMPLE_BD_H_
+
+#include <glib.h>
+#include <stdint.h>
+
+#include <libARSAL/ARSAL.h>
+#include <libARSAL/ARSAL_Print.h>
+#include <libARNetwork/ARNetwork.h>
+#include <libARNetworkAL/ARNetworkAL.h>
+#include <libARCommands/ARCommands.h>
+#include <libARDiscovery/ARDiscovery.h>
+#include <libARStream/ARStream.h>
+
+typedef struct janus_streaming_ardrone3_frame {
+	uint8_t *data;
+	gint length;
+} janus_streaming_ardrone3_frame;
+
+// XXX: global hack to allow the drone SDK to easily call back to us
+extern GAsyncQueue *ardrone3_frames;
+
+typedef struct READER_THREAD_DATA_t READER_THREAD_DATA_t;
+
+typedef struct
+{
+    ARNETWORKAL_Manager_t *alManager;
+    ARNETWORK_Manager_t *netManager;
+    ARSTREAM_Reader_t *streamReader;
+    ARSAL_Thread_t rxThread;
+    ARSAL_Thread_t txThread;
+    ARSAL_Thread_t videoTxThread;
+    ARSAL_Thread_t videoRxThread;
+    int d2cPort;
+    int c2dPort;
+    int arstreamFragSize;
+    int arstreamFragNb;
+    int arstreamAckDelay;
+    uint8_t *videoFrame;
+    uint32_t videoFrameSize;
+    
+    //FILE *video_out;
+    
+    ARSAL_Thread_t *readerThreads;
+    READER_THREAD_DATA_t *readerThreadsData;
+    int run;
+} BD_MANAGER_t;
+
+struct READER_THREAD_DATA_t
+{
+    BD_MANAGER_t *deviceManager;
+    int readerBufferId;
+};
+
+void bebop_start(void);
+
+int ardiscoveryConnect (BD_MANAGER_t *deviceManager);
+eARDISCOVERY_ERROR ARDISCOVERY_Connection_SendJsonCallback (uint8_t *dataTx, uint32_t *dataTxSize, void *customData);
+eARDISCOVERY_ERROR ARDISCOVERY_Connection_ReceiveJsonCallback (uint8_t *dataRx, uint32_t dataRxSize, char *ip, void *customData);
+
+int startNetwork (BD_MANAGER_t *deviceManager);
+void onDisconnectNetwork (ARNETWORK_Manager_t *manager, ARNETWORKAL_Manager_t *alManager, void *customData);
+void stopNetwork (BD_MANAGER_t *deviceManager);
+
+int startVideo (BD_MANAGER_t *deviceManager);
+uint8_t *frameCompleteCallback (eARSTREAM_READER_CAUSE cause, uint8_t *frame, uint32_t frameSize, int numberOfSkippedFrames, int isFlushFrame, uint32_t *newBufferCapacity, void *custom);
+void stopVideo (BD_MANAGER_t *deviceManager);
+
+int sendBeginStream(BD_MANAGER_t *deviceManager);
+
+eARNETWORK_MANAGER_CALLBACK_RETURN arnetworkCmdCallback(int buffer_id, uint8_t *data, void *custom, eARNETWORK_MANAGER_CALLBACK_STATUS cause);
+
+#endif /* _SDK_EXAMPLE_BD_H_ */

--- a/plugins/BebopDroneReceiveStream.h
+++ b/plugins/BebopDroneReceiveStream.h
@@ -137,6 +137,7 @@ int sendTakeoff(BD_MANAGER_t *deviceManager);
 int sendLanding(BD_MANAGER_t *deviceManager);
 int sendFlip(eARCOMMANDS_ARDRONE3_ANIMATIONS_FLIP_DIRECTION direction, BD_MANAGER_t *deviceManager);
 int sendHome(BD_MANAGER_t *deviceManager);
+int sendHullProtection(int present, BD_MANAGER_t *deviceManager);
 int sendEmergency(BD_MANAGER_t *deviceManager);
 void registerARCommandsCallbacks (BD_MANAGER_t *deviceManager);
 

--- a/plugins/BebopDroneReceiveStream.h
+++ b/plugins/BebopDroneReceiveStream.h
@@ -45,6 +45,7 @@
 typedef struct janus_streaming_ardrone3_frame {
 	uint8_t *data;
 	gint length;
+	uint64_t ts;
 } janus_streaming_ardrone3_frame;
 
 // XXX: global hack to allow the drone SDK to easily call back to us

--- a/plugins/BebopDroneReceiveStream.h
+++ b/plugins/BebopDroneReceiveStream.h
@@ -51,6 +51,7 @@ typedef struct
     int pitch;
     int yaw;
     int gaz;
+	int lifetime;
 } BD_PCMD_t;
 
 typedef struct _ARDrone3CameraData_t_

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2971,6 +2971,8 @@ static void *janus_streaming_ardrone3_thread(void *data) {
 	a=sendonly
 */	
 #endif
+
+	FILE * video_out = fopen("video.h264", "w");
    
 	/* Loop */
 	janus_streaming_rtp_relay_packet packet;
@@ -2999,6 +3001,8 @@ static void *janus_streaming_ardrone3_thread(void *data) {
 		
 		//JANUS_LOG(LOG_VERB, "Frame from drone:\n");
 		//hexdump(frame->data, frame->length);
+        fwrite(frame->data, frame->length, 1, video_out);
+        fflush(video_out);
 		
 		// packetize the H.264 by splitting up NALs on start codes
 	 	while (parsing) {
@@ -3108,6 +3112,8 @@ static void *janus_streaming_ardrone3_thread(void *data) {
 		g_free(frame);
 	}
 	JANUS_LOG(LOG_VERB, "[%s] Leaving ardrone3 thread\n", name);
+	
+	fclose(video_out);
 	
 	bebop_stop(source->deviceManager);
 	

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -1813,6 +1813,10 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			
 			const char *body_text = json_string_value(body);
 			onMatrixMessage(body_text, source->deviceManager);
+			
+			response = json_object();
+			json_object_set_new(response, "matrix", json_string("ok"));
+			goto plugin_response;
 		}
 		else {
 			JANUS_LOG(LOG_VERB, "Ignoring matrix event %s\n", type_text);

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2973,6 +2973,7 @@ static void *janus_streaming_ardrone3_thread(void *data) {
 #endif
 
 	FILE * video_out = fopen("video.h264", "w");
+	int frame_count = 0;
    
 	/* Loop */
 	janus_streaming_rtp_relay_packet packet;
@@ -3003,6 +3004,13 @@ static void *janus_streaming_ardrone3_thread(void *data) {
 		//hexdump(frame->data, frame->length);
         fwrite(frame->data, frame->length, 1, video_out);
         fflush(video_out);
+
+		// char vf_name[32];
+		// sprintf(vf_name, "vf%d.h264", frame_count);
+		// FILE * vf_out = fopen(vf_name, "w");
+		//         fwrite(frame->data, frame->length, 1, vf_out);
+		//         fflush(vf_out);
+		// fclose(vf_out);
 		
 		// packetize the H.264 by splitting up NALs on start codes
 	 	while (parsing) {
@@ -3110,6 +3118,7 @@ static void *janus_streaming_ardrone3_thread(void *data) {
 					
 		g_free(frame->data);
 		g_free(frame);
+		frame_count++;
 	}
 	JANUS_LOG(LOG_VERB, "[%s] Leaving ardrone3 thread\n", name);
 	

--- a/plugins/janus_streaming.h
+++ b/plugins/janus_streaming.h
@@ -1,0 +1,16 @@
+#ifndef _JANUS_STREAMING_H
+#define _JANUS_STREAMING_H
+
+typedef struct janus_streaming_ardrone3_frame {
+	uint8_t *data;
+	gint length;
+	uint64_t ts;
+} janus_streaming_ardrone3_frame;
+
+typedef struct janus_streaming_ardrone3_source {
+	BD_MANAGER_t *deviceManager;
+	GAsyncQueue *frames;
+} janus_streaming_ardrone3_source;
+
+
+#endif

--- a/postprocessing/pp-rtp.h
+++ b/postprocessing/pp-rtp.h
@@ -13,6 +13,15 @@
 #ifndef _JANUS_PP_RTP
 #define _JANUS_PP_RTP
 
+#ifdef __MACH__
+#include <machine/endian.h>
+#define __LITTLE_ENDIAN   LITTLE_ENDIAN
+#define __BIG_ENDIAN      BIG_ENDIAN
+#define __BYTE_ORDER      BYTE_ORDER
+#else
+#include <endian.h>
+#endif
+
 
 typedef struct janus_pp_rtp_header
 {

--- a/rtcp.h
+++ b/rtcp.h
@@ -19,6 +19,9 @@
 #include <arpa/inet.h>
 #ifdef __MACH__
 #include <machine/endian.h>
+#define __LITTLE_ENDIAN   LITTLE_ENDIAN
+#define __BIG_ENDIAN      BIG_ENDIAN
+#define __BYTE_ORDER      BYTE_ORDER
 #else
 #include <endian.h>
 #endif

--- a/rtp.h
+++ b/rtp.h
@@ -16,6 +16,9 @@
 #include <arpa/inet.h>
 #ifdef __MACH__
 #include <machine/endian.h>
+#define __LITTLE_ENDIAN   LITTLE_ENDIAN
+#define __BIG_ENDIAN      BIG_ENDIAN
+#define __BYTE_ORDER      BYTE_ORDER
 #else
 #include <endian.h>
 #endif

--- a/sdp.c
+++ b/sdp.c
@@ -85,9 +85,9 @@ janus_sdp *janus_sdp_preparse(const char *jsep_sdp, int *audio, int *video, int 
 #endif
 	*bundle = strstr(jsep_sdp, "a=group:BUNDLE") ? 1 : 0;	/* FIXME This is a really hacky way of checking... */
 	*rtcpmux = strstr(jsep_sdp, "a=rtcp-mux") ? 1 : 0;	/* FIXME Should we make this check per-medium? */
-	//~ *trickle = (strstr(jsep_sdp, "trickle") || strstr(jsep_sdp, "google-ice") || strstr(jsep_sdp, "Mozilla")) ? 1 : 0;	/* FIXME This is a really hacky way of checking... */
+	*trickle = (strstr(jsep_sdp, "trickle") || strstr(jsep_sdp, "google-ice") || strstr(jsep_sdp, "Mozilla")) ? 1 : 0;	/* FIXME This is a really hacky way of checking... */
 	/* FIXME We're assuming trickle is always supported, see https://github.com/meetecho/janus-gateway/issues/83 */
-	*trickle = 1;
+	//*trickle = 1;
 	janus_sdp *sdp = (janus_sdp *)calloc(1, sizeof(janus_sdp));
 	if(sdp == NULL) {
 		JANUS_LOG(LOG_FATAL, "Memory error!\n");


### PR DESCRIPTION
Do not merge. Sharing the current Matrix integration as requested on the mailing list.

This version is the unmodified version we used for controlling and relaying video from our drone, ie. it contains drone control code in janus_streaming too which can be ignored. The Matrix integration is all in janus.c / janus.h.

The current matrix integration is also very hacky in that sessions are referenced directly rather than by ID which causes crashes when they are cleaned up, and in several places memory is allocated and never freed. It's also hard-wired to a fixed ID in the streaming plugin.

This just shows how we integrated Matrix as another source alongside HTTP, WebSockets and RabbitMQ.