### PR TITLE
handle NULL error argument to janus_ice_trickle_parse()

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -484,6 +484,10 @@ janus_ice_trickle *janus_ice_trickle_new(janus_ice_handle *handle, const char *t
 }
 
 gint janus_ice_trickle_parse(janus_ice_handle *handle, json_t *candidate, const char **error) {
+	const char *ignore_error = NULL;
+	if (error == NULL) {
+		error = &ignore_error;
+	}
 	if(handle == NULL) {
 		*error = "Invalid handle";
 		return JANUS_ERROR_HANDLE_NOT_FOUND;


### PR DESCRIPTION
In a couple places in `janus.c`, `janus_ice_trickle_parse()` is called with `NULL` for the `error` argument, meaning "don't care about the error string". But `janus_ice_trickle_parse()` does not correctly handle `const char **error = NULL`.

... until now.

It would seem that nobody has regularly hit that code path, until one of my co-workers started sending multiple trickles together in a different way. (Maybe our code to consolidate trickles before they hit janus didn't work before? I dunno.) This experimental code can routinely crash janus:

```
Core was generated by `/janus/bin/janus --configs-folder=/conf'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x0000000000420009 in janus_ice_trickle_parse (handle=0x7fb58802d940, candidate=0x7fb5940281e0, error=0x0) at ice.c:484
484	ice.c: No such file or directory.
(gdb) bt
#0  0x0000000000420009 in janus_ice_trickle_parse (handle=0x7fb58802d940, candidate=0x7fb5940281e0, error=0x0) at ice.c:484
#1  0x0000000000431740 in janus_process_incoming_request (request=0x7fb594013890) at janus.c:1321
#2  0x0000000000437385 in janus_transport_task (data=0x7fb594013890, user_data=<optimized out>) at janus.c:2368
#3  0x00007fb5b9e771d8 in g_thread_pool_thread_proxy (data=<optimized out>) at /build/glib2.0-y6934K/glib2.0-2.42.1/./glib/gthreadpool.c:307
#4  0x00007fb5b9e76845 in g_thread_proxy (data=0x2450a80) at /build/glib2.0-y6934K/glib2.0-2.42.1/./glib/gthread.c:764
#5  0x00007fb5b8b3a0a4 in start_thread (arg=0x7fb59dcfa700) at pthread_create.c:309
#6  0x00007fb5b886f87d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:111
```

Line numbers are from my own branch which is from a few months back in janus history.

janus.c:1321 (is the line with `janus_ice_trickle_parse()`)

```c
			JANUS_LOG(LOG_HUGE, "Got multiple candidates (%zu)\n", json_array_size(candidates));
			if(json_array_size(candidates) > 0) {
				/* Handle remote candidates */
				size_t i = 0;
				for(i=0; i<json_array_size(candidates); i++) {
					json_t *c = json_array_get(candidates, i);
					/* FIXME We don't care if any trickle fails to parse */
					janus_ice_trickle_parse(handle, c, NULL);
				}
```

ice.c:484 (is the line with `*error = "..."`)

```c
		/* Handle remote candidate */
		json_t *mid = json_object_get(candidate, "sdpMid");
		if(!mid) {
			*error = "Trickle error: missing mandatory element (sdpMid)";
			return JANUS_ERROR_MISSING_MANDATORY_ELEMENT;
		}
```