### PR TITLE
Added optional SDES-SRTP support to SIP plugin

### DIFF
--- a/html/siptest.js
+++ b/html/siptest.js
@@ -218,7 +218,16 @@ $(document).ready(function() {
 																	success: function(jsep) {
 																		Janus.debug("Got SDP! audio=" + doAudio + ", video=" + doVideo);
 																		Janus.debug(jsep);
-																		var body = { "request": "accept" };
+																		var body = { request: "accept" };
+																		// Note: as with "call", you can add a "srtp" attribute to
+																		// negotiate/mandate SDES support for this incoming call.
+																		// The default behaviour is to automatically use it if
+																		// the caller negotiated it, but you may choose to require
+																		// SDES support by setting "srtp" to "sdes_mandatory", e.g.:
+																		//		var body = { request: "accept", srtp: "sdes_mandatory" };
+																		// This way you'll tell the plugin to accept the call, but ONLY
+																		// if SDES is available, and you don't want plain RTP. If it
+																		// is not available, you'll get an error (452) back.
 																		sipcall.send({"message": body, "jsep": jsep});
 																		$('#call').removeAttr('disabled').html('Hangup')
 																			.removeClass("btn-success").addClass("btn-danger")
@@ -520,8 +529,14 @@ function doCall() {
 				Janus.debug(jsep);
 				var body = { request: "call", uri: $('#peer').val() };
 				// Note: you can ask the plugin to negotiate SDES-SRTP, instead of the
-				// default plain RTP, by adding a srtp:true attribute to the request, e.g.:
-				//		var body = { request: "call", uri: $('#peer').val(), srtp: true };
+				// default plain RTP, by adding a "srtp" attribute to the request. Valid
+				// values are "sdes_optional" and "sdes_mandatory", e.g.:
+				//		var body = { request: "call", uri: $('#peer').val(), srtp: "sdes_optional" };
+				// "sdes_optional" will negotiate RTP/AVP and add a crypto line,
+				// "sdes_mandatory" will set the protocol to RTP/SAVP instead.
+				// Just beware that some endpoints will NOT accept an INVITE
+				// with a crypto line in it if the protocol is not RTP/SAVP,
+				// so if you want SDES use "sdes_optional" with care.
 				sipcall.send({"message": body, "jsep": jsep});
 			},
 			error: function(error) {

--- a/html/siptest.js
+++ b/html/siptest.js
@@ -518,7 +518,10 @@ function doCall() {
 			success: function(jsep) {
 				Janus.debug("Got SDP!");
 				Janus.debug(jsep);
-				var body = { "request": "call", uri: $('#peer').val() };
+				var body = { request: "call", uri: $('#peer').val() };
+				// Note: you can ask the plugin to negotiate SDES-SRTP, instead of the
+				// default plain RTP, by adding a srtp:true attribute to the request, e.g.:
+				//		var body = { request: "call", uri: $('#peer').val(), srtp: true };
 				sipcall.send({"message": body, "jsep": jsep});
 			},
 			error: function(error) {

--- a/html/siptest.js
+++ b/html/siptest.js
@@ -198,10 +198,17 @@ $(document).ready(function() {
 												Janus.debug("Audio " + (doAudio ? "has" : "has NOT") + " been negotiated");
 												Janus.debug("Video " + (doVideo ? "has" : "has NOT") + " been negotiated");
 											}
+											// Any security offered? A missing "srtp" attribute means plain RTP
+											var rtpType = "";
+											var srtp = result["srtp"];
+											if(srtp === "sdes_optional")
+												rtpType = " (SDES-SRTP offered)";
+											else if(srtp === "sdes_mandatory")
+												rtpType = " (SDES-SRTP mandatory)";
 											// Notify user
 											bootbox.hideAll();
 											incoming = bootbox.dialog({
-												message: "Incoming call from " + result["username"] + "!",
+												message: "Incoming call from " + result["username"] + "!" + rtpType,
 												title: "Incoming call",
 												closeButton: false,
 												buttons: {

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -431,13 +431,13 @@ static void janus_sip_srtp_cleanup(janus_sip_session *session) {
 	session->media.audio_srtp_out = NULL;
 	g_free(session->media.audio_local_policy.key);
 	session->media.audio_local_policy.key = NULL;
-	session->media.audio_srtp_suite_in = 0;
+	session->media.audio_srtp_suite_out = 0;
 	if(session->media.audio_srtp_in)
 		srtp_dealloc(session->media.audio_srtp_in);
 	session->media.audio_srtp_in = NULL;
 	g_free(session->media.audio_remote_policy.key);
 	session->media.audio_remote_policy.key = NULL;
-	session->media.audio_srtp_suite_out = 0;
+	session->media.audio_srtp_suite_in = 0;
 	/* Video */
 	if(session->media.video_srtp_out)
 		srtp_dealloc(session->media.video_srtp_out);
@@ -450,7 +450,7 @@ static void janus_sip_srtp_cleanup(janus_sip_session *session) {
 	session->media.video_srtp_in = NULL;
 	g_free(session->media.video_remote_policy.key);
 	session->media.video_remote_policy.key = NULL;
-	session->media.video_srtp_suite_out = 0;
+	session->media.video_srtp_suite_in = 0;
 }
 
 
@@ -2638,7 +2638,7 @@ char *janus_sip_sdp_manipulate(janus_sip_session *session, sdp_session_t *sdp) {
 		if(session->media.has_video) {
 			char *crypto = NULL;
 			session->media.video_srtp_suite_out = 80;
-			janus_sip_srtp_set_local(session, FALSE, &crypto);
+			janus_sip_srtp_set_local(session, TRUE, &crypto);
 			/* FIXME 32? 80? Both? */
 			char cryptoline[100];
 			g_snprintf(cryptoline, 100, "a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:%s", crypto);

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -12,7 +12,7 @@
  * and only the relevant events (e.g., INVITEs and BYEs) and functionality
  * (call, hangup) are made available to the web peer: peers can call
  * extensions at the SIP server or wait for incoming INVITEs, and during
- * a call they can send DTMF tones.
+ * a call they can send DTMF tones. Calls can do plain RTP or SDES-SRTP.
  *
  * The concept behind this plugin is to allow different web pages associated
  * to the same peer, and hence the same SIP user, to attach to the plugin
@@ -61,6 +61,9 @@
 #include <sofia-sip/sip_status.h>
 #include <sofia-sip/url.h>
 #include <sofia-sip/tport_tag.h>
+
+#include <srtp/srtp.h>
+#include <srtp/crypto_kernel.h>
 
 #include "../debug.h"
 #include "../apierror.h"
@@ -255,16 +258,23 @@ typedef struct janus_sip_account {
 typedef struct janus_sip_media {
 	char *remote_ip;
 	int ready:1;
+	gboolean has_srtp_local, has_srtp_remote;
 	int has_audio:1;
 	int audio_rtp_fd, audio_rtcp_fd;
 	int local_audio_rtp_port, remote_audio_rtp_port;
 	int local_audio_rtcp_port, remote_audio_rtcp_port;
 	guint32 audio_ssrc, audio_ssrc_peer;
+	srtp_t audio_srtp_in, audio_srtp_out;
+	srtp_policy_t audio_remote_policy, audio_local_policy;
+	int audio_srtp_suite_in, audio_srtp_suite_out;
 	int has_video:1;
 	int video_rtp_fd, video_rtcp_fd;
 	int local_video_rtp_port, remote_video_rtp_port;
 	int local_video_rtcp_port, remote_video_rtcp_port;
 	guint32 video_ssrc, video_ssrc_peer;
+	srtp_t video_srtp_in, video_srtp_out;
+	srtp_policy_t video_remote_policy, video_local_policy;
+	int video_srtp_suite_in, video_srtp_suite_out;
 } janus_sip_media;
 
 typedef struct janus_sip_session {
@@ -302,6 +312,145 @@ struct ssip_s {
 	nua_handle_t *s_nh_r, *s_nh_i;
 	janus_sip_session *session;
 };
+
+
+/* SRTP stuff (in case we need SDES) */
+#define SRTP_MASTER_KEY_LENGTH	16
+#define SRTP_MASTER_SALT_LENGTH	14
+#define SRTP_MASTER_LENGTH (SRTP_MASTER_KEY_LENGTH + SRTP_MASTER_SALT_LENGTH)
+static const char *janus_sip_srtp_error[] =
+{
+	"err_status_ok",
+	"err_status_fail",
+	"err_status_bad_param",
+	"err_status_alloc_fail",
+	"err_status_dealloc_fail",
+	"err_status_init_fail",
+	"err_status_terminus",
+	"err_status_auth_fail",
+	"err_status_cipher_fail",
+	"err_status_replay_fail",
+	"err_status_replay_old",
+	"err_status_algo_fail",
+	"err_status_no_such_op",
+	"err_status_no_ctx",
+	"err_status_cant_check",
+	"err_status_key_expired",
+	"err_status_socket_err",
+	"err_status_signal_err",
+	"err_status_nonce_bad",
+	"err_status_read_fail",
+	"err_status_write_fail",
+	"err_status_parse_err",
+	"err_status_encode_err",
+	"err_status_semaphore_err",
+	"err_status_pfkey_err",
+};
+static const gchar *janus_sip_get_srtp_error(int error) {
+	if(error < 0 || error > 24)
+		return NULL;
+	return janus_sip_srtp_error[error];
+}
+static int janus_sip_srtp_set_local(janus_sip_session *session, gboolean video, char **crypto) {
+	if(session == NULL)
+		return -1;
+	/* Generate key/salt */
+	uint8_t *key = g_malloc0(SRTP_MASTER_LENGTH);
+	crypto_get_random(key, SRTP_MASTER_LENGTH);
+	/* Set SRTP policies */
+	srtp_policy_t *policy = video ? &session->media.video_local_policy : &session->media.audio_local_policy;
+	crypto_policy_set_rtp_default(&(policy->rtp));
+	crypto_policy_set_rtcp_default(&(policy->rtcp));
+	policy->ssrc.type = ssrc_any_inbound;
+	policy->key = key;
+	policy->next = NULL;
+	/* Create SRTP context */
+	err_status_t res = srtp_create(video ? &session->media.video_srtp_out : &session->media.audio_srtp_out, policy);
+	if(res != err_status_ok) {
+		/* Something went wrong... */
+		JANUS_LOG(LOG_ERR, "Oops, error creating outbound SRTP session: %d (%s)\n", res, janus_sip_get_srtp_error(res));
+		g_free(key);
+		policy->key = NULL;
+		return -2;
+	}
+	/* Base64 encode the salt */
+	*crypto = g_base64_encode(key, SRTP_MASTER_LENGTH);
+	if((video && session->media.video_srtp_out) || (!video && session->media.audio_srtp_out)) {
+		JANUS_LOG(LOG_WARN, "%s outbound SRTP session created\n", video ? "Video" : "Audio");
+	}
+	return 0;
+}
+static int janus_sip_srtp_set_remote(janus_sip_session *session, gboolean video, const char *crypto, int suite) {
+	if(session == NULL || crypto == NULL)
+		return -1;
+	/* Base64 decode the crypto string and set it as the remote SRTP context */
+	gsize len = 0;
+	guchar *decoded = g_base64_decode(crypto, &len);
+	if(len < SRTP_MASTER_LENGTH) {
+		/* FIXME Can this happen? */
+		g_free(decoded);
+		return -2;
+	}
+	/* Set SRTP policies */
+	srtp_policy_t *policy = video ? &session->media.video_remote_policy : &session->media.audio_remote_policy;
+	crypto_policy_set_rtp_default(&(policy->rtp));
+	crypto_policy_set_rtcp_default(&(policy->rtcp));
+	if(suite == 32) {
+		crypto_policy_set_aes_cm_128_hmac_sha1_32(&(policy->rtp));
+		crypto_policy_set_aes_cm_128_hmac_sha1_32(&(policy->rtcp));
+	} else if(suite == 80) {
+		crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtp));
+		crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
+	}
+	policy->ssrc.type = ssrc_any_inbound;
+	policy->key = decoded;
+	policy->next = NULL;
+	/* Create SRTP context */
+	err_status_t res = srtp_create(video ? &session->media.video_srtp_in : &session->media.audio_srtp_in, policy);
+	if(res != err_status_ok) {
+		/* Something went wrong... */
+		JANUS_LOG(LOG_ERR, "Oops, error creating inbound SRTP session: %d (%s)\n", res, janus_sip_get_srtp_error(res));
+		g_free(decoded);
+		policy->key = NULL;
+		return -2;
+	}
+	if((video && session->media.video_srtp_in) || (!video && session->media.audio_srtp_in)) {
+		JANUS_LOG(LOG_WARN, "%s inbound SRTP session created\n", video ? "Video" : "Audio");
+	}
+	return 0;
+}
+static void janus_sip_srtp_cleanup(janus_sip_session *session) {
+	if(session == NULL)
+		return;
+	session->media.has_srtp_local = FALSE;
+	session->media.has_srtp_remote = FALSE;
+	/* Audio */
+	if(session->media.audio_srtp_out)
+		srtp_dealloc(session->media.audio_srtp_out);
+	session->media.audio_srtp_out = NULL;
+	g_free(session->media.audio_local_policy.key);
+	session->media.audio_local_policy.key = NULL;
+	session->media.audio_srtp_suite_in = 0;
+	if(session->media.audio_srtp_in)
+		srtp_dealloc(session->media.audio_srtp_in);
+	session->media.audio_srtp_in = NULL;
+	g_free(session->media.audio_remote_policy.key);
+	session->media.audio_remote_policy.key = NULL;
+	session->media.audio_srtp_suite_out = 0;
+	/* Video */
+	if(session->media.video_srtp_out)
+		srtp_dealloc(session->media.video_srtp_out);
+	session->media.video_srtp_out = NULL;
+	g_free(session->media.video_local_policy.key);
+	session->media.video_local_policy.key = NULL;
+	session->media.video_srtp_suite_out = 0;
+	if(session->media.video_srtp_in)
+		srtp_dealloc(session->media.video_srtp_in);
+	session->media.video_srtp_in = NULL;
+	g_free(session->media.video_remote_policy.key);
+	session->media.video_remote_policy.key = NULL;
+	session->media.video_srtp_suite_out = 0;
+}
 
 
 /* Sofia Event thread */
@@ -412,6 +561,7 @@ void *janus_sip_watchdog(void *data) {
 					    g_free(session->media.remote_ip);
 					    session->media.remote_ip = NULL;
 					}
+					janus_sip_srtp_cleanup(session);
 					session->handle = NULL;
 					g_free(session);
 					session = NULL;
@@ -654,6 +804,8 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->callee = NULL;
 	session->media.remote_ip = NULL;
 	session->media.ready = 0;
+	session->media.has_srtp_local = FALSE;
+	session->media.has_srtp_remote = FALSE;
 	session->media.has_audio = 0;
 	session->media.audio_rtp_fd = -1;
 	session->media.audio_rtcp_fd= -1;
@@ -663,6 +815,8 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.remote_audio_rtcp_port = 0;
 	session->media.audio_ssrc = 0;
 	session->media.audio_ssrc_peer = 0;
+	session->media.audio_srtp_suite_in = 0;
+	session->media.audio_srtp_suite_out = 0;
 	session->media.has_video = 0;
 	session->media.video_rtp_fd = -1;
 	session->media.video_rtcp_fd= -1;
@@ -672,6 +826,8 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.remote_video_rtcp_port = 0;
 	session->media.video_ssrc = 0;
 	session->media.video_ssrc_peer = 0;
+	session->media.video_srtp_suite_in = 0;
+	session->media.video_srtp_suite_out = 0;
 	session->destroyed = 0;
 	g_atomic_int_set(&session->hangingup, 0);
 	janus_mutex_init(&session->mutex);
@@ -728,8 +884,11 @@ char *janus_sip_query_session(janus_plugin_session *handle) {
 	json_object_set_new(info, "identity", session->account.identity ? json_string(session->account.identity) : NULL);
 	json_object_set_new(info, "registration_status", json_string(janus_sip_registration_status_string(session->account.registration_status)));
 	json_object_set_new(info, "call_status", json_string(janus_sip_call_status_string(session->status)));
-	if(session->callee)
+	if(session->callee) {
 		json_object_set_new(info, "callee", json_string(session->callee ? session->callee : "??"));
+		json_object_set_new(info, "sdes-local", json_string(session->media.has_srtp_local ? "yes" : "no"));
+		json_object_set_new(info, "sdes-remote", json_string(session->media.has_srtp_remote ? "yes" : "no"));
+	}
 	if(session->arc || session->vrc || session->arc_peer || session->vrc_peer) {
 		json_t *recording = json_object();
 		if(session->arc && session->arc->filename)
@@ -802,8 +961,26 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 				/* Save the frame if we're recording */
 				if(session->vrc)
 					janus_recorder_save_frame(session->vrc, buf, len);
-				/* Forward the frame to the peer */
-				send(session->media.video_rtp_fd, buf, len, 0);
+				/* Is SRTP involved? */
+				if(session->media.has_srtp_local) {
+					char sbuf[2048];
+					memcpy(&sbuf, buf, len);
+					int protected = len;
+					int res = srtp_protect(session->media.video_srtp_out, &sbuf, &protected);
+					if(res != err_status_ok) {
+						rtp_header *header = (rtp_header *)&sbuf;
+						guint32 timestamp = ntohl(header->timestamp);
+						guint16 seq = ntohs(header->seq_number);
+						JANUS_LOG(LOG_ERR, "[SIP-%s] Video SRTP protect error... %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")...\n",
+							session->account.username, janus_sip_get_srtp_error(res), len, protected, timestamp, seq);
+					} else {
+						/* Forward the frame to the peer */
+						send(session->media.video_rtp_fd, sbuf, protected, 0);
+					}
+				} else {
+					/* Forward the frame to the peer */
+					send(session->media.video_rtp_fd, buf, len, 0);
+				}
 			}
 		} else {
 			if(session->media.audio_ssrc == 0) {
@@ -815,8 +992,26 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 				/* Save the frame if we're recording */
 				if(session->arc)
 					janus_recorder_save_frame(session->arc, buf, len);
-				/* Forward the frame to the peer */
-				send(session->media.audio_rtp_fd, buf, len, 0);
+				/* Is SRTP involved? */
+				if(session->media.has_srtp_local) {
+					char sbuf[2048];
+					memcpy(&sbuf, buf, len);
+					int protected = len;
+					int res = srtp_protect(session->media.audio_srtp_out, &sbuf, &protected);
+					if(res != err_status_ok) {
+						rtp_header *header = (rtp_header *)&sbuf;
+						guint32 timestamp = ntohl(header->timestamp);
+						guint16 seq = ntohs(header->seq_number);
+						JANUS_LOG(LOG_ERR, "[SIP-%s] Audio SRTP protect error... %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")...\n",
+							session->account.username, janus_sip_get_srtp_error(res), len, protected, timestamp, seq);
+					} else {
+						/* Forward the frame to the peer */
+						send(session->media.audio_rtp_fd, sbuf, protected, 0);
+					}
+				} else {
+					/* Forward the frame to the peer */
+					send(session->media.audio_rtp_fd, buf, len, 0);
+				}
 			}
 		}
 	}
@@ -833,21 +1028,62 @@ void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf,
 		}
 		if(session->status != janus_sip_call_status_incall)
 			return;
-		/* Fix SSRCs as the gateway does */
-		JANUS_LOG(LOG_HUGE, "[SIP] Fixing SSRCs (local %u, peer %u)\n",
-			video ? session->media.video_ssrc : session->media.audio_ssrc,
-			video ? session->media.video_ssrc_peer : session->media.audio_ssrc_peer);
-		janus_rtcp_fix_ssrc((char *)buf, len, 1,
-			video ? session->media.video_ssrc : session->media.audio_ssrc,
-			video ? session->media.video_ssrc_peer : session->media.audio_ssrc_peer);
 		/* Forward to our SIP peer */
 		if(video) {
 			if(session->media.has_video && session->media.video_rtcp_fd) {
-				send(session->media.video_rtcp_fd, buf, len, 0);
+				/* Is SRTP involved? */
+				if(session->media.has_srtp_local) {
+					char sbuf[2048];
+					memcpy(&sbuf, buf, len);
+					int protected = len;
+					int res = srtp_protect_rtcp(session->media.video_srtp_out, &sbuf, &protected);
+					if(res != err_status_ok) {
+						JANUS_LOG(LOG_ERR, "[SIP-%s] Video SRTCP protect error... %s (len=%d-->%d)...\n",
+							session->account.username, janus_sip_get_srtp_error(res), len, protected);
+					} else {
+						/* Fix SSRCs as the gateway does */
+						JANUS_LOG(LOG_HUGE, "[SIP] Fixing SSRCs (local %u, peer %u)\n",
+							session->media.video_ssrc, session->media.video_ssrc_peer);
+						janus_rtcp_fix_ssrc((char *)buf, len, 1, session->media.video_ssrc, session->media.video_ssrc_peer);
+						/* Forward the message to the peer */
+						send(session->media.video_rtcp_fd, sbuf, protected, 0);
+					}
+				} else {
+					/* Fix SSRCs as the gateway does */
+					JANUS_LOG(LOG_HUGE, "[SIP] Fixing SSRCs (local %u, peer %u)\n",
+						session->media.video_ssrc, session->media.video_ssrc_peer);
+					janus_rtcp_fix_ssrc((char *)buf, len, 1, session->media.video_ssrc, session->media.video_ssrc_peer);
+					/* Forward the message to the peer */
+					send(session->media.video_rtcp_fd, buf, len, 0);
+				}
 			}
 		} else {
 			if(session->media.has_audio && session->media.audio_rtcp_fd) {
-				send(session->media.audio_rtcp_fd, buf, len, 0);
+				/* Is SRTP involved? */
+				if(session->media.has_srtp_local) {
+					char sbuf[2048];
+					memcpy(&sbuf, buf, len);
+					int protected = len;
+					int res = srtp_protect_rtcp(session->media.audio_srtp_out, &sbuf, &protected);
+					if(res != err_status_ok) {
+						JANUS_LOG(LOG_ERR, "[SIP-%s] Audio SRTCP protect error... %s (len=%d-->%d)...\n",
+							session->account.username, janus_sip_get_srtp_error(res), len, protected);
+					} else {
+						/* Fix SSRCs as the gateway does */
+						JANUS_LOG(LOG_HUGE, "[SIP] Fixing SSRCs (local %u, peer %u)\n",
+							session->media.audio_ssrc, session->media.audio_ssrc_peer);
+						janus_rtcp_fix_ssrc((char *)buf, len, 1, session->media.audio_ssrc, session->media.audio_ssrc_peer);
+						/* Forward the message to the peer */
+						send(session->media.audio_rtcp_fd, sbuf, protected, 0);
+					}
+				} else {
+					/* Fix SSRCs as the gateway does */
+					JANUS_LOG(LOG_HUGE, "[SIP] Fixing SSRCs (local %u, peer %u)\n",
+						session->media.audio_ssrc, session->media.audio_ssrc_peer);
+					janus_rtcp_fix_ssrc((char *)buf, len, 1, session->media.audio_ssrc, session->media.audio_ssrc_peer);
+					/* Forward the message to the peer */
+					send(session->media.audio_rtcp_fd, buf, len, 0);
+				}
 			}
 		}
 	}
@@ -1266,6 +1502,14 @@ static void *janus_sip_handler(void *data) {
 				g_snprintf(error_cause, 512, "Invalid element (uri should be a string)");
 				goto error;
 			}
+			json_t *srtp = json_object_get(root, "srtp");
+			if(srtp && !json_is_boolean(srtp)) {
+				JANUS_LOG(LOG_ERR, "Invalid element (srtp should be a boolean)\n");
+				error_code = JANUS_SIP_ERROR_INVALID_ELEMENT;
+				g_snprintf(error_cause, 512, "Invalid element (srtp should be a boolean)");
+				goto error;
+			}
+			gboolean offer_srtp = srtp ? json_is_true(srtp) : FALSE;
 			/* Parse address */
 			const char *uri_text = json_string_value(uri);
 			janus_sip_uri_t target_uri;
@@ -1284,6 +1528,12 @@ static void *janus_sip_handler(void *data) {
 			}
 			JANUS_LOG(LOG_VERB, "%s is calling %s\n", session->account.username, uri_text);
 			JANUS_LOG(LOG_VERB, "This is involving a negotiation (%s) as well:\n%s\n", msg->sdp_type, msg->sdp);
+			/* Clean up SRTP stuff from before first, in case it's still needed */
+			janus_sip_srtp_cleanup(session);
+			session->media.has_srtp_local = offer_srtp;
+			if(offer_srtp) {
+				JANUS_LOG(LOG_VERB, "Going to negotiate SDES-SRTP...\n");
+			}
 			/* Allocate RTP ports and merge them with the anonymized SDP */
 			if(strstr(msg->sdp, "m=audio")) {
 				JANUS_LOG(LOG_VERB, "Going to negotiate audio...\n");
@@ -1301,19 +1551,59 @@ static void *janus_sip_handler(void *data) {
 			}
 			char *sdp = g_strdup(msg->sdp);
 			sdp = janus_string_replace(sdp, " UDP/TLS/", " ");
-			sdp = janus_string_replace(sdp, "RTP/SAVPF", "RTP/AVP");
+			sdp = janus_string_replace(sdp, "RTP/SAVPF", offer_srtp ? "RTP/SAVP" : "RTP/AVP");
 			sdp = janus_string_replace(sdp, "1.1.1.1", local_ip);
 			if(session->media.has_audio) {
 				JANUS_LOG(LOG_VERB, "Setting local audio port: %d\n", session->media.local_audio_rtp_port);
 				char mline[20];
 				g_snprintf(mline, 20, "m=audio %d", session->media.local_audio_rtp_port);
 				sdp = janus_string_replace(sdp, "m=audio 1", mline);
+				if(offer_srtp) {
+					char *crypto = NULL;
+					session->media.audio_srtp_suite_out = 80;
+					janus_sip_srtp_set_local(session, FALSE, &crypto);
+					/* FIXME 32? 80? Both? */
+					char cryptoline[100];
+					g_snprintf(cryptoline, 100, "a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:%s", crypto);
+					g_free(crypto);
+					/* Add to SDP with what is without doubt the ugliest hack in the world */
+					int pt = janus_get_opus_pt(sdp);
+					if(pt < 0) {
+						JANUS_LOG(LOG_WARN, "Couldn't add crypto for audio m-line, expect trouble...\n");
+					} else {
+						char replaceme[100];
+						g_snprintf(replaceme, 100, "\r\na=rtpmap:%d", pt);
+						char withthis[500];
+						g_snprintf(withthis, 500, "\r\n%s\r\na=rtpmap:%d", cryptoline, pt);
+						sdp = janus_string_replace(sdp, replaceme, withthis);
+					}
+				}
 			}
 			if(session->media.has_video) {
 				JANUS_LOG(LOG_VERB, "Setting local video port: %d\n", session->media.local_video_rtp_port);
 				char mline[20];
 				g_snprintf(mline, 20, "m=video %d", session->media.local_video_rtp_port);
 				sdp = janus_string_replace(sdp, "m=video 1", mline);
+				if(offer_srtp) {
+					char *crypto = NULL;
+					session->media.video_srtp_suite_out = 80;
+					janus_sip_srtp_set_local(session, TRUE, &crypto);
+					char cryptoline[100];
+					/* FIXME 32? 80? Both? */
+					g_snprintf(cryptoline, 100, "a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:%s", crypto);
+					g_free(crypto);
+					/* Add to SDP with what is without doubt the ugliest hack in the world */
+					int pt = janus_get_vp8_pt(sdp);
+					if(pt < 0) {
+						JANUS_LOG(LOG_WARN, "Couldn't add crypto for video m-line, expect trouble...\n");
+					} else {
+						char replaceme[100];
+						g_snprintf(replaceme, 100, "\r\na=rtpmap:%d", pt);
+						char withthis[500];
+						g_snprintf(withthis, 500, "\r\n%s\r\na=rtpmap:%d", cryptoline, pt);
+						sdp = janus_string_replace(sdp, replaceme, withthis);
+					}
+				}
 			}
 			/* Send INVITE */
 			if(session->stack->s_nh_i != NULL)
@@ -1355,6 +1645,14 @@ static void *janus_sip_handler(void *data) {
 				g_snprintf(error_cause, 512, "Wrong state (no caller?)");
 				goto error;
 			}
+			json_t *srtp = json_object_get(root, "srtp");
+			if(srtp && !json_is_boolean(srtp)) {
+				JANUS_LOG(LOG_ERR, "Invalid element (srtp should be a boolean)\n");
+				error_code = JANUS_SIP_ERROR_INVALID_ELEMENT;
+				g_snprintf(error_cause, 512, "Invalid element (srtp should be a boolean)");
+				goto error;
+			}
+			gboolean answer_srtp =  session->media.has_srtp_remote || (srtp ? json_is_true(srtp) : FALSE);
 			/* Any SDP to handle? if not, something's wrong */
 			if(!msg->sdp) {
 				JANUS_LOG(LOG_ERR, "Missing SDP\n");
@@ -1365,6 +1663,12 @@ static void *janus_sip_handler(void *data) {
 			/* Accept a call from another peer */
 			JANUS_LOG(LOG_VERB, "We're accepting the call from %s\n", session->callee);
 			JANUS_LOG(LOG_VERB, "This is involving a negotiation (%s) as well:\n%s\n", msg->sdp_type, msg->sdp);
+			/* Clean up SRTP stuff from before first, in case it's still needed */
+			janus_sip_srtp_cleanup(session);
+			session->media.has_srtp_local = answer_srtp;
+			if(answer_srtp) {
+				JANUS_LOG(LOG_VERB, "Going to negotiate SDES-SRTP...\n");
+			}
 			/* Allocate RTP ports and merge them with the anonymized SDP */
 			if(strstr(msg->sdp, "m=audio")) {
 				JANUS_LOG(LOG_VERB, "Going to negotiate audio...\n");
@@ -1382,19 +1686,59 @@ static void *janus_sip_handler(void *data) {
 			}
 			char *sdp = g_strdup(msg->sdp);
 			sdp = janus_string_replace(sdp, " UDP/TLS/", " ");
-			sdp = janus_string_replace(sdp, "RTP/SAVPF", "RTP/AVP");
+			sdp = janus_string_replace(sdp, "RTP/SAVPF", answer_srtp ? "RTP/SAVP" : "RTP/AVP");
 			sdp = janus_string_replace(sdp, "1.1.1.1", local_ip);
 			if(session->media.has_audio) {
 				JANUS_LOG(LOG_VERB, "Setting local audio port: %d\n", session->media.local_audio_rtp_port);
 				char mline[20];
 				g_snprintf(mline, 20, "m=audio %d", session->media.local_audio_rtp_port);
 				sdp = janus_string_replace(sdp, "m=audio 1", mline);
+				if(answer_srtp) {
+					char *crypto = NULL;
+					session->media.audio_srtp_suite_out = 80;
+					janus_sip_srtp_set_local(session, FALSE, &crypto);
+					/* FIXME 32? 80? Both? */
+					char cryptoline[100];
+					g_snprintf(cryptoline, 100, "a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:%s", crypto);
+					g_free(crypto);
+					/* Add to SDP with what is without doubt the ugliest hack in the world */
+					int pt = janus_get_opus_pt(sdp);
+					if(pt < 0) {
+						JANUS_LOG(LOG_WARN, "Couldn't add crypto for audio m-line, expect trouble...\n");
+					} else {
+						char replaceme[100];
+						g_snprintf(replaceme, 100, "\r\na=rtpmap:%d", pt);
+						char withthis[500];
+						g_snprintf(withthis, 500, "\r\n%s\r\na=rtpmap:%d", cryptoline, pt);
+						sdp = janus_string_replace(sdp, replaceme, withthis);
+					}
+				}
 			}
 			if(session->media.has_video) {
 				JANUS_LOG(LOG_VERB, "Setting local video port: %d\n", session->media.local_video_rtp_port);
 				char mline[20];
 				g_snprintf(mline, 20, "m=video %d", session->media.local_video_rtp_port);
 				sdp = janus_string_replace(sdp, "m=video 1", mline);
+				if(answer_srtp) {
+					char *crypto = NULL;
+					session->media.video_srtp_suite_out = 80;
+					janus_sip_srtp_set_local(session, TRUE, &crypto);
+					/* FIXME 32? 80? Both? */
+					char cryptoline[100];
+					g_snprintf(cryptoline, 100, "a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:%s", crypto);
+					g_free(crypto);
+					/* Add to SDP with what is without doubt the ugliest hack in the world */
+					int pt = janus_get_vp8_pt(sdp);
+					if(pt < 0) {
+						JANUS_LOG(LOG_WARN, "Couldn't add crypto for video m-line, expect trouble...\n");
+					} else {
+						char replaceme[100];
+						g_snprintf(replaceme, 100, "\r\na=rtpmap:%d", pt);
+						char withthis[500];
+						g_snprintf(withthis, 500, "\r\n%s\r\na=rtpmap:%d", cryptoline, pt);
+						sdp = janus_string_replace(sdp, replaceme, withthis);
+					}
+				}
 			}
 			/* Send 200 OK */
 			g_atomic_int_set(&session->hangingup, 0);
@@ -1933,6 +2277,8 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			/* New incoming call */
 			session->callee = g_strdup(url_as_string(session->stack->s_home, sip->sip_from->a_url));
 			session->status = janus_sip_call_status_invited;
+			/* Clean up SRTP stuff from before first, in case it's still needed */
+			janus_sip_srtp_cleanup(session);
 			/* Parse SDP */
 			char *fixed_sdp = g_strdup(sip->sip_payload->pl_data);
 			JANUS_LOG(LOG_VERB, "Someone is inviting us in a call:\n%s", sip->sip_payload->pl_data);
@@ -1944,8 +2290,12 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			json_t *calling = json_object();
 			json_object_set_new(calling, "event", json_string("incomingcall"));
 			json_object_set_new(calling, "username", json_string(session->callee));
-			if (sip->sip_from && sip->sip_from->a_display) {
+			if(sip->sip_from && sip->sip_from->a_display) {
 				json_object_set_new(calling, "displayname", json_string(sip->sip_from->a_display));
+			}
+			if(session->media.has_srtp_remote) {
+				/* FIXME Maybe a true/false instead? */
+				json_object_set_new(calling, "encryption", json_string("sdes"));
 			}
 			json_object_set_new(call, "result", calling);
 			char *call_text = json_dumps(call, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
@@ -2053,6 +2403,18 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			char *fixed_sdp = g_strdup(sip->sip_payload->pl_data);
 			sdp_session_t *sdp = sdp_session(parser);
 			janus_sip_sdp_process(session, sdp);
+			/* If we asked for SRTP and are not getting it, fail */
+			if(session->media.has_srtp_local && !session->media.has_srtp_remote) {
+				JANUS_LOG(LOG_ERR, "\tWe asked for SRTP but didn't get any!\n");
+				sdp_parser_free(parser);
+				g_free(fixed_sdp);
+				/* Hangup immediately */
+				session->status = janus_sip_call_status_closing;
+				nua_bye(nh, TAG_END());
+				g_free(session->callee);
+				session->callee = NULL;
+				break;
+			}
 			session->media.ready = 1;	/* FIXME Maybe we need a better way to signal this */
 			GError *error = NULL;
 			g_thread_try_new("janus rtp handler", janus_sip_relay_thread, session, &error);
@@ -2199,6 +2561,33 @@ void janus_sip_sdp_process(janus_sip_session *session, sdp_session_t *sdp) {
 			if(a->a_name) {
 				if(!strcasecmp(a->a_name, "rtpmap")) {
 					JANUS_LOG(LOG_VERB, "         RTP Map:     %s\n", a->a_value);
+				} else if(!strcasecmp(a->a_name, "crypto")) {
+					JANUS_LOG(LOG_VERB, "         Crypto:      %s\n", a->a_value);
+					if(m->m_type == sdp_media_audio || m->m_type == sdp_media_video) {
+						gint32 tag = 0;
+						int suite;
+						char crypto[40];
+						/* FIXME inline can be more complex than that, and we're currently only offering SHA1_80 */
+						int res = sscanf(a->a_value, "%"SCNi32" AES_CM_128_HMAC_SHA1_%2d inline:%40s",
+							&tag, &suite, crypto);
+						if(res != 3) {
+							JANUS_LOG(LOG_WARN, "Failed to parse crypto line, ignoring... %s\n", a->a_value);
+						} else {
+							gboolean video = (m->m_type == sdp_media_video);
+							int current_suite = video ? session->media.video_srtp_suite_in : session->media.audio_srtp_suite_in;
+							if(current_suite == 0) {
+								if(video)
+									session->media.video_srtp_suite_in = suite;
+								else
+									session->media.audio_srtp_suite_in = suite;
+								janus_sip_srtp_set_remote(session, video, crypto, suite);
+								session->media.has_srtp_remote = TRUE;
+							} else {
+								JANUS_LOG(LOG_WARN, "We already configured a %s crypto context (AES_CM_128_HMAC_SHA1_%d), skipping additional crypto line\n",
+									video ? "video" : "audio", current_suite);
+							}
+						}
+					}
 				}
 			}
 			a = a->a_next;
@@ -2456,6 +2845,20 @@ static void *janus_sip_relay_thread(void *data) {
 						session->media.audio_ssrc_peer = ntohl(header->ssrc);
 						JANUS_LOG(LOG_VERB, "Got SIP peer audio SSRC: %"SCNu32"\n", session->media.audio_ssrc_peer);
 					}
+					/* Is this SRTP? */
+					if(session->media.has_srtp_remote) {
+						int buflen = bytes;
+						err_status_t res = srtp_unprotect(session->media.audio_srtp_in, buffer, &buflen);
+						if(res != err_status_ok && res != err_status_replay_fail && res != err_status_replay_old) {
+							rtp_header *header = (rtp_header *)buffer;
+							guint32 timestamp = ntohl(header->timestamp);
+							guint16 seq = ntohs(header->seq_number);
+							JANUS_LOG(LOG_ERR, "[SIP-%s] Audio SRTP unprotect error: %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")\n",
+								session->account.username, janus_sip_get_srtp_error(res), bytes, buflen, timestamp, seq);
+							continue;
+						}
+						bytes = buflen;
+					}
 					/* Save the frame if we're recording */
 					if(session->arc_peer)
 						janus_recorder_save_frame(session->arc_peer, buffer, bytes);
@@ -2467,6 +2870,17 @@ static void *janus_sip_relay_thread(void *data) {
 					addrlen = sizeof(remote);
 					bytes = recvfrom(session->media.audio_rtcp_fd, buffer, 1500, 0, (struct sockaddr*)&remote, &addrlen);
 					//~ JANUS_LOG(LOG_VERB, "************************\nGot %d bytes on the audio RTCP channel...\n", bytes);
+					/* Is this SRTCP? */
+					if(session->media.has_srtp_remote) {
+						int buflen = bytes;
+						err_status_t res = srtp_unprotect_rtcp(session->media.audio_srtp_in, buffer, &buflen);
+						if(res != err_status_ok && res != err_status_replay_fail && res != err_status_replay_old) {
+							JANUS_LOG(LOG_ERR, "[SIP-%s] Audio SRTCP unprotect error: %s (len=%d-->%d)\n",
+								session->account.username, janus_sip_get_srtp_error(res), bytes, buflen);
+							continue;
+						}
+						bytes = buflen;
+					}
 					/* Relay to browser */
 					gateway->relay_rtcp(session->handle, 0, buffer, bytes);
 					continue;
@@ -2483,6 +2897,20 @@ static void *janus_sip_relay_thread(void *data) {
 						session->media.video_ssrc_peer = ntohl(header->ssrc);
 						JANUS_LOG(LOG_VERB, "Got SIP peer video SSRC: %"SCNu32"\n", session->media.video_ssrc_peer);
 					}
+					/* Is this SRTP? */
+					if(session->media.has_srtp_remote) {
+						int buflen = bytes;
+						err_status_t res = srtp_unprotect(session->media.video_srtp_in, buffer, &buflen);
+						if(res != err_status_ok && res != err_status_replay_fail && res != err_status_replay_old) {
+							rtp_header *header = (rtp_header *)buffer;
+							guint32 timestamp = ntohl(header->timestamp);
+							guint16 seq = ntohs(header->seq_number);
+							JANUS_LOG(LOG_ERR, "[SIP-%s] Video SRTP unprotect error: %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")\n",
+								session->account.username, janus_sip_get_srtp_error(res), bytes, buflen, timestamp, seq);
+							continue;
+						}
+						bytes = buflen;
+					}
 					/* Save the frame if we're recording */
 					if(session->vrc_peer)
 						janus_recorder_save_frame(session->vrc_peer, buffer, bytes);
@@ -2494,6 +2922,17 @@ static void *janus_sip_relay_thread(void *data) {
 					addrlen = sizeof(remote);
 					bytes = recvfrom(session->media.video_rtcp_fd, buffer, 1500, 0, (struct sockaddr*)&remote, &addrlen);
 					//~ JANUS_LOG(LOG_VERB, "************************\nGot %d bytes on the video RTCP channel...\n", bytes);
+					/* Is this SRTCP? */
+					if(session->media.has_srtp_remote) {
+						int buflen = bytes;
+						err_status_t res = srtp_unprotect_rtcp(session->media.video_srtp_in, buffer, &buflen);
+						if(res != err_status_ok && res != err_status_replay_fail && res != err_status_replay_old) {
+							JANUS_LOG(LOG_ERR, "[SIP-%s] Video SRTP unprotect error: %s (len=%d-->%d)\n",
+								session->account.username, janus_sip_get_srtp_error(res), bytes, buflen);
+							continue;
+						}
+						bytes = buflen;
+					}
 					/* Relay to browser */
 					gateway->relay_rtcp(session->handle, 1, buffer, bytes);
 					continue;
@@ -2523,6 +2962,9 @@ static void *janus_sip_relay_thread(void *data) {
 	session->media.local_video_rtp_port = 0;
 	session->media.local_video_rtcp_port = 0;
 	session->media.video_ssrc = 0;
+	/* Clean up SRTP stuff, if needed */
+	janus_sip_srtp_cleanup(session);
+	/* Done */
 	JANUS_LOG(LOG_VERB, "Leaving SIP relay thread\n");
 	g_thread_unref(g_thread_self());
 	return NULL;


### PR DESCRIPTION
This PR adds support for SDES-SRTP to calls handled by the SIP plugin. To enable this for outgoing calls, just add a ```srtp:true``` attribute to a ```"call"``` request. It will be enabled automatically, instead, for incoming calls with a crypto line in it.

Tested in different scenarios and it seems to be working fine both for incoming and outgoing calls. The parsing of crypto lines can definitely be improved (we don't handle all the possibilities for the ```inline``` part, for instance, assuming it's always just the base64 encoded key/salt), but there will be time for that.

Feel free to play with this, especially if you have SDES endpoints you want to test this with (I've only tested this with Asterisk 13.6.0). Feedback welcome as I plan to merge this soon.