### PR TITLE
INI configuration utilities changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ on [github](https://github.com/meetecho/janus-gateway/issues) instead.
 To install it, you'll need to satisfy the following dependencies:
 
 * [libmicrohttpd](http://www.gnu.org/software/libmicrohttpd/)
-* [libini-config](https://fedorahosted.org/sssd/) (INI configurations)
 * [Jansson](http://www.digip.org/jansson/)
 * [libnice](http://nice.freedesktop.org/wiki/)
 * [OpenSSL](http://www.openssl.org/) (at least v1.0.1e)
@@ -51,15 +50,13 @@ instance, is very simple:
 
     yum install libmicrohttpd-devel jansson-devel libnice-devel \
        openssl-devel libsrtp-devel sofia-sip-devel glib-devel \
-       opus-devel libogg-devel libini_config-devel pkgconfig gengetopt \
-       libtool autoconf automake
+       opus-devel libogg-devel pkgconfig gengetopt libtool autoconf automake
 
 On Ubuntu or Debian, it would require something like this:
 
 	aptitude install libmicrohttpd-dev libjansson-dev libnice-dev \
 		libssl-dev libsrtp-dev libsofia-sip-ua-dev libglib2.0-dev \
-		libopus-dev libogg-dev libini-config-dev libcollection-dev \
-		pkg-config gengetopt libtool automake
+		libopus-dev libogg-dev pkg-config gengetopt libtool automake
 
 * *Note:* please notice that libopus may not be available out of the box
 on Ubuntu or Debian, unless you're using a recent version (e.g., Ubuntu

--- a/config.h
+++ b/config.h
@@ -2,7 +2,7 @@
  * \author   Lorenzo Miniero <lorenzo@meetecho.com>
  * \copyright GNU General Public License v3
  * \brief    Configuration files parsing (headers)
- * \details  Implementation of a parser of INI configuration files (based on libini-config).
+ * \details  Implementation of a parser of INI configuration files.
  * 
  * \ingroup core
  * \ref core
@@ -11,8 +11,7 @@
 #ifndef _JANUS_CONFIG_H
 #define _JANUS_CONFIG_H
 
-#include <ini_config.h>
-
+#include <glib.h>
 
 /*! \brief Configuration item (name=value) */
 typedef struct janus_config_item {
@@ -20,8 +19,6 @@ typedef struct janus_config_item {
 	const char *name;
 	/*! \brief Value of the item */
 	const char *value;
-	/*! \brief Next element in the linked list of items in this category */
-	struct janus_config_item *next;
 } janus_config_item;
 
 /*! \brief Configuration category ([category]) */
@@ -29,9 +26,7 @@ typedef struct janus_config_category {
 	/*! \brief Name of the category */
 	const char *name;
 	/*! \brief Linked list of items */
-	janus_config_item *items;
-	/*! \brief Next element in the linked list of categories in this configuration */
-	struct janus_config_category *next;
+	GList *items;
 } janus_config_category;
 
 /*! \brief Configuration container */
@@ -39,9 +34,9 @@ typedef struct janus_config {
 	/*! \brief Name of the configuration */
 	const char *name;
 	/*! \brief Linked list of uncategorized items */
-	janus_config_item *items;
+	GList *items;
 	/*! \brief Linked list of categories category */
-	janus_config_category *categories;
+	GList *categories;
 } janus_config;
 
 
@@ -53,19 +48,19 @@ janus_config *janus_config_parse(const char *config_file);
  * @param[in] name Name to give to the configuration
  * @returns A pointer to a valid janus_config instance if successful, NULL otherwise */ 
 janus_config *janus_config_create(const char *name);
-/*! \brief Get all categories from a parsed configuration
+/*! \brief Get the list of all categories from a parsed configuration as a GLib linked list
  * @param[in] config The configuration container
- * @returns A pointer to the first janus_config_category instance in the list if successful, NULL otherwise */ 
-janus_config_category *janus_config_get_categories(janus_config *config);
+ * @returns A pointer to the categories GLib linked list if successful, NULL otherwise */ 
+GList *janus_config_get_categories(janus_config *config);
 /*! \brief Get the category with a specific name from a parsed configuration
  * @param[in] config The configuration container
  * @param[in] name The name of the category
  * @returns A pointer to the janus_config_category instance if successful, NULL otherwise */ 
 janus_config_category *janus_config_get_category(janus_config *config, const char *name);
-/*! \brief Get all items from a category of a parsed configuration
+/*! \brief Get the list of all items in a category as a GLib linked list
  * @param[in] category The configuration category
- * @returns A pointer to the first janus_config_item instance in the list if successful, NULL otherwise */ 
-janus_config_item *janus_config_get_items(janus_config_category *category);
+ * @returns A pointer to the items GLib linked list if successful, NULL otherwise */ 
+GList *janus_config_get_items(janus_config_category *category);
 /*! \brief Get the item with a specific name from a category of a parsed configuration
  * @param[in] category The configuration category
  * @param[in] name The name of the item
@@ -78,6 +73,18 @@ janus_config_item *janus_config_get_item(janus_config_category *category, const 
  * @param[in] name The name of the item
  * @returns A pointer to the janus_config_item instance if successful, NULL otherwise */ 
 janus_config_item *janus_config_get_item_drilldown(janus_config *config, const char *category, const char *name);
+/*! \brief Add a new category with the specific name
+ * \note If the item already exists in the category, it is NOT overwritten, and the existing instance is returned
+ * @param[in] config The configuration container
+ * @param[in] category The category to create
+ * @returns A pointer to the janus_config_category instance if successful, NULL otherwise */ 
+janus_config_category *janus_config_add_category(janus_config *config, const char *category);
+/*! \brief Remove an existing category with the specific name
+ * \note This will also remove all items from that category
+ * @param[in] config The configuration container
+ * @param[in] category The category to remove
+ * @returns 0 if successful, a negative integer otherwise */ 
+int janus_config_remove_category(janus_config *config, const char *category);
 /*! \brief Add a new item with the specific name and value to a category, and create the category if it doesn't exist
  * \note If the item already exists in the category, its value is overwritten
  * @param[in] config The configuration container
@@ -86,6 +93,12 @@ janus_config_item *janus_config_get_item_drilldown(janus_config *config, const c
  * @param[in] value The value of the item
  * @returns A pointer to the janus_config_item instance if successful, NULL otherwise */ 
 janus_config_item *janus_config_add_item(janus_config *config, const char *category, const char *name, const char *value);
+/*! \brief Remove an existing item with the specific name from a category
+ * @param[in] config The configuration container
+ * @param[in] category The category to remove the item from
+ * @param[in] name The name of the item
+ * @returns 0 if successful, a negative integer otherwise */ 
+int janus_config_remove_item(janus_config *config, const char *category, const char *name);
 /*! \brief Helper method to print a configuration on the standard output
  * @param[in] config The configuration to print */
 void janus_config_print(janus_config *config);

--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,6 @@ PKG_CHECK_MODULES([JANUS],
                     libssl >= ssl_version
                     libcrypto
                     sofia-sip-ua
-                    ini_config
                   ])
 AC_SUBST(JANUS_MANUAL_LIBS)
 
@@ -222,7 +221,6 @@ PKG_CHECK_MODULES([PLUGINS],
                     glib-2.0 >= glib_version
                     sofia-sip-ua
                     jansson
-                    ini_config
                   ])
 
 AC_ARG_ENABLE([plugin-audiobridge],

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -247,6 +247,7 @@
 
 #include <dirent.h>
 #include <arpa/inet.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <jansson.h>
 
@@ -1517,12 +1518,13 @@ void janus_recordplay_update_recordings_list(void) {
 			JANUS_LOG(LOG_ERR, "Invalid recording '%s'...\n", recent->d_name);
 			continue;
 		}
-		janus_config_category *cat = janus_config_get_categories(nfo);
-		if(cat == NULL) {
+		GList *cl = janus_config_get_categories(nfo);
+		if(cl == NULL || cl->data == NULL) {
 			JANUS_LOG(LOG_WARN, "No recording info in '%s', skipping...\n", recent->d_name);
 			janus_config_destroy(nfo);
 			continue;
 		}
+		janus_config_category *cat = (janus_config_category *)cl->data;
 		guint64 id = atol(cat->name);
 		if(id == 0) {
 			JANUS_LOG(LOG_WARN, "Invalid ID, skipping...\n");

--- a/plugins/plugin.h
+++ b/plugins/plugin.h
@@ -164,7 +164,7 @@ janus_plugin *create(void) {
  * gateway or it will crash.
  * 
  */
-#define JANUS_PLUGIN_API_VERSION	4
+#define JANUS_PLUGIN_API_VERSION	5
 
 /*! \brief Initialization of all plugin properties to NULL
  * 


### PR DESCRIPTION
This pull request changes a few things in how INI configuration files are handled. Specifically:

1. it removes the dependency from ```libini_config```, which apparently was not that easy to satisfy in some environments (see OSX), and replaces it with a homemade implementation;
2. it changes the way you access categories and items: now both ```janus_config_get_categories``` and ```janus_config_get_items``` return a GList, which means ```janus_config_category``` and ```janus_config_item``` don't have a ```next``` anymore: to traverse them you use GList instead;
3. the patch also adds permanent saving features to Streaming, AudioBridge and VideoRoom plugins, meaning that you can now make sure a mountpoint/room created via API is also saved in the configuration file if you want; this feature was already available in the old config.c, but wasn't being used in any plugin so far.

This is a PR and not a plain commit mostly because of point 2., as there may be third-party plugins out there that may break if they're not fixed accordingly. If you're writing a plugin and using ```janus_config_get_categories``` and/or ```janus_config_get_items```, make sure you change the way they're called as I'm planning to merge this soon after this announcement.

Feedback welcome.