### PR TITLE
New transport module (Unix Sockets)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -179,6 +179,16 @@ conf_DATA += conf/janus.transport.rabbitmq.cfg.sample
 EXTRA_DIST += conf/janus.transport.rabbitmq.cfg.sample
 endif
 
+if ENABLE_PFUNIX
+transport_LTLIBRARIES += transports/libjanus_pfunix.la
+transports_libjanus_pfunix_la_SOURCES = transports/janus_pfunix.c
+transports_libjanus_pfunix_la_CFLAGS = $(transports_cflags)
+transports_libjanus_pfunix_la_LDFLAGS = $(transports_ldflags)
+transports_libjanus_pfunix_la_LIBADD = $(transports_libadd)
+conf_DATA += conf/janus.transport.pfunix.cfg.sample
+EXTRA_DIST += conf/janus.transport.pfunix.cfg.sample
+endif
+
 ##
 # Plugins
 ##

--- a/conf/janus.transport.pfunix.cfg.sample
+++ b/conf/janus.transport.pfunix.cfg.sample
@@ -5,6 +5,7 @@
 enabled = yes					; Whether to enable the Unix Sockets interface
 								; for Janus API clients
 path = /tmp/ux-janusapi			; Path to bind to (Janus API)
+;type = SOCK_SEQPACKET			; SOCK_SEQPACKET (default) or SOCK_DGRAM?
 
 ; As with other transport plugins, you can use Unix Sockets to interact
 ; with the Admin API as well: in case you're interested in it, a different
@@ -13,3 +14,4 @@ path = /tmp/ux-janusapi			; Path to bind to (Janus API)
 admin_enabled = no				; Whether to enable the Unix Sockets interface
 								; for Admin API clients
 admin_path = /tmp/ux-janusadmin	; Path to bind to (Admin API)
+;admin_type = SOCK_SEQPACKET	; SOCK_SEQPACKET (default) or SOCK_DGRAM?

--- a/conf/janus.transport.pfunix.cfg.sample
+++ b/conf/janus.transport.pfunix.cfg.sample
@@ -1,0 +1,15 @@
+; You can also control a Janus instance using Unix Sockets. The only
+; aspect you need to configure here is the path of the Unix Sockets
+; server.
+[general]
+enabled = yes					; Whether to enable the Unix Sockets interface
+								; for Janus API clients
+path = /tmp/ux-janusapi			; Path to bind to (Janus API)
+
+; As with other transport plugins, you can use Unix Sockets to interact
+; with the Admin API as well: in case you're interested in it, a different
+; path needs to be provided.
+[admin]
+admin_enabled = no				; Whether to enable the Unix Sockets interface
+								; for Admin API clients
+admin_path = /tmp/ux-janusadmin	; Path to bind to (Admin API)

--- a/configure.ac
+++ b/configure.ac
@@ -242,6 +242,26 @@ AC_CHECK_LIB([rabbitmq],
              ])
 AM_CONDITIONAL([ENABLE_RABBITMQ], [test "x$enable_rabbitmq" = "xyes"])
 
+AC_TRY_COMPILE([
+               #include <stdlib.h>
+               #include <sys/socket.h>
+               #include <sys/un.h>
+               void test() {
+                 int pfd = socket(PF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0);
+                 if(pfd < 0)
+                   exit(1);
+               }],
+               [],
+               [
+                 AS_IF([test "x$enable_pfunix" = "xyes"],
+                 [
+                    AC_DEFINE(HAVE_PFUNIX)
+                 ])
+               ],
+               [
+                 AS_IF([test "x$enable_pfunix" = "xyes"],
+                       [AC_MSG_ERROR([SOCK_SEQPACKET not defined in your OS. Use --disable-unix-sockets])])
+               ])
 AM_CONDITIONAL([ENABLE_PFUNIX], [test "x$enable_pfunix" = "xyes"])
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,12 @@ AC_ARG_ENABLE([rabbitmq],
               [],
               [enable_rabbitmq=yes])
 
