### PR TITLE
Post-processing recordings with more than a single timestamp reset

### DIFF
--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -342,7 +342,6 @@ int main(int argc, char *argv[])
 			/* Take into account the number of resets when setting the internal, 64-bit, timestamp */
 			p->ts = (times_resetted*max32)+ntohl(rtp->timestamp);
 		}
-		JANUS_LOG(LOG_INFO, "%"SCNu32" --> %"SCNu64"\n", ntohl(rtp->timestamp), p->ts);
 		last_ts = ntohl(rtp->timestamp);
 		post_reset_pkts++;
 		/* Fill in the rest of the details */

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -79,12 +79,15 @@ int main(int argc, char *argv[])
 	/* Evaluate arguments */
 	if(argc != 3) {
 		JANUS_LOG(LOG_INFO, "Usage: %s source.mjr destination.[opus|webm]\n", argv[0]);
-		JANUS_LOG(LOG_INFO, "       %s --header source.mjr\n", argv[0]);
+		JANUS_LOG(LOG_INFO, "       %s --header source.mjr (only parse header)\n", argv[0]);
+		JANUS_LOG(LOG_INFO, "       %s --parse source.mjr (only parse and re-order packets)\n", argv[0]);
 		return -1;
 	}
 	char *source = NULL, *destination = NULL;
