### PR TITLE
off by one buffer overflow

### DIFF
--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -202,7 +202,7 @@ static void janus_http_random_string(int length, char *buffer) {
 			int key = rand() % l;
 			buffer[i] = charset[key];
 		}
-		buffer[length] = '\0';
+		buffer[length-1] = '\0';
 	}
 }
 


### PR DESCRIPTION
Found this off by one bug using address sanitizer.
You may want to check the callers of janus_http_random_string to make sure that the string is long enough e.g. if you want 12 chars you need to provide a 13 char array because of the null termination. 