+AC_ARG_ENABLE([unix-sockets],
+              [AS_HELP_STRING([--disable-unix-sockets],
+                              [Disable Unix Sockets integration])],
+              [],
+              [enable_pfunix=yes])
+
 AC_ARG_ENABLE([boringssl],
               [AS_HELP_STRING([--enable-boringssl],
                               [Use BoringSSL instead of OpenSSL])],
@@ -236,6 +242,8 @@ AC_CHECK_LIB([rabbitmq],
              ])
 AM_CONDITIONAL([ENABLE_RABBITMQ], [test "x$enable_rabbitmq" = "xyes"])
 
+AM_CONDITIONAL([ENABLE_PFUNIX], [test "x$enable_pfunix" = "xyes"])
+
 
 ##
 # Plugins
@@ -385,6 +393,9 @@ AM_COND_IF([ENABLE_WEBSOCKETS],
 AM_COND_IF([ENABLE_RABBITMQ],
 	[echo "    RabbitMQ:              yes"],
 	[echo "    RabbitMQ:              no"])
+AM_COND_IF([ENABLE_PFUNIX],
+	[echo "    Unix Sockets:          yes"],
+	[echo "    Unix Sockets:          no"])
 echo "Plugins:"
 AM_COND_IF([ENABLE_PLUGIN_ECHOTEST],
 	[echo "    Echo Test:             yes"],

--- a/transports/janus_pfunix.c
+++ b/transports/janus_pfunix.c
@@ -450,7 +450,7 @@ void *janus_pfunix_thread(void *data) {
 					iov[0].iov_len = sizeof(buffer);
 					res = recvmsg(poll_fds[i].fd, &msg, MSG_WAITALL);
 					if(res < 0) {
-						if(errno != EWOULDBLOCK) {
+						if(errno != EAGAIN && errno != EWOULDBLOCK) {
 							JANUS_LOG(LOG_ERR, "Error reading from client %d...\n", poll_fds[i].fd);
 						}
 						continue;

--- a/transports/janus_pfunix.c
+++ b/transports/janus_pfunix.c
@@ -1,0 +1,532 @@
+/*! \file   janus_pfunix.c
+ * \author Lorenzo Miniero <lorenzo@meetecho.com>
+ * \copyright GNU General Public License v3
+ * \brief  Janus Unix Sockets transport plugin
+ * \details  This is an implementation of a Unix Sockets transport for the
+ * Janus API. This means that, with the help of this module, local
+ * applications can use Unix Sockets to make requests to the gateway.
+ * This plugin makes use of the \c SOCK_SEQPACKET socket type, so make
+ * sure you're using the right one when writing a client application.
+ * Pretty much as it happens with WebSockets, the same client socket can
+ * be used for both sending requests and receiving notifications, without
+ * any need for long polls. At the same time, without the concept of a
+ * REST path, requests sent through the Unix Sockets interface will need
+ * to include, when needed, additional pieces of information like
+ * \c session_id and \c handle_id. That is, where you'd send a Janus
+ * request related to a specific session to the \c /janus/<session> path,
+ * with Unix Sockets you'd have to send the same request with an additional
+ * \c session_id field in the JSON payload. The same applies for the handle.
+ * \note When you create a session using Unix Sockets, a subscription to
+ * the events related to it is done automatically, so no need for an
+ * explicit request as the GET in the plain HTTP API. Closing a client
+ * Unix Socket will also destroy all the sessions it created.
+ *
+ * \ingroup transports
+ * \ref transports
+ */
+
+#include "transport.h"
+
+#include <poll.h>
+#include <sys/un.h>
+
+#include "../debug.h"
+#include "../apierror.h"
+#include "../config.h"
+#include "../mutex.h"
+#include "../utils.h"
+
+
+/* Transport plugin information */
+#define JANUS_PFUNIX_VERSION			1
+#define JANUS_PFUNIX_VERSION_STRING		"0.0.1"
+#define JANUS_PFUNIX_DESCRIPTION		"This transport plugin adds Unix Sockets support to the Janus API."
+#define JANUS_PFUNIX_NAME				"JANUS Unix Sockets transport plugin"
+#define JANUS_PFUNIX_AUTHOR				"Meetecho s.r.l."
+#define JANUS_PFUNIX_PACKAGE			"janus.transport.pfunix"
+
+/* Transport methods */
+janus_transport *create(void);
+int janus_pfunix_init(janus_transport_callbacks *callback, const char *config_path);
+void janus_pfunix_destroy(void);
+int janus_pfunix_get_api_compatibility(void);
+int janus_pfunix_get_version(void);
+const char *janus_pfunix_get_version_string(void);
+const char *janus_pfunix_get_description(void);
+const char *janus_pfunix_get_name(void);
+const char *janus_pfunix_get_author(void);
+const char *janus_pfunix_get_package(void);
+gboolean janus_pfunix_is_janus_api_enabled(void);
+gboolean janus_pfunix_is_admin_api_enabled(void);
+int janus_pfunix_send_message(void *transport, void *request_id, gboolean admin, json_t *message);
+void janus_pfunix_session_created(void *transport, guint64 session_id);
+void janus_pfunix_session_over(void *transport, guint64 session_id, gboolean timeout);
+
+
+/* Transport setup */
+static janus_transport janus_pfunix_transport =
+	JANUS_TRANSPORT_INIT (
+		.init = janus_pfunix_init,
+		.destroy = janus_pfunix_destroy,
+
+		.get_api_compatibility = janus_pfunix_get_api_compatibility,
+		.get_version = janus_pfunix_get_version,
+		.get_version_string = janus_pfunix_get_version_string,
+		.get_description = janus_pfunix_get_description,
+		.get_name = janus_pfunix_get_name,
+		.get_author = janus_pfunix_get_author,
+		.get_package = janus_pfunix_get_package,
+
+		.is_janus_api_enabled = janus_pfunix_is_janus_api_enabled,
+		.is_admin_api_enabled = janus_pfunix_is_admin_api_enabled,
+
+		.send_message = janus_pfunix_send_message,
+		.session_created = janus_pfunix_session_created,
+		.session_over = janus_pfunix_session_over,
+	);
+
+/* Transport creator */
+janus_transport *create(void) {
+	JANUS_LOG(LOG_VERB, "%s created!\n", JANUS_PFUNIX_NAME);
+	return &janus_pfunix_transport;
+}
+
+
+/* Useful stuff */
+static gint initialized = 0, stopping = 0;
+static janus_transport_callbacks *gateway = NULL;
+
+
+/* Unix Sockets server thread */
+static GThread *pfunix_thread = NULL;
+void *janus_pfunix_thread(void *data);
+
+/* Unix Sockets servers */
+static int pfd = 0, admin_pfd = 0;
+/* Socket pair to notify about the need for outgoing data */
+static int write_fd[2];
+
+/* Unix Sockets client session */
+typedef struct janus_pfunix_client {
+	int fd;					/* Client socket */
+	gboolean admin;			/* Whether this client is for the Admin or Janus API */
+	GAsyncQueue *messages;	/* Queue of outgoing messages to push */
+	gint session_timeout:1;	/* Whether a Janus session timeout occurred in the core */
+} janus_pfunix_client;
+static GHashTable *clients = NULL, *clients_by_fd = NULL;
+static janus_mutex clients_mutex;
+
+
+/* Transport implementation */
+int janus_pfunix_init(janus_transport_callbacks *callback, const char *config_path) {
+	if(g_atomic_int_get(&stopping)) {
+		/* Still stopping from before */
+		return -1;
+	}
+	if(callback == NULL || config_path == NULL) {
+		/* Invalid arguments */
+		return -1;
+	}
+
+	/* This is the callback we'll need to invoke to contact the gateway */
+	gateway = callback;
+
+	/* Read configuration */
+	char filename[255];
+	g_snprintf(filename, 255, "%s/%s.cfg", config_path, JANUS_PFUNIX_PACKAGE);
+	JANUS_LOG(LOG_VERB, "Configuration file: %s\n", filename);
+	janus_config *config = janus_config_parse(filename);
+	if(config != NULL) {
+		/* Handle configuration */
+		janus_config_print(config);
+
+		/* First of all Initialize the socketpair for writeable notifications */
+		if(socketpair(PF_LOCAL, SOCK_STREAM, 0, write_fd) < 0) {
+			JANUS_LOG(LOG_FATAL, "Error creating socket pair for writeable events: %d, %s\n", errno, strerror(errno));
+			return -1;
+		}
+
+		/* Setup the Janus API Unix Sockets server(s) */
+		janus_config_item *item = janus_config_get_item_drilldown(config, "general", "enabled");
+		if(!item || !item->value || !janus_is_true(item->value)) {
+			JANUS_LOG(LOG_WARN, "Unix Sockets server disabled (Janus API)\n");
+		} else {
+			item = janus_config_get_item_drilldown(config, "general", "path");
+			char *pfname = (char *)(item && item->value ? item->value : "/tmp/ux-janusapi");
+			if(strlen(pfname) > 108) {
+				JANUS_LOG(LOG_WARN, "The provided path name (%s) is longer than 108 characters, it will be truncated\n", pfname);
+				pfname[108] = '\0';
+			}
+			/* Create socket */
+			pfd = socket(PF_UNIX, SOCK_SEQPACKET, 0);
+			if(pfd < 0) {
+				JANUS_LOG(LOG_FATAL, "Unix Sockets %s creation for Janus API failed: %d, %s\n", pfname, errno, strerror(errno));
+				pfd = 0;
+			} else {
+				/* Unlink before binding */
+				unlink(pfname);
+				/* Let's bind to the provided path now */
+				struct sockaddr_un address;
+				memset(&address, 0, sizeof(address));
+				address.sun_family = AF_UNIX;
+				g_snprintf(address.sun_path, 108, "%s", pfname);
+				JANUS_LOG(LOG_VERB, "Binding Unix Socket %s... (Janus API)\n", pfname);
+				if(bind(pfd, (struct sockaddr *)&address, sizeof(address)) != 0) {
+					JANUS_LOG(LOG_FATAL, "Bind for Unix Socket %s (Janus API) failed: %d, %s\n", pfname, errno, strerror(errno));
+					close(pfd);
+					pfd = 0;
+				} else {
+					JANUS_LOG(LOG_VERB, "Listening on Unix Socket %s... (Janus API)\n", pfname);
+					if(listen(pfd, 5) != 0) {
+						JANUS_LOG(LOG_FATAL, "Listening on Unix Socket %s (Janus API) failed: %d, %s\n", pfname, errno, strerror(errno));
+						close(pfd);
+						pfd = 0;
+					}
+				}
+			}
+		}
+		/* Do the same for the Admin API, if enabled */
+		item = janus_config_get_item_drilldown(config, "admin", "admin_enabled");
+		if(!item || !item->value || !janus_is_true(item->value)) {
+			JANUS_LOG(LOG_WARN, "Unix Sockets server disabled (Admin API)\n");
+		} else {
+			item = janus_config_get_item_drilldown(config, "general", "path");
+			char *pfname = (char *)(item && item->value ? item->value : "/tmp/ux-janusadmin");
+			if(strlen(pfname) > 108) {
+				JANUS_LOG(LOG_WARN, "The provided path name (%s) is longer than 108 characters, it will be truncated\n", pfname);
+				pfname[108] = '\0';
+			}
+			/* Create socket */
+			admin_pfd = socket(PF_UNIX, SOCK_SEQPACKET, 0);
+			if(admin_pfd < 0) {
+				JANUS_LOG(LOG_FATAL, "Unix Sockets %s creation for Admin API failed: %d, %s\n", pfname, errno, strerror(errno));
+				admin_pfd = 0;
+			} else {
+				/* Unlink before binding */
+				unlink(pfname);
+				/* Let's bind to the provided path now */
+				struct sockaddr_un address;
+				memset(&address, 0, sizeof(address));
+				address.sun_family = AF_UNIX;
+				g_snprintf(address.sun_path, 108, "%s", pfname);
+				JANUS_LOG(LOG_VERB, "Binding Unix Socket %s... (Admin API)\n", pfname);
+				if(bind(admin_pfd, (struct sockaddr *)&address, sizeof(address)) != 0) {
+					JANUS_LOG(LOG_FATAL, "Bind for Unix Socket %s (Admin API) failed: %d, %s\n", pfname, errno, strerror(errno));
+					close(admin_pfd);
+					admin_pfd = 0;
+				} else {
+					JANUS_LOG(LOG_VERB, "Listening on Unix Socket %s... (Admin API)\n", pfname);
+					if(listen(admin_pfd, 5) != 0) {
+						JANUS_LOG(LOG_FATAL, "Listening on Unix Socket %s (Admin API) failed: %d, %s\n", pfname, errno, strerror(errno));
+						close(admin_pfd);
+						admin_pfd = 0;
+					}
+				}
+			}
+		}
+	}
+	janus_config_destroy(config);
+	config = NULL;
+	if(pfd == 0 && admin_pfd == 0) {
+		JANUS_LOG(LOG_FATAL, "No Unix Sockets server started, giving up...\n");
+		return -1;	/* No point in keeping the plugin loaded */
+	}
+
+	/* Create a couple of hashtables for all clients */
+	clients = g_hash_table_new(NULL, NULL);
+	clients_by_fd = g_hash_table_new(NULL, NULL);
+	janus_mutex_init(&clients_mutex);
+
+	GError *error = NULL;
+	/* Start the Unix Sockets service thread */
+	if(pfd > 0 || admin_pfd > 0) {
+		pfunix_thread = g_thread_try_new("pfunix thread", &janus_pfunix_thread, NULL, &error);
+		if(!pfunix_thread) {
+			g_atomic_int_set(&initialized, 0);
+			JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the Unix Sockets thread...\n", error->code, error->message ? error->message : "??");
+			return -1;
+		}
+	}
+
+	/* Done */
+	g_atomic_int_set(&initialized, 1);
+	JANUS_LOG(LOG_INFO, "%s initialized!\n", JANUS_PFUNIX_NAME);
+	return 0;
+}
+
+void janus_pfunix_destroy(void) {
+	if(!g_atomic_int_get(&initialized))
+		return;
+	g_atomic_int_set(&stopping, 1);
+
+	/* Stop the service thread */
+	char c;
+	write(write_fd[1], &c, 1);
+	if(pfunix_thread != NULL) {
+		g_thread_join(pfunix_thread);
+		pfunix_thread = NULL;
+	}
+
+	g_atomic_int_set(&initialized, 0);
+	g_atomic_int_set(&stopping, 0);
+	JANUS_LOG(LOG_INFO, "%s destroyed!\n", JANUS_PFUNIX_NAME);
+}
+
+int janus_pfunix_get_api_compatibility(void) {
+	/* Important! This is what your plugin MUST always return: don't lie here or bad things will happen */
+	return JANUS_TRANSPORT_API_VERSION;
+}
+
+int janus_pfunix_get_version(void) {
+	return JANUS_PFUNIX_VERSION;
+}
+
+const char *janus_pfunix_get_version_string(void) {
+	return JANUS_PFUNIX_VERSION_STRING;
+}
+
+const char *janus_pfunix_get_description(void) {
+	return JANUS_PFUNIX_DESCRIPTION;
+}
+
+const char *janus_pfunix_get_name(void) {
+	return JANUS_PFUNIX_NAME;
+}
+
+const char *janus_pfunix_get_author(void) {
+	return JANUS_PFUNIX_AUTHOR;
+}
+
+const char *janus_pfunix_get_package(void) {
+	return JANUS_PFUNIX_PACKAGE;
+}
+
+gboolean janus_pfunix_is_janus_api_enabled(void) {
+	return pfd > 0;
+}
+
+gboolean janus_pfunix_is_admin_api_enabled(void) {
+	return admin_pfd > 0;
+}
+
+int janus_pfunix_send_message(void *transport, void *request_id, gboolean admin, json_t *message) {
+	if(message == NULL)
+		return -1;
+	if(transport == NULL) {
+		g_free(message);
+		return -1;
+	}
+	/* Make sure this is related to a still valid Unix Sockets session */
+	janus_pfunix_client *client = (janus_pfunix_client *)transport;
+	janus_mutex_lock(&clients_mutex);
+	if(g_hash_table_lookup(clients, client) == NULL || client->fd <= 0) {
+		janus_mutex_unlock(&clients_mutex);
+		JANUS_LOG(LOG_WARN, "Outgoing message for invalid client %p\n", client);
+		g_free(message);
+		message = NULL;
+		return -1;
+	}
+	janus_mutex_unlock(&clients_mutex);
+	/* Convert to string and enqueue */
+	char *payload = json_dumps(message, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+	json_decref(message);
+	g_async_queue_push(client->messages, payload);
+	/* Notify the thread there's data to send */
+	char c;
+	write(write_fd[1], &c, 1);
+	return 0;
+}
+
+void janus_pfunix_session_created(void *transport, guint64 session_id) {
+	/* We don't care */
+}
+
+void janus_pfunix_session_over(void *transport, guint64 session_id, gboolean timeout) {
+	/* We only care if it's a timeout: if so, close the connection */
+	if(transport == NULL || !timeout)
+		return;
+	/* FIXME Should we really close the connection in case of a timeout? */
+	janus_pfunix_client *client = (janus_pfunix_client *)transport;
+	janus_mutex_lock(&clients_mutex);
+	if(g_hash_table_lookup(clients, client) != NULL && client->fd > 0) {
+		/* Shutdown the client socket */
+		shutdown(client->fd, SHUT_WR);
+	}
+	janus_mutex_unlock(&clients_mutex);
+}
+
+
+/* Thread */
+void *janus_pfunix_thread(void *data) {
+	JANUS_LOG(LOG_INFO, "Unix Sockets thread started\n");
+
+	int fds = 0;
+	struct pollfd poll_fds[1024];	/* FIXME Should we allow for more clients? */
+	char buffer[4096];
+
+	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
+		/* Prepare poll list of file descriptors */
+		fds = 0;
+		/* Writeable monitor */
+		poll_fds[fds].fd = write_fd[0];
+		poll_fds[fds].events = POLLIN;
+		fds++;
+		if(pfd > 0) {
+			/* Janus API */
+			poll_fds[fds].fd = pfd;
+			poll_fds[fds].events = POLLIN;
+			fds++;
+		}
+		if(admin_pfd > 0) {
+			/* Admin API */
+			poll_fds[fds].fd = admin_pfd;
+			poll_fds[fds].events = POLLIN;
+			fds++;
+		}
+		/* Iterate on available clients, to see if we need to POLLIN or POLLOUT too */
+		janus_mutex_lock(&clients_mutex);
+		GHashTableIter iter;
+		gpointer value;
+		g_hash_table_iter_init(&iter, clients_by_fd);
+		while(g_hash_table_iter_next(&iter, NULL, &value)) {
+			janus_pfunix_client *client = value;
+			if(client->fd > 0) {
+				poll_fds[fds].fd = client->fd;
+				poll_fds[fds].events = POLLIN;
+				if(g_async_queue_length(client->messages) > 0) {
+					poll_fds[fds].events = POLLOUT;
+				}
+				fds++;
+			}
+		}
+		janus_mutex_unlock(&clients_mutex);
+
+		/* Start polling */
+		int res = poll(poll_fds, fds, 10000);
+		if(res == 0)
+			continue;
+		if(res < 0) {
+			JANUS_LOG(LOG_ERR, "poll() failed\n");
+			break;
+		}
+		for(int i=0; i<fds; i++) {
+			if((poll_fds[i].revents & POLLOUT) == POLLOUT) {
+				/* Find the client from its file descriptor */
+				janus_mutex_lock(&clients_mutex);
+				janus_pfunix_client *client = g_hash_table_lookup(clients_by_fd, GINT_TO_POINTER(poll_fds[i].fd));
+				if(client != NULL && client->fd > 0) {
+					char *payload = NULL;
+					while((payload = g_async_queue_try_pop(client->messages)) != NULL) {
+						int res = write(client->fd, payload, strlen(payload));
+						/* FIXME Should we check if sent everything? */
+						JANUS_LOG(LOG_HUGE, "Written %d/%zu bytes on %d\n", res, strlen(payload), client->fd);
+						g_free(payload);
+					}
+				}
+				janus_mutex_unlock(&clients_mutex);
+			}
+			if((poll_fds[i].revents & POLLIN) == POLLIN) {
+				if(poll_fds[i].fd == write_fd[0]) {
+					/* Read and ignore: we use this to unlock the poll if there's data to write */
+					res = read(poll_fds[i].fd, buffer, 4096);
+				} else if(poll_fds[i].fd == pfd) {
+					/* Janus API: accept the new client */
+					struct sockaddr_un address;
+					socklen_t address_length = 0;
+					int cfd = accept(pfd, (struct sockaddr *) &address, &address_length);
+					if(cfd > 0) {
+						JANUS_LOG(LOG_VERB, "Got new Unix Sockets Janus API client: %d\n", cfd);
+						/* Allocate new client */
+						janus_pfunix_client *client = g_malloc0(sizeof(janus_pfunix_client));
+						client->fd = cfd;
+						client->admin = FALSE;	/* Janus API client */
+						client->messages = g_async_queue_new();
+						client->session_timeout = 0;
+						/* Take note of this new client */
+						janus_mutex_lock(&clients_mutex);
+						g_hash_table_insert(clients_by_fd, GINT_TO_POINTER(cfd), client);
+						g_hash_table_insert(clients, client, client);
+						janus_mutex_unlock(&clients_mutex);
+					}
+				} else if(poll_fds[i].fd == admin_pfd) {
+					/* Admin API: accept the new client */
+					struct sockaddr_un address;
+					socklen_t address_length = 0;
+					int cfd = accept(admin_pfd, (struct sockaddr *) &address, &address_length);
+					if(cfd > 0) {
+						JANUS_LOG(LOG_VERB, "Got new Unix Sockets Admin API client: %d\n", cfd);
+						/* Allocate new client */
+						janus_pfunix_client *client = g_malloc0(sizeof(janus_pfunix_client));
+						client->fd = cfd;
+						client->admin = TRUE;	/* Admin API client */
+						client->messages = g_async_queue_new();
+						client->session_timeout = 0;
+						/* Take note of this new client */
+						janus_mutex_lock(&clients_mutex);
+						g_hash_table_insert(clients_by_fd, GINT_TO_POINTER(cfd), client);
+						g_hash_table_insert(clients, client, client);
+						janus_mutex_unlock(&clients_mutex);
+					}
+				} else {
+					/* Client data: receive */
+					res = read(poll_fds[i].fd, buffer, 4096);
+					if(res < 0) {
+						JANUS_LOG(LOG_ERR, "Error reading from client %d...\n", poll_fds[i].fd);
+						continue;
+					}
+					/* Find the client from its file descriptor */
+					janus_mutex_lock(&clients_mutex);
+					janus_pfunix_client *client = g_hash_table_lookup(clients_by_fd, GINT_TO_POINTER(poll_fds[i].fd));
+					if(client == NULL) {
+						janus_mutex_unlock(&clients_mutex);
+						JANUS_LOG(LOG_WARN, "Got data from unknown Unix Sockets client %d, closing connection...\n", poll_fds[i].fd);
+						/* Close socket */
+						shutdown(SHUT_RDWR, poll_fds[i].fd);
+						close(poll_fds[i].fd);
+						continue;
+					}
+					if(res == 0) {
+						JANUS_LOG(LOG_VERB, "Unix Sockets client disconnected (%d)\n", poll_fds[i].fd);
+						/* Close socket */
+						shutdown(SHUT_RDWR, poll_fds[i].fd);
+						close(poll_fds[i].fd);
+						/* Destroy the client */
+						g_hash_table_remove(clients_by_fd, GINT_TO_POINTER(poll_fds[i].fd));
+						g_hash_table_remove(clients, client);
+						if(client->messages != NULL) {
+							char *response = NULL;
+							while((response = g_async_queue_try_pop(client->messages)) != NULL) {
+								g_free(response);
+							}
+							g_async_queue_unref(client->messages);
+						}
+						g_free(client);
+						janus_mutex_unlock(&clients_mutex);
+						continue;
+					}
+					janus_mutex_unlock(&clients_mutex);
+					/* If we got here, there's data to handle */
+					buffer[res] = '\0';
+					JANUS_LOG(LOG_VERB, "Message from client %d (%d bytes)\n", poll_fds[i].fd, res);
+					JANUS_LOG(LOG_HUGE, "%s\n", buffer);
+					/* Parse the JSON payload */
+					json_error_t error;
+					json_t *root = json_loads(buffer, 0, &error);
+					/* Notify the core, passing both the object and, since it may be needed, the error */
+					gateway->incoming_request(&janus_pfunix_transport, client, NULL, client->admin, root, &error);
+				}
+			}
+		}
+	}
+
+	if(pfd > 0)
+		close(pfd);
+	pfd = 0;
+	if(admin_pfd > 0)
+		close(admin_pfd);
+	admin_pfd = 0;
+
+	/* Done */
+	JANUS_LOG(LOG_INFO, "Unix Sockets thread ended\n");
+	return NULL;
+}

--- a/transports/janus_pfunix.c
+++ b/transports/janus_pfunix.c
@@ -98,8 +98,9 @@ static janus_transport_callbacks *gateway = NULL;
 
 #define BUFFER_SIZE		8192
 
-#ifndef UNIX_MAX_PATH
-#define UNIX_MAX_PATH 108
+struct sockaddr_un sizecheck;
+#ifndef UNIX_PATH_MAX
+#define UNIX_PATH_MAX sizeof(sizecheck.sun_path)
 #endif
 
 /* Unix Sockets server thread */
@@ -127,9 +128,9 @@ static int janus_pfunix_create_socket(char *pfname) {
 	if(pfname == NULL)
 		return -1;
 	int fd = -1;
-	if(strlen(pfname) > UNIX_MAX_PATH) {
-		JANUS_LOG(LOG_WARN, "The provided path name (%s) is longer than %d characters, it will be truncated\n", pfname, UNIX_MAX_PATH);
-		pfname[UNIX_MAX_PATH] = '\0';
+	if(strlen(pfname) > UNIX_PATH_MAX) {
+		JANUS_LOG(LOG_WARN, "The provided path name (%s) is longer than %lu characters, it will be truncated\n", pfname, UNIX_PATH_MAX);
+		pfname[UNIX_PATH_MAX] = '\0';
 	}
 	/* Create socket */
 	fd = socket(PF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0);
@@ -142,7 +143,7 @@ static int janus_pfunix_create_socket(char *pfname) {
 		struct sockaddr_un address;
 		memset(&address, 0, sizeof(address));
 		address.sun_family = AF_UNIX;
-		g_snprintf(address.sun_path, UNIX_MAX_PATH, "%s", pfname);
+		g_snprintf(address.sun_path, UNIX_PATH_MAX, "%s", pfname);
 		JANUS_LOG(LOG_VERB, "Binding Unix Socket %s... (Janus API)\n", pfname);
 		if(bind(fd, (struct sockaddr *)&address, sizeof(address)) != 0) {
 			JANUS_LOG(LOG_FATAL, "Bind for Unix Socket %s failed: %d, %s\n", pfname, errno, strerror(errno));

--- a/transports/janus_pfunix.c
+++ b/transports/janus_pfunix.c
@@ -456,7 +456,8 @@ void *janus_pfunix_thread(void *data) {
 			JANUS_LOG(LOG_ERR, "poll() failed\n");
 			break;
 		}
-		for(int i=0; i<fds; i++) {
+		int i = 0;
+		for(i=0; i<fds; i++) {
 			if(poll_fds[i].revents & (POLLERR | POLLHUP)) {
 				/* Socket error? Shall we do something? */
 				if(poll_fds[i].fd == write_fd[0]) {

--- a/transports/janus_pfunix.c
+++ b/transports/janus_pfunix.c
@@ -411,7 +411,9 @@ void *janus_pfunix_thread(void *data) {
 					/* Error in the wake-up socketpair, that sucks: try recreating it */
 					JANUS_LOG(LOG_WARN, "Error in the wake-up socketpair, recreating it...\n");
 					close(write_fd[0]);
+					write_fd[0] = -1;
 					close(write_fd[1]);
+					write_fd[1] = -1;
 					if(socketpair(PF_LOCAL, SOCK_STREAM, 0, write_fd) < 0) {
 						JANUS_LOG(LOG_FATAL, "Error creating socket pair for writeable events: %d, %s\n", errno, strerror(errno));
 						continue;


### PR DESCRIPTION
This patch adds a new transport module, specifically for controlling a Janus instance via Unix Sockets as an alternative to the already available HTTP, WebSockets and RabbitMQ transports. This would be particularly useful in contexts where Janus and its controlling application are colocated, and where a dedicated control channel would be more efficient. Credits for the suggestion about the new module and hints go to @saghul!

As of now, you can configure two named server sockets, one for the Janus API and one for the Admin API. When writing a client, you need to specify the ```SOCK_SEQPACKET``` type, as that's what both interfaces make use of. Changing this to something different (e.g., ```SOCK_DGRAM```) would be trivial and I guess could be added to the configuration as well, so if there's interest in that we can do that. There's no plan on adding support for ```SOCK_STREAM```, instead, as we need the automatic message framing that a stream does not provide.

I haven't tested this extensively (just did a few validations), so feedback and bug reports are more than welcome!