### PR TITLE
Differentiate screen and window sharing in Firefox

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1297,7 +1297,7 @@ function Janus(gatewayCallbacks) {
 			}
 			var videoSupport = isVideoSendEnabled(media);
 			if(videoSupport === true && media != undefined && media != null) {
-				if(media.video && media.video != 'screen') {
+				if(media.video && media.video != 'screen' && media.video != 'window') {
 					var width = 0;
 					var height = 0, maxHeight = 0;
 					if(media.video === 'lowres') {
@@ -1373,7 +1373,7 @@ function Janus(gatewayCallbacks) {
 						videoSupport = media.video;
 					}
 					Janus.debug(videoSupport);
-				} else if(media.video === 'screen') {
+				} else if(media.video === 'screen' || media.video === 'window') {
 					// Not a webcam, but screen capture
 					if(window.location.protocol !== 'https:') {
 						// Screen sharing mandates HTTPS
@@ -1438,8 +1438,8 @@ function Janus(gatewayCallbacks) {
 							// Firefox 33+ has experimental support for screen sharing
 							constraints = {
 								video: {
-									mozMediaSource: 'window',
-									mediaSource: 'window'
+									mozMediaSource: media.video,
+									mediaSource: media.video
 								},
 								audio: isAudioSendEnabled(media)
 							};
@@ -1508,6 +1508,7 @@ function Janus(gatewayCallbacks) {
 							window.clearTimeout(event.data.id);
 						}
 					});
+					return;
 				}
 			}
 			// If we got here, we're not screensharing

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -1346,7 +1346,7 @@ function Janus(gatewayCallbacks) {
 			}
 			var videoSupport = isVideoSendEnabled(media);
 			if(videoSupport === true && media != undefined && media != null) {
-				if(media.video && media.video != 'screen') {
+				if(media.video && media.video != 'screen' && media.video != 'window') {
 					var width = 0;
 					var height = 0, maxHeight = 0;
 					if(media.video === 'lowres') {
@@ -1422,7 +1422,7 @@ function Janus(gatewayCallbacks) {
 						videoSupport = media.video;
 					}
 					Janus.debug(videoSupport);
-				} else if(media.video === 'screen') {
+				} else if(media.video === 'screen' || media.video === 'window') {
 					// Not a webcam, but screen capture
 					if(window.location.protocol !== 'https:') {
 						// Screen sharing mandates HTTPS
@@ -1487,8 +1487,8 @@ function Janus(gatewayCallbacks) {
 							// Firefox 33+ has experimental support for screen sharing
 							constraints = {
 								video: {
-									mozMediaSource: 'window',
-									mediaSource: 'window'
+									mozMediaSource: media.video,
+									mediaSource: media.video
 								},
 								audio: isAudioSendEnabled(media)
 							};
@@ -1557,6 +1557,7 @@ function Janus(gatewayCallbacks) {
 							window.clearTimeout(event.data.id);
 						}
 					});
+					return;
 				}
 			}
 			// If we got here, we're not screensharing

--- a/html/screensharingtest.js
+++ b/html/screensharingtest.js
@@ -56,6 +56,7 @@ var started = false;
 var myusername = null;
 var myid = null;
 
+var capture = null;
 var role = null;
 var room = null;
 var source = null;
@@ -105,7 +106,7 @@ $(document).ready(function() {
 									// Prepare the username registration
 									$('#screenmenu').removeClass('hide').show();
 									$('#createnow').removeClass('hide').show();
-									$('#create').click(shareScreen);
+									$('#create').click(preShareScreen);
 									$('#joinnow').removeClass('hide').show();
 									$('#join').click(joinScreen);
 									$('#desc').focus();
@@ -149,10 +150,10 @@ $(document).ready(function() {
 											Janus.log("Successfully joined room " + msg["room"] + " with ID " + myid);
 											if(role === "publisher") {
 												// This is our session, publish our stream
-												Janus.debug("Negotiating WebRTC stream for our screen");
+												Janus.debug("Negotiating WebRTC stream for our screen (capture " + capture + ")");
 												screentest.createOffer(
 													{
-														media: { video: "screen", audio: false, videoRecv: false},	// Screen sharing doesn't work with audio, and Publishers are sendonly
+														media: { video: capture, audio: false, videoRecv: false},	// Screen sharing doesn't work with audio, and Publishers are sendonly
 														success: function(jsep) {
 															Janus.debug("Got publisher SDP!");
 															Janus.debug(jsep);
@@ -248,7 +249,7 @@ $(document).ready(function() {
 function checkEnterShare(field, event) {
 	var theCode = event.keyCode ? event.keyCode : event.which ? event.which : event.charCode;
 	if(theCode == 13) {
-		shareScreen();
+		preShareScreen();
 		return false;
 	} else {
 		return true;
@@ -260,7 +261,7 @@ function switchToHttps() {
 	return false;
 }
 
-function shareScreen() {
+function preShareScreen() {
 	// Make sure HTTPS is being used
 	if(window.location.protocol !== 'https:') {
 		bootbox.alert('Sharing your screen only works on HTTPS: click <b><a href="#" onclick="return switchToHttps();">here</a></b> to try the https:// version of this page');
@@ -278,15 +279,53 @@ function shareScreen() {
 	$('#create').attr('disabled', true).unbind('click');
 	$('#roomid').attr('disabled', true);
 	$('#join').attr('disabled', true).unbind('click');
-	var desc = $('#desc').val();
-	if(desc === "") {
+	if($('#desc').val() === "") {
 		bootbox.alert("Please insert a description for the room");
 		$('#desc').removeAttr('disabled', true);
-		$('#create').removeAttr('disabled', true).click(shareScreen);
+		$('#create').removeAttr('disabled', true).click(preShareScreen);
 		$('#roomid').removeAttr('disabled', true);
 		$('#join').removeAttr('disabled', true).click(joinScreen);
 		return;
 	}
+	capture = "screen";
+	if(navigator.mozGetUserMedia) {
+		// Firefox needs a different constraint for screen and window sharing
+		bootbox.dialog({
+			title: "Share whole screen or a window?",
+			message: "Firefox handles screensharing in a different way: are you going to share the whole screen, or would you rather pick a single window/application to share instead?",
+			buttons: {
+				screen: {
+					label: "Share screen",
+					className: "btn-primary",
+					callback: function() {
+						capture = "screen";
+						shareScreen();
+					}
+				},
+				window: {
+					label: "Pick a window",
+					className: "btn-success",
+					callback: function() {
+						capture = "window";
+						shareScreen();
+					}
+				}
+			},
+			onEscape: function() {
+				$('#desc').removeAttr('disabled', true);
+				$('#create').removeAttr('disabled', true).click(preShareScreen);
+				$('#roomid').removeAttr('disabled', true);
+				$('#join').removeAttr('disabled', true).click(joinScreen);
+			}
+		});
+	} else {
+		shareScreen();
+	}
+}
+
+function shareScreen() {
+	// Create a new room
+	var desc = $('#desc').val();
 	role = "publisher";
 	var create = { "request": "create", "description": desc, "bitrate": 0, "publishers": 1 };
 	screentest.send({"message": create, success: function(result) {
@@ -323,7 +362,7 @@ function joinScreen() {
 	if(isNaN(roomid)) {
 		bootbox.alert("Session identifiers are numeric only");
 		$('#desc').removeAttr('disabled', true);
-		$('#create').removeAttr('disabled', true).click(shareScreen);
+		$('#create').removeAttr('disabled', true).click(preShareScreen);
 		$('#roomid').removeAttr('disabled', true);
 		$('#join').removeAttr('disabled', true).click(joinScreen);
 		return;


### PR DESCRIPTION
This PR tries to address the issue raised in #514, specifically with respect to the way Firefox handles screensharing, which is different from Chrome. In Firefox, you have to specify in advance whether you want to share the whole screen or a single window, while Chrome puts them all together in the picker later on.

As such, now `janus.js` allows for both `video: "screen"` and `video: "window"`. Both will end up in the same place for Chrome, while for Firefox this will drive the choice accordingly. The screen sharing demo has been updated as well, in order to show a dialog ("Screen or Window?") when you open it from Firefox.

This seems to be working as expected for me, so I plan to merge shortly. If you hate this or would like other improvements first, feel free to shout!