### PR TITLE
configure.ac: ssl_version and glib_version should be shell variables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,10 +77,10 @@ AC_ARG_ENABLE([turn-rest-api],
 
 PKG_CHECK_MODULES([JANUS],
                   [
-                    glib-2.0 >= glib_version
+                    glib-2.0 >= $glib_version
                     nice
                     jansson
-                    libssl >= ssl_version
+                    libssl >= $ssl_version
                     libcrypto
                     sofia-sip-ua
                   ])
@@ -183,7 +183,7 @@ fi
 
 PKG_CHECK_MODULES([TRANSPORTS],
                   [
-                    glib-2.0 >= glib_version
+                    glib-2.0 >= $glib_version
                     jansson
                   ])
 
@@ -243,7 +243,7 @@ AM_CONDITIONAL([ENABLE_RABBITMQ], [test "x$enable_rabbitmq" = "xyes"])
 
 PKG_CHECK_MODULES([PLUGINS],
                   [
-                    glib-2.0 >= glib_version
+                    glib-2.0 >= $glib_version
                     sofia-sip-ua
                     jansson
                   ])


### PR DESCRIPTION
otherwise, pkgconfig compares the literal strings ssl_version and glib_version
to the available versions, and for most versions of pkgconfig
(except apparently for the version included in RHEL6) finds the
available versions are "greater than" these literal strings

found by #410 

tested by invoking pkg-config manually:

```
vagrant@dockerdev:~/src/janus-gateway$ PKG_CONFIG_PATH=/opt/janroot/lib/pkgconfig pkg-config --exists --print-errors "
>                     glib-2.0 >= glib_version
>                     nice
>                     jansson
>                     libssl >= ssl_version
>                     libcrypto
>                     sofia-sip-ua
>                   "
vagrant@dockerdev:~/src/janus-gateway$ PKG_CONFIG_PATH=/opt/janroot/lib/pkgconfig pkg-config --exists --print-errors "
                    glib-2.0 >= 2.48        
                    nice
                    jansson
                    libssl >= 1.0.3      
                    libcrypto
                    sofia-sip-ua
                  "
Requested 'glib-2.0 >= 2.48' but version of GLib is 2.40.2
Requested 'libssl >= 1.0.3' but version of OpenSSL-libssl is 1.0.1
```

Also inspected the generated configure script before and after this change.