### PR TITLE
Enforce trickle after offer/answer

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -18,6 +18,7 @@
 #include <net/if.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <fcntl.h>
 #include <stun/usages/bind.h>
 #include <nice/debug.h>
 
@@ -98,9 +99,53 @@ gboolean janus_ice_is_bundle_forced(void) {
 
 /* Whether rtcp-mux support is mandatory or not (false by default) */
 static gboolean janus_force_rtcpmux;
+static gint janus_force_rtcpmux_blackhole_port = 1234;
+static gint janus_force_rtcpmux_blackhole_fd = -1;
 void janus_ice_force_rtcpmux(gboolean forced) {
 	janus_force_rtcpmux = forced;
 	JANUS_LOG(LOG_INFO, "rtcp-mux %s going to be forced\n", janus_force_rtcpmux ? "is" : "is NOT");
+	if(!janus_force_rtcpmux) {
+		/*
+		 * Since rtcp-mux is NOT going to be forced, we need to do some magic to get rid of unneeded
+		 * RTCP components when rtcp-mux is indeed negotiated when creating a PeerConnection. In
+		 * particular, there's no way to remove a component in libnice (you can only remove streams),
+		 * and you can read why this is a problem here:
+		 * 		https://github.com/meetecho/janus-gateway/issues/154
+		 * 		https://github.com/meetecho/janus-gateway/pull/362
+		 * This means that, to effectively do that without just ignoring the component, we need
+		 * to set a dummy candidate on it to "trick" libnice into thinking ICE is done for it.
+		 * Since libnice will still occasionally send keepalives to the dummy peer, and we don't
+		 * want it to send messages to a service that might not like it, we create a "blackhole"
+		 * UDP server to receive all those keepalives and then just discard them.
+		 */
+		int blackhole = socket(AF_INET, SOCK_DGRAM, 0);
+		if(blackhole < 0) {
+			JANUS_LOG(LOG_WARN, "Error creating RTCP component blackhole socket, using port %d instead\n", janus_force_rtcpmux_blackhole_port);
+			return;
+		}
+		int yes = 1;
+		setsockopt(blackhole, SOL_SOCKET, SO_REUSEADDR, (const void *)&yes , sizeof(int));
+		fcntl(blackhole, F_SETFL, O_NONBLOCK);
+		struct sockaddr_in serveraddr;
+		serveraddr.sin_family = AF_INET;
+		serveraddr.sin_addr.s_addr = htonl(INADDR_ANY);
+		serveraddr.sin_port = htons(0);		/* Choose a random port, that works for us */
+		if(bind(blackhole, (struct sockaddr *)&serveraddr, sizeof(serveraddr)) < 0) {
+			JANUS_LOG(LOG_WARN, "Error binding RTCP component blackhole socket, using port %d instead\n", janus_force_rtcpmux_blackhole_port);
+			return;
+		}
+		socklen_t len = sizeof(serveraddr);
+		if(getsockname(blackhole, (struct sockaddr *)&serveraddr, &len) < 0) {
+			JANUS_LOG(LOG_WARN, "Error retrieving port assigned to RTCP component blackhole socket, using port %d instead\n", janus_force_rtcpmux_blackhole_port);
+			return;
+		}
+		janus_force_rtcpmux_blackhole_port = ntohs(serveraddr.sin_port);
+		JANUS_LOG(LOG_VERB, "  -- RTCP component blackhole socket bound to port %d\n", janus_force_rtcpmux_blackhole_port);
+		janus_force_rtcpmux_blackhole_fd = blackhole;
+	}
+}
+gint janus_ice_get_rtcpmux_blackhole_port(void) {
+	return janus_force_rtcpmux_blackhole_port;
 }
 gboolean janus_ice_is_rtcpmux_forced(void) {
 	return janus_force_rtcpmux;
@@ -338,6 +383,18 @@ static gboolean janus_ice_handles_check(gpointer user_data) {
 		}
 	}
 	janus_mutex_unlock(&old_handles_mutex);
+
+	if(janus_force_rtcpmux_blackhole_fd > 0) {
+		/* Also read the blackhole socket (unneeded RTCP components keepalives) and dump the packets */
+		char buffer[1500];
+		struct sockaddr_storage addr;
+		socklen_t len = sizeof(addr);
+		ssize_t res = 0;
+		do {
+			/* Read and ignore */
+			res = recvfrom(janus_force_rtcpmux_blackhole_fd, buffer, sizeof(buffer), 0, (struct sockaddr*)&addr, &len);
+		} while(res > -1);
+	}
 
 	return G_SOURCE_CONTINUE;
 }

