### PR TITLE
janus.js: Try to share screen when share windows fails

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1401,7 +1401,16 @@ function Janus(gatewayCallbacks) {
 						Janus.debug(constraints);
 						navigator.mediaDevices.getUserMedia(constraints)
 							.then(function(stream) { gsmCallback(null, stream); })
-							.catch(function(error) { pluginHandle.consentDialog(false); gsmCallback(error); });
+							.catch(function(error) {
+								if (error.name === 'NotFoundError' && constraints.video.mozMediaSource === 'window' && constraints.video.mediaSource === 'window') {
+									constraints.video.mozMediaSource = 'screen'
+									constraints.video.mediaSource = 'screen'
+									getScreenMedia(constraints, gsmCallback)
+								} else {
+									pluginHandle.consentDialog(false);
+									gsmCallback(error);
+								}
+							});
 					};
 					if(window.navigator.userAgent.match('Chrome')) {
 						var chromever = parseInt(window.navigator.userAgent.match(/Chrome\/(.*) /)[1], 10);

--- a/html/janus.js
+++ b/html/janus.js
@@ -1402,7 +1402,7 @@ function Janus(gatewayCallbacks) {
 						navigator.mediaDevices.getUserMedia(constraints)
 							.then(function(stream) { gsmCallback(null, stream); })
 							.catch(function(error) {
-								if (error.name === 'NotFoundError' && constraints.video.mozMediaSource === 'window' && constraints.video.mediaSource === 'window') {
+								if (error.name === 'NotFoundError' && constraints.video && constraints.video.mozMediaSource === 'window' && constraints.video.mediaSource === 'window') {
 									constraints.video.mozMediaSource = 'screen'
 									constraints.video.mediaSource = 'screen'
 									getScreenMedia(constraints, gsmCallback)

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -1450,7 +1450,16 @@ function Janus(gatewayCallbacks) {
 						Janus.debug(constraints);
 						navigator.mediaDevices.getUserMedia(constraints)
 							.then(function(stream) { gsmCallback(null, stream); })
-							.catch(function(error) { pluginHandle.consentDialog(false); gsmCallback(error); });
+							.catch(function(error) {
+								if (error.name === 'NotFoundError' && constraints.video.mozMediaSource === 'window' && constraints.video.mediaSource === 'window') {
+									constraints.video.mozMediaSource = 'screen'
+									constraints.video.mediaSource = 'screen'
+									getScreenMedia(constraints, gsmCallback)
+								} else {
+									pluginHandle.consentDialog(false);
+									gsmCallback(error);
+								}
+							});
 					};
 					if(window.navigator.userAgent.match('Chrome')) {
 						var chromever = parseInt(window.navigator.userAgent.match(/Chrome\/(.*) /)[1], 10);

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -1451,7 +1451,7 @@ function Janus(gatewayCallbacks) {
 						navigator.mediaDevices.getUserMedia(constraints)
 							.then(function(stream) { gsmCallback(null, stream); })
 							.catch(function(error) {
-								if (error.name === 'NotFoundError' && constraints.video.mozMediaSource === 'window' && constraints.video.mediaSource === 'window') {
+								if (error.name === 'NotFoundError' && constraints.video && constraints.video.mozMediaSource === 'window' && constraints.video.mediaSource === 'window') {
 									constraints.video.mozMediaSource = 'screen'
 									constraints.video.mediaSource = 'screen'
 									getScreenMedia(constraints, gsmCallback)


### PR DESCRIPTION
For Firefox when try to share window and this fails with a
`MediaStreamError NotFound`, try to share screen.

Closes #513