### PR TITLE
First take at RTCP SR/RR in core

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,7 @@ PKG_CHECK_MODULES([JANUS],
                     libcrypto
                     sofia-sip-ua
                   ])
+JANUS_MANUAL_LIBS+=" -lm"
 AC_SUBST(JANUS_MANUAL_LIBS)
 
 AS_IF([test "x$enable_boringssl" = "xyes"],

--- a/ice.h
+++ b/ice.h
@@ -22,6 +22,7 @@
 
 #include "dtls.h"
 #include "sctp.h"
+#include "rtcp.h"
 #include "utils.h"
 #include "plugins/plugin.h"
 
@@ -319,6 +320,10 @@ struct janus_ice_stream {
 	guint32 video_ssrc_peer_rtx;
 	/*! \brief RTP payload type of this stream */
 	gint payload_type;
+	/*! \brief RTCP context for the audio stream (may be bundled) */
+	rtcp_context *audio_rtcp_ctx;
+	/*! \brief RTCP context for the video stream (may be bundled) */
+	rtcp_context *video_rtcp_ctx;
 	/*! \brief DTLS role of the gateway for this stream */
 	janus_dtls_role dtls_role;
 	/*! \brief Hashing algorhitm used by the peer for the DTLS certificate (e.g., "SHA-256") */

--- a/ice.h
+++ b/ice.h
@@ -332,6 +332,10 @@ struct janus_ice_stream {
 	rtcp_context *audio_rtcp_ctx;
 	/*! \brief RTCP context for the video stream (may be bundled) */
 	rtcp_context *video_rtcp_ctx;
+	/*! \brief Last sent audio RTP timestamp */
+	guint32 audio_last_ts;
+	/*! \brief Last sent video RTP timestamp */
+	guint32 video_last_ts;
 	/*! \brief DTLS role of the gateway for this stream */
 	janus_dtls_role dtls_role;
 	/*! \brief Hashing algorhitm used by the peer for the DTLS certificate (e.g., "SHA-256") */

--- a/janus.c
+++ b/janus.c
@@ -2203,6 +2203,28 @@ json_t *janus_admin_stream_summary(janus_ice_stream *stream) {
 		if(c)
 			json_array_append_new(components, c);
 	}
+	json_t *rtcp_stats = NULL;
+	if(stream->audio_rtcp_ctx != NULL) {
+		rtcp_stats = json_object();
+		json_t *audio_rtcp_stats = json_object();
+		json_object_set_new(audio_rtcp_stats, "lsr", json_integer(janus_rtcp_context_get_lsr(stream->audio_rtcp_ctx)));
+		json_object_set_new(audio_rtcp_stats, "lost", json_integer(janus_rtcp_context_get_lost(stream->audio_rtcp_ctx)));
+		json_object_set_new(audio_rtcp_stats, "lost-promille", json_integer(janus_rtcp_context_get_lost_promille(stream->audio_rtcp_ctx)));
+		json_object_set_new(audio_rtcp_stats, "jitter-ms", json_integer(janus_rtcp_context_get_jitter(stream->audio_rtcp_ctx)));
+		json_object_set_new(rtcp_stats, "audio", audio_rtcp_stats);
+	}
+	if(stream->video_rtcp_ctx != NULL) {
+		if(rtcp_stats == NULL)
+			rtcp_stats = json_object();
+		json_t *video_rtcp_stats = json_object();
+		json_object_set_new(video_rtcp_stats, "lsr", json_integer(janus_rtcp_context_get_lsr(stream->video_rtcp_ctx)));
+		json_object_set_new(video_rtcp_stats, "lost", json_integer(janus_rtcp_context_get_lost(stream->video_rtcp_ctx)));
+		json_object_set_new(video_rtcp_stats, "lost-promille", json_integer(janus_rtcp_context_get_lost_promille(stream->video_rtcp_ctx)));
+		json_object_set_new(video_rtcp_stats, "jitter-ms", json_integer(janus_rtcp_context_get_jitter(stream->video_rtcp_ctx)));
+		json_object_set_new(rtcp_stats, "video", video_rtcp_stats);
+	}
+	if(rtcp_stats != NULL)
+		json_object_set_new(s, "rtcp_stats", rtcp_stats);
 	json_object_set_new(s, "components", components);
 	return s;
 }

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -576,22 +576,9 @@ void janus_echotest_slow_link(janus_plugin_session *handle, int uplink, int vide
 			JANUS_LOG(LOG_WARN, "Getting a lot of NACKs (slow %s) for %s, forcing a lower REMB: %"SCNu64"\n",
 				uplink ? "uplink" : "downlink", video ? "video" : "audio", session->bitrate);
 			/* ... and send a new REMB back */
-			char rtcpbuf[200];
-			memset(rtcpbuf, 0, 200);
-			/* FIXME First put a RR (fake)... */
-			int rrlen = 32;
-			rtcp_rr *rr = (rtcp_rr *)&rtcpbuf;
-			rr->header.version = 2;
-			rr->header.type = RTCP_RR;
-			rr->header.rc = 1;
-			rr->header.length = htons((rrlen/4)-1);
-			/* ... then put a SDES... */
-			int sdeslen = janus_rtcp_sdes((char *)(&rtcpbuf)+rrlen, 200-rrlen, "janusvideo", 10);
-			if(sdeslen > 0) {
-				/* ... and then finally a REMB */
-				janus_rtcp_remb((char *)(&rtcpbuf)+rrlen+sdeslen, 24, session->bitrate);
-				gateway->relay_rtcp(handle, 1, rtcpbuf, rrlen+sdeslen+24);
-			}
+			char rtcpbuf[24];
+			janus_rtcp_remb((char *)(&rtcpbuf), 24, session->bitrate);
+			gateway->relay_rtcp(handle, 1, rtcpbuf, 24);
 			/* As a last thing, notify the user about this */
 			json_t *event = json_object();
 			json_object_set_new(event, "echotest", json_string("event"));

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1049,7 +1049,7 @@ void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf,
 						/* Fix SSRCs as the gateway does */
 						JANUS_LOG(LOG_HUGE, "[SIP] Fixing SSRCs (local %u, peer %u)\n",
 							session->media.video_ssrc, session->media.video_ssrc_peer);
-						janus_rtcp_fix_ssrc((char *)buf, len, 1, session->media.video_ssrc, session->media.video_ssrc_peer);
+						janus_rtcp_fix_ssrc(NULL, (char *)buf, len, 1, session->media.video_ssrc, session->media.video_ssrc_peer);
 						/* Forward the message to the peer */
 						send(session->media.video_rtcp_fd, sbuf, protected, 0);
 					}
@@ -1057,7 +1057,7 @@ void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf,
 					/* Fix SSRCs as the gateway does */
 					JANUS_LOG(LOG_HUGE, "[SIP] Fixing SSRCs (local %u, peer %u)\n",
 						session->media.video_ssrc, session->media.video_ssrc_peer);
-					janus_rtcp_fix_ssrc((char *)buf, len, 1, session->media.video_ssrc, session->media.video_ssrc_peer);
+					janus_rtcp_fix_ssrc(NULL, (char *)buf, len, 1, session->media.video_ssrc, session->media.video_ssrc_peer);
 					/* Forward the message to the peer */
 					send(session->media.video_rtcp_fd, buf, len, 0);
 				}
@@ -1077,7 +1077,7 @@ void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf,
 						/* Fix SSRCs as the gateway does */
 						JANUS_LOG(LOG_HUGE, "[SIP] Fixing SSRCs (local %u, peer %u)\n",
 							session->media.audio_ssrc, session->media.audio_ssrc_peer);
-						janus_rtcp_fix_ssrc((char *)buf, len, 1, session->media.audio_ssrc, session->media.audio_ssrc_peer);
+						janus_rtcp_fix_ssrc(NULL, (char *)buf, len, 1, session->media.audio_ssrc, session->media.audio_ssrc_peer);
 						/* Forward the message to the peer */
 						send(session->media.audio_rtcp_fd, sbuf, protected, 0);
 					}