--- a/ice.c
+++ b/ice.c
@@ -100,7 +100,7 @@ gboolean janus_ice_is_bundle_forced(void) {
 /* Whether rtcp-mux support is mandatory or not (false by default) */
 static gboolean janus_force_rtcpmux;
 static gint janus_force_rtcpmux_blackhole_port = 1234;
-static gint janus_force_rtcpmux_blackhole_fd = -1;
+static gint janus_force_rtcpmux_blackhole_fd = 0;
 void janus_ice_force_rtcpmux(gboolean forced) {
 	janus_force_rtcpmux = forced;
 	JANUS_LOG(LOG_INFO, "rtcp-mux %s going to be forced\n", janus_force_rtcpmux ? "is" : "is NOT");
@@ -1399,9 +1399,9 @@ void janus_ice_cb_new_selected_pair (NiceAgent *agent, guint stream_id, guint co
 		return;
 	}
 #ifndef HAVE_LIBNICE_TCP
-	JANUS_LOG(LOG_VERB, "[%"SCNu64"] New selected pair for component %d in stream %d: %s <-> %s\n", handle->handle_id, component_id, stream_id, local, remote);
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"] New selected pair for component %d in stream %d: %s <-> %s\n", handle ? handle->handle_id : 0, component_id, stream_id, local, remote);
 #else
-	JANUS_LOG(LOG_VERB, "[%"SCNu64"] New selected pair for component %d in stream %d: %s <-> %s\n", handle->handle_id, component_id, stream_id, local->foundation, remote->foundation);
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"] New selected pair for component %d in stream %d: %s <-> %s\n", handle ? handle->handle_id : 0, component_id, stream_id, local->foundation, remote->foundation);
 #endif
 	janus_ice_stream *stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(stream_id));
 	if(!stream) {

--- a/ice.h
+++ b/ice.h
@@ -116,6 +116,9 @@ gboolean janus_ice_is_rtcpmux_forced(void);
 /*! \brief Method to set the rtcp-mux support mode (true means mandatory, false means optional)
  * @param forced whether rtcp-mux support must be forced or not (default is false) */
 void janus_ice_force_rtcpmux(gboolean forced);
+/*! \brief Method to get the port that has been assigned for the RTCP component blackhole in case of rtcp-mux
+ * @returns The blackhole port */
+gint janus_ice_get_rtcpmux_blackhole_port(void);
 /*! \brief Method to modify the max NACK value (i.e., the number of packets per handle to store for retransmissions)
  * @param[in] mnq The new max NACK value */
 void janus_set_max_nack_queue(uint mnq);

--- a/janus.c
+++ b/janus.c
@@ -1779,7 +1779,7 @@ int janus_process_incoming_request(janus_request_source *source, json_t *root) {
 				cause = "waiting for the answer";
 			else if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_GOT_OFFER))
 				cause = "waiting for the offer";
-			JANUS_LOG(LOG_WARN, "[%"SCNu64"] Still %s, queueing this trickle to wait until we're done there...\n",
+			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Still %s, queueing this trickle to wait until we're done there...\n",
 				handle->handle_id, cause);
 			/* Enqueue this trickle candidate(s), we'll process this later */
 			janus_ice_trickle *early_trickle = janus_ice_trickle_new(handle, transaction_text, candidate ? candidate : candidates);

