### PR TITLE
Use the bundled adapter.js instead of an external dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "janus-gateway",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "homepage": "https://github.com/meetecho/janus-gateway",
   "authors": [
     "Lorenzo Miniero <lorenzo@meetecho.com>",
@@ -21,7 +21,7 @@
     "Scott <scottmortonashton@gmail.com>"
   ],
   "description": "A javascript library for interacting with the C based Janus WebRTC Gateway",
-  "main": "./html/janus.js",
+  "main": "./html/{adapter,janus}.js",
   "license": "GPLv3",
   "ignore": [
     "**/.*",
@@ -33,7 +33,6 @@
     "tests"
   ],
   "dependencies": {
-    "adapter.js": "git://github.com/webrtc/adapter.git#d197a97c198a6dbcde7aa58c7d50d454af7bb99c",
     "jquery": "*"    
   }
 }


### PR DESCRIPTION
This is actually not 100% correct, since the "main" property of a bower.json file should not include two different javascript files, but after investing quite some time testing many alternative approaches, this seems to be our current best option.

If, at some point, Janus goes back to using "vanilla" adapter.js we can bring the dependency back.

@lminiero I know you don't care much about bower support, so if you could please just merge this (I ensure you it's better than before :wink:)...