### PR TITLE
do not let stun public ip override nat_1_1_mapping ip

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -170,10 +170,9 @@ gchar *janus_get_public_ip(void) {
 	return public_ip ? public_ip : local_ip;
 }
 void janus_set_public_ip(const char *ip) {
-	if(ip == NULL)
+	/* once set do not override */
+	if(ip == NULL || public_ip != NULL)
 		return;
-	if(public_ip != NULL)
-		g_free(public_ip);
 	public_ip = g_strdup(ip);
 }
 static volatile gint stop = 0;
@@ -4845,6 +4844,7 @@ gint main(int argc, char *argv[])
 	/* Any 1:1 NAT mapping to take into account? */
 	item = janus_config_get_item_drilldown(config, "nat", "nat_1_1_mapping");
 	if(item && item->value) {
+		JANUS_LOG(LOG_VERB, "Using nat_1_1_mapping for public ip - %s\n", item->value);
 		janus_set_public_ip(item->value);
 		janus_ice_enable_nat_1_1();
 	}


### PR DESCRIPTION
One case where I used to use `public_ip` and I am now trying to use `nat_1_1_mapping` is for a testing virtual machine on my laptop, which has a virtual interface connected directly to a virtual interface on my host OS, like so:

```
(host vboxnet0 172.30.1.1) <-> (vm eth1 172.30.1.2)
```

I also have a stun server configured in janus.cfg. If I set nat_1_1_mapping, it will set public_ip and enable the substitution in host candidates, but then the stun server provided public ip will override the nat_1_1_mapping ip.


In our production servers, this is just fine, the nat_1_1_mapping and stun-provided public ip are the same.

In my test VM they're different, and the connection ends up using peer-reflexive candidates, sometimes through the host's lan IP (instead of the virtual interface IP), which is a bit awkward IMHO but does usually work.

Why are we using both nat_1_1_mapping and stun server? long story... I'm still hoping to leave open the option later of getting rid of the janus-side stun server :)