### PR TITLE
Raise default buffer size to 8192

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -1927,7 +1927,7 @@ void janus_ice_candidates_to_sdp(janus_ice_handle *handle, char *sdp, guint stre
 #endif
 			}
 		}
-		g_strlcat(sdp, buffer, BUFSIZE);
+		g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 		JANUS_LOG(LOG_VERB, "[%"SCNu64"]     %s", handle->handle_id, buffer); /* buffer already newline terminated */
 		if(log_candidates) {
 			/* Save for the summary, in case we need it */
@@ -2684,7 +2684,7 @@ void *janus_ice_send_thread(void *data) {
 				}
 			} else {
 				/* FIXME Copy in a buffer and fix SSRC */
-				char sbuf[BUFSIZE];
+				char sbuf[JANUS_BUFSIZE];
 				memcpy(&sbuf, pkt->data, pkt->length);
 				/* Fix all SSRCs! */
 				if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_PLAN_B)) {
@@ -2784,7 +2784,7 @@ void *janus_ice_send_thread(void *data) {
 					}
 				} else {
 					/* FIXME Copy in a buffer and fix SSRC */
-					char sbuf[BUFSIZE];
+					char sbuf[JANUS_BUFSIZE];
 					memcpy(&sbuf, pkt->data, pkt->length);
 					if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_PLAN_B)) {
 						/* Overwrite SSRC */

--- a/janus.h
+++ b/janus.h
@@ -42,7 +42,7 @@
 #include "plugins/plugin.h"
 
 
-#define JANUS_BUFSIZE	4096
+#define JANUS_BUFSIZE	8192
 
 
 /*! \brief Incoming HTTP message */

--- a/janus.h
+++ b/janus.h
@@ -42,7 +42,7 @@
 #include "plugins/plugin.h"
 
 
-#define BUFSIZE	4096
+#define JANUS_BUFSIZE	4096
 
 
 /*! \brief Incoming HTTP message */

--- a/sdp.c
+++ b/sdp.c
@@ -701,8 +701,8 @@ char *janus_sdp_anonymize(const char *sdp) {
 			m = m->m_next;
 		}
 	}
-	char buf[BUFSIZE];
-	sdp_printer_t *printer = sdp_print(home, anon, buf, BUFSIZE, 0);
+	char buf[JANUS_BUFSIZE];
+	sdp_printer_t *printer = sdp_print(home, anon, buf, JANUS_BUFSIZE, 0);
 	if(sdp_message(printer)) {
 		int retval = sdp_message_size(printer);
 		sdp_printer_free(printer);
@@ -740,7 +740,7 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 	/* Prepare SDP to merge */
 	gchar buffer[512];
 	memset(buffer, 0, 512);
-	char *sdp = (char*)calloc(BUFSIZE, sizeof(char));
+	char *sdp = (char*)calloc(JANUS_BUFSIZE, sizeof(char));
 	if(sdp == NULL) {
 		JANUS_LOG(LOG_FATAL, "Memory error!\n");
 		sdp_parser_free(parser);
@@ -756,21 +756,21 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 	}
 	/* Version v= */
 	g_strlcat(sdp,
-		"v=0\r\n", BUFSIZE);
+		"v=0\r\n", JANUS_BUFSIZE);
 	/* Origin o= */
 	if(anon->sdp_origin) {
 		g_snprintf(buffer, 512,
 			"o=%s %"SCNu64" %"SCNu64" IN IP4 127.0.0.1\r\n",	/* FIXME Should we fix the address? */
 				anon->sdp_origin->o_username ? anon->sdp_origin->o_username : "-",
 				anon->sdp_origin->o_id, anon->sdp_origin->o_version);
-		g_strlcat(sdp, buffer, BUFSIZE);
+		g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 	} else {
 		gint64 sessid = janus_get_monotonic_time();
 		gint64 version = sessid;	/* FIXME This needs to be increased when it changes, so time should be ok */
 		g_snprintf(buffer, 512,
 			"o=%s %"SCNi64" %"SCNi64" IN IP4 127.0.0.1\r\n",	/* FIXME Should we fix the address? */
 				"-", sessid, version);
-		g_strlcat(sdp, buffer, BUFSIZE);
+		g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 	}
 	/* Session name s= */
 	if(anon->sdp_subject && strlen(anon->sdp_subject) > 0) {
@@ -778,15 +778,15 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 	} else {
 		g_snprintf(buffer, 512, "s=%s\r\n", "Meetecho Janus");
 	}
