### PR TITLE
Support for recording data channel text messages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -313,6 +313,8 @@ janus_pp_rec_SOURCES = \
 	postprocessing/pp-opus.h \
 	postprocessing/pp-opus-silence.h \
 	postprocessing/pp-rtp.h \
+	postprocessing/pp-srt.c \
+	postprocessing/pp-srt.h \
 	postprocessing/pp-webm.c \
 	postprocessing/pp-webm.h \
 	postprocessing/janus-pp-rec.c \

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -180,11 +180,13 @@ typedef struct janus_echotest_session {
 	janus_plugin_session *handle;
 	gboolean has_audio;
 	gboolean has_video;
+	gboolean has_data;
 	gboolean audio_active;
 	gboolean video_active;
 	uint64_t bitrate;
 	janus_recorder *arc;	/* The Janus recorder instance for this user's audio, if enabled */
 	janus_recorder *vrc;	/* The Janus recorder instance for this user's video, if enabled */
+	janus_recorder *drc;	/* The Janus recorder instance for this user's data, if enabled */
 	janus_mutex rec_mutex;	/* Mutex to protect the recorders from race conditions */
 	guint16 slowlink_count;
 	volatile gint hangingup;
@@ -378,6 +380,7 @@ void janus_echotest_create_session(janus_plugin_session *handle, int *error) {
 	session->handle = handle;
 	session->has_audio = FALSE;
 	session->has_video = FALSE;
+	session->has_data = FALSE;
 	session->audio_active = TRUE;
 	session->video_active = TRUE;
 	janus_mutex_init(&session->rec_mutex);
@@ -429,12 +432,14 @@ char *janus_echotest_query_session(janus_plugin_session *handle) {
 	json_object_set_new(info, "audio_active", json_string(session->audio_active ? "true" : "false"));
 	json_object_set_new(info, "video_active", json_string(session->video_active ? "true" : "false"));
 	json_object_set_new(info, "bitrate", json_integer(session->bitrate));
-	if(session->arc || session->vrc) {
+	if(session->arc || session->vrc || session->drc) {
 		json_t *recording = json_object();
 		if(session->arc && session->arc->filename)
 			json_object_set_new(recording, "audio", json_string(session->arc->filename));
 		if(session->vrc && session->vrc->filename)
 			json_object_set_new(recording, "video", json_string(session->vrc->filename));
+		if(session->drc && session->drc->filename)
+			json_object_set_new(recording, "data", json_string(session->drc->filename));
 		json_object_set_new(info, "recording", recording);
 	}
 	json_object_set_new(info, "slowlink_count", json_integer(session->slowlink_count));
@@ -536,6 +541,8 @@ void janus_echotest_incoming_data(janus_plugin_session *handle, char *buf, int l
 		memcpy(text, buf, len);
 		*(text+len) = '\0';
 		JANUS_LOG(LOG_VERB, "Got a DataChannel message (%zu bytes) to bounce back: %s\n", strlen(text), text);
+		/* Save the frame if we're recording */
+		janus_recorder_save_frame(session->drc, text, strlen(text));
 		/* We send back the same text with a custom prefix */
 		const char *prefix = "Janus EchoTest here! You wrote: ";
 		char *reply = g_malloc0(strlen(prefix)+len+1);
@@ -632,10 +639,17 @@ void janus_echotest_hangup_media(janus_plugin_session *handle) {
 		janus_recorder_free(session->vrc);
 	}
 	session->vrc = NULL;
+	if(session->drc) {
+		janus_recorder_close(session->drc);
+		JANUS_LOG(LOG_INFO, "Closed data recording %s\n", session->drc->filename ? session->drc->filename : "??");
+		janus_recorder_free(session->drc);
+	}
+	session->drc = NULL;
 	janus_mutex_unlock(&session->rec_mutex);
 	/* Reset controls */
 	session->has_audio = FALSE;
 	session->has_video = FALSE;
+	session->has_data = FALSE;
 	session->audio_active = TRUE;
 	session->video_active = TRUE;
 	session->bitrate = 0;
@@ -771,6 +785,7 @@ static void *janus_echotest_handler(void *data) {
 			if(msg->sdp) {
 				session->has_audio = (strstr(msg->sdp, "m=audio") != NULL);
 				session->has_video = (strstr(msg->sdp, "m=video") != NULL);
+				session->has_data = (strstr(msg->sdp, "DTLS/SCTP") != NULL);
 			}
 			gboolean recording = json_is_true(record);
 			const char *recording_base = json_string_value(recfile);
@@ -790,6 +805,12 @@ static void *janus_echotest_handler(void *data) {
 					janus_recorder_free(session->vrc);
 				}
 				session->vrc = NULL;
+				if(session->drc) {
+					janus_recorder_close(session->drc);
+					JANUS_LOG(LOG_INFO, "Closed data recording %s\n", session->drc->filename ? session->drc->filename : "??");
+					janus_recorder_free(session->drc);
+				}
+				session->drc = NULL;
 			} else {
 				/* We've started recording, send a PLI and go on */
 				char filename[255];
@@ -842,6 +863,26 @@ static void *janus_echotest_handler(void *data) {
 					janus_rtcp_pli((char *)&buf, 12);
 					gateway->relay_rtcp(session->handle, 1, buf, 12);
 				}
+				if(session->has_data) {
+					memset(filename, 0, 255);
+					if(recording_base) {
+						/* Use the filename and path we have been provided */
+						g_snprintf(filename, 255, "%s-data", recording_base);
+						session->drc = janus_recorder_create(NULL, "text", filename);
+						if(session->drc == NULL) {
+							/* FIXME We should notify the fact the recorder could not be created */
+							JANUS_LOG(LOG_ERR, "Couldn't open a text data recording file for this EchoTest user!\n");
+						}
+					} else {
+						/* Build a filename */
+						g_snprintf(filename, 255, "echotest-%p-%"SCNi64"-data", session, now);
+						session->drc = janus_recorder_create(NULL, "text", filename);
+						if(session->drc == NULL) {
+							/* FIXME We should notify the fact the recorder could not be created */
+							JANUS_LOG(LOG_ERR, "Couldn't open a text data recording file for this EchoTest user!\n");
+						}
+					}
+				}
 			}
 			janus_mutex_unlock(&session->rec_mutex);
 		}
@@ -850,6 +891,7 @@ static void *janus_echotest_handler(void *data) {
 			JANUS_LOG(LOG_VERB, "This is involving a negotiation (%s) as well:\n%s\n", msg->sdp_type, msg->sdp);
 			session->has_audio = (strstr(msg->sdp, "m=audio") != NULL);
 			session->has_video = (strstr(msg->sdp, "m=video") != NULL);
+			session->has_data = (strstr(msg->sdp, "DTLS/SCTP") != NULL);
 		}
 
 		if(!audio && !video && !bitrate && !record && !msg->sdp) {

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -3,7 +3,7 @@
  * \copyright GNU General Public License v3
  * \brief    Simple utility to post-process .mjr files saved by Janus
  * \details  Our Janus WebRTC gateway provides a simple helper (janus_recorder)
- * to allow plugins to record audio and video frames sent by users. At the time
+ * to allow plugins to record audio, video and text frames sent by users. At the time
  * of writing, this helper has been integrated in several plugins in Janus.
  * To keep things simple on the Janus side, though, no processing
  * at all is done in the recording step: this means that the recorder
@@ -14,15 +14,16 @@
  * The tool will generate a .webm if the recording includes VP8 frames,
  * an .opus if the recording includes Opus frames, an .mp4 if the recording
  * includes H.264 frames, and a .wav file if the recording includes
- * G.711 (mu-law or a-law) frames.
+ * G.711 (mu-law or a-law) frames. In case the recording contains text
+ * frames as received via data channels, instead, a .srt file will be
+ * generated with the text content and the related timing information.
  * 
  * Using the utility is quite simple. Just pass, as arguments to the tool,
  * the path to the .mjr source file you want to post-process, and the
- * path to the destination file (a .webm if it's a video recording,
- * .opus otherwise), e.g.:
+ * path to the destination file, e.g.:
  * 
 \verbatim
-./janus-pp-rec /path/to/source.mjr /path/to/destination.[opus|wav|webm|h264]
+./janus-pp-rec /path/to/source.mjr /path/to/destination.[opus|wav|webm|h264|srt]
 \endverbatim 
  * 
  * An attempt to specify an output format that is not compliant with the
@@ -64,6 +65,11 @@
 #include "pp-h264.h"
 #include "pp-opus.h"
 #include "pp-g711.h"
+#include "pp-srt.h"
+
+#define htonll(x) ((1==htonl(1)) ? (x) : ((gint64)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
+#define ntohll(x) ((1==ntohl(1)) ? (x) : ((gint64)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
+
 
 int janus_log_level = 4;
 gboolean janus_log_timestamps = FALSE;
@@ -96,7 +102,7 @@ int main(int argc, char *argv[])
 	
 	/* Evaluate arguments */
 	if(argc != 3) {
-		JANUS_LOG(LOG_INFO, "Usage: %s source.mjr destination.[opus|wav|webm|mp4]\n", argv[0]);
+		JANUS_LOG(LOG_INFO, "Usage: %s source.mjr destination.[opus|wav|webm|mp4|srt]\n", argv[0]);
 		JANUS_LOG(LOG_INFO, "       %s --header source.mjr (only parse header)\n", argv[0]);
 		JANUS_LOG(LOG_INFO, "       %s --parse source.mjr (only parse and re-order packets)\n", argv[0]);
 		return -1;
@@ -130,7 +136,7 @@ int main(int argc, char *argv[])
 	/* Pre-parse */
 	JANUS_LOG(LOG_INFO, "Pre-parsing file to generate ordered index...\n");
 	gboolean parsed_header = FALSE;
-	int video = 0;
+	int video = 0, data = 0;
 	int opus = 0, g711 = 0, vp8 = 0, vp9 = 0, h264 = 0;
 	gint64 c_time = 0, w_time = 0;
 	int bytes = 0, skip = 0;
@@ -170,18 +176,24 @@ int main(int argc, char *argv[])
 				if(prebuffer[0] == 'v') {
 					JANUS_LOG(LOG_INFO, "This is a video recording, assuming VP8\n");
 					video = 1;
+					data = 0;
 					vp8 = 1;
 				} else if(prebuffer[0] == 'a') {
 					JANUS_LOG(LOG_INFO, "This is an audio recording, assuming Opus\n");
 					video = 0;
+					data = 0;
 					opus = 1;
+				} else if(prebuffer[0] == 'd') {
+					JANUS_LOG(LOG_INFO, "This is a text data recording, assuming SRT\n");
+					video = 0;
+					data = 1;
 				} else {
 					JANUS_LOG(LOG_WARN, "Unsupported recording media type...\n");
 					exit(1);
 				}
 				offset += len;
 				continue;
-			} else if(len < 12) {
+			} else if(!data && len < 12) {
 				/* Not RTP, skip */
 				JANUS_LOG(LOG_VERB, "Skipping packet (not RTP?)\n");
 				offset += len;
@@ -215,8 +227,13 @@ int main(int argc, char *argv[])
 				const char *t = json_string_value(type);
 				if(!strcasecmp(t, "v")) {
 					video = 1;
+					data = 0;
 				} else if(!strcasecmp(t, "a")) {
 					video = 0;
+					data = 0;
+				} else if(!strcasecmp(t, "d")) {
+					video = 0;
+					data = 1;
 				} else {
 					JANUS_LOG(LOG_WARN, "Unsupported recording type '%s' in info header...\n", t);
 					exit(1);
@@ -239,13 +256,18 @@ int main(int argc, char *argv[])
 						JANUS_LOG(LOG_WARN, "The post-processor only supports VP8, VP9 and H.264 video for now (was '%s')...\n", c);
 						exit(1);
 					}
-				} else if(!video) {
+				} else if(!video && !data) {
 					if(!strcasecmp(c, "opus")) {
 						opus = 1;
 					} else if(!strcasecmp(c, "g711")) {
 						g711 = 1;
 					} else {
-						JANUS_LOG(LOG_WARN, "The post-processor only suupports Opus and G.711 audio for now (was '%s')...\n", c);
+						JANUS_LOG(LOG_WARN, "The post-processor only supports Opus and G.711 audio for now (was '%s')...\n", c);
+						exit(1);
+					}
+				} else if(data) {
+					if(strcasecmp(c, "text")) {
+						JANUS_LOG(LOG_WARN, "The post-processor only supports text data for now (was '%s')...\n", c);
 						exit(1);
 					}
 				}
@@ -264,7 +286,7 @@ int main(int argc, char *argv[])
 				}
 				w_time = json_integer_value(written);
 				/* Summary */
-				JANUS_LOG(LOG_INFO, "This is %s recording:\n", video ? "a video" : "an audio");
+				JANUS_LOG(LOG_INFO, "This is %s recording:\n", video ? "a video" : (data ? "a text data" : "an audio"));
 				JANUS_LOG(LOG_INFO, "  -- Codec:   %s\n", c);
 				JANUS_LOG(LOG_INFO, "  -- Created: %"SCNi64"\n", c_time);
 				JANUS_LOG(LOG_INFO, "  -- Written: %"SCNi64"\n", w_time);
@@ -273,30 +295,32 @@ int main(int argc, char *argv[])
 			JANUS_LOG(LOG_ERR, "Invalid header...\n");
 			exit(1);
 		}
-		/* Only read RTP header */
-		bytes = fread(prebuffer, sizeof(char), 16, file);
-		janus_pp_rtp_header *rtp = (janus_pp_rtp_header *)prebuffer;
-		if(last_ts > 0) {
-			/* Is the new timestamp smaller than the next one, and if so, is it a timestamp reset or simply out of order? */
-			if(ntohl(rtp->timestamp) < last_ts && (last_ts-ntohl(rtp->timestamp) > 2*1000*1000*1000)) {
-				reset = ntohl(rtp->timestamp);
-				JANUS_LOG(LOG_WARN, "Timestamp reset: %"SCNu32"\n", reset);
-				times_resetted++;
-				post_reset_pkts = 0;
-			} else if(ntohl(rtp->timestamp) < reset) {
-				if(post_reset_pkts < 1000) {
-					JANUS_LOG(LOG_WARN, "Updating latest timestamp reset: %"SCNu32" (was %"SCNu32")\n", ntohl(rtp->timestamp), reset);
-					reset = ntohl(rtp->timestamp);
-				} else {
+		if(!data) {
+			/* Only read RTP header */
+			bytes = fread(prebuffer, sizeof(char), 16, file);
+			janus_pp_rtp_header *rtp = (janus_pp_rtp_header *)prebuffer;
+			if(last_ts > 0) {
+				/* Is the new timestamp smaller than the next one, and if so, is it a timestamp reset or simply out of order? */
+				if(ntohl(rtp->timestamp) < last_ts && (last_ts-ntohl(rtp->timestamp) > 2*1000*1000*1000)) {
 					reset = ntohl(rtp->timestamp);
 					JANUS_LOG(LOG_WARN, "Timestamp reset: %"SCNu32"\n", reset);
 					times_resetted++;
 					post_reset_pkts = 0;
+				} else if(ntohl(rtp->timestamp) < reset) {
+					if(post_reset_pkts < 1000) {
+						JANUS_LOG(LOG_WARN, "Updating latest timestamp reset: %"SCNu32" (was %"SCNu32")\n", ntohl(rtp->timestamp), reset);
+						reset = ntohl(rtp->timestamp);
+					} else {
+						reset = ntohl(rtp->timestamp);
+						JANUS_LOG(LOG_WARN, "Timestamp reset: %"SCNu32"\n", reset);
+						times_resetted++;
+						post_reset_pkts = 0;
+					}
 				}
 			}
+			last_ts = ntohl(rtp->timestamp);
+			post_reset_pkts++;
 		}
-		last_ts = ntohl(rtp->timestamp);
-		post_reset_pkts++;
 		/* Skip data for now */
 		offset += len;
 	}
@@ -328,15 +352,46 @@ int main(int argc, char *argv[])
 		len = ntohs(len);
 		JANUS_LOG(LOG_VERB, "  -- Length: %"SCNu16"\n", len);
 		offset += 2;
-		if(prebuffer[1] == 'J' || len < 12) {
+		if(prebuffer[1] == 'J' || (!data && len < 12)) {
 			/* Not RTP, skip */
 			JANUS_LOG(LOG_VERB, "  -- Not RTP, skipping\n");
 			offset += len;
 			continue;
 		}
-		if(len > 2000) {
+		if(!data && len > 2000) {
 			/* Way too large, very likely not RTP, skip */
 			JANUS_LOG(LOG_VERB, "  -- Too large packet (%d bytes), skipping\n", len);
+			offset += len;
+			continue;
+		}
+		if(data) {
+			/* Things are simpler for data, no reordering is needed: start by the data time */
+			gint64 when = 0;
+			bytes = fread(&when, sizeof(gint64), 1, file);
+			when = ntohll(when);
+			offset += sizeof(gint64);
+			len -= sizeof(gint64);
+			/* Generate frame packet and insert in the ordered list */
+			janus_pp_frame_packet *p = g_malloc0(sizeof(janus_pp_frame_packet));
+			if(p == NULL) {
+				JANUS_LOG(LOG_ERR, "Memory error!\n");
+				return -1;
+			}
+			/* We "abuse" the timestamp field for the timing info */
+			p->ts = when-c_time;
+			p->len = len;
+			p->drop = 0;
+			p->offset = offset;
+			p->skip = 0;
+			p->next = NULL;
+			p->prev = NULL;
+			if(list == NULL) {
+				list = p;
+			} else {
+				last->next = p;
+			}
+			last = p;
+			/* Done */
 			offset += len;
 			continue;
 		}
@@ -484,7 +539,10 @@ int main(int argc, char *argv[])
 	count = 0;
 	while(tmp) {
 		count++;
-		JANUS_LOG(LOG_VERB, "[%10lu][%4d] seq=%"SCNu16", ts=%"SCNu64", time=%"SCNu64"s\n", tmp->offset, tmp->len, tmp->seq, tmp->ts, (tmp->ts-list->ts)/90000);
+		if(!data)
+			JANUS_LOG(LOG_VERB, "[%10lu][%4d] seq=%"SCNu16", ts=%"SCNu64", time=%"SCNu64"s\n", tmp->offset, tmp->len, tmp->seq, tmp->ts, (tmp->ts-list->ts)/90000);
+		else
+			JANUS_LOG(LOG_VERB, "[%10lu][%4d] time=%"SCNu64"s\n", tmp->offset, tmp->len, tmp->ts);
 		tmp = tmp->next;
 	}
 	JANUS_LOG(LOG_INFO, "Counted %"SCNu16" frame packets\n", count);
@@ -510,7 +568,7 @@ int main(int argc, char *argv[])
 		exit(0);
 	}
 
-	if(!video) {
+	if(!video && !data) {
 		if(opus) {
 			if(janus_pp_opus_create(destination) < 0) {
 				JANUS_LOG(LOG_ERR, "Error creating .opus file...\n");
@@ -521,6 +579,11 @@ int main(int argc, char *argv[])
 				JANUS_LOG(LOG_ERR, "Error creating .wav file...\n");
 				exit(1);
 			}
+		}
+	} else if(data) {
+		if(janus_pp_srt_create(destination) < 0) {
+			JANUS_LOG(LOG_ERR, "Error creating .srt file...\n");
+			exit(1);
 		}
 	} else {
 		if(vp8 || vp9) {
@@ -537,7 +600,7 @@ int main(int argc, char *argv[])
 	}
 	
 	/* Loop */
-	if(!video) {
+	if(!video && !data) {
 		if(opus) {
 			if(janus_pp_opus_process(file, list, &working) < 0) {
 				JANUS_LOG(LOG_ERR, "Error processing Opus RTP frames...\n");
@@ -546,6 +609,10 @@ int main(int argc, char *argv[])
 			if(janus_pp_g711_process(file, list, &working) < 0) {
 				JANUS_LOG(LOG_ERR, "Error processing G.711 RTP frames...\n");
 			}
+		}
+	} else if(data) {
+		if(janus_pp_srt_process(file, list, &working) < 0) {
+			JANUS_LOG(LOG_ERR, "Error processing text data frames...\n");
 		}
 	} else {
 		if(vp8 || vp9) {
@@ -566,6 +633,8 @@ int main(int argc, char *argv[])
 		} else {
 			janus_pp_h264_close();
 		}
+	} else if(data) {
+		janus_pp_srt_close();
 	} else {
 		if(opus) {
 			janus_pp_opus_close();

--- a/postprocessing/pp-g711.c
+++ b/postprocessing/pp-g711.c
@@ -15,8 +15,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include <ogg/ogg.h>
-
 #include "pp-g711.h"
 #include "../debug.h"
 

--- a/postprocessing/pp-rtp.h
+++ b/postprocessing/pp-rtp.h
@@ -45,7 +45,7 @@ typedef struct janus_pp_rtp_header_extension {
 typedef struct janus_pp_frame_packet {
 	uint16_t seq;	/* RTP Sequence number */
 	uint64_t ts;	/* RTP Timestamp */
-	int len;		/* Length of the data */
+	uint16_t len;	/* Length of the data */
 	int pt;			/* Payload type of the data */
 	long offset;	/* Offset of the data in the file */
 	int skip;		/* Bytes to skip, besides the RTP header */

--- a/postprocessing/pp-srt.c
+++ b/postprocessing/pp-srt.c
@@ -1,0 +1,102 @@
+/*! \file    pp-srt.c
+ * \author   Lorenzo Miniero <lorenzo@meetecho.com>
+ * \copyright GNU General Public License v3
+ * \brief    Post-processing to generate .srt files
+ * \details  Implementation of the post-processing code needed to
+ * generate .srt files out of text data recordings.
+ * 
+ * \ingroup postprocessing
+ * \ref postprocessing
+ */
+
+#include <arpa/inet.h>
+#include <endian.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "pp-srt.h"
+#include "../debug.h"
+
+
+FILE *srt_file = NULL;
+
+/* Helper method to print times */
+static void janus_pp_srt_format_time(char *buffer, int len, guint64 when) {
+	gint64 seconds = when/G_USEC_PER_SEC;
+	gint64 ms = (when/1000)-seconds*1000;
+	gint64 minutes = seconds/60;
+	seconds -= minutes*60;
+	gint64 hours = minutes/60;
+	minutes -= hours*60;
+	g_snprintf(buffer, len, "%02"SCNi64":%02"SCNi64":%02"SCNi64".%03"SCNi64, hours, minutes, seconds, ms);
+}
+
+/* Processing methods */
+int janus_pp_srt_create(char *destination) {
+	/* Create srt file */
+	srt_file = fopen(destination, "wb");
+	if(srt_file == NULL) {
+		JANUS_LOG(LOG_ERR, "Couldn't open output file\n");
+		return -1;
+	}
+
+	/* TODO Any header? */
+
+	return 0;
+}
+
+int janus_pp_srt_process(FILE *file, janus_pp_frame_packet *list, int *working) {
+	if(!file || !list || !working)
+		return -1;
+	janus_pp_frame_packet *tmp = list;
+	int seq = 0;
+	int bytes = 0;
+	uint8_t *buffer = g_malloc0(1500);
+	char srt_buffer[2048], from[20], to[20];
+	size_t buflen = 0;
+
+	while(*working && tmp != NULL) {
+		if(tmp->drop) {
+			/* We marked this packet as one to drop, before */
+			JANUS_LOG(LOG_WARN, "Dropping previously marked text packet (time ~%"SCNu64"s)\n", tmp->ts);
+			tmp = tmp->next;
+			continue;
+		}
+		fseek(file, tmp->offset, SEEK_SET);
+		bytes = fread(buffer, sizeof(char), tmp->len, file);
+		if(bytes != tmp->len)
+			JANUS_LOG(LOG_WARN, "Didn't manage to read all the bytes we needed (%d < %d)...\n", bytes, tmp->len);
+		*(buffer+bytes) = '\0';
+		/* Increase sequence number */
+		seq++;
+		/* Compute from/to times */
+		janus_pp_srt_format_time(from, sizeof(from), tmp->ts);
+		if(tmp->next)
+			janus_pp_srt_format_time(to, sizeof(from), tmp->next->ts-1000);
+		else
+			janus_pp_srt_format_time(to, sizeof(from), tmp->ts + 5*G_USEC_PER_SEC);
+		/* Write the lines */
+		g_snprintf(srt_buffer, 2048, "%d\n%s --> %s\n%s\n\n", seq, from, to, buffer);
+		if(srt_file != NULL) {
+			buflen = strlen(srt_buffer);
+			if(fwrite(srt_buffer, sizeof(char), buflen, srt_file) != buflen) {
+				JANUS_LOG(LOG_ERR, "Couldn't write text...\n");
+			}
+			fflush(srt_file);
+		}
+		tmp = tmp->next;
+	}
+	g_free(buffer);
+
+	return 0;
+}
+
+void janus_pp_srt_close(void) {
+	/* Flush and close file */
+	if(srt_file != NULL) {
+		fflush(srt_file);
+		fclose(srt_file);
+	}
+	srt_file = NULL;
+}

--- a/postprocessing/pp-srt.c
+++ b/postprocessing/pp-srt.c
@@ -88,7 +88,7 @@ int janus_pp_srt_process(FILE *file, janus_pp_frame_packet *list, int *working) 
 				JANUS_LOG(LOG_ERR, "Error reading from file...\n");
 				break;
 			}
-			JANUS_LOG(LOG_WARN, "Read %d bytes...\n", bytes);
+			JANUS_LOG(LOG_VERB, "Read %d bytes...\n", bytes);
 			if(fwrite(buffer, sizeof(char), bytes, srt_file) != bytes) {
 				JANUS_LOG(LOG_ERR, "Couldn't write all the buffer...\n");
 			}

--- a/postprocessing/pp-srt.h
+++ b/postprocessing/pp-srt.h
@@ -1,0 +1,23 @@
+/*! \file    pp-srt.h
+ * \author   Lorenzo Miniero <lorenzo@meetecho.com>
+ * \copyright GNU General Public License v3
+ * \brief    Post-processing to generate .srt files (headers)
+ * \details  Implementation of the post-processing code needed to
+ * generate .srt files out of text data recordings.
+ * 
+ * \ingroup postprocessing
+ * \ref postprocessing
+ */
+
+#ifndef _JANUS_PP_SRT
+#define _JANUS_PP_SRT
+
+#include <stdio.h>
+
+#include "pp-rtp.h"
+
+int janus_pp_srt_create(char *destination);
+int janus_pp_srt_process(FILE *file, janus_pp_frame_packet *list, int *working);
+void janus_pp_srt_close(void);
+
+#endif

--- a/record.c
+++ b/record.c
@@ -27,6 +27,9 @@
 #include "debug.h"
 #include "utils.h"
 
+#define htonll(x) ((1==htonl(1)) ? (x) : ((gint64)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
+#define ntohll(x) ((1==ntohl(1)) ? (x) : ((gint64)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
+
 
 /* Info header in the structured recording */
 static const char *header = "MJR00001";
@@ -35,20 +38,23 @@ static const char *frame_header = "MEETECHO";
 
 
 janus_recorder *janus_recorder_create(const char *dir, const char *codec, const char *filename) {
-	int video = 0;
+	janus_recorder_medium type = JANUS_RECORDER_AUDIO;
 	if(codec == NULL) {
 		JANUS_LOG(LOG_ERR, "Missing codec information\n");
 		return NULL;
 	}
 	if(!strcasecmp(codec, "vp8") || !strcasecmp(codec, "vp9") || !strcasecmp(codec, "h264")) {
-		video = 1;
+		type = JANUS_RECORDER_VIDEO;
 		if(!strcasecmp(codec, "vp9")) {
 			JANUS_LOG(LOG_WARN, "The post-processor currently doesn't support VP9: recording anyway for the future\n");
 		}
 	} else if(!strcasecmp(codec, "opus") || !strcasecmp(codec, "g711") || !strcasecmp(codec, "pcmu") || !strcasecmp(codec, "pcma")) {
-		video = 0;
+		type = JANUS_RECORDER_AUDIO;
 		if(!strcasecmp(codec, "pcmu") || !strcasecmp(codec, "pcma"))
 			codec = "g711";
+	} else if(!strcasecmp(codec, "text")) {
+		/* FIXME We only handle text on data channels, so that's the only thing we can save too */
+		type = JANUS_RECORDER_DATA;
 	} else {
 		/* We don't recognize the codec: while we might go on anyway, we'd rather fail instead */
 		JANUS_LOG(LOG_ERR, "Unsupported codec '%s'\n", codec);
@@ -116,7 +122,7 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	if(dir)
 		rc->dir = g_strdup(dir);
 	rc->filename = g_strdup(newname);
-	rc->video = video;
+	rc->type = type;
 	/* Write the first part of the header */
 	fwrite(header, sizeof(char), strlen(header), rc->file);
 	rc->writable = 1;
@@ -126,7 +132,7 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	return rc;
 }
 
-int janus_recorder_save_frame(janus_recorder *recorder, char *buffer, int length) {
+int janus_recorder_save_frame(janus_recorder *recorder, char *buffer, uint length) {
 	if(!recorder)
 		return -1;
 	janus_mutex_lock_nodebug(&recorder->mutex);
@@ -146,7 +152,14 @@ int janus_recorder_save_frame(janus_recorder *recorder, char *buffer, int length
 		/* Write info header as a JSON formatted info */
 		json_t *info = json_object();
 		/* FIXME Codecs should be configurable in the future */
-		json_object_set_new(info, "t", json_string(recorder->video ? "v" : "a"));		/* Audio/Video */
+		const char *type = NULL;
+		if(recorder->type == JANUS_RECORDER_AUDIO)
+			type = "a";
+		else if(recorder->type == JANUS_RECORDER_VIDEO)
+			type = "v";
+		else if(recorder->type == JANUS_RECORDER_DATA)
+			type = "d";
+		json_object_set_new(info, "t", json_string(type));								/* Audio/Video/Data */
 		json_object_set_new(info, "c", json_string(recorder->codec));					/* Media codec */
 		json_object_set_new(info, "s", json_integer(recorder->created));				/* Created time */
 		json_object_set_new(info, "u", json_integer(janus_get_real_time()));			/* First frame written time */
@@ -160,8 +173,13 @@ int janus_recorder_save_frame(janus_recorder *recorder, char *buffer, int length
 	}
 	/* Write frame header */
 	fwrite(frame_header, sizeof(char), strlen(frame_header), recorder->file);
-	uint16_t header_bytes = htons(length);
+	uint16_t header_bytes = htons(recorder->type == JANUS_RECORDER_DATA ? (length+sizeof(gint64)) : length);
 	fwrite(&header_bytes, sizeof(uint16_t), 1, recorder->file);
+	if(recorder->type == JANUS_RECORDER_DATA) {
+		/* If it's data, then we need to prepend timing related info, as it's not there by itself */
+		gint64 now = htonll(janus_get_real_time());
+		fwrite(&now, sizeof(gint64), 1, recorder->file);
+	}
 	/* Save packet on file */
 	int temp = 0, tot = length;
 	while(tot > 0) {

--- a/record.h
+++ b/record.h
@@ -27,6 +27,13 @@
 #include "mutex.h"
 
 
+/*! \brief Media types we can record */
+typedef enum janus_recorder_medium {
+	JANUS_RECORDER_AUDIO,
+	JANUS_RECORDER_VIDEO,
+	JANUS_RECORDER_DATA
+} janus_recorder_medium;
+
 /*! \brief Structure that represents a recorder */
 typedef struct janus_recorder {
 	/*! \brief Absolute path to the directory where the recorder file is stored */ 
@@ -39,8 +46,8 @@ typedef struct janus_recorder {
 	char *codec;
 	/*! \brief When the recording file has been created */
 	gint64 created;
-	/*! \brief Whether this recorder instance is going to record video or audio */ 
-	int video:1;
+	/*! \brief Media this instance is recording */
+	janus_recorder_medium type;
 	/*! \brief Whether the info header for this recorder instance has already been written or not */
 	int header:1;
 	/*! \brief Whether this recorder instance can be used for writing or not */ 
@@ -63,7 +70,7 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
  * @param[in] buffer The frame data to save
  * @param[in] length The frame data length
  * @returns 0 in case of success, a negative integer otherwise */
-int janus_recorder_save_frame(janus_recorder *recorder, char *buffer, int length);
+int janus_recorder_save_frame(janus_recorder *recorder, char *buffer, uint length);
 /*! \brief Close the recorder
  * @param[in] recorder The janus_recorder instance to close
  * @returns 0 in case of success, a negative integer otherwise */


### PR DESCRIPTION
This PR extends the recording functionality in Janus, allowing you to also record data channel data, and then post-process the recording to an external file as you do with audio and video. Not sure if this is something that can be of interest, but it was not a big effort and so it seemed reasonable to have it there.

Since we currently only support text data, that's what we do record. The internal recorder adds timing related info to the data (`janus_get_real_time()`) that you can use in conjunction with the timing info in the header to figure out when exactly the data "appeared".

As to the post-processing, just for fun I created a `.srt` converter, which basically generates a subtitle file you can use with most players. I tested this with the EchoTest plugin (the only plugin where I added the data channel recording functionality) and it seems to be working fine: the subtitles appeared exactly when they were meant to, when played along the processed audio+video. Of course, different export formats can be envisaged for the future, especially for scenarios/contexts where a `.srt` file doesn't make much sense.

One noticeable thing that needs to be improved is how to handle large buffers. In the post-processor we usually dump whatever's larger than 1500 bytes, as that will typically never happen for RTP. Data channels don't have the same constraint, something that needs to be addressed in the code.

Feedback?