### PR TITLE
Correctly skip candidates when using bundle.

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -538,10 +538,7 @@ gint janus_ice_trickle_parse(janus_ice_handle *handle, json_t *candidate, const 
 		data = 0;
 #endif
 		if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)
-				&& (
-					((video || data) && handle->audio_stream != NULL) || 
-						((data) && handle->video_stream != NULL))
-					) {
+				&& sdpMLineIndex != 0) {
 			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Got a %s candidate but we're bundling, ignoring...\n", handle->handle_id, json_string_value(mid));
 		} else {
 			janus_ice_stream *stream = video ? handle->video_stream : (data ? handle->data_stream : handle->audio_stream);


### PR DESCRIPTION
When using bundle with at least audio and video, video_stream is null since all
the data is flowing throught the first stream (the audio_stream).

So in janus_ice_trickle_parse the value of the video variable is always 0 while
data is incorrectly set to 1.
Having this data == 1 the candidates for the additional medias are correctly
skipped.

If instead HAVE_SCTP isn't defined also data is 0 and the candidates for the
other medias are uncorrectly added to the nice agent.

This also triggers a problem with libnice handling multiple candidates having
the same foundation in the same component (randomly choosing the wrong remote
candidate).

The right fix will be problaby be to save the media type for every
sdpMLineIndex in the ice handle (something like the one just reported in the
FIXME).

This patch fixes this by skipping all the candidates with sdpMLineIndex != 0
since the code already assumes that the bundling is done on all the medias
instead of relying on the values of video and data variables.