### PR TITLE
fixbug for videoroom message handler thread

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -2193,9 +2193,7 @@ static void *janus_videoroom_handler(void *data) {
 		}
 		janus_videoroom_session *session = NULL;
 		janus_mutex_lock(&sessions_mutex);
-		if(g_hash_table_lookup(sessions, msg->handle) != NULL ) {
-			session = (janus_videoroom_session *)msg->handle->plugin_handle;
-		}
+		session = g_hash_table_lookup(sessions, msg->handle);
 		janus_mutex_unlock(&sessions_mutex);
 		if(!session) {
 			JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");


### PR DESCRIPTION
fixbug for videoroom message handler thread, the pointer `msg->handle` may freed in janus core.
I have 70+ participants in the videoroom。 the videoroom message handler thread process message will delay more then 3 seconds。in that condition the pointer `msg->handle` may freed in janus core, Janus will crash.