### PR TITLE
Added option to create/destroy/check PID file

### DIFF
--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -11,6 +11,8 @@ plugins_folder = @plugindir@		; Plugins folder
 ;log_to_file = /tmp/janus.log	; Whether to use a log file or not
 ;daemonize = true				; Whether Janus should run as a daemon
 								; or not (default=run in foreground)
+;pid_file = /tmp/janus.pid		; PID file to create when Janus has been
+								; started, and to destroy at shutdown
 ;interface = 1.2.3.4		; Interface to use (will be used in SDP)
 debug_level = 4				; Debug/logging level, valid values are 0-7
 ;debug_timestamps = yes		; Whether to show a timestamp for each log line

--- a/janus.c
+++ b/janus.c
@@ -215,6 +215,8 @@ static void janus_handle_signal(int signum) {
 static void janus_termination_handler(void) {
 	/* Remove the PID file if we created it */
 	janus_pidfile_remove();
+	/* Close the logger */
+	janus_log_destroy();
 }
 
 
@@ -3762,8 +3764,6 @@ gint main(int argc, char *argv[])
 	}
 
 	JANUS_PRINT("Bye!\n");
-
-	janus_log_destroy();
 
 	exit(0);
 }

--- a/janus.ggo
+++ b/janus.ggo
@@ -1,4 +1,5 @@
 option "daemon" b "Launch Janus in background as a daemon" flag off
+option "pid-file" p "Open the specified PID file when starting Janus (default=none)" string typestr="path" optional
 option "disable-stdout" N "Disable stdout based logging" flag off
 option "log-file" L "Log to the specified file (default=stdout only)" string typestr="path" optional
 option "interface" i "Interface to use (will be the public IP)" string typestr="ipaddress" optional

--- a/utils.h
+++ b/utils.h
@@ -100,4 +100,7 @@ gboolean janus_is_ip_valid(const char *ip, int *family);
  * @param address The sockaddr address to convert
  * @returns A string containing the IP address, if successful, NULL otherwise */
 char *janus_address_to_ip(struct sockaddr *address);
+
+int janus_pidfile_create(const char *file);
+int janus_pidfile_remove(void);
 #endif

--- a/utils.h
+++ b/utils.h
@@ -101,6 +101,12 @@ gboolean janus_is_ip_valid(const char *ip, int *family);
  * @returns A string containing the IP address, if successful, NULL otherwise */
 char *janus_address_to_ip(struct sockaddr *address);
 
+/*! \brief Create and lock a PID file
+ * @param file Path to the PID file to use
+ * @returns 0 if successful, a negative integer otherwise */
 int janus_pidfile_create(const char *file);
+
+/*! \brief Unlock and remove a previously created PID file
+ * @returns 0 if successful, a negative integer otherwise */
 int janus_pidfile_remove(void);
 #endif


### PR DESCRIPTION
This patch introduces a way to make Janus create (at startup) and remove (at shutdown) a PID file. If a PID file exists and is locked (flock), or the PID file cannot be created/updated/locked, Janus failes to start. Homemade implementation as ```pidfile_*``` methods are only available using [libbsd](http://libbsd.freedesktop.org/wiki/), and I'd rather avoid adding yet another dependency for something apparently so trivial.

Can be enabled in configuration file (```pid_file``` in ```[general]```) and via command line (```--pid-file``` or ```-p```).