### PR TITLE
fixed double free in echotest handler

### DIFF
--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -390,12 +390,14 @@ void janus_echotest_destroy_session(janus_plugin_session *handle, int *error) {
 	}
 	JANUS_LOG(LOG_VERB, "Removing Echo Test session...\n");
 	janus_mutex_lock(&sessions_mutex);
-	g_hash_table_remove(sessions, handle);
-	janus_mutex_unlock(&sessions_mutex);
-	/* Cleaning up and removing the session is done in a lazy way */
-	session->destroyed = janus_get_monotonic_time();
-	janus_mutex_lock(&sessions_mutex);
-	old_sessions = g_list_append(old_sessions, session);
+	if(g_hash_table_remove(sessions, handle)){
+		//janus_mutex_unlock(&sessions_mutex);
+		/* Cleaning up and removing the session is done in a lazy way */
+		session->destroyed = janus_get_monotonic_time();
+		//janus_mutex_lock(&sessions_mutex);
+		old_sessions = g_list_append(old_sessions, session);
+		handle->plugin_handle = NULL;
+	}
 	janus_mutex_unlock(&sessions_mutex);
 	return;
 }


### PR DESCRIPTION
echo plugin. When client detach request send twice for the same handler, janus-gateway crashed. 
It's safer to fixed it on server code.