-	if(!strcmp(argv[1], "--header")) {
-		/* Only parse the .mjr header */
+	gboolean header_only = !strcmp(argv[1], "--header");
+	gboolean parse_only = !strcmp(argv[1], "--parse");
+	if(header_only || parse_only) {
+		/* Only parse the .mjr header and/or re-order the packets, no processing */
 		source = argv[2];
 	} else {
 		/* Post-process the .mjr recording */
@@ -110,12 +113,14 @@ int main(int argc, char *argv[])
 	int bytes = 0, skip = 0;
 	long offset = 0;
 	uint16_t len = 0, count = 0;
-	uint32_t first_ts = 0, last_ts = 0, reset = 0;	/* To handle whether there's a timestamp reset in the recording */
+	uint32_t last_ts = 0, reset = 0;
+	int times_resetted = 0;
+	uint32_t post_reset_pkts = 0;
 	char prebuffer[1500];
 	memset(prebuffer, 0, 1500);
 	/* Let's look for timestamp resets first */
 	while(offset < fsize) {
-		if(destination == NULL && parsed_header) {
+		if(header_only && parsed_header) {
 			/* We only needed to parse the header */
 			exit(0);
 		}
@@ -232,28 +237,40 @@ int main(int argc, char *argv[])
 		/* Only read RTP header */
 		bytes = fread(prebuffer, sizeof(char), 16, file);
 		janus_pp_rtp_header *rtp = (janus_pp_rtp_header *)prebuffer;
-		if(last_ts == 0) {
-			first_ts = ntohl(rtp->timestamp);
-			if(first_ts > 1000*1000)	/* Just used to check whether a packet is pre- or post-reset */
-				first_ts -= 1000*1000;
-		} else {
-			if(ntohl(rtp->timestamp) < last_ts) {
-				/* The new timestamp is smaller than the next one, is it a timestamp reset or simply out of order? */
-				if(last_ts-ntohl(rtp->timestamp) > 2*1000*1000*1000) {
-					reset = ntohl(rtp->timestamp);
-					JANUS_LOG(LOG_INFO, "Timestamp reset: %"SCNu32"\n", reset);
-				}
-			} else if(ntohl(rtp->timestamp) < reset) {
-				JANUS_LOG(LOG_INFO, "Updating timestamp reset: %"SCNu32" (was %"SCNu32")\n", ntohl(rtp->timestamp), reset);
+		if(last_ts > 0) {
+			/* Is the new timestamp smaller than the next one, and if so, is it a timestamp reset or simply out of order? */
+			if(ntohl(rtp->timestamp) < last_ts && (last_ts-ntohl(rtp->timestamp) > 2*1000*1000*1000)) {
 				reset = ntohl(rtp->timestamp);
+				JANUS_LOG(LOG_WARN, "Timestamp reset: %"SCNu32"\n", reset);
+				times_resetted++;
+				post_reset_pkts = 0;
+			} else if(ntohl(rtp->timestamp) < reset) {
+				if(post_reset_pkts < 1000) {
+					JANUS_LOG(LOG_WARN, "Updating latest timestamp reset: %"SCNu32" (was %"SCNu32")\n", ntohl(rtp->timestamp), reset);
+					reset = ntohl(rtp->timestamp);
+				} else {
+					reset = ntohl(rtp->timestamp);
+					JANUS_LOG(LOG_WARN, "Timestamp reset: %"SCNu32"\n", reset);
+					times_resetted++;
+					post_reset_pkts = 0;
+				}
 			}
 		}
 		last_ts = ntohl(rtp->timestamp);
+		post_reset_pkts++;
 		/* Skip data for now */
 		offset += len;
 	}
+	JANUS_LOG(LOG_WARN, "Counted %d timestamp resets\n", times_resetted);
 	/* Now let's parse the frames and order them */
 	offset = 0;
+	/* Timestamp reset related stuff */
+	last_ts = 0;
+	reset = 0;
+	times_resetted = 0;
+	post_reset_pkts = 0;
+	uint64_t max32 = UINT32_MAX;
+	/* Start loop */
 	while(offset < fsize) {
 		/* Read frame header */
 		skip = 0;
@@ -300,21 +317,35 @@ int main(int argc, char *argv[])
 			return -1;
 		}
 		p->seq = ntohs(rtp->seq_number);
-		if(reset == 0) {
+		/* Due to resets, we need to mess a bit with the original timestamps */
+		if(last_ts == 0) {
 			/* Simple enough... */
 			p->ts = ntohl(rtp->timestamp);
 		} else {
-			/* Is this packet pre- or post-reset? */
-			if(ntohl(rtp->timestamp) > first_ts) {
-				/* Pre-reset... */
-				p->ts = ntohl(rtp->timestamp);
-			} else {
-				/* Post-reset... */
-				uint64_t max32 = UINT32_MAX;
-				max32++;
-				p->ts = max32+ntohl(rtp->timestamp);
+			/* Is the new timestamp smaller than the next one, and if so, is it a timestamp reset or simply out of order? */
+			if(ntohl(rtp->timestamp) < last_ts && (last_ts-ntohl(rtp->timestamp) > 2*1000*1000*1000)) {
+				reset = ntohl(rtp->timestamp);
+				JANUS_LOG(LOG_WARN, "Timestamp reset: %"SCNu32"\n", reset);
+				times_resetted++;
+				post_reset_pkts = 0;
+			} else if(ntohl(rtp->timestamp) < reset) {
+				if(post_reset_pkts < 1000) {
+					JANUS_LOG(LOG_WARN, "Updating latest timestamp reset: %"SCNu32" (was %"SCNu32")\n", ntohl(rtp->timestamp), reset);
+					reset = ntohl(rtp->timestamp);
+				} else {
+					reset = ntohl(rtp->timestamp);
+					JANUS_LOG(LOG_WARN, "Timestamp reset: %"SCNu32"\n", reset);
+					times_resetted++;
+					post_reset_pkts = 0;
+				}
 			}
+			/* Take into account the number of resets when setting the internal, 64-bit, timestamp */
+			p->ts = (times_resetted*max32)+ntohl(rtp->timestamp);
 		}
+		JANUS_LOG(LOG_INFO, "%"SCNu32" --> %"SCNu64"\n", ntohl(rtp->timestamp), p->ts);
+		last_ts = ntohl(rtp->timestamp);
+		post_reset_pkts++;
+		/* Fill in the rest of the details */
 		p->len = len;
 		p->offset = offset;
 		p->skip = skip;
@@ -399,6 +430,11 @@ int main(int argc, char *argv[])
 		tmp = tmp->next;
 	}
 	JANUS_LOG(LOG_INFO, "Counted %"SCNu16" frame packets\n", count);
+
+	if(parse_only) {
+		/* We only needed to parse and re-order the packets, we're done here */
+		exit(0);
+	}
 
 	if(!video) {
 		/* We don't need any pre-parsing for audio */


### PR DESCRIPTION
This PR follows the discussion started in #471 and tries to address the issue, by detecting multiple timestamp resets and fixing the problem. Highly experimental and so to be tested carefully, also to make sure it doesn't introduce any regression with existing recordings (particularly those containing, for instance, out of order packets and the like).

The patch also introduces a new command line parameter for the post-processor, ```--parse```, which besides reading the header (what ```---header``` did already) also goes through the recording to simply parse the file and re-order the packets. Once done, it does not actually process the recording and stops there. May be useful for testing and debugging without having to go through the whole processing, which might take longer.