--- a/janus.c
+++ b/janus.c
@@ -1513,13 +1513,49 @@ int janus_process_incoming_request(janus_request_source *source, json_t *root) {
 						JANUS_LOG(LOG_HUGE, "[%"SCNu64"]   -- rtcp-mux is supported by the browser, getting rid of RTCP components, if any...\n", handle->handle_id);
 						if(handle->audio_stream && handle->audio_stream->components != NULL) {
 							nice_agent_attach_recv(handle->agent, handle->audio_id, 2, g_main_loop_get_context (handle->iceloop), NULL, NULL);
+							/* Free the component */
 							janus_ice_component_free(handle->audio_stream->components, handle->audio_stream->rtcp_component);
 							handle->audio_stream->rtcp_component = NULL;
+							/* Create a dummy candidate and enforce it as the one to use for this now unneeded component */
+							NiceCandidate *c = nice_candidate_new(NICE_CANDIDATE_TYPE_HOST);
+							c->component_id = 2;
+							c->stream_id = handle->audio_stream->stream_id;
+#ifndef HAVE_LIBNICE_TCP
+							c->transport = NICE_CANDIDATE_TRANSPORT_UDP;
+#endif
+							strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
+							c->priority = 1;
+							nice_address_set_from_string(&c->addr, "1.2.3.4");
+							nice_address_set_port(&c->addr, 1234);
+							c->username = g_strdup(handle->audio_stream->ruser);
+							c->password = g_strdup(handle->audio_stream->rpass);
+							if(!nice_agent_set_selected_remote_candidate(handle->agent, handle->audio_stream->stream_id, 2, c)) {
+								JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error forcing dummy candidate on RTCP component of stream %d\n", handle->handle_id, handle->audio_stream->stream_id);
+								nice_candidate_free(c);
+							}
 						}
 						if(handle->video_stream && handle->video_stream->components != NULL) {
 							nice_agent_attach_recv(handle->agent, handle->video_id, 2, g_main_loop_get_context (handle->iceloop), NULL, NULL);
+							/* Free the component */
 							janus_ice_component_free(handle->video_stream->components, handle->video_stream->rtcp_component);
 							handle->video_stream->rtcp_component = NULL;
+							/* Create a dummy candidate and enforce it as the one to use for this now unneeded component */
+							NiceCandidate *c = nice_candidate_new(NICE_CANDIDATE_TYPE_HOST);
+							c->component_id = 2;
+							c->stream_id = handle->video_stream->stream_id;
+#ifndef HAVE_LIBNICE_TCP
+							c->transport = NICE_CANDIDATE_TRANSPORT_UDP;
+#endif
+							strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
+							c->priority = 1;
+							nice_address_set_from_string(&c->addr, "1.2.3.4");
+							nice_address_set_port(&c->addr, 1234);
+							c->username = g_strdup(handle->video_stream->ruser);
+							c->password = g_strdup(handle->video_stream->rpass);
+							if(!nice_agent_set_selected_remote_candidate(handle->agent, handle->video_stream->stream_id, 2, c)) {
+								JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error forcing dummy candidate on RTCP component of stream %d\n", handle->handle_id, handle->video_stream->stream_id);
+								nice_candidate_free(c);
+							}
 						}
 					}
 					/* FIXME Any disabled m-line? */
