### PR TITLE
Add calls to janus_videoroom_message_free

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -3159,6 +3159,7 @@ static void *janus_videoroom_handler(void *data) {
 					g_snprintf(error_cause, 512, "Error subscribing!");
 					goto error;
 				}
+				janus_videoroom_message_free(msg);
 				continue;
 			} else if(!strcasecmp(request_text, "remove")) {
 				/* Remove subscribed streams */
@@ -3199,6 +3200,7 @@ static void *janus_videoroom_handler(void *data) {
 					g_snprintf(error_cause, 512, "Error unsubscribing!");
 					goto error;
 				}
+				janus_videoroom_message_free(msg);
 				continue;
 			} else if(!strcasecmp(request_text, "start")) {
 				/* Start/restart receiving the publishers streams */


### PR DESCRIPTION
When reviewing your new PR, I noticed missing calls to `janus_videoroom_message_free`.

It might be easier to put the call to `janus_videoroom_message_free` at the beginning of the loop and right after the loop:

	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
		janus_videoroom_message_free(msg);
		msg = g_async_queue_pop(messages);
		...
	}
	janus_videoroom_message_free(msg);

That would avoid the need to call it before every `continue` statement.