### PR TITLE
Use MediaStreamTrack.stop() instead of MediaStream.stop() which is being deprecated

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1737,7 +1737,10 @@ function Janus(gatewayCallbacks) {
 			try {
 				if(!config.streamExternal && config.myStream !== null && config.myStream !== undefined) {
 					Janus.log("Stopping local stream");
-					config.myStream.stop();
+					if(config.myStream.getVideoTracks()[0])
+						config.myStream.getVideoTracks()[0].stop();
+					if(config.myStream.getAudioTracks()[0])
+						config.myStream.getAudioTracks()[0].stop();
 				}
 			} catch(e) {
 				// Do nothing


### PR DESCRIPTION
As mentioned in issue #363 MediaStream.stop() is being deprecated, I've changed janus.js to use MediaStreamTrack.stop() instead