-	g_strlcat(sdp, buffer, BUFSIZE);
+	g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 	/* Timing t= */
 	g_snprintf(buffer, 512,
 		"t=%lu %lu\r\n", anon->sdp_time ? anon->sdp_time->t_start : 0, anon->sdp_time ? anon->sdp_time->t_stop : 0);
-	g_strlcat(sdp, buffer, BUFSIZE);
+	g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 	/* ICE Full or Lite? */
 	if(janus_ice_is_ice_lite_enabled()) {
 		/* Janus is acting in ICE Lite mode, advertize this */
-		g_strlcat(sdp, "a=ice-lite\r\n", BUFSIZE);
+		g_strlcat(sdp, "a=ice-lite\r\n", JANUS_BUFSIZE);
 	}
 	/* bundle: add new global attribute */
 	int audio = (strstr(origsdp, "m=audio") != NULL);
@@ -796,30 +796,30 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 #else
 	int data = 0;
 #endif
-	g_strlcat(sdp, "a=group:BUNDLE", BUFSIZE);
+	g_strlcat(sdp, "a=group:BUNDLE", JANUS_BUFSIZE);
 	if(audio) {
 		g_snprintf(buffer, 512,
 			" %s", handle->audio_mid ? handle->audio_mid : "audio");
-		g_strlcat(sdp, buffer, BUFSIZE);
+		g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 	}
 	if(video) {
 		g_snprintf(buffer, 512,
 			" %s", handle->video_mid ? handle->video_mid : "video");
-		g_strlcat(sdp, buffer, BUFSIZE);
+		g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 	}
 	if(data) {
 		g_snprintf(buffer, 512,
 			" %s", handle->data_mid ? handle->data_mid : "data");
-		g_strlcat(sdp, buffer, BUFSIZE);
+		g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 	}
-	g_strlcat(sdp, "\r\n", BUFSIZE);
+	g_strlcat(sdp, "\r\n", JANUS_BUFSIZE);
 	/* msid-semantic: add new global attribute */
 	g_strlcat(sdp,
 		"a=msid-semantic: WMS janus\r\n",
-		BUFSIZE);
-	char wms[BUFSIZE];
-	memset(wms, 0, BUFSIZE);
-	g_strlcat(wms, "WMS", BUFSIZE);
+		JANUS_BUFSIZE);
+	char wms[JANUS_BUFSIZE];
+	memset(wms, 0, JANUS_BUFSIZE);
+	g_strlcat(wms, "WMS", JANUS_BUFSIZE);
 	/* Copy other global attributes, if any */
 	if(anon->sdp_attributes) {
 		sdp_attribute_t *a = anon->sdp_attributes;
@@ -827,11 +827,11 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 			if(a->a_value == NULL) {
 				g_snprintf(buffer, 512,
 					"a=%s\r\n", a->a_name);
-				g_strlcat(sdp, buffer, BUFSIZE);
+				g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 			} else {
 				g_snprintf(buffer, 512,
 					"a=%s:%s\r\n", a->a_name, a->a_value);
-				g_strlcat(sdp, buffer, BUFSIZE);
+				g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 			}
 			a = a->a_next;
 		}
@@ -850,11 +850,11 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 				audio++;
 				if(audio > 1 || !handle->audio_id) {
 					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping audio line (we have %d audio lines, and the id is %d)\n", handle->handle_id, audio, handle->audio_id);
-					g_strlcat(sdp, "m=audio 0 RTP/SAVPF 0\r\n", BUFSIZE);
+					g_strlcat(sdp, "m=audio 0 RTP/SAVPF 0\r\n", JANUS_BUFSIZE);
 					/* FIXME Adding a c-line anyway because otherwise Firefox complains? ("c= connection line not specified for every media level, validation failed") */
 					g_snprintf(buffer, 512,
 						"c=IN %s %s\r\n", ipv6 ? "IP6" : "IP4", janus_get_public_ip());
-					g_strlcat(sdp, buffer, BUFSIZE);
+					g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 					m = m->m_next;
 					continue;
 				}
