### PR TITLE
janus buffered logging

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,7 +30,7 @@ bin_PROGRAMS = janus
 headerdir = $(includedir)/janus
 header_HEADERS = \
 	plugins/plugin.h transports/transport.h apierror.h config.h debug.h dtls.h \
-	janus.h ice.h mutex.h record.h rtcp.h rtp.h sctp.h sdp.h turnrest.h utils.h
+	janus.h ice.h mutex.h record.h rtcp.h rtp.h sctp.h sdp.h turnrest.h utils.h log.h
 
 confdir = $(sysconfdir)/janus
 conf_DATA = conf/janus.cfg.sample
@@ -89,6 +89,8 @@ janus_SOURCES = \
 	ice.h \
 	janus.c \
 	janus.h \
+	log.c \
+	log.h \
 	mutex.h \
 	record.c \
 	record.h \

--- a/debug.h
+++ b/debug.h
@@ -102,10 +102,10 @@ do { \
 			         "[%s:%s:%d] ", __FILE__, __FUNCTION__, __LINE__); \
 		} \
 		JANUS_PRINT("%s%s%s" format, \
-    		        janus_log_ts, \
-    		        janus_log_prefix[level | ((int)janus_log_colors << 3)], \
-    		        janus_log_src, \
-    		        ##__VA_ARGS__); \
+			janus_log_ts, \
+			janus_log_prefix[level | ((int)janus_log_colors << 3)], \
+			janus_log_src, \
+			##__VA_ARGS__); \
 	} \
 } while (0)
 ///@}

--- a/debug.h
+++ b/debug.h
@@ -4,7 +4,7 @@
  * \brief    Logging and Debugging
  * \details  Implementation of a wrapper on printf (or g_print) to either log or debug.
  * \todo     Improve this wrappers to optionally save logs on file
- * 
+ *
  * \ingroup core
  * \ref core
  */
@@ -14,7 +14,8 @@
 
 #include <glib.h>
 #include <glib/gprintf.h>
- 
+#include "log.h"
+
 extern int janus_log_level;
 extern gboolean janus_log_timestamps;
 extern gboolean janus_log_colors;
@@ -80,7 +81,7 @@ static const char *janus_log_prefix[] = {
  */
 ///@{
 /*! \brief Simple wrapper to g_print/printf */
-#define JANUS_PRINT g_print
+#define JANUS_PRINT janus_vprintf
 /*! \brief Logger based on different levels, which can either be displayed
  * or not according to the configuration of the gateway.
  * The format must be a string literal. */
@@ -100,11 +101,11 @@ do { \
 			snprintf(janus_log_src, sizeof(janus_log_src), \
 			         "[%s:%s:%d] ", __FILE__, __FUNCTION__, __LINE__); \
 		} \
-		g_print("%s%s%s" format, \
-		        janus_log_ts, \
-		        janus_log_prefix[level | ((int)janus_log_colors << 3)], \
-		        janus_log_src, \
-		        ##__VA_ARGS__); \
+		JANUS_PRINT("%s%s%s" format, \
+    		        janus_log_ts, \
+    		        janus_log_prefix[level | ((int)janus_log_colors << 3)], \
+    		        janus_log_src, \
+    		        ##__VA_ARGS__); \
 	} \
 } while (0)
 ///@}

--- a/janus.c
+++ b/janus.c
@@ -2896,7 +2896,7 @@ gint main(int argc, char *argv[])
 	core_limits.rlim_cur = core_limits.rlim_max = RLIM_INFINITY;
 	setrlimit(RLIMIT_CORE, &core_limits);
 
-        janus_log_init();
+	janus_log_init();
 
 	struct gengetopt_args_info args_info;
 	/* Let's call our cmdline parser */

--- a/janus.c
+++ b/janus.c
@@ -28,6 +28,7 @@
 #include "cmdline.h"
 #include "config.h"
 #include "apierror.h"
+#include "log.h"
 #include "debug.h"
 #include "rtcp.h"
 #include "sdp.h"
@@ -2895,6 +2896,8 @@ gint main(int argc, char *argv[])
 	core_limits.rlim_cur = core_limits.rlim_max = RLIM_INFINITY;
 	setrlimit(RLIMIT_CORE, &core_limits);
 
+        janus_log_init();
+
 	struct gengetopt_args_info args_info;
 	/* Let's call our cmdline parser */
 	if(cmdline_parser(argc, argv, &args_info) != 0)
@@ -3704,5 +3707,6 @@ gint main(int argc, char *argv[])
 	}
 
 	JANUS_PRINT("Bye!\n");
