### PR TITLE
ice: ignore non-matching host candidates when public IP is specified

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -1818,6 +1818,10 @@ void janus_ice_candidates_to_sdp(janus_ice_handle *handle, char *sdp, guint stre
 		/* SDP time */
 		gchar buffer[100];
 		if(c->type == NICE_CANDIDATE_TYPE_HOST) {
+			/* if the public IP is specified, igonre candidates which don't match */
+			if (host_ip != NULL && strcmp(host_ip, address) != 0)
+				continue
+
 			/* 'host' candidate */
 			if(c->transport == NICE_CANDIDATE_TRANSPORT_UDP) {
 				g_snprintf(buffer, 100,
@@ -1826,7 +1830,7 @@ void janus_ice_candidates_to_sdp(janus_ice_handle *handle, char *sdp, guint stre
 						c->component_id,
 						"udp",
 						c->priority,
-						host_ip ? host_ip : address,
+						address,
 						port);
 			} else {
 				if(!janus_ice_tcp_enabled) {
@@ -1867,7 +1871,7 @@ void janus_ice_candidates_to_sdp(janus_ice_handle *handle, char *sdp, guint stre
 							c->component_id,
 							"tcp",
 							c->priority,
-							host_ip ? host_ip : address,
+							address,
 							port,
 							type);
 				}


### PR DESCRIPTION
Before:

~~~~
v=0
o=- 3651822123 3651822123 IN IP4 127.0.0.1
s=Blink Pro 4.3.0 (MacOSX)
t=0 0
a=ice-lite
a=group:BUNDLE audio video
a=msid-semantic: WMS janus
m=video 1 RTP/SAVPF 97 102
c=IN IP4 81.23.228.146
a=mid:video
a=sendrecv
a=rtcp-mux
a=rtpmap:97 H264/90000
a=rtpmap:102 VP8/90000
a=fmtp:97 profile-level-id=42e01f;packetization-mode=1
a=ice-ufrag:M5F3
a=ice-pwd:7V8z14IB9er85rndvkT3MS
a=ice-options:trickle
a=fingerprint:sha-256 D2:B9:31:8F:DF:24:D8:0E:ED:D2:EF:25:9E:AF:6F:B8:34:AE:53:9C:E6:F3:8F:F2:64:15:FA:E8:7F:53:2D:38
a=setup:actpass
a=connection:new
a=zrtp-hash:1.10 e71010c50859245ef2005a8d1b59e811ea8f79daa7c3132d2fcb9965147e078c
a=ssrc:670684509 cname:janusvideo
a=ssrc:670684509 msid:janus janusv0
a=ssrc:670684509 mslabel:janus
a=ssrc:670684509 label:janusv0
a=candidate:13 1 udp 2013266431 81.23.228.146 58393 typ host
a=candidate:14 1 tcp 1019216383 81.23.228.146 0 typ host tcptype active
a=candidate:15 1 tcp 1015022079 81.23.228.146 41801 typ host tcptype passive
a=candidate:16 1 udp 2013266431 81.23.228.146 54218 typ host
a=candidate:17 1 tcp 1019216383 81.23.228.146 0 typ host tcptype active
a=candidate:18 1 tcp 1015022079 81.23.228.146 50295 typ host tcptype passive
a=candidate:19 1 udp 2013266431 81.23.228.146 59208 typ host
a=candidate:20 1 tcp 1019216383 81.23.228.146 0 typ host tcptype active
a=candidate:21 1 tcp 1015022079 81.23.228.146 34745 typ host tcptype passive
a=candidate:22 1 udp 2013266431 81.23.228.146 46982 typ host
a=candidate:23 1 tcp 1019216383 81.23.228.146 0 typ host tcptype active
a=candidate:24 1 tcp 1015022079 81.23.228.146 52333 typ host tcptype passive
a=candidate:13 2 udp 2013266430 81.23.228.146 58578 typ host
a=candidate:14 2 tcp 1019216382 81.23.228.146 0 typ host tcptype active
a=candidate:15 2 tcp 1015022078 81.23.228.146 55131 typ host tcptype passive
a=candidate:16 2 udp 2013266430 81.23.228.146 35745 typ host
a=candidate:17 2 tcp 1019216382 81.23.228.146 0 typ host tcptype active
a=candidate:18 2 tcp 1015022078 81.23.228.146 34742 typ host tcptype passive
a=candidate:19 2 udp 2013266430 81.23.228.146 40443 typ host
a=candidate:20 2 tcp 1019216382 81.23.228.146 0 typ host tcptype active
a=candidate:21 2 tcp 1015022078 81.23.228.146 35629 typ host tcptype passive
a=candidate:22 2 udp 2013266430 81.23.228.146 35254 typ host
a=candidate:23 2 tcp 1019216382 81.23.228.146 0 typ host tcptype active
a=candidate:24 2 tcp 1015022078 81.23.228.146 46194 typ host tcptype passive
m=audio 1 RTP/SAVPF 113 9 0 8 101
c=IN IP4 81.23.228.146
a=mid:audio
a=sendrecv
a=rtcp-mux
a=rtpmap:113 opus/48000/2
a=rtpmap:9 G722/8000
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:101 telephone-event/8000
a=fmtp:113 useinbandfec=1
a=fmtp:101 0-16
a=ice-ufrag:3a6t
a=ice-pwd:BsudQw7ROJvNJicdlyKm15
a=ice-options:trickle
a=fingerprint:sha-256 D2:B9:31:8F:DF:24:D8:0E:ED:D2:EF:25:9E:AF:6F:B8:34:AE:53:9C:E6:F3:8F:F2:64:15:FA:E8:7F:53:2D:38
a=setup:actpass
a=connection:new
a=zrtp-hash:1.10 3b063f72fca58b24ad2f858e0b9726afab0440884a016f4aa81b532ef337df72
a=ssrc:2863345091 cname:janusaudio
a=ssrc:2863345091 msid:janus janusa0
a=ssrc:2863345091 mslabel:janus
a=ssrc:2863345091 label:janusa0
a=candidate:1 1 udp 2013266431 81.23.228.146 41265 typ host
a=candidate:2 1 tcp 1019216383 81.23.228.146 0 typ host tcptype active
a=candidate:3 1 tcp 1015022079 81.23.228.146 36418 typ host tcptype passive
a=candidate:4 1 udp 2013266431 81.23.228.146 55705 typ host
a=candidate:5 1 tcp 1019216383 81.23.228.146 0 typ host tcptype active
a=candidate:6 1 tcp 1015022079 81.23.228.146 59702 typ host tcptype passive
a=candidate:7 1 udp 2013266431 81.23.228.146 39877 typ host
a=candidate:8 1 tcp 1019216383 81.23.228.146 0 typ host tcptype active
a=candidate:9 1 tcp 1015022079 81.23.228.146 54144 typ host tcptype passive
a=candidate:10 1 udp 2013266431 81.23.228.146 47700 typ host
a=candidate:11 1 tcp 1019216383 81.23.228.146 0 typ host tcptype active
a=candidate:12 1 tcp 1015022079 81.23.228.146 34560 typ host tcptype passive
a=candidate:1 2 udp 2013266430 81.23.228.146 56635 typ host
a=candidate:2 2 tcp 1019216382 81.23.228.146 0 typ host tcptype active
a=candidate:3 2 tcp 1015022078 81.23.228.146 46654 typ host tcptype passive
a=candidate:4 2 udp 2013266430 81.23.228.146 36590 typ host
a=candidate:5 2 tcp 1019216382 81.23.228.146 0 typ host tcptype active
a=candidate:6 2 tcp 1015022078 81.23.228.146 42128 typ host tcptype passive
a=candidate:7 2 udp 2013266430 81.23.228.146 41609 typ host
a=candidate:8 2 tcp 1019216382 81.23.228.146 0 typ host tcptype active
a=candidate:9 2 tcp 1015022078 81.23.228.146 43048 typ host tcptype passive
a=candidate:10 2 udp 2013266430 81.23.228.146 60181 typ host
a=candidate:11 2 tcp 1019216382 81.23.228.146 0 typ host tcptype active
a=candidate:12 2 tcp 1015022078 81.23.228.146 38928 typ host tcptype passive
~~~~

After:

~~~~
v=0
o=- 3651824984 3651824984 IN IP4 127.0.0.1
s=Blink Pro 4.3.0 (MacOSX)
t=0 0
a=ice-lite
a=group:BUNDLE audio video
a=msid-semantic: WMS janus
m=video 1 RTP/SAVPF 97 102
c=IN IP4 81.23.228.146
a=mid:video
a=sendrecv
a=rtcp-mux
a=rtpmap:97 H264/90000
a=rtpmap:102 VP8/90000
a=fmtp:97 profile-level-id=42e01f;packetization-mode=1
a=ice-ufrag:fiTf
a=ice-pwd:NvZArty017CSZTAkVFYwfK
a=ice-options:trickle
a=fingerprint:sha-256 D2:B9:31:8F:DF:24:D8:0E:ED:D2:EF:25:9E:AF:6F:B8:34:AE:53:9C:E6:F3:8F:F2:64:15:FA:E8:7F:53:2D:38
a=setup:actpass
a=connection:new
a=zrtp-hash:1.10 a12e4469df9ae3179c1ea56b47173e5221b1b97a5a06aa27584d7997ed15ac79
a=ssrc:343613018 cname:janusvideo
a=ssrc:343613018 msid:janus janusv0
a=ssrc:343613018 mslabel:janus
a=ssrc:343613018 label:janusv0
a=candidate:16 1 udp 2013266431 81.23.228.146 49509 typ host
a=candidate:17 1 tcp 1019216383 81.23.228.146 0 typ host tcptype active
a=candidate:18 1 tcp 1015022079 81.23.228.146 58771 typ host tcptype passive
a=candidate:16 2 udp 2013266430 81.23.228.146 40549 typ host
a=candidate:17 2 tcp 1019216382 81.23.228.146 0 typ host tcptype active
a=candidate:18 2 tcp 1015022078 81.23.228.146 52155 typ host tcptype passive
m=audio 1 RTP/SAVPF 113 9 0 8 101
c=IN IP4 81.23.228.146
a=mid:audio
a=sendrecv
a=rtcp-mux
a=rtpmap:113 opus/48000/2
a=rtpmap:9 G722/8000
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:101 telephone-event/8000
a=fmtp:113 useinbandfec=1
a=fmtp:101 0-16
a=ice-ufrag:esnc
a=ice-pwd:1uwPY+83cIQhLcp+33vbPf
a=ice-options:trickle
a=fingerprint:sha-256 D2:B9:31:8F:DF:24:D8:0E:ED:D2:EF:25:9E:AF:6F:B8:34:AE:53:9C:E6:F3:8F:F2:64:15:FA:E8:7F:53:2D:38
a=setup:actpass
a=connection:new
a=zrtp-hash:1.10 e6f321733b9f3e793ee6ce47cb5a079e31fa3d147627f618baa595a404a016cc
a=ssrc:4109118841 cname:janusaudio
a=ssrc:4109118841 msid:janus janusa0
a=ssrc:4109118841 mslabel:janus
a=ssrc:4109118841 label:janusa0
a=candidate:4 1 udp 2013266431 81.23.228.146 44421 typ host
a=candidate:5 1 tcp 1019216383 81.23.228.146 0 typ host tcptype active
a=candidate:6 1 tcp 1015022079 81.23.228.146 49715 typ host tcptype passive
a=candidate:4 2 udp 2013266430 81.23.228.146 58350 typ host
a=candidate:5 2 tcp 1019216382 81.23.228.146 0 typ host tcptype active
a=candidate:6 2 tcp 1015022078 81.23.228.146 60323 typ host tcptype passive
~~~~