@@ -862,15 +862,15 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 				stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(handle->audio_id));
 				if(stream == NULL) {
 					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping audio line (invalid stream %d)\n", handle->handle_id, handle->audio_id);
-					g_strlcat(sdp, "m=audio 0 RTP/SAVPF 0\r\n", BUFSIZE);
+					g_strlcat(sdp, "m=audio 0 RTP/SAVPF 0\r\n", JANUS_BUFSIZE);
 					/* FIXME Adding a c-line anyway because otherwise Firefox complains? ("c= connection line not specified for every media level, validation failed") */
 					g_snprintf(buffer, 512,
 						"c=IN %s %s\r\n", ipv6 ? "IP6" : "IP4", janus_get_public_ip());
-					g_strlcat(sdp, buffer, BUFSIZE);
+					g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 					m = m->m_next;
 					continue;
 				}
-				g_strlcat(sdp, "m=audio 1 RTP/SAVPF", BUFSIZE);
+				g_strlcat(sdp, "m=audio 1 RTP/SAVPF", JANUS_BUFSIZE);
 			} else if(m->m_type == sdp_media_video && m->m_port > 0) {
 				video++;
 				gint id = handle->video_id;
@@ -879,11 +879,11 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 				if(video > 1 || !id) {
 					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping video line (we have %d video lines, and the id is %d)\n", handle->handle_id, video,
 						janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE) ? handle->audio_id : handle->video_id);
-					g_strlcat(sdp, "m=video 0 RTP/SAVPF 0\r\n", BUFSIZE);
+					g_strlcat(sdp, "m=video 0 RTP/SAVPF 0\r\n", JANUS_BUFSIZE);
 					/* FIXME Adding a c-line anyway because otherwise Firefox complains? ("c= connection line not specified for every media level, validation failed") */
 					g_snprintf(buffer, 512,
 						"c=IN %s %s\r\n", ipv6 ? "IP6" : "IP4", janus_get_public_ip());
-					g_strlcat(sdp, buffer, BUFSIZE);
+					g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 					m = m->m_next;
 					continue;
 				}
@@ -891,15 +891,15 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 				stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(id));
 				if(stream == NULL) {
 					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping video line (invalid stream %d)\n", handle->handle_id, id);
-					g_strlcat(sdp, "m=video 0 RTP/SAVPF 0\r\n", BUFSIZE);
+					g_strlcat(sdp, "m=video 0 RTP/SAVPF 0\r\n", JANUS_BUFSIZE);
 					/* FIXME Adding a c-line anyway because otherwise Firefox complains? ("c= connection line not specified for every media level, validation failed") */
 					g_snprintf(buffer, 512,
 						"c=IN %s %s\r\n", ipv6 ? "IP6" : "IP4", janus_get_public_ip());
-					g_strlcat(sdp, buffer, BUFSIZE);
+					g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 					m = m->m_next;
 					continue;
 				}
-				g_strlcat(sdp, "m=video 1 RTP/SAVPF", BUFSIZE);
+				g_strlcat(sdp, "m=video 1 RTP/SAVPF", JANUS_BUFSIZE);
 #ifdef HAVE_SCTP
 			} else if(m->m_type == sdp_media_application) {
 				/* Is this SCTP for DataChannels? */
@@ -914,11 +914,11 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 						g_snprintf(buffer, 512,
 							"m=%s 0 %s 0\r\n",
 							m->m_type_name, m->m_proto_name);
-						g_strlcat(sdp, buffer, BUFSIZE);
+						g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 						/* FIXME Adding a c-line anyway because otherwise Firefox complains? ("c= connection line not specified for every media level, validation failed") */
 						g_snprintf(buffer, 512,
 							"c=IN %s %s\r\n", ipv6 ? "IP6" : "IP4", janus_get_public_ip());
-						g_strlcat(sdp, buffer, BUFSIZE);
+						g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 						m = m->m_next;
 						continue;
 					}
@@ -929,21 +929,21 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 						g_snprintf(buffer, 512,
 							"m=%s 0 %s 0\r\n",
 							m->m_type_name, m->m_proto_name);
-						g_strlcat(sdp, buffer, BUFSIZE);
+						g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 						/* FIXME Adding a c-line anyway because otherwise Firefox complains? ("c= connection line not specified for every media level, validation failed") */
 						g_snprintf(buffer, 512,
 							"c=IN %s %s\r\n", ipv6 ? "IP6" : "IP4", janus_get_public_ip());
