### PR TITLE
config comment parsing off by one

### DIFF
--- a/config.c
+++ b/config.c
@@ -105,25 +105,15 @@ janus_config *janus_config_parse(const char *config_file) {
 		/* Strip comments */
 		char *line = line_buffer, *sc = line, *c = NULL;
 		while((c = strchr(sc, ';')) != NULL) {
-			if(c == line) {
-				/* Comment starts here */
-				*c = '\0';
-				break;
-			}
-			c--;
-			if(*c != '\\') {
+			if(c == line || *(c-1) != '\\') {
 				/* Comment starts here */
 				*c = '\0';
 				break;
 			}
 			/* Escaped semicolon, remove the slash */
-			sc = c;
-			int len = strlen(line)-(sc-line), pos = 0;
-			for(pos = 0; pos < len; pos++)
-				sc[pos] = sc[pos+1];
-			sc[len-1] = '\0';
-			if(len == 2)
-				break;
+			sc = c-1;
+			/* length will be at least 2: ';' '\0' */
+			memmove(sc, c, strlen(c)+1);
 			/* Go on */
 			sc++;
 		}

--- a/janus.c
+++ b/janus.c
@@ -3576,7 +3576,7 @@ gint main(int argc, char *argv[])
 	item = janus_config_get_item_drilldown(config, "general", "transports_folder");
 	if(item && item->value)
 		path = (char *)item->value;
-	JANUS_LOG(LOG_INFO, "Transpor plugins folder: %s\n", path);
+	JANUS_LOG(LOG_INFO, "Transport plugins folder: %s\n", path);
 	dir = opendir(path);
 	if(!dir) {
 		JANUS_LOG(LOG_FATAL, "\tCouldn't access transport plugins folder...\n");


### PR DESCRIPTION
the character just before the semicolon would be stripped

I went ahead and rewrote that little part of the comment parsing while I was fixing it.