### PR TITLE
janus-pp-rec should always janus_log_destroy() at exit

### DIFF
--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -76,6 +76,7 @@ void janus_pp_handle_signal(int signum) {
 int main(int argc, char *argv[])
 {
 	janus_log_init(FALSE, TRUE, NULL);
+	atexit(janus_log_destroy);
 
 	/* Check the JANUS_PPREC_DEBUG environment variable for the debugging level */
 	if(g_getenv("JANUS_PPREC_DEBUG") != NULL) {
@@ -519,8 +520,5 @@ int main(int argc, char *argv[])
 	}
 
 	JANUS_LOG(LOG_INFO, "Bye!\n");
-
-	janus_log_destroy();
-
 	return 0;
 }


### PR DESCRIPTION
otherwise JANUS_LOG() messages may not be written out before the process exits

should fix #496 