### PR TITLE
ICE 'enforce' list

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,12 +236,15 @@ or on the command line:
 	-k, --cert-key=filename       HTTPS/DTLS certificate key
 	-S, --stun-server=filename    STUN server(:port) to use, if needed (e.g., 
 								  gateway behind NAT, default=none)
+	-E, --ice-enforce-list=list   Comma-separated list of the only interfaces to
+                                  use for ICE gathering; partial strings are
+                                  supported (e.g., eth0 or eno1,wlan0,
+                                  default=none)
 	-X, --ice-ignore-list=list    Comma-separated list of interfaces or IP 
                                   addresses to ignore for ICE gathering; 
                                   partial strings are supported (e.g., 
                                   vmnet8,192.168.0.1,10.0.0.1 or 
                                   vmnet,192.168., default=vmnet)
-	-e, --public-ip=ipaddress     Public address of the machine, to use in SDP
 	-6, --ipv6-candidates         Whether to enable IPv6 candidates or not 
                                   (experimental)  (default=off)
 	-l, --libnice-debug           Whether to enable libnice debugging or not  

--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ or on the command line:
 	-k, --cert-key=filename       HTTPS/DTLS certificate key
 	-S, --stun-server=filename    STUN server(:port) to use, if needed (e.g., 
 								  gateway behind NAT, default=none)
