### PR TITLE
Max NACK queue in seconds, instead of packets, plus some other RTCP tweaks

### DIFF
--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -48,14 +48,14 @@ cert_key = @certdir@/mycert.key
 
 ; Media-related stuff: you can configure whether if you want
 ; to enable IPv6 support (still WIP, so handle with care), the maximum size
-; of the NACK queue for retransmissions per handle the range of ports to
-; use for RTP and RTCP (by default, no range is envisaged), the
+; of the NACK queue (in seconds, defaults to 1s) for retransmissions, the
+; range of ports to use for RTP and RTCP (by default, no range is envisaged), the
 ; starting MTU for DTLS (1472 by default, it adapts automatically),
 ; if BUNDLE should be forced (defaults to false) and if RTCP muxing should
 ; be forced (defaults to false).
 [media]
 ;ipv6 = true
-;max_nack_queue = 300
+;max_nack_queue = 1
 ;rtp_port_range = 20000-40000
 ;dtls_mtu = 1200
 ;force-bundle = true

--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -48,14 +48,14 @@ cert_key = @certdir@/mycert.key
 
 ; Media-related stuff: you can configure whether if you want
 ; to enable IPv6 support (still WIP, so handle with care), the maximum size
-; of the NACK queue (in seconds, defaults to 1s) for retransmissions, the
+; of the NACK queue (in milliseconds, defaults to 1000ms=1s) for retransmissions, the
 ; range of ports to use for RTP and RTCP (by default, no range is envisaged), the
 ; starting MTU for DTLS (1472 by default, it adapts automatically),
 ; if BUNDLE should be forced (defaults to false) and if RTCP muxing should
 ; be forced (defaults to false).
 [media]
 ;ipv6 = true
-;max_nack_queue = 1
+;max_nack_queue = 1000
 ;rtp_port_range = 20000-40000
 ;dtls_mtu = 1200
 ;force-bundle = true

--- a/ice.c
+++ b/ice.c
@@ -3175,8 +3175,8 @@ void *janus_ice_send_thread(void *data) {
 			}
 			video_rtcp_last_sr = now;
 		}
-		/* Should we clean up old NACK buffers? */
-		if(max_nack_queue > 0 && (now-last_nack_cleanup >= (max_nack_queue/4))) {
+		/* Should we clean up old NACK buffers? (we check each 1/4 of the max_nack_queue time) */
+		if(max_nack_queue > 0 && (now-last_nack_cleanup >= (max_nack_queue*250))) {
 			/* Check if we do for both streams */
 			janus_cleanup_nack_buffer(now, handle->audio_stream);
 			janus_cleanup_nack_buffer(now, handle->video_stream);

--- a/ice.c
+++ b/ice.c
@@ -3433,16 +3433,18 @@ void *janus_ice_send_thread(void *data) {
 								stream->video_last_ts = timestamp;
 							}
 						}
-						/* Save the packet for retransmissions that may be needed later */
-						janus_rtp_packet *p = (janus_rtp_packet *)g_malloc0(sizeof(janus_rtp_packet));
-						p->data = (char *)g_malloc0(protected);
-						memcpy(p->data, sbuf, protected);
-						p->length = protected;
-						p->created = janus_get_monotonic_time();
-						p->last_retransmit = 0;
-						janus_mutex_lock(&component->mutex);
-						component->retransmit_buffer = g_list_append(component->retransmit_buffer, p);
-						janus_mutex_unlock(&component->mutex);
+						if(max_nack_queue > 0) {
+							/* Save the packet for retransmissions that may be needed later */
+							janus_rtp_packet *p = (janus_rtp_packet *)g_malloc0(sizeof(janus_rtp_packet));
+							p->data = (char *)g_malloc0(protected);
+							memcpy(p->data, sbuf, protected);
+							p->length = protected;
+							p->created = janus_get_monotonic_time();
+							p->last_retransmit = 0;
+							janus_mutex_lock(&component->mutex);
+							component->retransmit_buffer = g_list_append(component->retransmit_buffer, p);
+							janus_mutex_unlock(&component->mutex);
+						}
 					}
 				}
 			} else {

--- a/janus.c
+++ b/janus.c
@@ -1593,8 +1593,8 @@ int janus_process_incoming_admin_request(janus_request *request) {
 				goto jsondone;
 			}
 			int mnq_num = json_integer_value(mnq);
-			if(mnq_num < 0) {
-				ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_INVALID_ELEMENT_TYPE, "Invalid element type (max_nack_queue should be a positive integer)");
+			if(mnq_num < 0 || (mnq_num > 0 || mnq_num < 200)) {
+				ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_INVALID_ELEMENT_TYPE, "Invalid element type (max_nack_queue, if provided, should be greater than 200)");
 				goto jsondone;
 			}
 			janus_set_max_nack_queue(mnq_num);
