### PR TITLE
Fix for occasional race conditions when shutting down the SIP stack

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -2547,6 +2547,7 @@ gpointer janus_sip_sofia_thread(gpointer user_data) {
 	session->stack->s_nh_r = NULL;
 	session->stack->s_nh_i = NULL;
 	session->stack->s_root = su_root_create(session->stack);
+	su_home_init(session->stack->s_home);
 	JANUS_LOG(LOG_VERB, "Setting up sofia stack (sip:%s@%s)\n", session->account.username, local_ip);
 	char sip_url[128];
 	char sips_url[128];

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1954,6 +1954,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, call_text, "offer", fixed_sdp);
 			JANUS_LOG(LOG_VERB, "  >> %d (%s)\n", ret, janus_get_api_error(ret));
 			g_free(call_text);
+			g_free(fixed_sdp);
 			/* Send a Ringing back */
 			nua_respond(nh, 180, sip_status_phrase(180), TAG_END());
 			session->stack->s_nh_i = nh;
@@ -2071,6 +2072,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, call_text, "answer", fixed_sdp);
 			JANUS_LOG(LOG_VERB, "  >> %d (%s)\n", ret, janus_get_api_error(ret));
 			g_free(call_text);
+			g_free(fixed_sdp);
 			break;
 		}
 		case nua_r_register: {


### PR DESCRIPTION
This PR fixes a problem that @bhakimi reported. Specifically, Janus would at times crash, apparently for no reason, while using the SIP plugin. Looking at traces, we found out that, when this happened, the Sofia stack had just received a shutdown event (```nua_r_shutdown```), and the exact cause was a race condition where the plugin session had already been freed, thus crashing the plugin when trying to access its content.

To fix this, I modified the plugin code to do the following:

1. only initialise the SIP stack within the ```janus_sip_sofia_thread``` Sofia loop thread: this way the stack is only freed when the loop ends, that is after the shutdown event;
2. modified the way the lazy garbage collector kicks in: immediately adding the session to the "old" list if there is no stack (i.e., plugin session never handled a successfull register request), or at the end of the above mentioned Sofia loop thread (so that the session is only collected after the stack has been shut down).

I also fixed a couple of leaks here and there, and verified this seems to be working as expected now, but since this is a serious change and I don't want it to break anything people has working correctly as of now, I decided to publish it as a PR for the moment.

If you're using SIP please test this and let me know if it's safe to merge. Mentioning some of the people I know are using this because of recent related issues/PR activity, so forgive the spam: @saghul @hoangtuansu @cwerner-bfs @s-schumann @phillcz @MichaelB76 @shrhoads