### PR TITLE
Have the parent wait for an exit code from the child during startup, when daemonizing

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -2995,6 +2995,7 @@ gint main(int argc, char *argv[])
 		}
 		if(pid > 0) {
 			/* Ok, we're the parent: let's wait for the child to tell us everything started fine */
+			close(pipefd[1]);
 			int code = -1;
 			struct pollfd pollfds;
 
@@ -3006,6 +3007,8 @@ gint main(int argc, char *argv[])
 					break;
 				if(res == 0)
 					continue;
+				if(pollfds.revents & POLLERR || pollfds.revents & POLLHUP)
+					break;
 				if(pollfds.revents & POLLIN) {
 					read(pipefd[0], &code, sizeof(int));
 					break;

--- a/janus.c
+++ b/janus.c
@@ -229,9 +229,7 @@ static void janus_termination_handler(void) {
 		ssize_t res = 0;
 		do {
 			res = write(pipefd[1], &code, sizeof(int));
-			if(res == -1 && errno == EINTR)
-				res = 0;	/* Try again */
-		} while(res <= 0);
+		} while(res == -1 && errno == EINTR);
 	}
 }
 
@@ -3740,9 +3738,7 @@ gint main(int argc, char *argv[])
 		ssize_t res = 0;
 		do {
 			res = write(pipefd[1], &code, sizeof(int));
-			if(res == -1 && errno == EINTR)
-				res = 0;	/* Try again */
-		} while(res <= 0);
+		} while(res == -1 && errno == EINTR);
 	}
 
 	while(!g_atomic_int_get(&stop)) {

--- a/janus.c
+++ b/janus.c
@@ -226,7 +226,12 @@ static void janus_termination_handler(void) {
 	/* If we're daemonizing, we send an error code to the parent */
 	if(daemonize) {
 		int code = 1;
-		write(pipefd[1], &code, sizeof(int));
+		ssize_t res = 0;
+		do {
+			res = write(pipefd[1], &code, sizeof(int));
+			if(res == -1 && errno == EINTR)
+				res = 0;	/* Try again */
+		} while(res <= 0);
 	}
 }
 
@@ -3732,7 +3737,12 @@ gint main(int argc, char *argv[])
 	/* Ok, Janus has started! Let the parent now about this if we're daemonizing */
 	if(daemonize) {
 		int code = 0;
-		write(pipefd[1], &code, sizeof(int));
+		ssize_t res = 0;
+		do {
+			res = write(pipefd[1], &code, sizeof(int));
+			if(res == -1 && errno == EINTR)
+				res = 0;	/* Try again */
+		} while(res <= 0);
 	}
 
 	while(!g_atomic_int_get(&stop)) {


### PR DESCRIPTION
A quick'n'dirty patch to allow for feedback on whether Janus started or not, when daemonizing. A pipe is created, and the parent waits on one end for an exit code before actually exiting: the child either writes a 0 when everything was started correctly, or a 1 when it didn't (currently done in ```janus_termination_handler```).

The patch is much more basic than what @saghul proposed in #408 (no grandparents/grandchildren, for instance, but just the parent/child we already had), but seems to do the job. I'm just puzzled as to how to handle the cases where Janus crashes instead: I thought this would result in the child end of the pipe being closed, and so the poll to exit, but it didn't (the poll keeps waiting), meaning we should handle it accordingly. I guess there are some flags/controls that can be set on the pipe for that, I'll look into it.

Feedback welcome!