### PR TITLE
Fix Sofia SIP when both Record-Route and Contact are there

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1646,6 +1646,7 @@ static void *janus_sip_handler(void *data) {
 				NUTAG_PROXY(session->account.proxy),
 				TAG_IF(strlen(custom_headers) > 0, SIPTAG_HEADER_STR(custom_headers)),
 				NUTAG_AUTOANSWER(0),
+				NUTAG_AUTOACK(0),
 				TAG_END());
 			g_free(sdp);
 			sdp_parser_free(parser);
@@ -2408,6 +2409,13 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				sdp_parser_free(parser);
 				break;
 			}
+			/* Send an ACK */
+			char *route = sip->sip_record_route ? url_as_string(session->stack->s_home, sip->sip_record_route->r_url) : NULL;
+			JANUS_LOG(LOG_WARN, "Sending ACK (route=%s)\n", route ? route : "none");
+			nua_ack(nh,
+				TAG_IF(route, NTATAG_DEFAULT_PROXY(route)),
+				TAG_END());
+			/* Parse SDP */
 			JANUS_LOG(LOG_VERB, "Peer accepted our call:\n%s", sip->sip_payload->pl_data);
 			session->status = janus_sip_call_status_incall;
 			char *fixed_sdp = g_strdup(sip->sip_payload->pl_data);


### PR DESCRIPTION
This PR tries to address issues #484 and, potentially, #451 too.

The main problem is that apparently Sofia SIP is not respecting the Record-Route set in responses: in particular, @nbansalvox found out that, when sending an INVITE to a Proxy registering as a guest, a ```Contact``` header present in the ```200 OK``` would override any ```Record-Route``` set in the same response, thus leading our stack to send an ACK to the wrong place and breaking the call.

Long story short, if you're too lazy to read my explaination a few lines below, the only easy way I could find to fix this broken behaviour was to:

1. disable the automatic ACK when receiving a 200 OK, so that we could send it ourselves;
2. check if there's a ```Record-Route``` header present and, if so, use ```NTATAG_DEFAULT_PROXY``` to force the Sofia stack to pass through that proxy from there on for that dialog.

Now, ```NTATAG_DEFAULT_PROXY``` is probably an ugly way to do that, and it may cause problems if we don't handle this properly (e.g., re-adjusting this in case the route is changed again later and so on), but it apparently is the _only_ way to get this done using Sofia SIP's NUA stack.

Coming to the more detailed explaination (feel free to zone out if you don't care, but please don't if you want to provide feedback and suggestions), the reason for this relies in how the internals of Sofia SIP handle the whole transaction/routing process. Digging in the code these past few days, trying to figure out where the broken behaviour might happen and why, I think I found out where the problem occurs, and more specifically in a method called ```leg_route``` in ```nta.c```:

https://github.com/jart/sofia-sip/blob/master/libsofia-sip-ua/nta/nta.c#L4991

Looking at the code there, it appears that the route is indeed handled, but that if a ```Contact``` header has been provided then it takes precedence, as it was outlined in the original issue that was reported. Now, that method is called in a few parts, more importantly from a method called ```nta_leg_client_reroute```, which in turn is called by ```nua_dialog_uac_route```. That method, interestingly enough, is called in ```nua_client_response```, which is where a SIP response is handled (e.g., a 200 OK), and apparently only when (surprise surprise!) a ```Contact``` header is found:

https://github.com/jart/sofia-sip/blob/master/libsofia-sip-ua/nua/nua_client.c#L1049

Now, I initially thought that fixing this behaviour could be done by using those same methods, by managing the transmission of the ACK ourselves (hence the ```NUTAG_AUTOACK(0)```, or otherwise the ACK is automatically sent to the broken route), intercepting a ```Record-Route``` header, and enforcing it using ```nua_dialog_uac_route``` or something like that. Unfortunately, that's not possible, as while the leg/agent info is obviously part of the ```nua_t``` Sofia SIP uses as the NUA stack, every structure in Sofia SIP is completely opaque and hidden to the application: this means there is no means for us, from the plugin, to directly access the leg or the agent needed as arguments to those methods, and there isn't even any complementar method to get the same information from the ```nua_t``` instance itself.

As such, I thought about a few alternatives, namely:

1. copying the private structures from ```nua_stack.h``` within our plugin as well, in order to have access to those definitions in a brutally hacky way (which is a mess not only because it's hacky, but also because there are tons of cross references to other private structures, all of which should be added if you need to figure out the proper offsets of the members);
2. moving from the NUA to NTA, that is stop using the UserAgent helpers Sofia SIP provides and handle all the SIP transactions and states ourselves directly, something I have absolutely no intention of doing (I like SIP, but not that much);
3. using a different approach to force Sofia SIP to go where I want it to.

After realizing how 1. and 2. were not an option, I tried looking for a way to do 3., and that's how I found ```NTATAG_DEFAULT_PROXY```, which is documented here:

http://sofia-sip.sourceforge.net/refdocs/nta/nta__tag_8h.html#a470c3d7c598ed2d4514836d3bb916fc7

    URL for (default) proxy.

    The requests are sent towards the default outbound proxy regardless the values of
    request-URI or Route headers in the request. The URL of the default proxy is not
    added to the request in the Route header or in the request-URI (against the
    recommendation of RFC 3261 section 8.1.2).

    The outbound proxy set by NTATAG_DEFAULT_PROXY() is used even if the dialog
    had an established route set or registration provided User-Agent with a
    Service-Route set.

So, probably a bit hacky and dirty, but it seems to work in my case when trying to replicate the sample scenario described in #484.

Any feedback on this? Any suggestion on how we could do this better? Any hint on where we should do this, besides ```nua_r_invite``` as I'm doing now for this proof of concept? Any places/scenarios this could go horribly wrong?