@@ -4215,13 +4251,49 @@ json_t *janus_handle_sdp(janus_plugin_session *plugin_session, janus_plugin *plu
 				JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- rtcp-mux is supported by the browser, getting rid of RTCP components, if any...\n", ice_handle->handle_id);
 				if(ice_handle->audio_stream && ice_handle->audio_stream->rtcp_component && ice_handle->audio_stream->components != NULL) {
 					nice_agent_attach_recv(ice_handle->agent, ice_handle->audio_id, 2, g_main_loop_get_context (ice_handle->iceloop), NULL, NULL);
+					/* Free the component */
 					janus_ice_component_free(ice_handle->audio_stream->components, ice_handle->audio_stream->rtcp_component);
 					ice_handle->audio_stream->rtcp_component = NULL;
+					/* Create a dummy candidate and enforce it as the one to use for this now unneeded component */
+					NiceCandidate *c = nice_candidate_new(NICE_CANDIDATE_TYPE_HOST);
+					c->component_id = 2;
+					c->stream_id = ice_handle->audio_stream->stream_id;
+#ifndef HAVE_LIBNICE_TCP
+					c->transport = NICE_CANDIDATE_TRANSPORT_UDP;
+#endif
+					strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
+					c->priority = 1;
+					nice_address_set_from_string(&c->addr, "1.2.3.4");
+					nice_address_set_port(&c->addr, 1234);
+					c->username = g_strdup(ice_handle->audio_stream->ruser);
+					c->password = g_strdup(ice_handle->audio_stream->rpass);
+					if(!nice_agent_set_selected_remote_candidate(ice_handle->agent, ice_handle->audio_stream->stream_id, 2, c)) {
+						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error forcing dummy candidate on RTCP component of stream %d\n", ice_handle->handle_id, ice_handle->audio_stream->stream_id);
+						nice_candidate_free(c);
+					}
 				}
 				if(ice_handle->video_stream && ice_handle->video_stream->rtcp_component && ice_handle->video_stream->components != NULL) {
 					nice_agent_attach_recv(ice_handle->agent, ice_handle->video_id, 2, g_main_loop_get_context (ice_handle->iceloop), NULL, NULL);
+					/* Free the component */
 					janus_ice_component_free(ice_handle->video_stream->components, ice_handle->video_stream->rtcp_component);
 					ice_handle->video_stream->rtcp_component = NULL;
+					/* Create a dummy candidate and enforce it as the one to use for this now unneeded component */
+					NiceCandidate *c = nice_candidate_new(NICE_CANDIDATE_TYPE_HOST);
+					c->component_id = 2;
+					c->stream_id = ice_handle->video_stream->stream_id;
+#ifndef HAVE_LIBNICE_TCP
+					c->transport = NICE_CANDIDATE_TRANSPORT_UDP;
+#endif
+					strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
+					c->priority = 1;
+					nice_address_set_from_string(&c->addr, "1.2.3.4");
+					nice_address_set_port(&c->addr, 1234);
+					c->username = g_strdup(ice_handle->video_stream->ruser);
+					c->password = g_strdup(ice_handle->video_stream->rpass);
+					if(!nice_agent_set_selected_remote_candidate(ice_handle->agent, ice_handle->video_stream->stream_id, 2, c)) {
+						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error forcing dummy candidate on RTCP component of stream %d\n", ice_handle->handle_id, ice_handle->video_stream->stream_id);
+						nice_candidate_free(c);
+					}
 				}
 			}
 			janus_mutex_lock(&ice_handle->mutex);

