### PR TITLE
Check if adapter is already loaded

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -56,7 +56,6 @@ Janus.init = function(options) {
 			if(src === 'adapter.js') {
 				if(window.RTCPeerConnection) {
 					// Already loaded
-					options.callback();
 					return;
 				}
 			}

--- a/html/janus.js
+++ b/html/janus.js
@@ -53,6 +53,13 @@ Janus.init = function(options) {
 					return;
 				}
 			}
+			if(src === 'adapter.js') {
+				if(window.RTCPeerConnection) {
+					// Already loaded
+					options.callback();
+					return;
+				}
+			}
 			var oHead = document.getElementsByTagName('head').item(0);
 			var oScript = document.createElement("script");
 			oScript.type = "text/javascript";


### PR DESCRIPTION
I adapter is already loaded, it's not necesary to try to charge it again. Or if it's not available at root, trying to load it as it will cause a fatal error. It is probably most pertinent if you can let the choice to the user of the place of the script