### PR TITLE
Don't warn in response to a "detached" event

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -392,7 +392,7 @@ function Janus(gatewayCallbacks) {
 			}
 			var pluginHandle = pluginHandles[sender];
 			if(pluginHandle === undefined || pluginHandle === null) {
-				Janus.warn("This handle is not attached to this session");
+				// Don't warn here because destroyHandle causes this situation.
 				return;
 			}
 			pluginHandle.ondetached();

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -441,7 +441,7 @@ function Janus(gatewayCallbacks) {
 			}
 			var pluginHandle = pluginHandles[sender];
 			if(pluginHandle === undefined || pluginHandle === null) {
-				Janus.warn("This handle is not attached to this session");
+				// Don't warn here because destroyHandle causes this situation.
 				return;
 			}
 			pluginHandle.ondetached();


### PR DESCRIPTION
When `plugin.detach()` is called from JavaScript, a "detach" request is sent to the server and then the plugin is deleted from `pluginHandles`.  In response, the server sends a "detached" event but there is no plugin to receive it.  While the warning in the console causes no harm, if gives the impression that something went wrong.

I only observed this with the WebSockets transport but I believe that it would happen with the HTTP transport, too.