### PR TITLE
Introduce Janus JS logger

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -22,6 +22,29 @@ Janus.isExtensionEnabled = function() {
 
 Janus.noop = function() {};
 
+Janus.logger = function(level) {
+	this.level = level || 0;
+
+	methods = ["trace", "debug", "info", "warn", "error"];
+	levels = {};
+
+	this.log = function(msg) {
+		(console.log === undefined) ? Janus.noop : console.log(msg);
+	};
+
+	methods.forEach(function(level, index) {
+		levels[level] = index;
+
+		this[level] = function(msg) {
+			if(this.level > levels[level]) {
+				return; // No need to log at all!
+			}
+
+			(console[level] === undefined) ? this.log(msg) : console[level](msg);
+		};
+	}.bind(this));
+}
+
 // Initialization
 Janus.init = function(options) {
 	options = options || {};


### PR DESCRIPTION
As I was lost in the huge amount of logs, which are produced by `janus.js` when debugging is enabled, I created as simple logger with log level support which makes use of browsers `console.trace`, `console.warn`, etc. and provides fallback methods if these are not supported.

If it is something desirable, I could go ahead and replace `Janus.log` in javascript code with appropriate methods of the logger before the merge.