### PR TITLE
fix a problem in wav header

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -2374,7 +2374,7 @@ static void *janus_audiobridge_mixer_thread(void *data) {
 				1,
 				1,
 				audiobridge->sampling_rate,
-				audiobridge->sampling_rate,
+				audiobridge->sampling_rate * 2,
 				2,
 				16,
 				{'d', 'a', 't', 'a'},


### PR DESCRIPTION
see http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html, the nAvgBytesPerSec fileld should be (sample rate * sample format / 8), here is audiobridge->sampling_rate * 2