### PR TITLE
sip: fix handling subsequent incoming calls

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1738,6 +1738,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			if(callstate == nua_callstate_terminated &&
 					(session->stack->s_nh_i == nh || session->stack->s_nh_i == NULL)) {
 				session->status = janus_sip_call_status_idle;
+				session->stack->s_nh_i = NULL;
 				json_t *call = json_object();
 				json_object_set_new(call, "sip", json_string("event"));
 				json_t *calling = json_object();


### PR DESCRIPTION
In 1cefe04 yours truly relied on the fact that the Sofia handle would be
reset after each call terminates. Turns out I was wrong. This patch
fixes that by null-ing the handle once the call is terminated. This is
generally a good practice since the handle is dead anyway, but more
importantly, it makes the logic work properly.