@@ -3527,6 +3527,8 @@ gint main(int argc, char *argv[])
 		int mnq = atoi(item->value);
 		if(mnq < 0) {
 			JANUS_LOG(LOG_WARN, "Ignoring max_nack_queue value as it's not a positive integer\n");
+		} else if(mnq > 0 && mnq < 200) {
+			JANUS_LOG(LOG_WARN, "Ignoring max_nack_queue value as it's less than 200\n");
 		} else {
 			janus_set_max_nack_queue(mnq);
 		}

--- a/rtcp.h
+++ b/rtcp.h
@@ -186,7 +186,7 @@ typedef struct rtcp_fb
 typedef struct rtcp_context
 {
 	/* Whether we received any RTP packet at all (don't send RR otherwise) */
-	uint8_t enabled:1;
+	uint8_t rtp_recvd:1;
 
 	uint16_t last_seq_nr;
 	uint16_t seq_cycle;
@@ -204,6 +204,8 @@ typedef struct rtcp_context
 	uint32_t lsr;
 	/* Monotonic time of last SR received */
 	int64_t lsr_ts;
+	/* Monotonic time of first SR sent */
+	int64_t fsr_ts;
 
 	/* Last RR/SR we sent */
 	int64_t last_sent;
@@ -281,9 +283,8 @@ char *janus_rtcp_filter(char *packet, int len, int *newlen);
  * @param[in] ctx RTCP context to update, if needed (optional)
  * @param[in] packet The RTP packet
  * @param[in] len The packet data length in bytes
- * @param[in] max_nack_queue Current value of the max NACK value in the handle stack
  * @returns 0 in case of success, -1 on errors */
-int janus_rtcp_process_incoming_rtp(rtcp_context *ctx, char *packet, int len, int max_nack_queue);
+int janus_rtcp_process_incoming_rtp(rtcp_context *ctx, char *packet, int len);
 
 /*! \brief Method to fill in a Report Block in a Receiver Report
  * @param[in] ctx The RTCP context to use for the report

--- a/rtp.h
+++ b/rtp.h
@@ -52,6 +52,7 @@ typedef struct rtp_header
 typedef struct janus_rtp_packet {
 	char *data;
 	gint length;
+	gint64 created;
 	gint64 last_retransmit;
 } janus_rtp_packet;
 


### PR DESCRIPTION
While investigating the infamous #390 (which apparently is a problem in Chrome, tracking an issue there), I fixed some things here and there related to RTCP management.

This is only a PR and not a direct commit as I also changed the way the Max NACK queue is handled, though, which means the existing configuration changes meaning in that respect. The way it has worked so far was in terms of packets: e.g., a `MAX_NACK_QUEUE=300` meant we'd store at max 300 packets to be ready to NACK, and then get rid of older ones when newer arrived. This kinda worked, but is not very effective and can actually be counterproductive, considering it doesn't take into account that different media may have a different number of packets per second (e.g., 50 for audio, 30 or more/less for video), which made it hardly configurable for more fine tuning. Besides, the default value of 300 stored way too many packets, possibly leading to excessive buffering and delayed playout on slow links.

This patch changes that, and turns the Max NACK queue value to a timing one: now the value you can configure in the settings is in seconds, and means "only store RTP packets if they're not older than X seconds", no matter how many there are and no matter what media they refer to. The default is one second, which should be reasonable.

Played with it a bit and it seems to be working fine, but feedback is welcome. As soon as I have an ack I'll merge.