### PR TITLE
Remove ini_config from configure.ac, since it's not required.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,7 +185,6 @@ PKG_CHECK_MODULES([TRANSPORTS],
                   [
                     glib-2.0 >= glib_version
                     jansson
-                    ini_config
                   ])
 
 PKG_CHECK_MODULES([MHD],


### PR DESCRIPTION
I removed `ini_config` as a dependency in `configure.ac`, since it seems that it's no longer used. (I actually couldn't find `libini_config` anywhere on the internet, so it's a good thing it's not required anymore).

If merging this PR requires agreement with the CLA, feel free to replicate the patch yourself and close the PR.
I don't feel comfortable with the terms in the agreement. I'm also not sure I'm in a legal position to license the patents of my "Affiliates". If I make considerable modifications to janus-gateway I'll probably have to fork until I'm comfortable with signing the CLA.