+	-1, --nat-1-1=ip              Public IP to put in all host candidates,
+                                  assuming a 1:1 NAT is in place (e.g., Amazon
+                                  EC2 instances, default=none)
 	-E, --ice-enforce-list=list   Comma-separated list of the only interfaces to
                                   use for ICE gathering; partial strings are
                                   supported (e.g., eth0 or eno1,wlan0,

--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -128,7 +128,6 @@ cert_key = @certdir@/mycert.key
 ; be used for gathering candidates, and enable or disable the
 ; internal libnice debugging, if needed. 
 [nat]
-;public_ip = 1.2.3.4
 ;stun_server = stun.voip.eutelia.it
 ;stun_port = 3478
 nice_debug = false

--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -156,12 +156,14 @@ nice_debug = false
 ; You can also choose which interfaces should be explicitly used by the
 ; gateway for the purpose of ICE candidates gathering, thus excluding
 ; others that may be available. To do so, use the 'ice_enforce_list'
-; setting and pass it a comma-separated list of interfaces to enforce.
-; This is especially useful if the server hosting the gateway has several
-; interfaces, and you only want a subset to be used. Any of the following
-; examples are valid:
+; setting and pass it a comma-separated list of interfaces or IP addresses
+; to enforce. This is especially useful if the server hosting the gateway
+; has several interfaces, and you only want a subset to be used. Any of
+; the following examples are valid:
 ;     ice_enforce_list = eth0
 ;     ice_enforce_list = eth0,eth1
+;     ice_enforce_list = eth0,192.168.
+;     ice_enforce_list = eth0,192.168.0.1
 ; By default, no interface is enforced, meaning Janus will try to use them all.
 ;ice_enforce_list = eth0
 

--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -114,13 +114,9 @@ cert_key = @certdir@/mycert.key
 ;dtls_mtu = 1200
 
 
-; NAT-related stuff: specifically, you can either manually specify the 
-; public IP of the machine (i.e., what would be used in SDP) or
-; configure the STUN/TURN servers to use to gather candidates if the gateway
-; is behind a NAT, and srflx/relay candidates are needed. Please beware that
-; just blindly setting the public IP may break connectivity, especially
-; if Janus is installed behind a NAT: when unsure, just enable a STUN
-; server instead, which will take care of this automatically. In case
+; NAT-related stuff: specifically, you can configure the STUN/TURN
+; servers to use to gather candidates if the gateway is behind a NAT,
+; and srflx/relay candidates are needed. In case STUN is not enough and
 ; this is needed (it shouldn't), you can also configure Janus to use a
 ; TURN server; please notice that this does NOT refer to TURN usage in
 ; browsers, but in the gathering of relay candidates by Janus itself,
@@ -128,7 +124,8 @@ cert_key = @certdir@/mycert.key
 ; private machine. Furthermore, you can choose whether Janus should be
 ; configured to work in ICE-Lite mode (by default it doesn't). Finally,
 ; you can also enable ICE-TCP support (beware that it currently *only*
-; works if you enable ICE Lite as well) and enable or disable the
+; works if you enable ICE Lite as well), choose which interfaces should
+; be used for gathering candidates, and enable or disable the
 ; internal libnice debugging, if needed. 
 [nat]
 ;public_ip = 1.2.3.4
@@ -157,17 +154,34 @@ nice_debug = false
 ;turn_rest_api = http://yourbackend.com/path/to/api
 ;turn_rest_api_key = anyapikeyyoumayhaveset
 
-; You can also choose which interfaces or IP addresses should be excluded
-; and ignored by the gateway for the purpose of ICE candidates gathering.
-; To do so, use the 'ice_ignore_list' setting and pass it a comma-separated
-; list of interfaces or IP addresses to ignore. This is especially useful
-; if the server hosting the gateway has several interfaces you already
-; know will not be used or will simply always slow down ICE (e.g., virtual
-; interfaces created by VMware). Partial strings are supported, which
-; means that any of the following examples are valid:
+; You can also choose which interfaces should be explicitly used by the
+; gateway for the purpose of ICE candidates gathering, thus excluding
+; others that may be available. To do so, use the 'ice_enforce_list'
+; setting and pass it a comma-separated list of interfaces to enforce.
+; This is especially useful if the server hosting the gateway has several
+; interfaces, and you only want a subset to be used. Any of the following
+; examples are valid:
+;     ice_enforce_list = eth0
+;     ice_enforce_list = eth0,eth1
+; By default, no interface is enforced, meaning Janus will try to use them all.
+;ice_enforce_list = eth0
+
+; In case you don't want to specify specific interfaces to use, but would
+; rather tell Janus to use all the available interfaces except some that
+; you don't want to involve, you can also choose which interfaces or IP
+; addresses should be excluded and ignored by the gateway for the purpose
+; of ICE candidates gathering. To do so, use the 'ice_ignore_list' setting
+; and pass it a comma-separated list of interfaces or IP addresses to
+; ignore. This is especially useful if the server hosting the gateway
+; has several interfaces you already know will not be used or will simply
+; always slow down ICE (e.g., virtual interfaces created by VMware).
+; Partial strings are supported, which means that any of the following
+; examples are valid:
 ;     ice_ignore_list = vmnet8,192.168.0.1,10.0.0.1
 ;     ice_ignore_list = vmnet,192.168.
-; By default, we ignore all interfaces whose name starts with 'vmnet':
+; Just beware that the ICE ignore list is not used if an enforce list
+; has been configured. By default, Janus ignores all interfaces whose
+; name starts with 'vmnet', to skip VMware interfaces:
 ice_ignore_list = vmnet
 
 ; Finally, you can choose which of the available plugins should be

--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -134,6 +134,14 @@ nice_debug = false
 ;ice_lite = true
 ;ice_tcp = true
 
+; In case you're deploying Janus on a server which is configured with
+; a 1:1 NAT (e.g., Amazon EC2), you might want to also specify the public
+; address of the machine using the setting below. This will result in
+; all host candidates (which normally have a private IP address) to
+; be rewritten with the public address provided in the settings. As
+; such, use the option with caution and only if you know what you're doing.
+;nat_1_1_mapping = 1.2.3.4
+
 ; You can configure a TURN server in two different ways: specifying a
 ; statically configured TURN server, and thus provide the address of the
 ; TURN server, the transport (udp/tcp/tls) to use, and a set of valid

--- a/ice.c
+++ b/ice.c
@@ -134,6 +134,12 @@ void janus_ice_debugging_disable(void) {
 }
 
 
+/* NAT 1:1 stuff */
+static gboolean nat_1_1_enabled = FALSE;
+void janus_ice_enable_nat_1_1(void) {
+	nat_1_1_enabled = TRUE;
+}
+
 /* Interface/IP enforce/ignore lists */
 GList *janus_ice_enforce_list = NULL, *janus_ice_ignore_list = NULL;
 janus_mutex ice_list_mutex;
@@ -1826,6 +1832,11 @@ void janus_ice_candidates_to_sdp(janus_ice_handle *handle, char *sdp, guint stre
 	NiceAgent* agent = handle->agent;
 	/* adding a stream should cause host candidates to be generated */
 	char *host_ip = NULL;
+	if(nat_1_1_enabled) {
+		/* A 1:1 NAT mapping was specified, overwrite all the host addresses with the public IP */
+		host_ip = janus_get_public_ip();
+		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Public IP specified and 1:1 NAT mapping enabled (%s), using that as host address in the candidates\n", handle->handle_id, host_ip);
+	}
 	GSList *candidates, *i;
 	candidates = nice_agent_get_local_candidates (agent, stream_id, component_id);
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] We have %d candidates for Stream #%d, Component #%d\n", handle->handle_id, g_slist_length(candidates), stream_id, component_id);

--- a/ice.h
+++ b/ice.h
@@ -70,6 +70,8 @@ uint16_t janus_ice_get_turn_port(void);
 /*! \brief Method to get the specified TURN REST API backend, if any
  * @returns The currently specified  TURN REST API backend, if available, or NULL if not */
 char *janus_ice_get_turn_rest_api(void);
+/*! \brief Helper method to force Janus to overwrite all host candidates with the public IP */
+void janus_ice_enable_nat_1_1(void);
 /*! \brief Method to add an interface/IP to the enforce list for ICE (that is, only gather candidates from these and ignore the others)
  * \note This method is especially useful to speed up the ICE gathering process on the gateway: in fact,
  * if you know in advance which interface must be used (e.g., the main interface connected to the internet),

--- a/ice.h
+++ b/ice.h
@@ -70,11 +70,25 @@ uint16_t janus_ice_get_turn_port(void);
 /*! \brief Method to get the specified TURN REST API backend, if any
  * @returns The currently specified  TURN REST API backend, if available, or NULL if not */
 char *janus_ice_get_turn_rest_api(void);
+/*! \brief Method to add an interface to the enforce list for ICE (that is, only gather candidates from these and ignore the others)
+ * \note This method is especially useful to speed up the ICE gathering process on the gateway: in fact,
+ * if you know in advance which interface must be used (e.g., the main interface connected to the internet),
+ * adding it to the enforce list will prevent libnice from gathering candidates from other interfaces.
+ * Do \b NOT add IP addresses here: the enforce list only accepts interfaces.
+ * If you're interested in excluding interfaces explicitly, instead, check janus_ice_ignore_interface.
+ * @param[in] interface Interface to enforce (e.g., eth0) */
+void janus_ice_enforce_interface(const char *interface);
+/*! \brief Method to check whether an interface is currently in the enforce list for ICE (that is, won't have candidates)
+ * @param[in] interface Interface to check (e.g., eth1)
+ * @returns true if the interface/IP is in the enforce list, false otherwise */
+gboolean janus_ice_is_enforced(const char *interface);
 /*! \brief Method to add an interface/IP to the ignore list for ICE (that is, don't gather candidates)
  * \note This method is especially useful to speed up the ICE gathering process on the gateway: in fact,
  * if you know in advance an interface is not going to be used (e.g., one of those created by VMware),
  * adding it to the ignore list will prevent libnice from gathering a candidate for it.
- * @param[in] ip Interface/IP to ignore (e.g., 192.168.244.1 or eth1) */
+ * Unlike the enforce list, the ignore list also accepts IP addresses, partial or complete.
+ * If you're interested in only using specific interfaces, instead, check janus_ice_enforce_interface.
+ * @param[in] ip Interface/IP to ignore (e.g., 192.168. or eth1) */
 void janus_ice_ignore_interface(const char *ip);
 /*! \brief Method to check whether an interface/IP is currently in the ignore list for ICE (that is, won't have candidates)
  * @param[in] ip Interface/IP to check (e.g., 192.168.244.1 or eth1)

--- a/ice.h
+++ b/ice.h
@@ -70,18 +70,17 @@ uint16_t janus_ice_get_turn_port(void);
 /*! \brief Method to get the specified TURN REST API backend, if any
  * @returns The currently specified  TURN REST API backend, if available, or NULL if not */
 char *janus_ice_get_turn_rest_api(void);
-/*! \brief Method to add an interface to the enforce list for ICE (that is, only gather candidates from these and ignore the others)
+/*! \brief Method to add an interface/IP to the enforce list for ICE (that is, only gather candidates from these and ignore the others)
  * \note This method is especially useful to speed up the ICE gathering process on the gateway: in fact,
  * if you know in advance which interface must be used (e.g., the main interface connected to the internet),
  * adding it to the enforce list will prevent libnice from gathering candidates from other interfaces.
- * Do \b NOT add IP addresses here: the enforce list only accepts interfaces.
  * If you're interested in excluding interfaces explicitly, instead, check janus_ice_ignore_interface.
- * @param[in] interface Interface to enforce (e.g., eth0) */
-void janus_ice_enforce_interface(const char *interface);
+ * @param[in] ip Interface/IP to enforce (e.g., 192.168. or eth0) */
+void janus_ice_enforce_interface(const char *ip);
 /*! \brief Method to check whether an interface is currently in the enforce list for ICE (that is, won't have candidates)
- * @param[in] interface Interface to check (e.g., eth1)
+ * @param[in] ip Interface/IP to check (e.g., 192.168.244.1 or eth1)
  * @returns true if the interface/IP is in the enforce list, false otherwise */
-gboolean janus_ice_is_enforced(const char *interface);
+gboolean janus_ice_is_enforced(const char *ip);
 /*! \brief Method to add an interface/IP to the ignore list for ICE (that is, don't gather candidates)
  * \note This method is especially useful to speed up the ICE gathering process on the gateway: in fact,
  * if you know in advance an interface is not going to be used (e.g., one of those created by VMware),

--- a/janus.c
+++ b/janus.c
@@ -4195,6 +4195,9 @@ gint main(int argc, char *argv[])
 			janus_config_add_item(config, "nat", "stun_port", "3478");
 		}
 	}
+	if(args_info.nat_1_1_given) {
+		janus_config_add_item(config, "nat", "nat_1_1_mapping", args_info.nat_1_1_arg);
+	}
 	if(args_info.ice_enforce_list_given) {
 		janus_config_add_item(config, "nat", "ice_enforce_list", args_info.ice_enforce_list_arg);
 	}
@@ -4434,6 +4437,12 @@ gint main(int argc, char *argv[])
 	item = janus_config_get_item_drilldown(config, "nat", "stun_port");
 	if(item && item->value)
 		stun_port = atoi(item->value);
+	/* Any 1:1 NAT mapping to take into account? */
+	item = janus_config_get_item_drilldown(config, "nat", "nat_1_1_mapping");
+	if(item && item->value) {
+		janus_set_public_ip(item->value);
+		janus_ice_enable_nat_1_1();
+	}
 	/* Any TURN server to use in Janus? */
 	item = janus_config_get_item_drilldown(config, "nat", "turn_server");
 	if(item && item->value)

--- a/janus.c
+++ b/janus.c
@@ -146,6 +146,29 @@ gchar *janus_get_server_key(void) {
 }
 
 
+/* IP addresses */
+static gchar local_ip[INET6_ADDRSTRLEN];
+gchar *janus_get_local_ip(void) {
+	return local_ip;
+}
+static gchar *public_ip = NULL;
+gchar *janus_get_public_ip(void) {
+	/* Fallback to the local IP, if we have no public one */
+	return public_ip ? public_ip : local_ip;
+}
+void janus_set_public_ip(const char *ip) {
+	if(ip == NULL)
+		return;
+	if(public_ip != NULL)
+		g_free(public_ip);
+	public_ip = g_strdup(ip);
+}
+static volatile gint stop = 0;
+gint janus_is_stopping(void) {
+	return g_atomic_int_get(&stop);
+}
+
+
 /* Information */
 char *janus_info(const char *transaction);
 char *janus_info(const char *transaction) {
@@ -173,6 +196,9 @@ char *janus_info(const char *transaction) {
 #else
 	json_object_set_new(info, "rabbitmq", json_string("false"));
 #endif
+	json_object_set_new(info, "local-ip", json_string(local_ip));
+	if(public_ip != NULL)
+		json_object_set_new(info, "public-ip", json_string(public_ip));
 	json_object_set_new(info, "ipv6", json_string(janus_ice_is_ipv6_enabled() ? "true" : "false"));
 	json_object_set_new(info, "ice-tcp", json_string(janus_ice_is_ice_tcp_enabled() ? "true" : "false"));
 	if(janus_ice_get_stun_server() != NULL) {
@@ -210,27 +236,6 @@ char *janus_info(const char *transaction) {
 	json_decref(info);
 	
 	return info_text;
-}
-
-static gchar local_ip[INET6_ADDRSTRLEN];
-gchar *janus_get_local_ip(void) {
-	return local_ip;
-}
-static gchar *public_ip = NULL;
-gchar *janus_get_public_ip(void) {
-	/* Fallback to the local IP, if we have no public one */
-	return public_ip ? public_ip : local_ip;
-}
-void janus_set_public_ip(const char *ip) {
-	if(ip == NULL)
-		return;
-	if(public_ip != NULL)
-		g_free(public_ip);
-	public_ip = g_strdup(ip);
-}
-static volatile gint stop = 0;
-gint janus_is_stopping(void) {
-	return g_atomic_int_get(&stop);
 }
 
 
@@ -4159,8 +4164,8 @@ gint main(int argc, char *argv[])
 			janus_config_add_item(config, "nat", "stun_port", "3478");
 		}
 	}
-	if(args_info.public_ip_given) {
-		janus_config_add_item(config, "nat", "public_ip", args_info.public_ip_arg);
+	if(args_info.ice_enforce_list_given) {
+		janus_config_add_item(config, "nat", "ice_enforce_list", args_info.ice_enforce_list_arg);
 	}
 	if(args_info.ice_ignore_list_given) {
 		janus_config_add_item(config, "nat", "ice_ignore_list", args_info.ice_ignore_list_arg);
@@ -4204,7 +4209,25 @@ gint main(int argc, char *argv[])
 		janus_log_colors = janus_is_true(item->value);
 	JANUS_PRINT("Debug/log colors are %s\n", janus_log_colors ? "enabled" : "disabled");
 
-	/* Any IP/interface to ignore? */
+	/* Any IP/interface to enforce/ignore? */
+	item = janus_config_get_item_drilldown(config, "nat", "ice_enforce_list");
+	if(item && item->value) {
+		gchar **list = g_strsplit(item->value, ",", -1);
+		gchar *index = list[0];
+		if(index != NULL) {
+			int i=0;
+			while(index != NULL) {
+				if(strlen(index) > 0) {
+					JANUS_LOG(LOG_INFO, "Adding '%s' to the ICE enforce list...\n", index);
+					janus_ice_enforce_interface(g_strdup(index));
+				}
+				i++;
+				index = list[i];
+			}
+		}
+		g_strfreev(list);
+		list = NULL;
+	}
 	item = janus_config_get_item_drilldown(config, "nat", "ice_ignore_list");
 	if(item && item->value) {
 		gchar **list = g_strsplit(item->value, ",", -1);
@@ -4469,19 +4492,6 @@ gint main(int argc, char *argv[])
 		}
 	}
 
-	/* Is there a public_ip value to be used for NAT traversal instead? */
-	item = janus_config_get_item_drilldown(config, "nat", "public_ip");
-	if(item && item->value) {
-		if(public_ip != NULL)
-			g_free(public_ip);
-		public_ip = g_strdup((char *)item->value);
-		if(public_ip == NULL) {
-			JANUS_LOG(LOG_FATAL, "Memory error\n");
-			exit(1);
-		}
-		JANUS_LOG(LOG_INFO, "Using %s as our public IP in SDP\n", public_ip);
-	}
-	
 	/* Setup OpenSSL stuff */
 	item = janus_config_get_item_drilldown(config, "certificates", "cert_pem");
 	if(!item || !item->value) {

--- a/janus.ggo
+++ b/janus.ggo
@@ -18,6 +18,7 @@ option "configs-folder" F "Configuration files folder (default=./conf)" string t
 option "cert-pem" c "HTTPS/DTLS certificate" string typestr="filename" optional
 option "cert-key" k "HTTPS/DTLS certificate key" string typestr="filename" optional
 option "stun-server" S "STUN server(:port) to use, if needed (e.g., gateway behind NAT, default=none)" string typestr="ip:port" optional
+option "nat-1-1" 1 "Public IP to put in all host candidates, assuming a 1:1 NAT is in place (e.g., Amazon EC2 instances, default=none)" string typestr="ip" optional
 option "ice-enforce-list" E "Comma-separated list of the only interfaces to use for ICE gathering; partial strings are supported (e.g., eth0 or eno1,wlan0, default=none)" string typestr="list" optional
 option "ice-ignore-list" X "Comma-separated list of interfaces or IP addresses to ignore for ICE gathering; partial strings are supported (e.g., vmnet8,192.168.0.1,10.0.0.1 or vmnet,192.168., default=vmnet)" string typestr="list" optional
 option "ipv6-candidates" 6 "Whether to enable IPv6 candidates or not (experimental)" flag off

--- a/janus.ggo
+++ b/janus.ggo
@@ -18,8 +18,8 @@ option "configs-folder" F "Configuration files folder (default=./conf)" string t
 option "cert-pem" c "HTTPS/DTLS certificate" string typestr="filename" optional
 option "cert-key" k "HTTPS/DTLS certificate key" string typestr="filename" optional
 option "stun-server" S "STUN server(:port) to use, if needed (e.g., gateway behind NAT, default=none)" string typestr="ip:port" optional
+option "ice-enforce-list" E "Comma-separated list of the only interfaces to use for ICE gathering; partial strings are supported (e.g., eth0 or eno1,wlan0, default=none)" string typestr="list" optional
 option "ice-ignore-list" X "Comma-separated list of interfaces or IP addresses to ignore for ICE gathering; partial strings are supported (e.g., vmnet8,192.168.0.1,10.0.0.1 or vmnet,192.168., default=vmnet)" string typestr="list" optional
-option "public-ip" e "Public address of the machine, to use in SDP" string typestr="ipaddress" optional
 option "ipv6-candidates" 6 "Whether to enable IPv6 candidates or not (experimental)" flag off
 option "libnice-debug" l "Whether to enable libnice debugging or not" flag off
 option "ice-lite" I "Whether to enable the ICE Lite mode or not" flag off

--- a/sdp.c
+++ b/sdp.c
@@ -758,16 +758,17 @@ char *janus_sdp_merge(janus_ice_handle *handle, const char *origsdp) {
 	/* Origin o= */
 	if(anon->sdp_origin) {
 		g_snprintf(buffer, 512,
-			"o=%s %"SCNu64" %"SCNu64" IN IP4 127.0.0.1\r\n",	/* FIXME Should we fix the address? */
+			"o=%s %"SCNu64" %"SCNu64" IN IP4 %s\r\n",
 				anon->sdp_origin->o_username ? anon->sdp_origin->o_username : "-",
-				anon->sdp_origin->o_id, anon->sdp_origin->o_version);
+				anon->sdp_origin->o_id, anon->sdp_origin->o_version,
+				janus_get_public_ip());
 		g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 	} else {
 		gint64 sessid = janus_get_monotonic_time();
 		gint64 version = sessid;	/* FIXME This needs to be increased when it changes, so time should be ok */
 		g_snprintf(buffer, 512,
-			"o=%s %"SCNi64" %"SCNi64" IN IP4 127.0.0.1\r\n",	/* FIXME Should we fix the address? */
-				"-", sessid, version);
+			"o=%s %"SCNi64" %"SCNi64" IN IP4 %s\r\n",
+				"-", sessid, version, janus_get_public_ip());
 		g_strlcat(sdp, buffer, JANUS_BUFSIZE);
 	}
 	/* Session name s= */


### PR DESCRIPTION
Added new ICE 'enforce' list, to specify the only interfaces to use for gathering candidates, to address the point made in #335 by @saghul.

This acts as a complementary feature to the existing ICE 'ignore' list, over which it takes precedence. While the ignore list allowed you to specify partial/full IP addresses or interface names to ignore for the purpose of ICE gathering, this new enforce list allows you to tell Janus which are the only interfaces you want to be used for that. As such, it only accepts interface names and not IP addresses, partial or not: if an enforce list is provided and an interface name is not listed, the interface is NOT used for any ICE candidate. When the enforce list is active, the ignore list is (no pun intended) ignored.

This patch also removes the old (and useless) ```-e``` flag to set the public IP. Now the public IP is automatically set to either the autodetected local IP address, or whatever STUN gave us back if configured. The public IP is then only used in some parts of the SDP, but not for candidates.

Seems to be working fine here, feedback welcome!