### PR TITLE
sip: fix SDP parser leak when handling reinvites

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1808,8 +1808,8 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 					int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, missed_text, NULL, NULL);
 					JANUS_LOG(LOG_VERB, "  >> %d (%s)\n", ret, janus_get_api_error(ret));
 					g_free(missed_text);
-					sdp_parser_free(parser);
 				}
+				sdp_parser_free(parser);
 				break;
 			}
 			/* New incoming call */


### PR DESCRIPTION
Thanks @MichaelB76 for noticing.