### PR TITLE
sip: add ability to choose the response code for 'decline'

### DIFF
--- a/html/siptest.js
+++ b/html/siptest.js
@@ -160,6 +160,9 @@ $(document).ready(function() {
 										} else if(event === 'calling') {
 											console.log("Waiting for the peer to answer...");
 											// TODO Any ringtone?
+											$('#call').removeAttr('disabled').html('Hangup')
+												  .removeClass("btn-success").addClass("btn-danger")
+												  .unbind('click').click(doHangup);
 										} else if(event === 'incomingcall') {
 											console.log("Incoming call from " + result["username"] + "!");
 											var doAudio = true, doVideo = true;
@@ -224,9 +227,6 @@ $(document).ready(function() {
 											if(jsep !== null && jsep !== undefined) {
 												sipcall.handleRemoteJsep({jsep: jsep, error: doHangup });
 											}
-											$('#call').removeAttr('disabled').html('Hangup')
-												.removeClass("btn-success").addClass("btn-danger")
-												.unbind('click').click(doHangup);
 										} else if(event === 'hangup') {
 											if(incoming != null) {
 												incoming.modal('hide');

--- a/html/siptest.js
+++ b/html/siptest.js
@@ -232,8 +232,8 @@ $(document).ready(function() {
 												incoming.modal('hide');
 												incoming = null;
 											}
-											console.log("Call hung up by " + result["username"] + " (" + result["reason"] + ")!");
-											bootbox.alert(result["reason"]);
+											console.log("Call hung up (" + result["code"] + " " + result["reason"] + ")!");
+											bootbox.alert(result["code"] + " " + result["reason"]);
 											// Reset status
 											sipcall.hangup();
 											$('#dovideo').removeAttr('disabled').val('');


### PR DESCRIPTION
Also emit a 'declined' event afterwards.

Closes #267 and #268.