### PR TITLE
janus.js: firefox 38 supports new video constraints format

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1080,13 +1080,6 @@ function Janus(gatewayCallbacks) {
 						height = 720;
 						maxHeight = 720;
 						width = 1280;
-						if(navigator.mozGetUserMedia) {
-							// Unless this is Firefox, which doesn't support it
-							Janus.log(media.video + " unsupported, falling back to stdres (Firefox)");
-							height = 480;
-							maxHeight = 480;
-							width  = 640;
-						}
 					} else if(media.video === 'stdres') {
 						// Normal resolution, 4:3
 						height = 480;
@@ -1105,10 +1098,10 @@ function Janus(gatewayCallbacks) {
 					}
 					Janus.log("Adding media constraint " + media.video);
 					if(navigator.mozGetUserMedia) {
+						// http://stackoverflow.com/questions/28282385/webrtc-firefox-constraints/28911694#28911694
 						videoSupport = {
-						    'require': ['height', 'width'],
-						    'height': {'max': maxHeight, 'min': height},
-						    'width':  {'max': width,  'min': width}
+						    'height': {'ideal': height},
+						    'width':  {'ideal': width}
 						};
 					} else {
 						videoSupport = {


### PR DESCRIPTION
This simplifies the constraints a bit, though Firefox still refuses to do anything except 640x480 or 320x240 in my experience.

You may not want to actually merge this, to keep support for older firefox. Luckily, firefox 38 is becoming the new "ESR" release (and you can already download it as such). You may just want to wait 3 months until Firefox 31 ESR is no longer supported.

see also http://stackoverflow.com/questions/28282385/webrtc-firefox-constraints/28911694#28911694