### PR TITLE
getUserMedia belongs to navigator.mediaDevices, not to window

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -162,7 +162,7 @@ Janus.init = function(options) {
 				}
 			}
 			if(src === 'adapter.js') {
-				if(window.getUserMedia && window.RTCPeerConnection) {
+				if(navigator.mediaDevices.getUserMedia && window.RTCPeerConnection) {
 					// Already loaded
 					done();
 					return;
@@ -185,7 +185,7 @@ Janus.init = function(options) {
 
 // Helper method to check whether WebRTC is supported by this browser
 Janus.isWebrtcSupported = function() {
-	return window.RTCPeerConnection && window.getUserMedia;
+	return window.RTCPeerConnection && navigator.mediaDevices.getUserMedia;
 };
 
 function Janus(gatewayCallbacks) {

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -209,7 +209,7 @@ Janus.init = function(options) {
 		}
 		function addJs(src,done) {
 			if(src === 'adapter.js') {
-				if(window.getUserMedia && window.RTCPeerConnection) {
+				if(navigator.mediaDevices.getUserMedia && window.RTCPeerConnection) {
 					// Already loaded
 					done();
 					return;
@@ -232,7 +232,7 @@ Janus.init = function(options) {
 
 // Helper method to check whether WebRTC is supported by this browser
 Janus.isWebrtcSupported = function() {
-	return window.RTCPeerConnection && window.getUserMedia;
+	return window.RTCPeerConnection && navigator.mediaDevices.getUserMedia;
 };
 
 


### PR DESCRIPTION
References:
* https://developer.mozilla.org/en/docs/Web/API/Navigator/getUserMedia
* https://github.com/webrtc/adapter/blob/v1.1.0/src/js/firefox/getusermedia.js