### PR TITLE
upgrade to libwebsockets 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ HTTP REST API, you'll have to install it manually:
 
 	git clone git://git.libwebsockets.org/libwebsockets
 	cd libwebsockets
-	git checkout v1.5-chrome47-firefox41
+	git checkout v1.6.0-chrome48-firefox42
 	mkdir build
 	cd build
 	cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_C_FLAGS="-fpic" ..

--- a/configure.ac
+++ b/configure.ac
@@ -196,7 +196,7 @@ PKG_CHECK_MODULES([MHD],
 AM_CONDITIONAL([ENABLE_REST], [test "x$enable_rest" = "xyes"])
 
 AC_CHECK_LIB([websockets_shared],
-             [libwebsocket_get_internal_extensions],
+             [lws_get_internal_extensions],
              [
                AS_IF([test "x$enable_websockets" = "xyes"],
                [
@@ -206,7 +206,7 @@ AC_CHECK_LIB([websockets_shared],
              ],
              [
 				AC_CHECK_LIB([websockets],
-							 [libwebsocket_get_internal_extensions],
+							 [lws_get_internal_extensions],
 							 [
 							   AS_IF([test "x$enable_websockets" = "xyes"],
 							   [


### PR DESCRIPTION
janus-gateway did not work with v1.6 of libwebsockets nor the latest master. This PR should solves that.

The changes are as follows:

* Change prefix `libwebsockets_` to `lws_`.
* Remove `libwebsocket_context *this` argument from libwebsockets functions.
* Change 1.5 to 1.6 in readme.

Related to #436 and #434