@@ -1085,7 +1085,7 @@ void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf,
 					/* Fix SSRCs as the gateway does */
 					JANUS_LOG(LOG_HUGE, "[SIP] Fixing SSRCs (local %u, peer %u)\n",
 						session->media.audio_ssrc, session->media.audio_ssrc_peer);
-					janus_rtcp_fix_ssrc((char *)buf, len, 1, session->media.audio_ssrc, session->media.audio_ssrc_peer);
+					janus_rtcp_fix_ssrc(NULL, (char *)buf, len, 1, session->media.audio_ssrc, session->media.audio_ssrc_peer);
 					/* Forward the message to the peer */
 					send(session->media.audio_rtcp_fd, buf, len, 0);
 				}

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -844,7 +844,7 @@ void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf,
 		JANUS_LOG(LOG_HUGE, "[SIP] Fixing SSRCs (local %u, peer %u)\n",
 			video ? session->media.video_ssrc : session->media.audio_ssrc,
 			video ? session->media.video_ssrc_peer : session->media.audio_ssrc_peer);
-		janus_rtcp_fix_ssrc((char *)buf, len, 1,
+		janus_rtcp_fix_ssrc(NULL, (char *)buf, len, 1,
 			video ? session->media.video_ssrc : session->media.audio_ssrc,
 			video ? session->media.video_ssrc_peer : session->media.audio_ssrc_peer);
 		/* Forward to our SIP peer */

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -755,22 +755,9 @@ void janus_videocall_slow_link(janus_plugin_session *handle, int uplink, int vid
 			JANUS_LOG(LOG_WARN, "Getting a lot of NACKs (slow %s) for %s, forcing a lower REMB: %"SCNu64"\n",
 				uplink ? "uplink" : "downlink", video ? "video" : "audio", uplink ? session->peer->bitrate : session->bitrate);
 			/* ... and send a new REMB back */
-			char rtcpbuf[200];
-			memset(rtcpbuf, 0, 200);
-			/* FIXME First put a RR (fake)... */
-			int rrlen = 32;
-			rtcp_rr *rr = (rtcp_rr *)&rtcpbuf;
-			rr->header.version = 2;
-			rr->header.type = RTCP_RR;
-			rr->header.rc = 1;
-			rr->header.length = htons((rrlen/4)-1);
-			/* ... then put a SDES... */
-			int sdeslen = janus_rtcp_sdes((char *)(&rtcpbuf)+rrlen, 200-rrlen, "janusvideo", 10);
-			if(sdeslen > 0) {
-				/* ... and then finally a REMB */
-				janus_rtcp_remb((char *)(&rtcpbuf)+rrlen+sdeslen, 24, uplink ? session->peer->bitrate : session->bitrate);
-				gateway->relay_rtcp(uplink ? session->peer->handle : handle, 1, rtcpbuf, rrlen+sdeslen+24);
-			}
+			char rtcpbuf[24];
+			janus_rtcp_remb((char *)(&rtcpbuf), 24, uplink ? session->peer->bitrate : session->bitrate);
+			gateway->relay_rtcp(uplink ? session->peer->handle : handle, 1, rtcpbuf, 24);
 			/* As a last thing, notify the affected user about this */
 			json_t *event = json_object();
 			json_object_set_new(event, "videocall", json_string("event"));

--- a/rtcp.c
+++ b/rtcp.c
@@ -453,10 +453,10 @@ uint32_t janus_rtcp_context_get_lost(rtcp_context *ctx) {
 	if(ctx == NULL)
 		return 0;
 	uint32_t lost;
-	if(ctx->lost > 0x7fffff) {
-		lost = 0x7fffff;
+	if(ctx->lost > 0x7FFFFF) {
+		lost = 0x7FFFFF;
 	} else {
-		lost = 0x00FFFFFF & ctx->lost;
+		lost = ctx->lost;
 	}
 	return lost;
 }

--- a/rtcp.h
+++ b/rtcp.h
@@ -96,7 +96,7 @@ typedef struct rtcp_rr
 /*! \brief RTCP SDES (http://tools.ietf.org/html/rfc3550#section-6.5) */
 typedef struct rtcp_sdes_chunk
 {
-	uint32_t csrc;
+	uint32_t ssrc;
 } rtcp_sdes_chunk;
 
 typedef struct rtcp_sdes_item
@@ -109,7 +109,6 @@ typedef struct rtcp_sdes_item
 typedef struct rtcp_sdes
 {
 	rtcp_header header;
-	uint32_t ssrc;
 	rtcp_sdes_chunk chunk;
 	rtcp_sdes_item item;
 } rtcp_sdes;
@@ -187,7 +186,7 @@ typedef struct rtcp_fb
 typedef struct rtcp_context
 {
 	/* Whether we received any RTP packet at all (don't send RR otherwise) */
-	uint16_t enabled:1;
+	uint8_t enabled:1;
 
 	uint16_t last_seq_nr;
 	uint16_t seq_cycle;
@@ -270,6 +269,13 @@ int janus_rtcp_parse(rtcp_context *ctx, char *packet, int len);
  * @param[in] newssrcr The SSRC of the receiver to put in the message
  * @returns 0 in case of success, -1 on errors */
 int janus_rtcp_fix_ssrc(rtcp_context *ctx, char *packet, int len, int fixssrc, uint32_t newssrcl, uint32_t newssrcr);
+
+/*! \brief Method to filter an outgoing RTCP message (http://tools.ietf.org/html/draft-ietf-straw-b2bua-rtcp-00)
+ * @param[in] packet The message data
+ * @param[in] len The message data length in bytes
+ * @param[in,out] newlen The data length of the filtered RTCP message
+ * @returns A pointer to the new RTCP message data, NULL in case all messages have been filtered out */
+char *janus_rtcp_filter(char *packet, int len, int *newlen);
 
 /*! \brief Method to quickly process the header of an incoming RTP packet to update the associated RTCP context
  * @param[in] ctx RTCP context to update, if needed (optional)

--- a/rtcp.h
+++ b/rtcp.h
@@ -183,6 +183,65 @@ typedef struct rtcp_fb
 } rtcp_fb;
 
 
+/*! \brief Internal RTCP state context (for RR/SR) */
+typedef struct rtcp_context
+{
+	/* Whether we received any RTP packet at all (don't send RR otherwise) */
+	uint16_t enabled:1;
+
+	uint16_t last_seq_nr;
+	uint16_t seq_cycle;
+	uint16_t base_seq;
+	/* Payload type */
+	uint16_t pt;
+
+	/* RFC 3550 A.8 Interarrival Jitter */
+	uint64_t transit;
+	double jitter;
+	/* Timestamp base (e.g., 48000 for opus audio, or 90000 for video) */
+	uint32_t tb;
+
+	/* Last SR received */
+	uint32_t lsr;
+	/* Monotonic time of last SR received */
+	int64_t lsr_ts;
+
+	/* Last RR/SR we sent */
+	int64_t last_sent;
+
+	/* RFC 3550 A.3 */
+	uint32_t received;
+	uint32_t received_prior;
+	uint32_t expected;
+	uint32_t expected_prior;
+	int32_t lost;
+} rtcp_context;
+/*! \brief Method to retrieve the LSR from an existing RTCP context
+ * @param[in] ctx The RTCP context to query
+ * @returns The last SR received */
+uint32_t janus_rtcp_context_get_lsr(rtcp_context *ctx);
+/*! \brief Method to retrieve the number of received packets from an existing RTCP context
+ * @param[in] ctx The RTCP context to query
+ * @returns The number of received packets */
+uint32_t janus_rtcp_context_get_received(rtcp_context *ctx);
+/*! \brief Method to retrieve the number of lost packets from an existing RTCP context
+ * @param[in] ctx The RTCP context to query
+ * @returns The number of lost packets */
+uint32_t janus_rtcp_context_get_lost(rtcp_context *ctx);
+/*! \brief Method to compute the fraction of lost packets from an existing RTCP context
+ * @param[in] ctx The RTCP context to query
+ * @returns The fraction of lost packets */
+uint32_t janus_rtcp_context_get_lost_fraction(rtcp_context *ctx);
+/*! \brief Method to conpute the number of lost packets (pro mille) from an existing RTCP context
+ * @param[in] ctx The RTCP context to query
+ * @returns The number of lost packets (pro mille) */
+uint32_t janus_rtcp_context_get_lost_promille(rtcp_context *ctx);
+/*! \brief Method to retrieve the jitter from an existing RTCP context
+ * @param[in] ctx The RTCP context to query
+ * @returns The computed jitter */
+uint32_t janus_rtcp_context_get_jitter(rtcp_context *ctx);
+
+
 /*! \brief Method to quickly retrieve the sender SSRC (needed for demuxing RTCP in BUNDLE)
  * @param[in] packet The message data
  * @param[in] len The message data length in bytes
@@ -195,19 +254,36 @@ guint32 janus_rtcp_get_sender_ssrc(char *packet, int len);
 guint32 janus_rtcp_get_receiver_ssrc(char *packet, int len);
 
 /*! \brief Method to parse/validate an RTCP message
+ * @param[in] ctx RTCP context to update, if needed (optional)
  * @param[in] packet The message data
  * @param[in] len The message data length in bytes
  * @returns 0 in case of success, -1 on errors */
-int janus_rtcp_parse(char *packet, int len);
+int janus_rtcp_parse(rtcp_context *ctx, char *packet, int len);
 
 /*! \brief Method to fix an RTCP message (http://tools.ietf.org/html/draft-ietf-straw-b2bua-rtcp-00)
+ * @param[in] ctx RTCP context to update, if needed (optional)
  * @param[in] packet The message data
  * @param[in] len The message data length in bytes
+ * @param[in] fixssrc Whether the method needs to fix the message or just parse it
  * @param[in] fixssrc Whether the method needs to fix the message or just parse it
  * @param[in] newssrcl The SSRC of the sender to put in the message
  * @param[in] newssrcr The SSRC of the receiver to put in the message
  * @returns 0 in case of success, -1 on errors */
-int janus_rtcp_fix_ssrc(char *packet, int len, int fixssrc, uint32_t newssrcl, uint32_t newssrcr);
+int janus_rtcp_fix_ssrc(rtcp_context *ctx, char *packet, int len, int fixssrc, uint32_t newssrcl, uint32_t newssrcr);
+
+/*! \brief Method to quickly process the header of an incoming RTP packet to update the associated RTCP context
+ * @param[in] ctx RTCP context to update, if needed (optional)
+ * @param[in] packet The RTP packet
+ * @param[in] len The packet data length in bytes
+ * @param[in] max_nack_queue Current value of the max NACK value in the handle stack
+ * @returns 0 in case of success, -1 on errors */
+int janus_rtcp_process_incoming_rtp(rtcp_context *ctx, char *packet, int len, int max_nack_queue);
+
+/*! \brief Method to fill in a Report Block in a Receiver Report
+ * @param[in] ctx The RTCP context to use for the report
+ * @param[in] rb Pointer to a valid report_block area of the RTCP data
+ * @returns 0 in case of success, -1 on errors */
+int janus_rtcp_report_block(rtcp_context *ctx, report_block *rb);
 
 /*! \brief Method to check whether an RTCP message contains a FIR request
  * @param[in] packet The message data


### PR DESCRIPTION
This PR continues the effort started by @fpn in #382. Specifically, it moves the original code from plugin to core, so that the functionality is actually automatically shared across different plugins for each PeerConnection. The collected info is then also made available in the Admin API.

It is not at all complete, as I still have to figure out the best way for getting this to work seamlessly with what plugins originate and do. To make a simple example, the VideoRoom plugin still sends empty RR just to attach a compound REMB, all while the core tries to send proper RR in the meantime every 5 seconds.

That said, it should be a good starting point to get better RTCP management here, so feedback welcome.