### PR TITLE
ice: fix enabling ICE Lite mode

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -2205,11 +2205,13 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 	handle->controlling = janus_ice_lite_enabled ? FALSE : !offer;
 	JANUS_LOG(LOG_INFO, "[%"SCNu64"] Creating ICE agent (ICE %s mode, %s)\n", handle->handle_id,
 		janus_ice_lite_enabled ? "Lite" : "Full", handle->controlling ? "controlling" : "controlled");
-	handle->agent = nice_agent_new(handle->icectx, NICE_COMPATIBILITY_DRAFT19);
+	handle->agent = g_object_new(NICE_TYPE_AGENT,
+		"compatibility", NICE_COMPATIBILITY_DRAFT19,
+		"main-context", handle->icectx,
+		"reliable", FALSE,
+		"full-mode", janus_ice_lite_enabled ? FALSE : TRUE,
+		NULL);
 	handle->agent_created = janus_get_monotonic_time();
-	if(janus_ice_lite_enabled) {
-		g_object_set(G_OBJECT(handle->agent), "full-mode", FALSE, NULL);
-	}
 	/* Any STUN server to use? */
 	if(janus_stun_server != NULL && janus_stun_port > 0) {
 		g_object_set(G_OBJECT(handle->agent),


### PR DESCRIPTION
'full-mode' is a constructor only property, setting it at runtime gives
the following warning and doesn't actually enable ICE Lite mode:

GLib-GObject-WARNING **: g_object_set_valist: construct property "full-mode" for object 'NiceAgent' can't be set after construction
libnice-DEBUG: Created NiceStream (1 created, 0 destroyed)
libnice-DEBUG: Created NiceComponent (1 created, 0 destroyed)
libnice-DEBUG: Created NiceComponent (2 created, 0 destroyed)
libnice-DEBUG: Agent 0xb2409000 : allocating stream id 1 (0xb2409e00)
libnice-DEBUG: Agent 0xb2409000 : In ICE-FULL mode, starting candidate gathering.