### PR TITLE
RTP stream timestamps

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -1020,8 +1020,10 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			if(mp->streaming_source == janus_streaming_source_rtp) {
 				janus_streaming_rtp_source *source = mp->source;
 				gint64 now = janus_get_monotonic_time();
-				json_object_set_new(ml, "audio_age_ms", json_integer((now - source->last_received_audio) / 1000));
-				json_object_set_new(ml, "video_age_ms", json_integer((now - source->last_received_video) / 1000));
+				if ( source->audio_fd != -1 )
+					json_object_set_new(ml, "audio_age_ms", json_integer((now - source->last_received_audio) / 1000));
+				if ( source->video_fd != -1 )
+					json_object_set_new(ml, "video_age_ms", json_integer((now - source->last_received_video) / 1000));
 			}
 			json_array_append_new(list, ml);
 		}
@@ -2771,8 +2773,8 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 	live_rtp_source->vrc = NULL;
 	live_rtp_source->audio_fd = audio_fd;
 	live_rtp_source->video_fd = video_fd;
-	live_rtp_source->last_received_audio = 0;
-	live_rtp_source->last_received_video = 0;
+	live_rtp_source->last_received_audio = janus_get_monotonic_time();
+	live_rtp_source->last_received_video = janus_get_monotonic_time();
 	live_rtp_source->keyframe.enabled = bufferkf;
 	live_rtp_source->keyframe.latest_keyframe = NULL;
 	live_rtp_source->keyframe.temp_keyframe = NULL;

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -1019,9 +1019,9 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			json_object_set_new(ml, "type", json_string(mp->streaming_type == janus_streaming_type_live ? "live" : "on demand"));
 			if(mp->streaming_source == janus_streaming_source_rtp) {
 				janus_streaming_rtp_source *source = mp->source;
-				json_object_set_new(ml, "last_received_audio", json_integer(source->last_received_audio));
-				json_object_set_new(ml, "last_received_video", json_integer(source->last_received_video));
-				json_object_set_new(ml, "now", json_integer(janus_get_monotonic_time()));
+				gint64 now = janus_get_monotonic_time();
+				json_object_set_new(ml, "audio_age_ms", json_integer((now - source->last_received_audio) / 1000));
+				json_object_set_new(ml, "video_age_ms", json_integer((now - source->last_received_video) / 1000));
 			}
 			json_array_append_new(list, ml);
 		}


### PR DESCRIPTION
#485 

I added rtp timestamps to the streaming plugin.  It adds two variables to the janus_streaming_mountpoint struct: last_received_video and last_received_audio.  It uses janus_get_monotonic_time to timestamp when an RTP packet has arrived and updates the struct's variable.  In the message handling for the 'list' command it outputs the timestamps if it's an RTP stream and a 'now' json member which is the current monotonic time.  This allows a client to calculate the time since the last packet (audio or video) has arrived and decide if the stream has timed out/stopped sending packets.