### PR TITLE
Enhancement: also report display-name of caller when present.

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1850,6 +1850,9 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			json_t *calling = json_object();
 			json_object_set_new(calling, "event", json_string("incomingcall"));
 			json_object_set_new(calling, "username", json_string(session->callee));
+			if (sip->sip_from->a_display) {
+				json_object_set_new(calling, "displayname", json_string(sip->sip_from->a_display));
+			}
 			json_object_set_new(call, "result", calling);
 			char *call_text = json_dumps(call, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
 			json_decref(call);

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1850,7 +1850,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			json_t *calling = json_object();
 			json_object_set_new(calling, "event", json_string("incomingcall"));
 			json_object_set_new(calling, "username", json_string(session->callee));
-			if (sip->sip_from->a_display) {
+			if (sip->sip_from && sip->sip_from->a_display) {
 				json_object_set_new(calling, "displayname", json_string(sip->sip_from->a_display));
 			}
 			json_object_set_new(call, "result", calling);


### PR DESCRIPTION
With this change, a client can also show the display name of who is calling (json will also contain a `displayname` of the caller when present in the `INVITE`).

Please review and commit.

TIA,
Tom.