### PR TITLE
JS client: Properly remove WebSocket event listeners

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -144,7 +144,7 @@ function Janus(gatewayCallbacks) {
 	}
 	var websockets = false;
 	var ws = null;
-	var wsHanders = {};
+	var wsHandlers = {};
 
 	var servers = null, serversIndex = 0;
 	var server = gatewayCallbacks.server;
@@ -404,7 +404,7 @@ function Janus(gatewayCallbacks) {
 		}
 		if(websockets) {
 			ws = new WebSocket(server, 'janus-protocol'); 
-			wsHanders = {
+			wsHandlers = {
 				'error': function() {
 					Janus.error("Error connecting to the Janus WebSockets server... " + server);
 					if ($.isArray(servers)) {
@@ -457,8 +457,8 @@ function Janus(gatewayCallbacks) {
 				}
 			};
 
-			for(eventName in wsHanders) {
-				ws.addEventListener(eventName, wsHanders[eventName]);
+			for(eventName in wsHandlers) {
+				ws.addEventListener(eventName, wsHandlers[eventName]);
 			}
 
 			return;
@@ -542,8 +542,8 @@ function Janus(gatewayCallbacks) {
 			var unbindWebSocket = function(event){
 				var data = JSON.parse(event.data);
 				if(data.session_id == request.session_id && data.transaction == request.transaction) {
-					for(eventName in wsHanders) {
-						ws.removeEventListener(eventName, wsHanders[eventName]);
+					for(eventName in wsHandlers) {
+						ws.removeEventListener(eventName, wsHandlers[eventName]);
 					}
 					ws.removeEventListener('message', unbindWebSocket);
 					callbacks.success();

--- a/html/janus.js
+++ b/html/janus.js
@@ -144,6 +144,8 @@ function Janus(gatewayCallbacks) {
 	}
 	var websockets = false;
 	var ws = null;
+	var wsHanders = {};
+
 	var servers = null, serversIndex = 0;
 	var server = gatewayCallbacks.server;
 	if($.isArray(server)) {
@@ -402,50 +404,63 @@ function Janus(gatewayCallbacks) {
 		}
 		if(websockets) {
 			ws = new WebSocket(server, 'janus-protocol'); 
-			ws.onerror = function() {
-				Janus.error("Error connecting to the Janus WebSockets server... " + server);
-				if($.isArray(servers)) {
-					serversIndex++;
-					if(serversIndex == servers.length) {
-						// We tried all the servers the user gave us and they all failed
-						callbacks.error("Error connecting to any of the provided Janus servers: Is the gateway down?");
+			wsHanders = {
+				'error': function() {
+					Janus.error("Error connecting to the Janus WebSockets server... " + server);
+					if ($.isArray(servers)) {
+						serversIndex++;
+						if (serversIndex == servers.length) {
+							// We tried all the servers the user gave us and they all failed
+							callbacks.error("Error connecting to any of the provided Janus servers: Is the gateway down?");
+							return;
+						}
+						// Let's try the next server
+						server = null;
+						setTimeout(function() {
+							createSession(callbacks);
+						}, 200);
 						return;
 					}
-					// Let's try the next server
-					server = null;
-					setTimeout(function() { createSession(callbacks); }, 200);
-					return;
+					callbacks.error("Error connecting to the Janus WebSockets server: Is the gateway down?");
+				},
+
+				'open': function() {
+					// We need to be notified about the success
+					transactions[transaction] = function(json) {
+						Janus.debug(json);
+						if (json["janus"] !== "success") {
+							Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+							callbacks.error(json["error"].reason);
+							return;
+						}
+						setTimeout(keepAlive, 30000);
+						connected = true;
+						sessionId = json.data["id"];
+						Janus.log("Created session: " + sessionId);
+						Janus.sessions[sessionId] = that;
+						callbacks.success();
+					};
+					ws.send(JSON.stringify(request));
+				},
+
+				'message': function(event) {
+					handleEvent(JSON.parse(event.data));
+				},
+
+				'close': function() {
+					if (server === null || !connected) {
+						return;
+					}
+					connected = false;
+					// FIXME What if this is called when the page is closed?
+					gatewayCallbacks.error("Lost connection to the gateway (is it down?)");
 				}
-				callbacks.error("Error connecting to the Janus WebSockets server: Is the gateway down?");
 			};
-			ws.onopen = function() {
-				// We need to be notified about the success
-				transactions[transaction] = function(json) {
-					Janus.debug(json);
-					if(json["janus"] !== "success") {
-						Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
-						callbacks.error(json["error"].reason);
-						return;
-					}
-					setTimeout(keepAlive, 30000);
-					connected = true;
-					sessionId = json.data["id"];
-					Janus.log("Created session: " + sessionId);
-					Janus.sessions[sessionId] = that;
-					callbacks.success();
-				};
-				ws.send(JSON.stringify(request));
-			};
-			ws.onmessage = function(event) {
-				handleEvent(JSON.parse(event.data));
-			};
-			ws.onclose = function() {
-				if(server === null || !connected)
-					return;
-				connected = false;
-				// FIXME What if this is called when the page is closed?
-				gatewayCallbacks.error("Lost connection to the gateway (is it down?)");
-			};
+
+			for(eventName in wsHanders) {
+				ws.addEventListener(eventName, wsHanders[eventName]);
+			}
+
 			return;
 		}
 		$.ajax({
@@ -524,9 +539,19 @@ function Janus(gatewayCallbacks) {
 			request["apisecret"] = apisecret;
 		if(websockets) {
 			request["session_id"] = sessionId;
+			var unbindWebSocket = function(event){
+				var data = JSON.parse(event.data);
+				if(data.session_id == request.session_id && data.transaction == request.transaction) {
+					for(eventName in wsHanders) {
+						ws.removeEventListener(eventName, wsHanders[eventName]);
+					}
+					ws.removeEventListener('message', unbindWebSocket);
+					callbacks.success();
+					gatewayCallbacks.destroyed();
+				}
+			};
+			ws.addEventListener('message', unbindWebSocket);
 			ws.send(JSON.stringify(request));
-			callbacks.success();
-			gatewayCallbacks.destroyed();
 			return;
 		}
 		$.ajax({


### PR DESCRIPTION
When the `Janus` client is destroyed and recreated, the previous `WebSocket` is still listening to previous messages and throw `Ooops: 458 No such session 1896383161` error.