### PR TITLE
fix structs janus_request and janus_ice_trickle being typedef'ed twice

### DIFF
--- a/ice.h
+++ b/ice.h
@@ -401,7 +401,7 @@ struct janus_ice_component {
 };
 
 /*! \brief Helper to handle pending trickle candidates (e.g., when we're still waiting for an offer) */
-typedef struct janus_ice_trickle {
+struct janus_ice_trickle {
 	/*! \brief Janus ICE handle this trickle candidate belongs to */
 	janus_ice_handle *handle;
 	/*! \brief Monotonic time of when this trickle candidate has been received */
@@ -410,7 +410,7 @@ typedef struct janus_ice_trickle {
 	char *transaction;
 	/*! \brief JSON object of the trickle candidate(s) */
 	json_t *candidate;
-} janus_ice_trickle;
+};
 
 /** @name Janus ICE trickle candidates methods
  */

--- a/janus.h
+++ b/janus.h
@@ -97,7 +97,7 @@ void janus_session_free(janus_session *session);
  */
 ///@{
 /*! \brief Helper to address requests and their sources (e.g., a specific HTTP connection, websocket, RabbitMQ or others) */
-typedef struct janus_request {
+struct janus_request {
 	/*! \brief Pointer to the transport plugin */
 	janus_transport *transport;
 	/*! \brief Opaque pointer to the transport-provided instance */
@@ -108,7 +108,7 @@ typedef struct janus_request {
 	gboolean admin;
 	/*! \brief Pointer to the original request, if available */
 	json_t *message;
-} janus_request;
+};
 /*! \brief Helper to allocate a janus_request instance
  * @param[in] transport Pointer to the transport
  * @param[in] instance Opaque pointer to the transport-provided instance


### PR DESCRIPTION
In addition to this diff, see
  * https://github.com/ploxiln/janus-gateway/blob/ad1cdba29589d024a3b31c3ca36351c5e5e56a1f/ice.h#L152
  * https://github.com/ploxiln/janus-gateway/blob/ad1cdba29589d024a3b31c3ca36351c5e5e56a1f/janus.h#L42

recent gcc doesn't care about it, but gcc-4.4 from RHEL6 does - see #414 