### PR TITLE
build: clean doxygen generated sqlite files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -271,3 +271,10 @@ endif
 configs:
 	$(MKDIR_P) $(DESTDIR)$(confdir)
 	$(foreach config,$(conf_DATA),cp "$(CURDIR)/$(config)" "$(DESTDIR)$(confdir)/$(notdir $(basename $(config) .sample))";)
+
+##
+# Extra cleanup
+##
+
+clean-local:
+	-rm -f docs/doxygen_sqlite3.db


### PR DESCRIPTION
The SQLite DB is left back, thus creating problems with Debian
packaging, because the tree is not reverted back to its original form
when doing `make distclean`.