+	janus_log_destroy();
 	exit(0);
 }

--- a/log.c
+++ b/log.c
@@ -16,14 +16,14 @@
 #define THREAD_NAME   "log"
 
 
-static gint	 initialized = 0;
-static gint	 stopping = 0;
+static gint     initialized = 0;
+static gint     stopping = 0;
 /* Maximum sleep in ms for the print thread */
-static gint	 maxdelay = 3000;
+static gint     maxdelay = 3000;
 /* Buffers over this size will be freed */
-static gsize	maxbuffer = 1024*16;
+static gsize    maxbuffer = 1024*16;
 static GMutex   lock;
-static GCond	cond;
+static GCond    cond;
 static GSList   *printqueue = NULL;
 static GQueue   *freebufs = NULL;
 static GThread  *printthread = NULL;

--- a/log.c
+++ b/log.c
@@ -1,0 +1,129 @@
+/*! \file	log.h
+ * \author   Jay Ridgeway <jayridge@gmail.com>
+ * \copyright GNU General Public License v3
+ * \brief	Buffered logging
+ * \details  Implementation of a simple buffered logger designed to remove
+ * I/O wait from threads that may be sensitive to such delays. Buffers are
+ * saved and reused to reduce allocation calls.
+ *
+ * \ingroup core
+ * \ref core
+ */
+
+#include "log.h"
+
+#define INITIAL_BUFSZ   2048
+#define THREAD_NAME     "log"
+
+
+static gint     initialized = 0;
+static gint     stopping = 0;
+/* Maximum sleep in ms for the print thread */
+static gint     maxdelay = 3000;
+/* Buffers over this size will be freed */
+static gsize    maxbuffer = 1024*16;
+static GMutex   lock;
+static GCond	cond;
+static GSList   *printqueue = NULL;
+static GQueue   *freebufs = NULL;
+static GThread  *printthread = NULL;
+
+
+static void stringfree(void *s)
+{
+	if (s) {
+		g_string_free((GString *)s, TRUE);
+	}
+}
+
+static GString * getbuf(void)
+{
+	GString *s;
+
+	g_mutex_lock(&lock);
+	s = (GString *)g_queue_pop_head(freebufs);
+	g_mutex_unlock(&lock);
+	if (s == NULL) {
+		s = g_string_sized_new(INITIAL_BUFSZ);
+	}
+	return s;
+}
+
+static void * janus_log_thread(void *ctx)
+{
+	GSList  *head, *p;
+	GString *s;
+	gint64  abstime;
+
+	while (!g_atomic_int_get(&stopping)) {
+		abstime = g_get_monotonic_time() + maxdelay * G_TIME_SPAN_MILLISECOND;
+		g_mutex_lock(&lock);
+		g_cond_wait_until(&cond, &lock, abstime);
+		head = printqueue;
+		printqueue = NULL;
+		g_mutex_unlock(&lock);
+
+		if (head) {
+			for (p = head; p; p = g_slist_next(p)) {
+				s = (GString *)p->data;
+				fputs(s->str, stdout);
+                if (s->allocated_len > maxbuffer) {
+                    g_string_free(s, TRUE);
+                } else {
+                    g_mutex_lock(&lock);
+    				g_queue_push_head(freebufs, s);
+    				g_mutex_unlock(&lock);
+                }
+			}
+            fflush(stdout);
+			g_slist_free(head);
+		}
+	}
+	g_mutex_lock(&lock);
+	/* free buffers, printqueue should be NULL */
+	g_queue_free_full(freebufs, stringfree);
+	g_mutex_unlock(&lock);
+
+	g_mutex_clear(&lock);
+	g_cond_clear(&cond);
+	return NULL;
+}
+
+void janus_vprintf(const gchar *format, ...)
+{
+    va_list args;
+    GString *s = getbuf();
+
+    va_start(args, format);
+    g_string_vprintf(s, format, args);
+    va_end(args);
+
+    g_mutex_lock(&lock);
+    printqueue = g_slist_append(printqueue, s);
+    g_cond_signal(&cond);
+    g_mutex_unlock(&lock);
+}
+
+void janus_log_init(void)
+{
+	if (g_atomic_int_get(&initialized)) {
+		return;
+	}
+	g_atomic_int_set(&initialized, 1);
+	g_mutex_init(&lock);
+	g_cond_init(&cond);
+    /* Set stdout to block buffering, see BUFSIZ in stdio.h */
+    setvbuf(stdout, NULL, _IOFBF, 0);
+	freebufs = g_queue_new();
+	printthread = g_thread_new(THREAD_NAME, &janus_log_thread, NULL);
+}
+
+void janus_log_destroy(void)
+{
+	g_atomic_int_set(&stopping, 1);
+	g_mutex_lock(&lock);
+	/* signal print thread to print any remaining message */
+	g_cond_signal(&cond);
+	g_mutex_unlock(&lock);
+	g_thread_join(printthread);
+}

