### PR TITLE
Include fcntl.h to fix build error

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <arpa/inet.h>
 #include <sys/file.h>
 #include <sys/types.h>


### PR DESCRIPTION
Building Janus on my box running Alpine Linux somehow fails with the compiler complaining:
```
utils.c:512:24: error: 'O_RDWR' undeclared (first use in this function)
utils.c:512:31: error: 'O_CREAT' undeclared (first use in this function)
```
This may have something to do with Alpine using musl as its default libc.
Anyways this change fixes the build error.