-						g_strlcat(sdp, buffer, BUFSIZE);
+						g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 						m = m->m_next;
 						continue;
 					}
-					g_strlcat(sdp, "m=application 1 DTLS/SCTP", BUFSIZE);
+					g_strlcat(sdp, "m=application 1 DTLS/SCTP", JANUS_BUFSIZE);
 				} else {
 					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping unsupported application media line...\n", handle->handle_id);
 					g_snprintf(buffer, 512,
 						"m=%s 0 %s 0\r\n",
 						m->m_type_name, m->m_proto_name);
-					g_strlcat(sdp, buffer, BUFSIZE);
+					g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 					m = m->m_next;
 					continue;
 				}
@@ -953,11 +953,11 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 				g_snprintf(buffer, 512,
 					"m=%s 0 %s 0\r\n",
 					m->m_type_name, m->m_proto_name);
-				g_strlcat(sdp, buffer, BUFSIZE);
+				g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 				/* FIXME Adding a c-line anyway because otherwise Firefox complains? ("c= connection line not specified for every media level, validation failed") */
 				g_snprintf(buffer, 512,
 					"c=IN %s %s\r\n", ipv6 ? "IP6" : "IP4", janus_get_public_ip());
-				g_strlcat(sdp, buffer, BUFSIZE);
+				g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 				m = m->m_next;
 				continue;
 			}
@@ -966,12 +966,12 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 				JANUS_LOG(LOG_VERB, "[%"SCNu64"] No RTP maps?? trying formats...\n", handle->handle_id);
 				if(!m->m_format) {
 					JANUS_LOG(LOG_ERR, "[%"SCNu64"] No formats either?? this sucks!\n", handle->handle_id);
-					g_strlcat(sdp, " 0", BUFSIZE);	/* FIXME Won't work apparently */
+					g_strlcat(sdp, " 0", JANUS_BUFSIZE);	/* FIXME Won't work apparently */
 				} else {
 					sdp_list_t *fmt = m->m_format;
 					while(fmt) {
 						g_snprintf(buffer, 512, " %s", fmt->l_text);
-						g_strlcat(sdp, buffer, BUFSIZE);
+						g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 						fmt = fmt->l_next;
 					}
 				}
@@ -979,22 +979,22 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 				sdp_rtpmap_t *r = m->m_rtpmaps;
 				while(r) {
 					g_snprintf(buffer, 512, " %d", r->rm_pt);
-					g_strlcat(sdp, buffer, BUFSIZE);
+					g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 					r = r->rm_next;
 				}
 			}
-			g_strlcat(sdp, "\r\n", BUFSIZE);
+			g_strlcat(sdp, "\r\n", JANUS_BUFSIZE);
 			/* Media connection c= */
 			g_snprintf(buffer, 512,
 				"c=IN %s %s\r\n", ipv6 ? "IP6" : "IP4", janus_get_public_ip());
-			g_strlcat(sdp, buffer, BUFSIZE);
+			g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 			/* Any bandwidth? */
 			if(m->m_bandwidths) {
 				g_snprintf(buffer, 512,
 					"b=%s:%lu\r\n",	/* FIXME Are we doing this correctly? */
 						m->m_bandwidths->b_modifier_name ? m->m_bandwidths->b_modifier_name : "AS",
 						m->m_bandwidths->b_value);
-				g_strlcat(sdp, buffer, BUFSIZE);
+				g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 			}
 			/* a=mid:(audio|video|data) */
 			switch(m->m_type) {
@@ -1014,27 +1014,27 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 				default:
 					break;
 			}
