### PR TITLE
Make DTLS alert and related events more asynchronous

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -1031,7 +1031,7 @@ void janus_ice_webrtc_hangup(janus_ice_handle *handle) {
 		return;
 	if(handle->queued_packets != NULL)
 		g_async_queue_push(handle->queued_packets, &janus_ice_dtls_alert);
-	if(handle->icethread != NULL) {
+	if(handle->icethread == NULL) {
 		/* Get rid of the PeerConnection */
 		if(handle->iceloop) {
 			gint64 waited = 0;

--- a/ice.c
+++ b/ice.c
@@ -265,6 +265,21 @@ gboolean janus_is_rtcp(gchar *buf) {
 }
 
 
+#define JANUS_ICE_PACKET_AUDIO	0
+#define JANUS_ICE_PACKET_VIDEO	1
+#define JANUS_ICE_PACKET_DATA	2
+/* Janus enqueued (S)RTP/(S)RTCP packet to send */
+typedef struct janus_ice_queued_packet {
+	char *data;
+	gint length;
+	gint type;
+	gboolean control;
+	gboolean encrypted;
+} janus_ice_queued_packet;
+/* This is a static, fake, message we use as a trigger to send a DTLS alert */
+static janus_ice_queued_packet janus_ice_dtls_alert;
+
+
 /* Maximum values for the NACK queue/retransmissions */
 #define DEFAULT_MAX_NACK_QUEUE	300
 /* Maximum ignore count after retransmission (100ms) */
@@ -1014,32 +1029,29 @@ void janus_ice_free(janus_ice_handle *handle) {
 void janus_ice_webrtc_hangup(janus_ice_handle *handle) {
 	if(handle == NULL)
 		return;
-	janus_mutex_lock(&handle->mutex);
-	handle->icethread = NULL;
-	if(handle->streams != NULL) {
-		if(handle->audio_stream) {
-			janus_ice_stream *stream = handle->audio_stream;
-			if(stream->rtp_component)
-				janus_dtls_srtp_send_alert(stream->rtp_component->dtls);
-			if(stream->rtcp_component)
-				janus_dtls_srtp_send_alert(stream->rtcp_component->dtls);
-		}
-		if(handle->video_stream) {
-			janus_ice_stream *stream = handle->video_stream;
-			if(stream->rtp_component)
-				janus_dtls_srtp_send_alert(stream->rtp_component->dtls);
-			if(stream->rtcp_component)
-				janus_dtls_srtp_send_alert(stream->rtcp_component->dtls);
-		}
-		if(handle->data_stream) {
-			janus_ice_stream *stream = handle->data_stream;
-			if(stream->rtp_component)
-				janus_dtls_srtp_send_alert(stream->rtp_component->dtls);
-			if(stream->rtcp_component)
-				janus_dtls_srtp_send_alert(stream->rtcp_component->dtls);
+	if(handle->queued_packets != NULL)
+		g_async_queue_push(handle->queued_packets, &janus_ice_dtls_alert);
+	if(handle->icethread != NULL) {
+		/* Get rid of the PeerConnection */
+		if(handle->iceloop) {
+			gint64 waited = 0;
+			while(handle->iceloop && !g_main_loop_is_running(handle->iceloop)) {
+				JANUS_LOG(LOG_VERB, "[%"SCNu64"] ICE loop exists but is not running, waiting for it to run\n", handle->handle_id);
+				g_usleep (100000);
+				waited += 100000;
+				if(waited >= G_USEC_PER_SEC) {
+					JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Waited a second, that's enough!\n", handle->handle_id);
+					break;
+				}
+			}
+			if(handle->iceloop && g_main_loop_is_running(handle->iceloop)) {
+				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Forcing ICE loop to quit (%s)\n", handle->handle_id, g_main_loop_is_running(handle->iceloop) ? "running" : "NOT running");
+				g_main_loop_quit(handle->iceloop);
+				g_main_context_wakeup(handle->icectx);
+			}
 		}
 	}
-	janus_mutex_unlock(&handle->mutex);
+	handle->icethread = NULL;
 }
 
 void janus_ice_webrtc_free(janus_ice_handle *handle) {
@@ -1093,7 +1105,7 @@ void janus_ice_webrtc_free(janus_ice_handle *handle) {
 		janus_ice_queued_packet *pkt = NULL;
 		while(g_async_queue_length(handle->queued_packets) > 0) {
 			pkt = g_async_queue_try_pop(handle->queued_packets);
-			if(pkt != NULL) {
+			if(pkt != NULL && pkt != &janus_ice_dtls_alert) {
 				g_free(pkt->data);
 				pkt->data = NULL;
 				g_free(pkt);
@@ -2945,6 +2957,33 @@ void *janus_ice_send_thread(void *data) {
 		if(pkt == NULL) {
 			/* Sleep 10ms */
 			g_usleep(10000);
+			continue;
+		}
+		if(pkt == &janus_ice_dtls_alert) {
+			/* The session is over, send an alert on all streams and components */
+			if(handle->streams != NULL) {
+				if(handle->audio_stream) {
+					janus_ice_stream *stream = handle->audio_stream;
+					if(stream->rtp_component)
+						janus_dtls_srtp_send_alert(stream->rtp_component->dtls);
+					if(stream->rtcp_component)
+						janus_dtls_srtp_send_alert(stream->rtcp_component->dtls);
+				}
+				if(handle->video_stream) {
+					janus_ice_stream *stream = handle->video_stream;
+					if(stream->rtp_component)
+						janus_dtls_srtp_send_alert(stream->rtp_component->dtls);
+					if(stream->rtcp_component)
+						janus_dtls_srtp_send_alert(stream->rtcp_component->dtls);
+				}
+				if(handle->data_stream) {
+					janus_ice_stream *stream = handle->data_stream;
+					if(stream->rtp_component)
+						janus_dtls_srtp_send_alert(stream->rtp_component->dtls);
+					if(stream->rtcp_component)
+						janus_dtls_srtp_send_alert(stream->rtcp_component->dtls);
+				}
+			}
 			continue;
 		}
 		if(pkt->data == NULL) {

--- a/ice.h
+++ b/ice.h
@@ -146,8 +146,6 @@ typedef struct janus_ice_handle janus_ice_handle;
 typedef struct janus_ice_stream janus_ice_stream;
 /*! \brief Janus ICE component */
 typedef struct janus_ice_component janus_ice_component;
-/*! \brief Janus enqueued (S)RTP/(S)RTCP packet to send */
-typedef struct janus_ice_queued_packet janus_ice_queued_packet;
 /*! \brief Helper to handle pending trickle candidates (e.g., when we're still waiting for an offer) */
 typedef struct janus_ice_trickle janus_ice_trickle;
 
@@ -432,24 +430,6 @@ gint janus_ice_trickle_parse(janus_ice_handle *handle, json_t *candidate, const 
 void janus_ice_trickle_destroy(janus_ice_trickle *trickle);
 ///@}
 
-
-
-#define JANUS_ICE_PACKET_AUDIO	0
-#define JANUS_ICE_PACKET_VIDEO	1
-#define JANUS_ICE_PACKET_DATA	2
-/*! \brief Janus enqueued (S)RTP/(S)RTCP packet to send */
-struct janus_ice_queued_packet {
-	/*! \brief Packet data */
-	char *data;
-	/*! \brief Packet length */
-	gint length;
-	/*! \brief Type of data (audio/video/data, or RTCP related to any of them) */
-	gint type;
-	/*! \brief Whether this is an RTCP message or not */
-	gboolean control;
-	/*! \brief Whether the data is already encrypted or not */
-	gboolean encrypted;
-};
 
 /** @name Janus ICE handle methods
  */

--- a/janus.c
+++ b/janus.c
@@ -2833,24 +2833,6 @@ void janus_plugin_close_pc(janus_plugin_session *plugin_session) {
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Plugin asked to hangup PeerConnection: sending alert\n", ice_handle->handle_id);
 	/* Send an alert on all the DTLS connections */
 	janus_ice_webrtc_hangup(ice_handle);
-	/* Get rid of the PeerConnection */
-	if(ice_handle->iceloop) {
-		gint64 waited = 0;
-		while(ice_handle->iceloop && !g_main_loop_is_running(ice_handle->iceloop)) {
-			JANUS_LOG(LOG_VERB, "[%"SCNu64"] ICE loop exists but is not running, waiting for it to run\n", ice_handle->handle_id);
-			g_usleep (100000);
-			waited += 100000;
-			if(waited >= G_USEC_PER_SEC) {
-				JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Waited a second, that's enough!\n", ice_handle->handle_id);
-				break;
-			}
-		}
-		if(ice_handle->iceloop && g_main_loop_is_running(ice_handle->iceloop)) {
-			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Forcing ICE loop to quit (%s)\n", ice_handle->handle_id, g_main_loop_is_running(ice_handle->iceloop) ? "running" : "NOT running");
-			g_main_loop_quit(ice_handle->iceloop);
-			g_main_context_wakeup(ice_handle->icectx);
-		}
-	}
 }
 
 void janus_plugin_end_session(janus_plugin_session *plugin_session) {


### PR DESCRIPTION
This pull request tries to fix a problem that had been lingering in the background for some time, now.

Plugins can ask the core to tear down a PeerConnection using the ```close_pc``` callback request. This method was conceived so that it would send a DTLS alert to the peer and get rid of the PeerConnection at the core level. Of course, this would also result in a ```hangup_media``` event to the plugin itself, to confirm the PeerConnection was actually closed and trigger the related logic in the plugin.

The problem with the code we had was that the thread invoking ```hangup_media``` was the same that called ```close_pc```. As you can imagine, this could easily lead to trouble: e.g., if the part of the code calling ```close_pc``` and the ```hangup_media``` code had to work on the same mutex, this would lead to a deadlock.

This was caused by the fact that ```janus_plugin_close_pc``` (the core method ```close_pc``` redirects to) called ```janus_ice_webrtc_hangup```, which in turn invoked ```SSL_shutdown```. This OpenSSL method, apparently, also automatically results in a callback to ```janus_dtls_callback``` with SSL_CB_ALERT in the same thread context, and from there to ```hangup_media```, while I thought this would always require an incoming DTLS alert from the peer to happen.

Having all of this happen within the same thread context made little sense, considering we have an ad-hoc thread for all outgoing data (which is why, for instance, a ```relay_rtp``` never blocks: it just adds data to the outgoing queue and immediately returns), so this patch tries to make sending a DTLS alert more in line with that approach. Whenever a DTLS alert needs to be sent, a fake message to address that intention is enqueued, and it's the outgoing data thread that sends the alert. This in turn triggers all the logic that eventually leads to the PeerConnection being removed from the core and the plugin being informed about it. In case no outgoing data thread is available (e.g., ICE not completed yet), it's ```janus_ice_webrtc_hangup``` that stops the ICE loop and not ```janus_plugin_close_pc``` (which now is much "thinner").

I verified this fixed the issue for me, and apparently with no harm done to other parts of Janus. Before merging, I'd like to be sure that's indeed the case, so please test and let me know if it's safe to do so.