### PR TITLE
rtp_listener feature added for videoroom plugin

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -266,12 +266,11 @@ static GHashTable *sessions;
 static GList *old_sessions;
 static janus_mutex sessions_mutex;
 
-//a host whose ports gets streamed rtp packets of the corresponding type.
-typedef struct rtp_listener {
-	int audio_port;
-	int video_port;
-	gchar* host;
-} rtp_listener;
+/* a host whose ports gets streamed rtp packets of the corresponding type. */
+typedef struct rtp_forwarder {
+	int is_video;
+	struct sockaddr_in serv_addr;
+} rtp_forwarder;
 
 typedef struct janus_videoroom_participant {
 	janus_videoroom_session *session;
@@ -295,12 +294,13 @@ typedef struct janus_videoroom_participant {
 	janus_recorder *vrc;	/* The Janus recorder instance for this publisher's video, if enabled */
 	GSList *listeners;
 	janus_mutex listeners_mutex;
-	GHashTable *rtp_listeners;
-	janus_mutex rtp_listeners_mutex;
-    int udp_sock; /* Socket over which rtp streams can be forwarded */
+	GHashTable *rtp_forwarders;
+	janus_mutex rtp_forwarders_mutex;
+	int udp_sock; /* The udp socket on which to forward rtp packets */
 } janus_videoroom_participant;
 static void janus_videoroom_participant_free(janus_videoroom_participant *p);
-static void janus_rtp_listener_free_helper(gpointer data);
+static void janus_rtp_forwarder_free_helper(gpointer data);
+static guint32 janus_rtp_forwarder_add_helper(janus_videoroom_participant *p, const gchar* host, int port, int is_video);
 typedef struct janus_videoroom_listener_context {
 	/* Needed to fix seq and ts in case of publisher switching */
 	uint32_t a_last_ssrc, a_last_ts, a_base_ts, a_base_ts_prev,
@@ -341,7 +341,7 @@ typedef struct janus_videoroom_data_relay_packet {
 } janus_videoroom_data_relay_packet;
 
 /* SDP offer/answer templates */
-#define OPUS_PT		111
+#define OPUS_PT		8
 #define VP8_PT		100
 #define sdp_template \
 		"v=0\r\n" \
@@ -353,7 +353,7 @@ typedef struct janus_videoroom_data_relay_packet {
 		"m=audio 1 RTP/SAVPF %d\r\n"		/* Opus payload type */ \
 		"c=IN IP4 1.1.1.1\r\n" \
 		"a=%s\r\n"							/* Media direction */ \
-		"a=rtpmap:%d opus/48000/2\r\n"		/* Opus payload type */
+		"a=rtpmap:%d pcma/8000\r\n"		/* Opus payload type */
 #define sdp_v_template \
 		"m=video 1 RTP/SAVPF %d\r\n"		/* VP8 payload type */ \
 		"c=IN IP4 1.1.1.1\r\n" \
@@ -396,6 +396,27 @@ int janus_videoroom_muxed_subscribe(janus_videoroom_listener_muxed *muxed_listen
 int janus_videoroom_muxed_unsubscribe(janus_videoroom_listener_muxed *muxed_listener, GList *feeds, char *transaction);
 int janus_videoroom_muxed_offer(janus_videoroom_listener_muxed *muxed_listener, char *transaction, char *event_text);
 
+static guint32 janus_rtp_forwarder_add_helper(janus_videoroom_participant* p, const gchar* host, int port, int is_video) {
+	if(!p || !host) {
+		return 0;
+	}
+	rtp_forwarder* forward = malloc(sizeof(rtp_forwarder));
+	forward->is_video = is_video;
+	forward->serv_addr.sin_family = AF_INET;
+	inet_pton(AF_INET, host, &(forward->serv_addr.sin_addr));
+	forward->serv_addr.sin_port = htons(port);
+	janus_mutex_lock(&p->rtp_forwarders_mutex);
+	guint32 stream_id = g_random_int();
+	while(g_hash_table_lookup(p->rtp_forwarders, GUINT_TO_POINTER(stream_id)) != NULL) {
+		stream_id = g_random_int();
+	}
+	g_hash_table_insert(p->rtp_forwarders, GUINT_TO_POINTER(stream_id), forward);
+	janus_mutex_unlock(&p->rtp_forwarders_mutex);
+	JANUS_LOG(LOG_VERB, "Added %s rtp_forward to participant %"SCNu64" host: %s:%d stream_id: %"SCNu32"\n", is_video ? "video":"audio", p->user_id, host, port, stream_id);
+	return stream_id;
+}
+
+
 /* Convenience function for freeing a session */
 static void session_free(gpointer data) {
 	if(data) {
@@ -419,14 +440,12 @@ static void session_free(gpointer data) {
 	}
 }
 
-static void janus_rtp_listener_free_helper(gpointer data) {
+static void janus_rtp_forwarder_free_helper(gpointer data) {
 	if(data) {
-		rtp_listener* listener = (rtp_listener*)data;
-		if(listener) {
-			free(listener->host);
-			listener->host = NULL;
-			free(listener);
-			listener = NULL;
+		rtp_forwarder* forward = (rtp_forwarder*)data;
+		if(forward) {
+			free(forward);
+			forward = NULL;
 		}
 	}
 }
@@ -1206,7 +1225,7 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		json_object_set_new(response, "videoroom", json_string("success"));
 		json_object_set_new(response, "list", list);
 		goto plugin_response;
-	} else if(!strcasecmp(request_text, "rtp_listen")) {
+	} else if(!strcasecmp(request_text, "rtp_forward")) {
 		json_t *room = json_object_get(root, "room");
 		if(!room) {
 			JANUS_LOG(LOG_ERR, "Missing element (room)\n");
@@ -1233,31 +1252,27 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 			g_snprintf(error_cause, 512, "Invalid element (publisher_id should be a positive integer)");
 			goto error;
 		}
+		int video_port = -1;
+		int audio_port = -1;
 		json_t *vid_port = json_object_get(root, "video_port");
-		if(!vid_port) {
-			JANUS_LOG(LOG_ERR, "Missing element (video_port)\n");
-			error_code = JANUS_VIDEOROOM_ERROR_MISSING_ELEMENT;
-			g_snprintf(error_cause, 512, "Missing element (video_port)");
-			goto error;
-		}
-		if(!json_is_integer(vid_port) || json_integer_value(vid_port) < 0) {
+		if(vid_port && (!json_is_integer(vid_port) || json_integer_value(vid_port) < 0)) {
 			JANUS_LOG(LOG_ERR, "Invalid element (video_port should be a positive integer)\n");
 			error_code = JANUS_VIDEOROOM_ERROR_INVALID_ELEMENT;
 			g_snprintf(error_cause, 512, "Invalid element (video_port should be a positive integer)");
 			goto error;
 		}
-		json_t *au_port = json_object_get(root, "audio_port");
-		if(!au_port) {
-			JANUS_LOG(LOG_ERR, "Missing element (audio_port)\n");
-			error_code = JANUS_VIDEOROOM_ERROR_MISSING_ELEMENT;
-			g_snprintf(error_cause, 512, "Missing element (audio_port)");
-			goto error;
+		if(vid_port) {
+			video_port = json_integer_value(vid_port);
 		}
-		if(!json_is_integer(au_port) || json_integer_value(au_port) <0) {
+		json_t *au_port = json_object_get(root, "audio_port");
+		if(au_port && (!json_is_integer(au_port) || json_integer_value(au_port) <0)) {
 			JANUS_LOG(LOG_ERR, "Invalid element (audio_port should be a positive integer)\n");
 			error_code = JANUS_VIDEOROOM_ERROR_INVALID_ELEMENT;
 			g_snprintf(error_cause, 512, "Invalid element (audio_port should be a positive integer)");
 			goto error;
+		}
+		if(au_port) {
+			audio_port = json_integer_value(au_port);
 		}
 		json_t *json_host = json_object_get(root, "host");
 		if(!json_host) {
@@ -1275,8 +1290,6 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		
 		guint64 room_id = json_integer_value(room);
 		guint64 publisher_id = json_integer_value(pub_id);
-		int video_port = json_integer_value(vid_port);
-		int audio_port = json_integer_value(au_port);
 		const gchar* host = json_string_value(json_host);
 		janus_mutex_lock(&rooms_mutex);
 		janus_videoroom *videoroom = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
@@ -1339,30 +1352,32 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 				goto error;
 			}
 		}
-		rtp_listener* rtp_listen = malloc(sizeof(rtp_listener));
-		rtp_listen->audio_port = audio_port;
-		rtp_listen->video_port = video_port;
-		rtp_listen->host = g_strdup(host);
-		janus_mutex_lock(&publisher->rtp_listeners_mutex);
-		guint32 stream_id = g_random_int();
-		while(g_hash_table_lookup(publisher->rtp_listeners, GUINT_TO_POINTER(stream_id)) != NULL) {
-			stream_id = g_random_int();
+		guint32 audio_handle = 0;
+		guint32 video_handle = 0;
+		if(audio_port > 0) {
+			audio_handle = janus_rtp_forwarder_add_helper(publisher, host, audio_port, 0);
 		}
-		g_hash_table_insert(publisher->rtp_listeners, GUINT_TO_POINTER(stream_id), rtp_listen);
-		janus_mutex_unlock(&publisher->rtp_listeners_mutex);
+		if(video_port > 0) {
+			video_handle = janus_rtp_forwarder_add_helper(publisher, host, video_port, 1);
+		}
 		janus_mutex_unlock(&videoroom->participants_mutex);
 		response = json_object();
 		json_t* rtp_stream = json_object();
-		json_object_set_new(rtp_stream, "stream_id", json_integer(stream_id));
-		json_object_set_new(rtp_stream, "audio", json_integer(audio_port));
-		json_object_set_new(rtp_stream, "video", json_integer(video_port));
-		json_object_set_new(rtp_stream, "host", json_string(rtp_listen->host));
+		if(audio_handle > 0) {
+			json_object_set_new(rtp_stream, "audio_stream_id", json_integer(audio_handle));
+			json_object_set_new(rtp_stream, "audio", json_integer(audio_port));
+		}
+		if(video_handle > 0) {
+			json_object_set_new(rtp_stream, "video_stream_id", json_integer(video_handle));
+			json_object_set_new(rtp_stream, "video", json_integer(video_port));
+		}
+		json_object_set_new(rtp_stream, "host", json_string(host));
 		json_object_set_new(response, "publisher_id", json_integer(publisher_id));
 		json_object_set_new(response, "rtp_stream", rtp_stream);
 		json_object_set_new(response, "room", json_integer(room_id));
-		json_object_set_new(response, "videoroom", json_string("rtp_listen"));
+		json_object_set_new(response, "videoroom", json_string("rtp_forward"));
 		goto plugin_response;
-	} else if(!strcasecmp(request_text, "stop_rtp_listen")) {
+	} else if(!strcasecmp(request_text, "stop_rtp_forward")) {
 		json_t *room = json_object_get(root, "room");
 		if(!room) {
 			JANUS_LOG(LOG_ERR, "Missing element (room)\n");
@@ -1457,12 +1472,12 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 			g_snprintf(error_cause, 512, "No such feed (%"SCNu64")", publisher_id);
 			goto error;
 		}
-		janus_mutex_lock(&publisher->rtp_listeners_mutex);
-		g_hash_table_remove(publisher->rtp_listeners, GUINT_TO_POINTER(stream_id));
-		janus_mutex_unlock(&publisher->rtp_listeners_mutex);
+		janus_mutex_lock(&publisher->rtp_forwarders_mutex);
+		g_hash_table_remove(publisher->rtp_forwarders, GUINT_TO_POINTER(stream_id));
+		janus_mutex_unlock(&publisher->rtp_forwarders_mutex);
 		janus_mutex_unlock(&videoroom->participants_mutex);
 		response = json_object();
-		json_object_set_new(response, "videoroom", json_string("stop_rtp_listen"));
+		json_object_set_new(response, "videoroom", json_string("stop_rtp_forward"));
 		json_object_set_new(response, "room", json_integer(room_id));
 		json_object_set_new(response, "publisher_id", json_integer(publisher_id));
 		json_object_set_new(response, "stream_id", json_integer(stream_id));
@@ -1680,25 +1695,21 @@ void janus_videoroom_incoming_rtp(janus_plugin_session *handle, int video, char 
 		rtp_header *rtp = (rtp_header *)buf;
 		rtp->type = video ? VP8_PT : OPUS_PT;
 		rtp->ssrc = htonl(video ? participant->video_ssrc : participant->audio_ssrc);
-		/* Forward RTP to the appropriate port for the rtp_listeners associated wih this publisher, if there are any */
-		struct sockaddr_in serv_addr;
-		serv_addr.sin_family = AF_INET;
+		/* Forward RTP to the appropriate port for the rtp_forwarders associated wih this publisher, if there are any */
 		GHashTableIter iter;
 		gpointer value;
-		g_hash_table_iter_init(&iter, participant->rtp_listeners);
-		janus_mutex_lock(&participant->rtp_listeners_mutex);
+		g_hash_table_iter_init(&iter, participant->rtp_forwarders);
+		janus_mutex_lock(&participant->rtp_forwarders_mutex);
 		while(participant->udp_sock > 0 && g_hash_table_iter_next(&iter, NULL, &value)) {
-			rtp_listener* rtp_listen = (rtp_listener*)value;
-			inet_pton(AF_INET, rtp_listen->host, &(serv_addr.sin_addr));
-			if(video) {
-				serv_addr.sin_port = htons(rtp_listen->video_port);
+			rtp_forwarder* rtp_forward = (rtp_forwarder*)value;
+			if(video && rtp_forward->is_video) {
+				sendto(participant->udp_sock, buf, len, 0, (struct sockaddr*)&rtp_forward->serv_addr, sizeof(rtp_forward->serv_addr));
 			}
-			else {
-				serv_addr.sin_port = htons(rtp_listen->audio_port);
+			else if(!video && !rtp_forward->is_video) {
+				sendto(participant->udp_sock, buf, len, 0, (struct sockaddr*)&rtp_forward->serv_addr, sizeof(rtp_forward->serv_addr));
 			}
-			sendto(participant->udp_sock, buf, len, 0, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
 		}
-		janus_mutex_unlock(&participant->rtp_listeners_mutex);
+		janus_mutex_unlock(&participant->rtp_forwarders_mutex);
 		/* Save the frame if we're recording */
 		if(video && participant->vrc)
 			janus_recorder_save_frame(participant->vrc, buf, len);
@@ -2215,8 +2226,8 @@ static void *janus_videoroom_handler(void *data) {
 				publisher->remb_latest = 0;
 				publisher->fir_latest = 0;
 				publisher->fir_seq = 0;
-				janus_mutex_init(&publisher->rtp_listeners_mutex);
-				publisher->rtp_listeners = g_hash_table_new_full(NULL, NULL, NULL, (GDestroyNotify)janus_rtp_listener_free_helper);
+				janus_mutex_init(&publisher->rtp_forwarders_mutex);
+				publisher->rtp_forwarders = g_hash_table_new_full(NULL, NULL, NULL, (GDestroyNotify)janus_rtp_forwarder_free_helper);
 				publisher->udp_sock = -1;
 				/* In case we also wanted to configure */
 				if(audio) {
@@ -3646,17 +3657,17 @@ static void janus_videoroom_participant_free(janus_videoroom_participant *p) {
 		}
 	}
 	janus_mutex_unlock(&p->listeners_mutex);
-	janus_mutex_lock(&p->rtp_listeners_mutex);
-	if(p->udp_sock > 0) { //this is only closed if the listeners mutex is locked, so that we can be assured that we are not trying to send over the socket
+	janus_mutex_lock(&p->rtp_forwarders_mutex);
+	if(p->udp_sock > 0) {
 		close(p->udp_sock);
 		p->udp_sock = 0;
 	}
-	g_hash_table_destroy(p->rtp_listeners);
-	p->rtp_listeners = NULL;
-	janus_mutex_unlock(&p->rtp_listeners_mutex);
+	g_hash_table_destroy(p->rtp_forwarders);
+	p->rtp_forwarders = NULL;
+	janus_mutex_unlock(&p->rtp_forwarders_mutex);
 	g_slist_free(p->listeners);
 
 	janus_mutex_destroy(&p->listeners_mutex);
-	janus_mutex_destroy(&p->rtp_listeners_mutex);
+	janus_mutex_destroy(&p->rtp_forwarders_mutex);
 	free(p);
 }

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -341,7 +341,7 @@ typedef struct janus_videoroom_data_relay_packet {
 } janus_videoroom_data_relay_packet;
 
 /* SDP offer/answer templates */
-#define OPUS_PT		8
+#define OPUS_PT		111
 #define VP8_PT		100
 #define sdp_template \
 		"v=0\r\n" \
@@ -353,7 +353,7 @@ typedef struct janus_videoroom_data_relay_packet {
 		"m=audio 1 RTP/SAVPF %d\r\n"		/* Opus payload type */ \
 		"c=IN IP4 1.1.1.1\r\n" \
 		"a=%s\r\n"							/* Media direction */ \
-		"a=rtpmap:%d pcma/8000\r\n"		/* Opus payload type */
+		"a=rtpmap:%d opus/48000/2\r\n"		/* Opus payload type */
 #define sdp_v_template \
 		"m=video 1 RTP/SAVPF %d\r\n"		/* VP8 payload type */ \
 		"c=IN IP4 1.1.1.1\r\n" \


### PR DESCRIPTION
This adds a new feature to the videoroom plugin.

Publishers in a specific room can have an rtp_listen request made against them which will cause the publisher to forward the correct media give the specific port to the given host. 

```
{
   "request" : "rtp_listen",
   "publisher_id": 1234,
   "room" : 111,
   "video_port": 5001,
   "audio_port": 5000,
   "host" : "192.168.0.123"
}
```
response
```
{
   "videoroom" : "rtp_listen",
   "publisher_id" : 1234,
   "room" : 111,
   "rtp_stream" :
   {
      "stream_id" : <unique_id>,
      "audio" : 5000,
      "video": 5001,
      "host": "192.168.0.123"
    }
}
```

A stream can also be told to stop forward rtp packets through a `stop_rtp_listen` request which references the publisher_id, room number, and stream_id.
