### PR TITLE
Add optional BoringSSL support via configure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -108,9 +108,11 @@ janus_CFLAGS = \
 	$(JANUS_CFLAGS) \
 	-DPLUGINDIR=\"$(plugindir)\" \
 	-DCONFDIR=\"$(confdir)\" \
+	$(BORINGSSL_CFLAGS) \
 	$(NULL)
 
 janus_LDADD = \
+	$(BORINGSSL_LIBS) \
 	$(JANUS_LIBS) \
 	$(JANUS_MANUAL_LIBS) \
 	-lsrtp \

--- a/README.md
+++ b/README.md
@@ -79,6 +79,37 @@ is quite straightforward:
 * *Note:* you may need to pass --libdir=/usr/lib64 to the configure
 script if you're installing on a x86_64 distribution.
 
+If you want to make use of BoringSSL instead of OpenSSL for any reason
+(read [here](https://github.com/meetecho/janus-gateway/issues/136) for
+some background on this), you'll have to manually install a specific
+version of the library to a specific location. Use the following steps:
+
+	git clone https://boringssl.googlesource.com/boringssl
+	cd boringssl
+	# We need a specific revision
+	git fetch origin 12fe1b25ead258858309d22ffa9e1f9a316358d7
+	# Don't barf on errors
+	sed -i s/" -Werror"//g CMakeLists.txt
+	# Build
+	mkdir -p build
+	cd build
+	cmake -DCMAKE_CXX_FLAGS="-lrt" ..
+	make
+	cd ..
+	# Install
+	sudo mkdir -p /opt/boringssl
+	sudo cp -R include /opt/boringssl/
+	sudo mkdir -p /opt/boringssl/lib
+	sudo cp build/ssl/libssl.a /opt/boringssl/lib/
+	sudo cp build/crypto/libcrypto.a /opt/boringssl/lib/
+
+Once the library is installed, you'll have to pass an additional
+```--enable-boringssl``` flag to the configure script, as by default
+Janus will be build assuming OpenSSL will be used. If you were using
+OpenSSL and want to switch to BoringSSL, make sure you also do a
+```make clean``` in the Janus folder before compiling with the new
+BoringSSL support.
+
 For what concerns usrsctp, which is needed for Data Channels support, it
 is usually not available in repositories, so if you're interested in
 them (support is optional) you'll have to install it manually. It is a

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ version of the library to a specific location. Use the following steps:
 	git clone https://boringssl.googlesource.com/boringssl
 	cd boringssl
 	# We need a specific revision
-	git fetch origin 12fe1b25ead258858309d22ffa9e1f9a316358d7
+	git checkout 12fe1b25ead258858309d22ffa9e1f9a316358d7
 	# Don't barf on errors
 	sed -i s/" -Werror"//g CMakeLists.txt
 	# Build

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,12 @@ AC_ARG_ENABLE([rabbitmq],
               [],
               [enable_rabbitmq=yes])
 
+AC_ARG_ENABLE([boringssl],
+              [AS_HELP_STRING([--enable-boringssl],
+                              [Use BoringSSL instead of OpenSSL])],
+              [],
+              [enable_boringssl=no])
+
 AC_ARG_ENABLE([turn-rest-api],
               [AS_HELP_STRING([--disable-turn-rest-api],
                               [Disable TURN REST API client (via libcurl)])],
@@ -74,8 +80,20 @@ PKG_CHECK_MODULES([JANUS],
                     sofia-sip-ua
                     ini_config
                   ])
-
 AC_SUBST(JANUS_MANUAL_LIBS)
+
+AS_IF([test "x$enable_boringssl" = "xyes"],
+	  [echo "Trying to use BoringSSL instead of OpenSSL...";
+	   CFLAGS="$CFLAGS -I/opt/boringssl/include";
+	   BORINGSSL_CFLAGS=" -I/opt/boringssl/include";
+       AC_SUBST(BORINGSSL_CFLAGS)
+	   BORINGSSL_LIBS=" -L/opt/boringssl/lib";
+       AC_SUBST(BORINGSSL_LIBS)
+	   AC_CHECK_HEADERS([openssl/opensslfeatures.h],
+	                    [],
+	                    [AC_MSG_ERROR([BoringSSL headers not found in /opt/boringssl, use --disable-boringssl if you want to use OpenSSL instead])])
+      ])
+AM_CONDITIONAL([ENABLE_BORINGSSL], [test "x$enable_boringssl" = "xyes"])
 
 AC_CHECK_LIB([nice],
              [nice_agent_set_port_range],
@@ -328,6 +346,9 @@ AM_COND_IF([ENABLE_WEBSOCKETS],
 AM_COND_IF([ENABLE_SCTP],
 	[echo "DataChannels support:      yes"],
 	[echo "DataChannels support:      no"])
+AM_COND_IF([ENABLE_BORINGSSL],
+	[echo "BoringSSL (no OpenSSL):    yes"],
+	[echo "BoringSSL (no OpenSSL):    no"])
 AM_COND_IF([ENABLE_POST_PROCESSING],
 	[echo "Recordings post-processor: yes"],
 	[echo "Recordings post-processor: no"])


### PR DESCRIPTION
This pull request adds optional BoringSSL support via a new flag in the configure script, ```--enable-boringssl```. If enabled, it looks for BoringSSL in a specific folder and updates the Makefile accordingly to make use of it.

The README has also been updated with instructions on how to build BoringSSL, partly derived from info gathered on #136 and partly coming from what I needed to get it working.

Feedback welcome on whether this is indeed working for everybody.