--- a/janus.c
+++ b/janus.c
@@ -1525,7 +1525,7 @@ int janus_process_incoming_request(janus_request_source *source, json_t *root) {
 #endif
 							strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
 							c->priority = 1;
-							nice_address_set_from_string(&c->addr, "1.2.3.4");
+							nice_address_set_from_string(&c->addr, "127.0.0.1");
 							nice_address_set_port(&c->addr, 1234);
 							c->username = g_strdup(handle->audio_stream->ruser);
 							c->password = g_strdup(handle->audio_stream->rpass);
@@ -1548,7 +1548,7 @@ int janus_process_incoming_request(janus_request_source *source, json_t *root) {
 #endif
 							strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
 							c->priority = 1;
-							nice_address_set_from_string(&c->addr, "1.2.3.4");
+							nice_address_set_from_string(&c->addr, "127.0.0.1");
 							nice_address_set_port(&c->addr, 1234);
 							c->username = g_strdup(handle->video_stream->ruser);
 							c->password = g_strdup(handle->video_stream->rpass);
@@ -4263,7 +4263,7 @@ json_t *janus_handle_sdp(janus_plugin_session *plugin_session, janus_plugin *plu
 #endif
 					strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
 					c->priority = 1;
-					nice_address_set_from_string(&c->addr, "1.2.3.4");
+					nice_address_set_from_string(&c->addr, "127.0.0.1");
 					nice_address_set_port(&c->addr, 1234);
 					c->username = g_strdup(ice_handle->audio_stream->ruser);
 					c->password = g_strdup(ice_handle->audio_stream->rpass);
@@ -4286,7 +4286,7 @@ json_t *janus_handle_sdp(janus_plugin_session *plugin_session, janus_plugin *plu
 #endif
 					strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
 					c->priority = 1;
-					nice_address_set_from_string(&c->addr, "1.2.3.4");
+					nice_address_set_from_string(&c->addr, "127.0.0.1");
 					nice_address_set_port(&c->addr, 1234);
 					c->username = g_strdup(ice_handle->video_stream->ruser);
 					c->password = g_strdup(ice_handle->video_stream->rpass);

--- a/janus.c
+++ b/janus.c
@@ -1526,7 +1526,7 @@ int janus_process_incoming_request(janus_request_source *source, json_t *root) {
 							strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
 							c->priority = 1;
 							nice_address_set_from_string(&c->addr, "127.0.0.1");
-							nice_address_set_port(&c->addr, 1234);
+							nice_address_set_port(&c->addr, janus_ice_get_rtcpmux_blackhole_port());
 							c->username = g_strdup(handle->audio_stream->ruser);
 							c->password = g_strdup(handle->audio_stream->rpass);
 							if(!nice_agent_set_selected_remote_candidate(handle->agent, handle->audio_stream->stream_id, 2, c)) {
@@ -1549,7 +1549,7 @@ int janus_process_incoming_request(janus_request_source *source, json_t *root) {
 							strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
 							c->priority = 1;
 							nice_address_set_from_string(&c->addr, "127.0.0.1");
-							nice_address_set_port(&c->addr, 1234);
+							nice_address_set_port(&c->addr, janus_ice_get_rtcpmux_blackhole_port());
 							c->username = g_strdup(handle->video_stream->ruser);
 							c->password = g_strdup(handle->video_stream->rpass);
 							if(!nice_agent_set_selected_remote_candidate(handle->agent, handle->video_stream->stream_id, 2, c)) {
@@ -4264,7 +4264,7 @@ json_t *janus_handle_sdp(janus_plugin_session *plugin_session, janus_plugin *plu
 					strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
 					c->priority = 1;
 					nice_address_set_from_string(&c->addr, "127.0.0.1");
-					nice_address_set_port(&c->addr, 1234);
+					nice_address_set_port(&c->addr, janus_ice_get_rtcpmux_blackhole_port());
 					c->username = g_strdup(ice_handle->audio_stream->ruser);
 					c->password = g_strdup(ice_handle->audio_stream->rpass);
 					if(!nice_agent_set_selected_remote_candidate(ice_handle->agent, ice_handle->audio_stream->stream_id, 2, c)) {
@@ -4287,7 +4287,7 @@ json_t *janus_handle_sdp(janus_plugin_session *plugin_session, janus_plugin *plu
 					strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
 					c->priority = 1;
 					nice_address_set_from_string(&c->addr, "127.0.0.1");
-					nice_address_set_port(&c->addr, 1234);
+					nice_address_set_port(&c->addr, janus_ice_get_rtcpmux_blackhole_port());
 					c->username = g_strdup(ice_handle->video_stream->ruser);
 					c->password = g_strdup(ice_handle->video_stream->rpass);
 					if(!nice_agent_set_selected_remote_candidate(ice_handle->agent, ice_handle->video_stream->stream_id, 2, c)) {


### PR DESCRIPTION
Pull request to make sure trickle candidates are not passed to the stack until we have both offer and answer ready. This should help fixing issue #154, as that way we're sure we're never going to set any remote candidate for a remote candidate we won't be using (see rtcp-mux).

Published as a PR for now as I want to be sure this doesn't cause potential failures in negotiating a PeerConnection.