-			g_strlcat(sdp, buffer, BUFSIZE);
+			g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 			if(m->m_type != sdp_media_application) {
 				/* What is the direction? */
 				switch(m->m_mode) {
 					case sdp_sendonly:
-						g_strlcat(sdp, "a=sendonly\r\n", BUFSIZE);
+						g_strlcat(sdp, "a=sendonly\r\n", JANUS_BUFSIZE);
 						break;
 					case sdp_recvonly:
-						g_strlcat(sdp, "a=recvonly\r\n", BUFSIZE);
+						g_strlcat(sdp, "a=recvonly\r\n", JANUS_BUFSIZE);
 						break;
 					case sdp_inactive:
-						g_strlcat(sdp, "a=inactive\r\n", BUFSIZE);
+						g_strlcat(sdp, "a=inactive\r\n", JANUS_BUFSIZE);
 						break;
 					case sdp_sendrecv:
 					default:
-						g_strlcat(sdp, "a=sendrecv\r\n", BUFSIZE);
+						g_strlcat(sdp, "a=sendrecv\r\n", JANUS_BUFSIZE);
 						break;
 				}
 				/* rtcp-mux */
 				g_snprintf(buffer, 512, "a=rtcp-mux\n");
-				g_strlcat(sdp, buffer, BUFSIZE);
+				g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 				/* RTP maps */
 				if(m->m_rtpmaps) {
 					sdp_rtpmap_t *rm = NULL;
@@ -1043,12 +1043,12 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 							rm->rm_pt, rm->rm_encoding, rm->rm_rate,
 							rm->rm_params ? "/" : "", 
 							rm->rm_params ? rm->rm_params : "");
-						g_strlcat(sdp, buffer, BUFSIZE);
+						g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 					}
 					for(rm = m->m_rtpmaps; rm; rm = rm->rm_next) {
 						if(rm->rm_fmtp) {
 							g_snprintf(buffer, 512, "a=fmtp:%u %s\r\n", rm->rm_pt, rm->rm_fmtp);
-							g_strlcat(sdp, buffer, BUFSIZE);
+							g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 						}
 					}
 				}
@@ -1074,7 +1074,7 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 			if(password != NULL)
 				g_free(password);
 			password = NULL;
-			g_strlcat(sdp, buffer, BUFSIZE);
+			g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 			/* Copy existing media attributes, if any */
 			if(m->m_attributes) {
 				sdp_attribute_t *a = m->m_attributes;
@@ -1087,11 +1087,11 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 					if(a->a_value == NULL) {
 						g_snprintf(buffer, 512,
 							"a=%s\r\n", a->a_name);
-						g_strlcat(sdp, buffer, BUFSIZE);
+						g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 					} else {
 						g_snprintf(buffer, 512,
 							"a=%s:%s\r\n", a->a_name, a->a_value);
-						g_strlcat(sdp, buffer, BUFSIZE);
+						g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 					}
 					a = a->a_next;
 				}
@@ -1106,7 +1106,7 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 						"a=ssrc:%"SCNu32" mslabel:janus\r\n"
 						"a=ssrc:%"SCNu32" label:janusa0\r\n",
 							stream->audio_ssrc, stream->audio_ssrc, stream->audio_ssrc, stream->audio_ssrc);
-					g_strlcat(sdp, buffer, BUFSIZE);
+					g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 				} else if(m->m_type == sdp_media_video && m->m_mode != sdp_inactive && m->m_mode != sdp_recvonly) {
 					g_snprintf(buffer, 512,
 						"a=ssrc:%"SCNu32" cname:janusvideo\r\n"
@@ -1114,7 +1114,7 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 						"a=ssrc:%"SCNu32" mslabel:janus\r\n"
 						"a=ssrc:%"SCNu32" label:janusv0\r\n",
 							stream->video_ssrc, stream->video_ssrc, stream->video_ssrc, stream->video_ssrc);
-					g_strlcat(sdp, buffer, BUFSIZE);
+					g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 				}
 			} else {
 				/* Multiple SSRCs */
@@ -1151,11 +1151,11 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 								"a=ssrc:%"SCNu32" label:%sv0\r\n",
 									ssrc, id, ssrc, id, id, ssrc, id, ssrc, id);
 						}
-						g_strlcat(sdp, buffer, BUFSIZE);
+						g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 						/* Add to msid-semantic, if needed */
 						if(!strstr(wms, id)) {
 							g_snprintf(mslabel, 255, " %s", id);
-							g_strlcat(wms, mslabel, BUFSIZE);
+							g_strlcat(wms, mslabel, JANUS_BUFSIZE);
 						}
 						/* Go on */
 						a = a->a_next;


### PR DESCRIPTION
Ideally the buffer should grow according to the needed space, but that would be a pretty extensive change.

I can easily go over the default 4096 size when Janus generates an SDP with audio + video, ICE + TCP and the server has 4 IP addresses. 