### PR TITLE
fix for janus_videoroom_listener leak for janus_videoroom_listener_muxed

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -3925,7 +3925,6 @@ static void janus_videoroom_listener_free(janus_videoroom_listener *l) {
 static void janus_videoroom_muxed_listener_free(janus_videoroom_listener_muxed *l) {
 	JANUS_LOG(LOG_VERB, "Freeing muxed-listener\n");
 	GSList *ls = l->listeners;
-	JANUS_LOG(LOG_VERB, "Freeing muxed-listener %p with %d listener\n", l, g_slist_length(ls));
 	while(ls) {
 		janus_videoroom_listener *listener = (janus_videoroom_listener *)ls->data;
 		if(listener) {
@@ -3933,6 +3932,7 @@ static void janus_videoroom_muxed_listener_free(janus_videoroom_listener_muxed *
 		}
 		ls = ls->next;
 	}
+	g_slist_free(l->listeners);
 	g_free(l);
 }
 


### PR DESCRIPTION
i has find memleaks when i use janus_videoroom_listener_muxed 
it don't free any janus_videoroom_listener , this is the pactch i made for it
can you check if is ok and then merge with master .