### PR TITLE
Prevent bower to use a too recent adapter.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "janus-gateway",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "homepage": "https://github.com/meetecho/janus-gateway",
   "authors": [
     "Lorenzo Miniero <lorenzo@meetecho.com>",
@@ -33,7 +33,7 @@
     "tests"
   ],
   "dependencies": {
-    "adapter.js": "*",
+    "adapter.js": "git://github.com/webrtc/adapter.git#d197a97c198a6dbcde7aa58c7d50d454af7bb99c",
     "jquery": "*"    
   }
 }


### PR DESCRIPTION
Janus.js uses MediaStreamTrack.getSources which is not longer provided for Firefox by adapter.js. This change ensures bower uses the last adapter.js version still defining that function which prevents janus.js from breaking. The limitation can be removed in the future if janus,js stops calling MediaStreamTrack.getSources directly.

Since I was modifying the file, I also updated the version.