--- a/log.h
+++ b/log.h
@@ -20,7 +20,7 @@
 * @param[in] format Format string as defined by glib
 * @param[in] args Parameters to insert into formatted string
 * \note This output is buffered and may not appear immediately on stdout. */
-void janus_vprintf(const gchar *format, ...) G_GNUC_PRINTF(1, 2);
+void janus_vprintf(const char *format, ...) G_GNUC_PRINTF(1, 2);
 /*! \brief Log initialization
 * \note This should be called before attempting to use the logger. A buffer
 * pool and processing thread are created. */

--- a/log.h
+++ b/log.h
@@ -1,0 +1,31 @@
+/*! \file    log.h
+ * \author   Jay Ridgeway <jayridge@gmail.com>
+ * \copyright GNU General Public License v3
+ * \brief    Buffered logging (headers)
+ * \details  Implementation of a simple buffered logger designed to remove
+ * I/O wait from threads that may be sensitive to such delays. Buffers are
+ * saved and reused to reduce allocation calls.
+ *
+ * \ingroup core
+ * \ref core
+ */
+
+#ifndef _JANUS_LOG_H
+#define _JANUS_LOG_H
+
+#include <stdio.h>
+#include <glib.h>
+
+/*! \brief Buffered vprintf
+* @param[in] format Format string as defined by glib
+* @param[in] args Parameters to insert into formatted string
+* \note This output is buffered and may not appear immediately on stdout. */
+void janus_vprintf(const gchar *format, ...) G_GNUC_PRINTF(1, 2);
+/*! \brief Log initialization
+* \note This should be called before attempting to use the logger. A buffer
+* pool and processing thread are created. */
+void janus_log_init(void);
+/*! \brief Log destruction */
+void janus_log_destroy(void);
+
+#endif


### PR DESCRIPTION
\+ @ploxiln 

A stab at buffered logging in janus core. A few notes.

1. I took a look at glib async queues. The implementation was similar to this pull with extra overhead. Not implemented.
1. The init sequence is likely not technically correct. The application logs before the signal handlers are installed or glib is initialized ( N.B. not required for modern versions ).
1. There was no clear advantage to explicit buffers over glib dynamic strings. Resizing of the buffers would have followed the same model. Also, glib provides a platform agnostic vsprintf that does not reallocate if the buffer is bug enough.
1. Reclamation of buffers is prioritized over lock avoidance. I do not anticipate lock contention here - we can test with mutex metering on.