### PR TITLE
Added new plugin (and demo) for datachannel based text broadcasting

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -297,6 +297,16 @@ conf_DATA += conf/janus.plugin.voicemail.cfg.sample
 EXTRA_DIST += conf/janus.plugin.voicemail.cfg.sample
 endif
 
+if ENABLE_PLUGIN_TEXTROOM
+plugin_LTLIBRARIES += plugins/libjanus_textroom.la
+plugins_libjanus_textroom_la_SOURCES = plugins/janus_textroom.c
+plugins_libjanus_textroom_la_CFLAGS = $(plugins_cflags)
+plugins_libjanus_textroom_la_LDFLAGS = $(plugins_ldflags)
+plugins_libjanus_textroom_la_LIBADD = $(plugins_libadd)
+conf_DATA += conf/janus.plugin.textroom.cfg.sample
+EXTRA_DIST += conf/janus.plugin.textroom.cfg.sample
+endif
+
 ##
 # Post-processing
 ##

--- a/conf/janus.plugin.textroom.cfg.sample
+++ b/conf/janus.plugin.textroom.cfg.sample
@@ -1,0 +1,13 @@
+; [<unique room ID>]
+; description = This is my awesome room
+; is_private = yes|no (whether this room should be in the public list, default=yes)
+; secret = <optional password needed for manipulating (e.g. destroying) the room>
+; pin = <optional password needed for joining the room>
+; post = <optional backend to contact via HTTP post for all incoming messages>
+
+[1234]
+description = Demo Room
+; is_private = yes
+secret = adminpwd
+; pin = roompwd
+; post = http://example.com/forward/here

--- a/configure.ac
+++ b/configure.ac
@@ -330,6 +330,12 @@ AC_ARG_ENABLE([plugin-voicemail],
               [],
               [enable_plugin_voicemail=yes])
 
+AC_ARG_ENABLE([plugin-textroom],
+              [AS_HELP_STRING([--disable-plugin-textroom],
+                              [Disable textroom plugin])],
+              [],
+              [enable_plugin_textroom=yes])
+
 PKG_CHECK_MODULES([OPUS],
                   [opus],
                   [],
@@ -354,6 +360,7 @@ AM_CONDITIONAL([ENABLE_PLUGIN_STREAMING], [test "x$enable_plugin_streaming" = "x
 AM_CONDITIONAL([ENABLE_PLUGIN_VIDEOCALL], [test "x$enable_plugin_videocall" = "xyes"])
 AM_CONDITIONAL([ENABLE_PLUGIN_VIDEOROOM], [test "x$enable_plugin_videoroom" = "xyes"])
 AM_CONDITIONAL([ENABLE_PLUGIN_VOICEMAIL], [test "x$enable_plugin_voicemail" = "xyes"])
+AM_CONDITIONAL([ENABLE_PLUGIN_TEXTROOM], [test "x$enable_plugin_textroom" = "xyes"])
 
 ##
 # Post-processing
@@ -451,6 +458,9 @@ AM_COND_IF([ENABLE_PLUGIN_VOICEMAIL],
 AM_COND_IF([ENABLE_PLUGIN_RECORDPLAY],
 	[echo "    Record&Play:           yes"],
 	[echo "    Record&Play:           no"])
+AM_COND_IF([ENABLE_PLUGIN_TEXTROOM],
+	[echo "    Text Room:             yes"],
+	[echo "    Text Room:             no"])
 
 echo
 echo "If this configuration is ok for you, do a 'make' to start building Janus. A 'make install' will install Janus and its plugins to the specified prefix. Finally, a 'make configs' will install some sample configuration files too (something you'll only want to do the first time, though)."

--- a/html/demos.html
+++ b/html/demos.html
@@ -61,14 +61,18 @@
 					<td>An audio mixing/bridge demo, allowing you join an Audio Room room.</td>
 				</tr>
 				<tr class="active">
+					<td><a href="textroomtest.html">Text Room</a></td>
+					<td>A text room demo, using DataChannels only.</td>
+				</tr>
+				<tr>
 					<td><a href="voicemailtest.html">Voice Mail</a></td>
 					<td>A simple audio recorder demo, returning an .opus file after 10 seconds.</td>
 				</tr>
-				<tr>
+				<tr class="active">
 					<td><a href="recordplaytest.html">Recorder/Playout</a></td>
 					<td>A demo to record audio/video messages, and subsequently replay them through WebRTC.</td>
 				</tr>
-				<tr class="active">
+				<tr>
 					<td><a href="screensharingtest.html">Screen Sharing</a></td>
 					<td>A webinar-like screen sharing session, based on the Video Room plugin.</td>
 				</tr>

--- a/html/navbar.html
+++ b/html/navbar.html
@@ -20,6 +20,7 @@
 					<li><a href="siptest.html">SIP Gateway</a></li>
 					<li><a href="videoroomtest.html">Video Room</a></li>
 					<li><a href="audiobridgetest.html">Audio Room</a></li>
+					<li><a href="textroomtest.html">Text Room</a></li>
 					<li><a href="voicemailtest.html">Voice Mail</a></li>
 					<li><a href="recordplaytest.html">Recorder/Playout</a></li>
 					<li><a href="screensharingtest.html">Screen Sharing</a></li>

--- a/html/textroomtest.html
+++ b/html/textroomtest.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>Janus WebRTC Gateway: Text Room</title>
+<script type="text/javascript" src="jquery.min.js" ></script>
+<script type="text/javascript" src="jquery.blockUI.js" ></script>
+<script type="text/javascript" src="js/bootstrap.js"></script>
+<script type="text/javascript" src="js/bootbox.min.js"></script>
+<script type="text/javascript" src="js/spin.min.js"></script>
+<script type="text/javascript" src="janus.js" ></script>
+<script type="text/javascript" src="textroomtest.js"></script>
+<script>
+	$(function() {
+		$(".navbar-static-top").load("navbar.html", function() {
+			$(".navbar-static-top li.dropdown").addClass("active");
+			$(".navbar-static-top a[href='textroomtest.html']").parent().addClass("active");
+		});
+		$(".footer").load("footer.html");
+	});
+</script>
+<link rel="stylesheet" href="css/cerulean/bootstrap.css" type="text/css"/>
+<link rel="stylesheet" href="css/demo.css" type="text/css"/>
+<link rel="stylesheet" href="css/font-awesome.css" type="text/css"/>
+</head>
+<body>
+
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+
+<nav class="navbar navbar-default navbar-static-top">
+</nav>
+
+<div class="container">
+	<div class="row">
+		<div class="col-md-12">
+			<div class="page-header">
+				<h1>Plugin Demo: Text Room
+					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+				</h1>
+			</div>
+			<div class="container" id="details">
+				<div class="row">
+					<div class="col-md-12">
+						<h3>Demo details</h3>
+						<p>The Text Room demo is a simple example of how you can use this text
+						broadcasting plugin, which uses Data Channels, to implement something
+						similar to a chatroom. More specifically, the demo allows you to join
+						a previously created and configured text room together with other
+						participants, and send/receive public and private messages to
+						individual participants. To send messages on the chatroom, just type
+						your text and send. To send private messages to individual participants,
+						click the participant name in the list on the right and a custom dialog
+						will appear.</code>.</p>
+						<p>To try the demo, just insert a username to join the room. This will
+						add you to chatroom, and allow you to interact with the other participants.</p>
+						<p>Notice that this is just a very basic demo, and that is just one of
+						the several different ways you can use this plugin for. The plugin
+						actually allows you to join multiple rooms at the same time, and also
+						to forward incoming messages to the room to external components. This
+						makes it a useful tool whenever you have to interact with third party
+						applications and exchange text data.</p>
+						<p>Press the <code>Start</code> button above to launch the demo.</p>
+					</div>
+				</div>
+			</div>
+			<div class="container hide" id="roomjoin">
+				<div class="row">
+					<span class="label label-info" id="you"></span>
+					<div class="col-md-12" id="controls">
+						<div class="input-group margin-bottom-md hide" id="registernow">
+							<span class="input-group-addon">@</span>
+							<input class="form-control" type="text" placeholder="Choose a display name" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);"></input>
+							<span class="input-group-btn">
+								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>
+							</span>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="container hide" id="room">
+				<div class="row">
+					<div class="col-md-4">
+						<div class="panel panel-default">
+							<div class="panel-heading">
+								<h3 class="panel-title">Participants <span class="label label-info hide" id="participant"></span></h3>
+							</div>
+							<div class="panel-body">
+								<ul id="list" class="list-group">
+								</ul>
+							</div>
+						</div>
+					</div>
+					<div class="col-md-8">
+						<div class="panel panel-default">
+							<div class="panel-heading">
+								<h3 class="panel-title">Public Chatroom</span></h3>
+							</div>
+							<div class="panel-body relative" style="overflow-x: auto;" id="chatroom">
+							</div>
+							<div class="panel-footer">
+								<div class="input-group margin-bottom-sm">
+									<span class="input-group-addon"><i class="fa fa-cloud-upload fa-fw"></i></span>
+									<input class="form-control" type="text" placeholder="Write a chatroom message" autocomplete="off" id="datasend" onkeypress="return checkEnter(this, event);" disabled></input>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<hr>
+	<div class="footer">
+	</div>
+</div>
+
+</body>
+</html>

--- a/html/textroomtest.js
+++ b/html/textroomtest.js
@@ -1,0 +1,364 @@
+// We make use of this 'server' variable to provide the address of the
+// REST Janus API. By default, in this example we assume that Janus is
+// co-located with the web server hosting the HTML pages but listening
+// on a different port (8088, the default for HTTP in Janus), which is
+// why we make use of the 'window.location.hostname' base address. Since
+// Janus can also do HTTPS, and considering we don't really want to make
+// use of HTTP for Janus if your demos are served on HTTPS, we also rely
+// on the 'window.location.protocol' prefix to build the variable, in
+// particular to also change the port used to contact Janus (8088 for
+// HTTP and 8089 for HTTPS, if enabled).
+// In case you place Janus behind an Apache frontend (as we did on the
+// online demos at http://janus.conf.meetecho.com) you can just use a
+// relative path for the variable, e.g.:
+//
+// 		var server = "/janus";
+//
+// which will take care of this on its own.
+//
+//
+// If you want to use the WebSockets frontend to Janus, instead, you'll
+// have to pass a different kind of address, e.g.:
+//
+// 		var server = "ws://" + window.location.hostname + ":8188";
+//
+// Of course this assumes that support for WebSockets has been built in
+// when compiling the gateway. WebSockets support has not been tested
+// as much as the REST API, so handle with care!
+//
+//
+// If you have multiple options available, and want to let the library
+// autodetect the best way to contact your gateway (or pool of gateways),
+// you can also pass an array of servers, e.g., to provide alternative
+// means of access (e.g., try WebSockets first and, if that fails, fall
+// back to plain HTTP) or just have failover servers:
+//
+//		var server = [
+//			"ws://" + window.location.hostname + ":8188",
+//			"/janus"
+//		];
+//
+// This will tell the library to try connecting to each of the servers
+// in the presented order. The first working server will be used for
+// the whole session.
+//
+var server = null;
+if(window.location.protocol === 'http:')
+	server = "http://" + window.location.hostname + ":8088/janus";
+else
+	server = "https://" + window.location.hostname + ":8089/janus";
+
+var janus = null;
+var textroom = null;
+var started = false;
+
+var myroom = 1234;	// Demo room
+var myusername = null;
+var myid = null;
+var participants = {}
+var transactions = {}
+
+$(document).ready(function() {
+	// Initialize the library (all console debuggers enabled)
+	Janus.init({debug: "all", callback: function() {
+		// Use a button to start the demo
+		$('#start').click(function() {
+			if(started)
+				return;
+			started = true;
+			$(this).attr('disabled', true).unbind('click');
+			// Make sure the browser supports WebRTC
+			if(!Janus.isWebrtcSupported()) {
+				bootbox.alert("No WebRTC support... ");
+				return;
+			}
+			// Create session
+			janus = new Janus(
+				{
+					server: server,
+					success: function() {
+						// Attach to echo test plugin
+						janus.attach(
+							{
+								plugin: "janus.plugin.textroom",
+								success: function(pluginHandle) {
+									$('#details').remove();
+									textroom = pluginHandle;
+									Janus.log("Plugin attached! (" + textroom.getPlugin() + ", id=" + textroom.getId() + ")");
+									// Setup the DataChannel
+									var body = { "request": "setup" };
+									Janus.debug("Sending message (" + JSON.stringify(body) + ")");
+									textroom.send({"message": body});
+									$('#start').removeAttr('disabled').html("Stop")
+										.click(function() {
+											$(this).attr('disabled', true);
+											janus.destroy();
+										});
+								},
+								error: function(error) {
+									console.error("  -- Error attaching plugin...", error);
+									bootbox.alert("Error attaching plugin... " + error);
+								},
+								webrtcState: function(on) {
+									Janus.log("Janus says our WebRTC PeerConnection is " + (on ? "up" : "down") + " now");
+									$("#videoleft").parent().unblock();
+								},
+								onmessage: function(msg, jsep) {
+									Janus.debug(" ::: Got a message :::");
+									Janus.debug(JSON.stringify(msg));
+									if(msg["error"] !== undefined && msg["error"] !== null) {
+										bootbox.alert(msg["error"]);
+									}
+									if(jsep !== undefined && jsep !== null) {
+										// Answer
+										textroom.createAnswer(
+											{
+												jsep: jsep,
+												media: { audio: false, video: false, data: true },	// We only use datachannels
+												success: function(jsep) {
+													Janus.debug("Got SDP!");
+													Janus.debug(jsep);
+													var body = { "request": "ack" };
+													textroom.send({"message": body, "jsep": jsep});
+												},
+												error: function(error) {
+													Janus.error("WebRTC error:", error);
+													bootbox.alert("WebRTC error... " + JSON.stringify(error));
+												}
+											});
+									}
+								},
+								ondataopen: function(data) {
+									Janus.log("The DataChannel is available!");
+									// Prompt for a display name to join the default room
+									$('#roomjoin').removeClass('hide').show();
+									$('#registernow').removeClass('hide').show();
+									$('#register').click(registerUsername);
+									$('#username').focus();
+								},
+								ondata: function(data) {
+									Janus.debug("We got data from the DataChannel! " + data);
+									//~ $('#datarecv').val(data);
+									var json = JSON.parse(data);
+									var transaction = json["transaction"];
+									if(transactions[transaction]) {
+										// Someone was waiting for this
+										transactions[transaction](json);
+										delete transactions[transaction];
+										return;
+									}
+									var what = json["textroom"];
+									if(what === "message") {
+										// Incoming message: public or private?
+										var msg = json["text"];
+										msg = msg.replace(new RegExp('<', 'g'), '&lt');
+										msg = msg.replace(new RegExp('>', 'g'), '&gt');
+										var from = json["from"];
+										var whisper = json["whisper"];
+										if(whisper === true) {
+											// Private message
+											$('#chatroom').append('<p style="color: purple;"><b>[whisper from ' + participants[from] + ']</b> ' + msg);
+											$('#chatroom').get(0).scrollTop = $('#chatroom').get(0).scrollHeight;				
+										} else {
+											// Public message
+											$('#chatroom').append('<p><b>' + participants[from] + ':</b> ' + msg);
+											$('#chatroom').get(0).scrollTop = $('#chatroom').get(0).scrollHeight;				
+										}
+									} else if(what === "join") {
+										// Somebody joined
+										var username = json["username"];
+										var display = json["display"];
+										participants[username] = display ? display : username;
+										if(username !== myid && $('#rp' + username).length === 0) {
+											// Add to the participants list
+											$('#list').append('<li id="rp' + username + '" class="list-group-item">' + participants[username] + '</li>');
+											$('#rp' + username).css('cursor', 'pointer').click(function() {
+												var username = $(this).attr('id').split("rp")[1];
+												sendPrivateMsg(username);
+											});
+										}
+										$('#chatroom').append('<p style="color: green;"><i>' + participants[username] + ' joined</i></p>');
+										$('#chatroom').get(0).scrollTop = $('#chatroom').get(0).scrollHeight;				
+									} else if(what === "leave") {
+										// Somebody left
+										var username = json["username"];
+										$('#rp' + username).remove();
+										$('#chatroom').append('<p><i style="color: green;">' + participants[username] + ' left</i></p>');
+										$('#chatroom').get(0).scrollTop = $('#chatroom').get(0).scrollHeight;				
+										delete participants[username];
+									} else if(what === "destroyed") {
+										// Room was destroyed, goodbye!
+										Janus.warn("The room has been destroyed!");
+										bootbox.alert("The room has been destroyed", function() {
+											window.location.reload();
+										});
+									}
+								},
+								oncleanup: function() {
+									Janus.log(" ::: Got a cleanup notification :::");
+									$('#datasend').attr('disabled', true);
+								}
+							});
+					},
+					error: function(error) {
+						Janus.error(error);
+						bootbox.alert(error, function() {
+							window.location.reload();
+						});
+					},
+					destroyed: function() {
+						window.location.reload();
+					}
+				});
+		});
+	}});
+});
+
+function checkEnter(field, event) {
+	var theCode = event.keyCode ? event.keyCode : event.which ? event.which : event.charCode;
+	if(theCode == 13) {
+		if(field.id == 'username')
+			registerUsername();
+		else if(field.id == 'datasend')
+			sendData();
+		return false;
+	} else {
+		return true;
+	}
+}
+
+function registerUsername() {
+	if($('#username').length === 0) {
+		// Create fields to register
+		$('#register').click(registerUsername);
+		$('#username').focus();
+	} else {
+		// Try a registration
+		$('#username').attr('disabled', true);
+		$('#register').attr('disabled', true).unbind('click');
+		var username = $('#username').val();
+		if(username === "") {
+			$('#you')
+				.removeClass().addClass('label label-warning')
+				.html("Insert your display name (e.g., pippo)");
+			$('#username').removeAttr('disabled');
+			$('#register').removeAttr('disabled').click(registerUsername);
+			return;
+		}
+		if(/[^a-zA-Z0-9]/.test(username)) {
+			$('#you')
+				.removeClass().addClass('label label-warning')
+				.html('Input is not alphanumeric');
+			$('#username').removeAttr('disabled').val("");
+			$('#register').removeAttr('disabled').click(registerUsername);
+			return;
+		}
+		myid = randomString(12);
+		var transaction = randomString(12);
+		var register = {
+			textroom: "join",
+			transaction: transaction,
+			room: myroom,
+			username: myid,
+			display: username
+		};
+		myusername = username;
+		transactions[transaction] = function(response) {
+			if(response["textroom"] === "error") {
+				// Something went wrong
+				bootbox.alert(response["error"]);
+				$('#username').removeAttr('disabled').val("");
+				$('#register').removeAttr('disabled').click(registerUsername);
+				return;
+			}
+			// We're in
+			$('#roomjoin').hide();
+			$('#room').removeClass('hide').show();
+			$('#participant').removeClass('hide').html(myusername).show();
+			$('#chatroom').css('height', ($(window).height()-420)+"px");
+			$('#datasend').removeAttr('disabled');
+			// Any participants already in?
+			console.log("Participants:", response.participants);
+			if(response.participants && response.participants.length > 0) {
+				for(var i in response.participants) {
+					var p = response.participants[i];
+					participants[p.username] = p.display ? p.display : p.username;
+					if(p.username !== myid && $('#rp' + p.username).length === 0) {
+						// Add to the participants list
+						$('#list').append('<li id="rp' + p.username + '" class="list-group-item">' + participants[p.username] + '</li>');
+						$('#rp' + p.username).css('cursor', 'pointer').click(function() {
+							var username = $(this).attr('id').split("rp")[1];
+							sendPrivateMsg(username);
+						});
+					}
+					$('#chatroom').append('<p><i style="color: green;">' + participants[p.username] + ' joined</i></p>');
+					$('#chatroom').get(0).scrollTop = $('#chatroom').get(0).scrollHeight;				
+				}
+			}
+		};
+		textroom.data({
+			text: JSON.stringify(register),
+			error: function(reason) {
+				bootbox.alert(reason);
+				$('#username').removeAttr('disabled').val("");
+				$('#register').removeAttr('disabled').click(registerUsername);
+			}
+		});
+	}
+}
+
+function sendPrivateMsg(username) {
+	var display = participants[username];
+	if(!display)
+		return;
+	bootbox.prompt("Private message to " + display, function(result) {
+		if(result && result !== "") {
+			var message = {
+				textroom: "message",
+				transaction: randomString(12),
+				room: myroom,
+				to: username,
+				text: result
+			};
+			textroom.data({
+				text: JSON.stringify(message),
+				error: function(reason) { bootbox.alert(reason); },
+				success: function() {
+					$('#chatroom').append('<p style="color: purple;"><b>[whisper to ' + display + ']</b> ' + result);
+					$('#chatroom').get(0).scrollTop = $('#chatroom').get(0).scrollHeight;				
+				}
+			});
+		}
+	});
+	return;
+}
+
+function sendData() {
+	var data = $('#datasend').val();
+	if(data === "") {
+		bootbox.alert('Insert a message to send on the DataChannel');
+		return;
+	}
+	var message = {
+		textroom: "message",
+		transaction: randomString(12),
+		room: myroom,
+		text: data
+	};
+	textroom.data({
+		text: JSON.stringify(message),
+		error: function(reason) { bootbox.alert(reason); },
+		success: function() { $('#datasend').val(''); }
+	});
+}
+
+// Just an helper to generate random usernames
+function randomString(len, charSet) {
+    charSet = charSet || 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    var randomString = '';
+    for (var i = 0; i < len; i++) {
+    	var randomPoz = Math.floor(Math.random() * charSet.length);
+    	randomString += charSet.substring(randomPoz,randomPoz+1);
+    }
+    return randomString;
+}

--- a/janus.c
+++ b/janus.c
@@ -776,7 +776,7 @@ int janus_process_incoming_request(janus_request *request) {
 			janus_mutex_lock(&session->mutex);
 			g_hash_table_remove(session->ice_handles, GUINT_TO_POINTER(handle_id));
 			janus_mutex_unlock(&session->mutex);
-
+			JANUS_LOG(LOG_ERR, "Couldn't attach to plugin '%s', error '%d'\n", plugin_text, error);
 			ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_PLUGIN_ATTACH, "Couldn't attach to plugin: error '%d'", error);
 			goto jsondone;
 		}

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -1,0 +1,1417 @@
+/*! \file   janus_textroom.c
+ * \author Lorenzo Miniero <lorenzo@meetecho.com>
+ * \copyright GNU General Public License v3
+ * \brief  Janus TextRoom plugin
+ * \details This is a plugin implementing a DataChannel only text room.
+ * As such, it does NOT support or negotiate audio or video, but only
+ * data channels, in order to provide text broadcasting features. The
+ * plugin allows users to join multiple text-only rooms via a single
+ * PeerConnection. Users can send messages either to a room in general
+ * (broadcasting), or to individual users (whispers). This plugin can be
+ * used within the context of any application that needs real-time text
+ * broadcasting (e.g., chatrooms, but not only).
+ * 
+ * The only message that is sent to the plugin through the Janus API is
+ * a "setup" message, by which the user initializes the PeerConnection
+ * itself. Apart from that, all other messages are exchanged directly
+ * via Data Channels.
+ * 
+ * Each room can also be configured with an HTTP backend to contact for
+ * incoming messages. If configured, messages addressed to that room will
+ * also be forwarded, by means of an HTTP POST, to the specified address.
+ * Notice that this will only work if libcurl was available when
+ * configuring and installing Janus.
+ * 
+ * \note This plugin is only meant to showcase what you can do with
+ * data channels involving multiple participants at the same time. While
+ * functional, it's not inherently better or faster than doing the same
+ * thing using the Janus API messaging itself (e.g., as part of the
+ * plugin API messaging) or using existing instant messaging protocols
+ * (e.g., Jabber). In fact, while data channels are being used, you're
+ * still going through a server, so it's not really peer-to-peer. That
+ * said, the plugin can be useful if you don't plan to use any other
+ * infrastructure than Janus, and yet you also want to have text-based
+ * communication (e.g., to add a chatroom to an audio or video conference).
+ * 
+ * \section textroomapi Text Room API
+ * TBD.
+ * 
+ * \ingroup plugins
+ * \ref plugins
+ */
+
+#include "plugins/plugin.h"
+
+#include <jansson.h>
+
+#ifdef HAVE_LIBCURL
+#include <curl/curl.h>
+#endif
+
+#include "debug.h"
+#include "apierror.h"
+#include "config.h"
+#include "mutex.h"
+#include "utils.h"
+
+
+/* Plugin information */
+#define JANUS_TEXTROOM_VERSION			1
+#define JANUS_TEXTROOM_VERSION_STRING	"0.0.1"
+#define JANUS_TEXTROOM_DESCRIPTION		"This is a plugin implementing a text-only room for Janus, using DataChannels."
+#define JANUS_TEXTROOM_NAME				"JANUS TextRoom plugin"
+#define JANUS_TEXTROOM_AUTHOR			"Meetecho s.r.l."
+#define JANUS_TEXTROOM_PACKAGE			"janus.plugin.textroom"
+
+/* Plugin methods */
+janus_plugin *create(void);
+int janus_textroom_init(janus_callbacks *callback, const char *config_path);
+void janus_textroom_destroy(void);
+int janus_textroom_get_api_compatibility(void);
+int janus_textroom_get_version(void);
+const char *janus_textroom_get_version_string(void);
+const char *janus_textroom_get_description(void);
+const char *janus_textroom_get_name(void);
+const char *janus_textroom_get_author(void);
+const char *janus_textroom_get_package(void);
+void janus_textroom_create_session(janus_plugin_session *handle, int *error);
+struct janus_plugin_result *janus_textroom_handle_message(janus_plugin_session *handle, char *transaction, char *message, char *sdp_type, char *sdp);
+void janus_textroom_setup_media(janus_plugin_session *handle);
+void janus_textroom_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_textroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_textroom_incoming_data(janus_plugin_session *handle, char *buf, int len);
+void janus_textroom_slow_link(janus_plugin_session *handle, int uplink, int video);
+void janus_textroom_hangup_media(janus_plugin_session *handle);
+void janus_textroom_destroy_session(janus_plugin_session *handle, int *error);
+char *janus_textroom_query_session(janus_plugin_session *handle);
+
+/* Plugin setup */
+static janus_plugin janus_textroom_plugin =
+	JANUS_PLUGIN_INIT (
+		.init = janus_textroom_init,
+		.destroy = janus_textroom_destroy,
+
+		.get_api_compatibility = janus_textroom_get_api_compatibility,
+		.get_version = janus_textroom_get_version,
+		.get_version_string = janus_textroom_get_version_string,
+		.get_description = janus_textroom_get_description,
+		.get_name = janus_textroom_get_name,
+		.get_author = janus_textroom_get_author,
+		.get_package = janus_textroom_get_package,
+		
+		.create_session = janus_textroom_create_session,
+		.handle_message = janus_textroom_handle_message,
+		.setup_media = janus_textroom_setup_media,
+		.incoming_rtp = janus_textroom_incoming_rtp,
+		.incoming_rtcp = janus_textroom_incoming_rtcp,
+		.incoming_data = janus_textroom_incoming_data,
+		.slow_link = janus_textroom_slow_link,
+		.hangup_media = janus_textroom_hangup_media,
+		.destroy_session = janus_textroom_destroy_session,
+		.query_session = janus_textroom_query_session,
+	);
+
+/* Plugin creator */
+janus_plugin *create(void) {
+	JANUS_LOG(LOG_VERB, "%s created!\n", JANUS_TEXTROOM_NAME);
+	return &janus_textroom_plugin;
+}
+
+
+/* Parameter validation */
+static struct janus_json_parameter request_parameters[] = {
+	{"request", JSON_STRING, JANUS_JSON_PARAM_REQUIRED}
+};
+static struct janus_json_parameter transaction_parameters[] = {
+	{"textroom", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
+	{"transaction", JSON_STRING, JANUS_JSON_PARAM_REQUIRED}
+};
+static struct janus_json_parameter room_parameters[] = {
+	{"room", JSON_INTEGER, JANUS_JSON_PARAM_REQUIRED | JANUS_JSON_PARAM_POSITIVE}
+};
+static struct janus_json_parameter create_parameters[] = {
+	{"description", JSON_STRING, 0},
+	{"secret", JSON_STRING, 0},
+	{"pin", JSON_STRING, 0},
+	{"post", JSON_STRING, 0},
+	{"is_private", JANUS_JSON_BOOL, 0}
+};
+static struct janus_json_parameter join_parameters[] = {
+	{"room", JSON_INTEGER, JANUS_JSON_PARAM_REQUIRED | JANUS_JSON_PARAM_POSITIVE},
+	{"username", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
+	{"display", JSON_STRING, 0}
+};
+static struct janus_json_parameter message_parameters[] = {
+	{"room", JSON_INTEGER, JANUS_JSON_PARAM_REQUIRED | JANUS_JSON_PARAM_POSITIVE},
+	{"text", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
+	{"to", JSON_STRING, 0},
+	{"tos", JSON_ARRAY, 0}
+};
+
+/* Static configuration instance */
+static janus_config *config = NULL;
+static const char *config_folder = NULL;
+static janus_mutex config_mutex;
+
+/* Useful stuff */
+static volatile gint initialized = 0, stopping = 0;
+static janus_callbacks *gateway = NULL;
+static GThread *handler_thread;
+static GThread *watchdog;
+static void *janus_textroom_handler(void *data);
+
+
+typedef struct janus_textroom_message {
+	janus_plugin_session *handle;
+	char *transaction;
+	char *message;
+	char *sdp_type;
+	char *sdp;
+} janus_textroom_message;
+static GAsyncQueue *messages = NULL;
+static janus_textroom_message exit_message;
+
+static void janus_textroom_message_free(janus_textroom_message *msg) {
+	if(!msg || msg == &exit_message)
+		return;
+
+	msg->handle = NULL;
+
+	g_free(msg->transaction);
+	msg->transaction = NULL;
+	g_free(msg->message);
+	msg->message = NULL;
+	g_free(msg->sdp_type);
+	msg->sdp_type = NULL;
+	g_free(msg->sdp);
+	msg->sdp = NULL;
+
+	g_free(msg);
+}
+
+typedef struct janus_textroom_room {
+	guint64 room_id;			/* Unique room ID */
+	gchar *room_name;			/* Room description */
+	gchar *room_secret;			/* Secret needed to manipulate (e.g., destroy) this room */
+	gchar *room_pin;			/* Password needed to join this room, if any */
+	gboolean is_private;		/* Whether this room is 'private' (as in hidden) or not */
+	gchar *http_backend;		/* Server to contact via HTTP POST for incoming messages, if any */
+	GHashTable *participants;	/* Map of participants */
+	gint64 destroyed;			/* When this room has been destroyed */
+	janus_mutex mutex;			/* Mutex to lock this room instance */
+} janus_textroom_room;
+static GHashTable *rooms;
+static janus_mutex rooms_mutex;
+static GList *old_rooms;
+
+typedef struct janus_textroom_session {
+	janus_plugin_session *handle;
+	GHashTable *rooms;			/* Map of rooms this user is in, and related participant instance */
+	janus_mutex mutex;			/* Mutex to lock this session */
+	volatile gint setup;
+	volatile gint hangingup;
+	gint64 destroyed;	/* Time at which this session was marked as destroyed */
+} janus_textroom_session;
+static GHashTable *sessions;
+static GList *old_sessions;
+static janus_mutex sessions_mutex;
+
+typedef struct janus_textroom_participant {
+	janus_textroom_session *session;
+	janus_textroom_room *room;	/* Room this participant is in */
+	gchar *username;			/* Unique username in the room */
+	gchar *display;				/* Display name in the room, if any */
+	janus_mutex mutex;			/* Mutex to lock this session */
+	gint64 destroyed;			/* When this participant was destroyed */
+} janus_textroom_participant;
+
+
+/* SDP template: we only offer data channels */
+#define sdp_template \
+		"v=0\r\n" \
+		"o=- %"SCNu64" %"SCNu64" IN IP4 127.0.0.1\r\n"	/* We need current time here */ \
+		"s=Janus TextRoom plugin\r\n" \
+		"t=0 0\r\n" \
+		"m=application 1 DTLS/SCTP 5000\r\n" \
+		"c=IN IP4 1.1.1.1\r\n" \
+		"a=sctpmap:5000 webrtc-datachannel 16\r\n"
+
+
+/* Error codes */
+#define JANUS_TEXTROOM_ERROR_NO_MESSAGE			411
+#define JANUS_TEXTROOM_ERROR_INVALID_JSON		412
+#define JANUS_TEXTROOM_ERROR_MISSING_ELEMENT	413
+#define JANUS_TEXTROOM_ERROR_INVALID_ELEMENT	414
+#define JANUS_TEXTROOM_ERROR_INVALID_REQUEST	415
+#define JANUS_TEXTROOM_ERROR_ALREADY_SETUP		416
+#define JANUS_TEXTROOM_ERROR_NO_SUCH_ROOM		417
+#define JANUS_TEXTROOM_ERROR_ROOM_EXISTS		418
+#define JANUS_TEXTROOM_ERROR_UNAUTHORIZED		419
+#define JANUS_TEXTROOM_ERROR_USERNAME_EXISTS	420
+#define JANUS_TEXTROOM_ERROR_ALREADY_IN_ROOM	421
+#define JANUS_TEXTROOM_ERROR_NOT_IN_ROOM		422
+#define JANUS_TEXTROOM_ERROR_UNKNOWN_ERROR		499
+
+/* TextRoom watchdog/garbage collector (sort of) */
+static void *janus_textroom_watchdog(void *data) {
+	JANUS_LOG(LOG_INFO, "TextRoom watchdog started\n");
+	gint64 now = 0;
+	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
+		janus_mutex_lock(&sessions_mutex);
+		/* Iterate on all the sessions */
+		now = janus_get_monotonic_time();
+		if(old_sessions != NULL) {
+			GList *sl = old_sessions;
+			JANUS_LOG(LOG_HUGE, "Checking %d old TextRoom sessions...\n", g_list_length(old_sessions));
+			while(sl) {
+				janus_textroom_session *session = (janus_textroom_session *)sl->data;
+				if(!session) {
+					sl = sl->next;
+					continue;
+				}
+				if(now-session->destroyed >= 5*G_USEC_PER_SEC) {
+					/* We're lazy and actually get rid of the stuff only after a few seconds */
+					JANUS_LOG(LOG_VERB, "Freeing old TextRoom session\n");
+					GList *rm = sl->next;
+					old_sessions = g_list_delete_link(old_sessions, sl);
+					sl = rm;
+					session->handle = NULL;
+					/* TODO Free session stuff */
+					g_free(session);
+					session = NULL;
+					continue;
+				}
+				sl = sl->next;
+			}
+		}
+		janus_mutex_unlock(&sessions_mutex);
+		janus_mutex_lock(&rooms_mutex);
+		if(old_rooms != NULL) {
+			GList *rl = old_rooms;
+			now = janus_get_monotonic_time();
+			while(rl) {
+				janus_textroom_room *textroom = (janus_textroom_room*)rl->data;
+				if(!g_atomic_int_get(&initialized) || g_atomic_int_get(&stopping)){
+					break;
+				}
+				if(!textroom) {
+					rl = rl->next;
+					continue;
+				}
+				if(now - textroom->destroyed >= 5*G_USEC_PER_SEC) {
+					/* Free resources */
+					JANUS_LOG(LOG_VERB, "Freeing old TextRoom room %"SCNu64"\n", textroom->room_id);
+					g_free(textroom->room_name);
+					g_free(textroom->room_secret);
+					g_free(textroom->room_pin);
+					g_hash_table_destroy(textroom->participants);
+					g_free(textroom);
+					/* Move on */
+					GList *rm = rl->next;
+					old_rooms = g_list_delete_link(old_rooms, rl);
+					rl = rm;
+					continue;
+				}
+				rl = rl->next;
+			}
+		}
+		janus_mutex_unlock(&rooms_mutex);
+		g_usleep(500000);
+	}
+	JANUS_LOG(LOG_INFO, "TextRoom watchdog stopped\n");
+	return NULL;
+}
+
+#ifdef HAVE_LIBCURL
+static size_t janus_textroom_write_data(void *buffer, size_t size, size_t nmemb, void *userp) {
+	return size*nmemb;
+}
+#endif
+
+void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *text, gboolean internal);
+
+
+/* Plugin implementation */
+int janus_textroom_init(janus_callbacks *callback, const char *config_path) {
+	if(g_atomic_int_get(&stopping)) {
+		/* Still stopping from before */
+		return -1;
+	}
+	if(callback == NULL || config_path == NULL) {
+		/* Invalid arguments */
+		return -1;
+	}
+
+	/* Read configuration */
+	char filename[255];
+	g_snprintf(filename, 255, "%s/%s.cfg", config_path, JANUS_TEXTROOM_PACKAGE);
+	JANUS_LOG(LOG_VERB, "Configuration file: %s\n", filename);
+	config = janus_config_parse(filename);
+	config_folder = config_path;
+	if(config != NULL)
+		janus_config_print(config);
+	janus_mutex_init(&config_mutex);
+	
+	rooms = g_hash_table_new(NULL, NULL);
+	janus_mutex_init(&rooms_mutex);
+	sessions = g_hash_table_new(NULL, NULL);
+	messages = g_async_queue_new_full((GDestroyNotify) janus_textroom_message_free);
+	janus_mutex_init(&sessions_mutex);
+	/* This is the callback we'll need to invoke to contact the gateway */
+	gateway = callback;
+
+	/* Parse configuration to populate the rooms list */
+	if(config != NULL) {
+		GList *cl = janus_config_get_categories(config);
+		while(cl != NULL) {
+			janus_config_category *cat = (janus_config_category *)cl->data;
+			if(cat->name == NULL) {
+				cl = cl->next;
+				continue;
+			}
+			JANUS_LOG(LOG_VERB, "Adding text room '%s'\n", cat->name);
+			janus_config_item *desc = janus_config_get_item(cat, "description");
+			janus_config_item *priv = janus_config_get_item(cat, "is_private");
+			janus_config_item *secret = janus_config_get_item(cat, "secret");
+			janus_config_item *pin = janus_config_get_item(cat, "pin");
+			janus_config_item *post = janus_config_get_item(cat, "post");
+			/* Create the text room */
+			janus_textroom_room *textroom = g_malloc0(sizeof(janus_textroom_room));
+			textroom->room_id = atol(cat->name);
+			char *description = NULL;
+			if(desc != NULL && desc->value != NULL && strlen(desc->value) > 0)
+				description = g_strdup(desc->value);
+			else
+				description = g_strdup(cat->name);
+			textroom->room_name = description;
+			textroom->is_private = priv && priv->value && janus_is_true(priv->value);
+			if(secret != NULL && secret->value != NULL) {
+				textroom->room_secret = g_strdup(secret->value);
+			}
+			if(pin != NULL && pin->value != NULL) {
+				textroom->room_pin = g_strdup(pin->value);
+			}
+			if(post != NULL && post->value != NULL) {
+#ifdef HAVE_LIBCURL	
+				/* FIXME Should we check if this is a valid HTTP address? */
+				textroom->http_backend = g_strdup(post->value);
+#else
+				JANUS_LOG(LOG_WARN, "HTTP backend specified, but libcurl support was not built in...\n");
+#endif
+			}
+			textroom->participants = g_hash_table_new(g_str_hash, g_str_equal);
+			textroom->destroyed = 0;
+			janus_mutex_init(&textroom->mutex);
+			JANUS_LOG(LOG_VERB, "Created textroom: %"SCNu64" (%s, %s, secret: %s, pin: %s)\n",
+				textroom->room_id, textroom->room_name,
+				textroom->is_private ? "private" : "public",
+				textroom->room_secret ? textroom->room_secret : "no secret",
+				textroom->room_pin ? textroom->room_pin : "no pin");
+			g_hash_table_insert(rooms, GUINT_TO_POINTER(textroom->room_id), textroom);
+			cl = cl->next;
+		}
+		/* Done: we keep the configuration file open in case we get a "create" or "destroy" with permanent=true */
+	}
+
+	/* Show available rooms */
+	janus_mutex_lock(&rooms_mutex);
+	GHashTableIter iter;
+	gpointer value;
+	g_hash_table_iter_init(&iter, rooms);
+	while (g_hash_table_iter_next(&iter, NULL, &value)) {
+		janus_textroom_room *tr = value;
+		JANUS_LOG(LOG_VERB, "  ::: [%"SCNu64"][%s]\n", tr->room_id, tr->room_name);
+	}
+	janus_mutex_unlock(&rooms_mutex);
+
+#ifdef HAVE_LIBCURL	
+	curl_global_init(CURL_GLOBAL_ALL);
+#endif	
+
+	GError *error = NULL;
+	/* Start the sessions watchdog */
+	watchdog = g_thread_try_new("textroom watchdog", &janus_textroom_watchdog, NULL, &error);
+	if(error != NULL) {
+		g_atomic_int_set(&initialized, 0);
+		JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the TextRoom watchdog thread...\n", error->code, error->message ? error->message : "??");
+		return -1;
+	}
+	/* Launch the thread that will handle incoming messages */
+	handler_thread = g_thread_try_new("janus textroom handler", janus_textroom_handler, NULL, &error);
+	if(error != NULL) {
+		g_atomic_int_set(&initialized, 0);
+		JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the EchoTest handler thread...\n", error->code, error->message ? error->message : "??");
+		return -1;
+	}
+	g_atomic_int_set(&initialized, 1);
+	JANUS_LOG(LOG_INFO, "%s initialized!\n", JANUS_TEXTROOM_NAME);
+	return 0;
+}
+
+void janus_textroom_destroy(void) {
+	if(!g_atomic_int_get(&initialized))
+		return;
+	g_atomic_int_set(&stopping, 1);
+
+	g_async_queue_push(messages, &exit_message);
+	if(handler_thread != NULL) {
+		g_thread_join(handler_thread);
+		handler_thread = NULL;
+	}
+	if(watchdog != NULL) {
+		g_thread_join(watchdog);
+		watchdog = NULL;
+	}
+
+	/* FIXME We should destroy the sessions cleanly */
+	janus_mutex_lock(&sessions_mutex);
+	g_hash_table_destroy(sessions);
+	janus_mutex_unlock(&sessions_mutex);
+	g_async_queue_unref(messages);
+	messages = NULL;
+	sessions = NULL;
+
+#ifdef HAVE_LIBCURL	
+	curl_global_cleanup();
+#endif
+
+	g_atomic_int_set(&initialized, 0);
+	g_atomic_int_set(&stopping, 0);
+	JANUS_LOG(LOG_INFO, "%s destroyed!\n", JANUS_TEXTROOM_NAME);
+}
+
+int janus_textroom_get_api_compatibility(void) {
+	/* Important! This is what your plugin MUST always return: don't lie here or bad things will happen */
+	return JANUS_PLUGIN_API_VERSION;
+}
+
+int janus_textroom_get_version(void) {
+	return JANUS_TEXTROOM_VERSION;
+}
+
+const char *janus_textroom_get_version_string(void) {
+	return JANUS_TEXTROOM_VERSION_STRING;
+}
+
+const char *janus_textroom_get_description(void) {
+	return JANUS_TEXTROOM_DESCRIPTION;
+}
+
+const char *janus_textroom_get_name(void) {
+	return JANUS_TEXTROOM_NAME;
+}
+
+const char *janus_textroom_get_author(void) {
+	return JANUS_TEXTROOM_AUTHOR;
+}
+
+const char *janus_textroom_get_package(void) {
+	return JANUS_TEXTROOM_PACKAGE;
+}
+
+void janus_textroom_create_session(janus_plugin_session *handle, int *error) {
+	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized)) {
+		*error = -1;
+		return;
+	}	
+	janus_textroom_session *session = (janus_textroom_session *)g_malloc0(sizeof(janus_textroom_session));
+	session->handle = handle;
+	session->rooms = g_hash_table_new(NULL, NULL);
+	session->destroyed = 0;
+	janus_mutex_init(&session->mutex);
+	g_atomic_int_set(&session->setup, 0);
+	g_atomic_int_set(&session->hangingup, 0);
+	handle->plugin_handle = session;
+	janus_mutex_lock(&sessions_mutex);
+	g_hash_table_insert(sessions, handle, session);
+	janus_mutex_unlock(&sessions_mutex);
+
+	return;
+}
+
+void janus_textroom_destroy_session(janus_plugin_session *handle, int *error) {
+	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized)) {
+		*error = -1;
+		return;
+	}	
+	janus_textroom_session *session = (janus_textroom_session *)handle->plugin_handle;
+	if(!session) {
+		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
+		*error = -2;
+		return;
+	}
+	JANUS_LOG(LOG_VERB, "Removing Echo Test session...\n");
+	janus_mutex_lock(&sessions_mutex);
+	if(!session->destroyed) {
+		g_hash_table_remove(sessions, handle);
+		janus_textroom_hangup_media(handle);
+		session->destroyed = janus_get_monotonic_time();
+		/* Cleaning up and removing the session is done in a lazy way */
+		old_sessions = g_list_append(old_sessions, session);
+	}
+	janus_mutex_unlock(&sessions_mutex);
+	return;
+}
+
+char *janus_textroom_query_session(janus_plugin_session *handle) {
+	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized)) {
+		return NULL;
+	}	
+	janus_textroom_session *session = (janus_textroom_session *)handle->plugin_handle;
+	if(!session) {
+		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
+		return NULL;
+	}
+	/* TODO Return meaningful info: participant details, rooms they're in, etc. */
+	json_t *info = json_object();
+	json_object_set_new(info, "destroyed", json_integer(session->destroyed));
+	char *info_text = json_dumps(info, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+	json_decref(info);
+	return info_text;
+}
+
+struct janus_plugin_result *janus_textroom_handle_message(janus_plugin_session *handle, char *transaction, char *message, char *sdp_type, char *sdp) {
+	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
+		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized");
+	janus_textroom_message *msg = g_malloc0(sizeof(janus_textroom_message));
+	msg->handle = handle;
+	msg->transaction = transaction;
+	msg->message = message;
+	msg->sdp_type = sdp_type;
+	msg->sdp = sdp;
+	g_async_queue_push(messages, msg);
+
+	/* All the requests to this plugin are handled asynchronously */
+	return janus_plugin_result_new(JANUS_PLUGIN_OK_WAIT, "I'm taking my time!");
+}
+
+void janus_textroom_setup_media(janus_plugin_session *handle) {
+	JANUS_LOG(LOG_INFO, "WebRTC media is now available\n");
+	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
+		return;
+	janus_textroom_session *session = (janus_textroom_session *)handle->plugin_handle;	
+	if(!session) {
+		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
+		return;
+	}
+	if(session->destroyed)
+		return;
+	g_atomic_int_set(&session->hangingup, 0);
+}
+
+void janus_textroom_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len) {
+	/* We don't do audio/video */
+}
+
+void janus_textroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+	/* We don't do audio/video */
+}
+
+void janus_textroom_incoming_data(janus_plugin_session *handle, char *buf, int len) {
+	if(handle == NULL || handle->stopped || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
+		return;
+	/* Incoming request from this user: what should we do? */
+	janus_textroom_session *session = (janus_textroom_session *)handle->plugin_handle;	
+	if(!session) {
+		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
+		return;
+	}
+	if(session->destroyed)
+		return;
+	if(buf == NULL || len <= 0)
+		return;
+	char *text = g_malloc0(len+1);
+	memcpy(text, buf, len);
+	*(text+len) = '\0';
+	JANUS_LOG(LOG_VERB, "Got a DataChannel message (%zu bytes): %s\n", strlen(text), text);
+	janus_textroom_handle_incoming_request(handle, text, FALSE);
+}
+
+/* Helper method to handle incoming messages from the data channel */
+void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *text, gboolean internal) {
+	janus_textroom_session *session = (janus_textroom_session *)handle->plugin_handle;	
+	/* Parse JSON */
+	json_error_t error;
+	json_t *root = json_loads(text, 0, &error);
+	g_free(text);
+	if(!root) {
+		JANUS_LOG(LOG_ERR, "Error parsing data channel message (JSON error: on line %d: %s)\n", error.line, error.text);
+		return;
+	}
+	/* Handle request */
+	int error_code = 0;
+	char error_cause[512];
+	JANUS_VALIDATE_JSON_OBJECT(root, transaction_parameters,
+		error_code, error_cause, TRUE,
+		JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
+	const char *transaction_text = NULL;
+	if(error_code != 0)
+		goto error;
+	json_t *request = json_object_get(root, "textroom");
+	json_t *transaction = json_object_get(root, "transaction");
+	const char *request_text = json_string_value(request);
+	transaction_text = json_string_value(transaction);
+	if(!strcasecmp(request_text, "message")) {
+		JANUS_VALIDATE_JSON_OBJECT(root, message_parameters,
+			error_code, error_cause, TRUE,
+			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
+		if(error_code != 0)
+			goto error;
+		json_t *room = json_object_get(root, "room");
+		guint64 room_id = json_integer_value(room);
+		janus_mutex_lock(&rooms_mutex);
+		janus_textroom_room *textroom = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+		if(textroom == NULL) {
+			janus_mutex_unlock(&rooms_mutex);
+			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
+			error_code = JANUS_TEXTROOM_ERROR_NO_SUCH_ROOM;
+			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
+			goto error;
+		}
+		janus_mutex_lock(&textroom->mutex);
+		janus_mutex_unlock(&rooms_mutex);
+		janus_textroom_participant *participant = g_hash_table_lookup(session->rooms, GUINT_TO_POINTER(room_id));
+		if(participant == NULL) {
+			janus_mutex_unlock(&textroom->mutex);
+			JANUS_LOG(LOG_ERR, "Not in room %"SCNu64"\n", room_id);
+			error_code = JANUS_TEXTROOM_ERROR_NOT_IN_ROOM;
+			g_snprintf(error_cause, 512, "Not in room %"SCNu64, room_id);
+			goto error;
+		}
+		json_t *username = json_object_get(root, "to");
+		json_t *usernames = json_object_get(root, "tos");
+		if(username && usernames) {
+			janus_mutex_unlock(&textroom->mutex);
+			JANUS_LOG(LOG_ERR, "Both to and tos array provided\n");
+			error_code = JANUS_TEXTROOM_ERROR_INVALID_ELEMENT;
+			g_snprintf(error_cause, 512, "Both to and tos array provided");
+			goto error;
+		}
+		json_t *text = json_object_get(root, "text");
+		const char *message = json_string_value(text);
+		/* Prepare outgoing message */
+		json_t *msg = json_object();
+		json_object_set_new(msg, "textroom", json_string("message"));
+		json_object_set_new(msg, "room", json_integer(room_id));
+		json_object_set_new(msg, "from", json_string(participant->username));
+		json_object_set_new(msg, "text", json_string(message));
+		if(username || usernames)
+			json_object_set_new(msg, "whisper", json_true());
+		char *msg_text = json_dumps(msg, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+		json_decref(msg);
+		/* Start preparing the response too */
+		json_t *reply = json_object();
+		json_object_set_new(reply, "textroom", json_string("success"));
+		json_object_set_new(reply, "transaction", json_string(transaction_text));
+		/* Who should we send this message to? */
+		if(username) {
+			/* A single user */
+			json_t *sent = json_object();
+			const char *to = json_string_value(username);
+			JANUS_LOG(LOG_VERB, "To %s in %"SCNu64": %s\n", to, room_id, message);
+			janus_textroom_participant *top = g_hash_table_lookup(textroom->participants, to);
+			if(top) {
+				gateway->relay_data(top->session->handle, msg_text, strlen(msg_text));
+				json_object_set_new(sent, to, json_true());
+			} else {
+				JANUS_LOG(LOG_WARN, "User %s is not in room %"SCNu64", failed to send message\n", to, room_id);
+				json_object_set_new(sent, to, json_false());
+			}
+			json_object_set_new(reply, "sent", sent);
+		} else if(usernames) {
+			/* A limited number of users */
+			json_t *sent = json_object();
+			size_t i = 0;
+			for(i=0; i<json_array_size(usernames); i++) {
+				json_t *u = json_array_get(usernames, i);
+				const char *to = json_string_value(u);
+				JANUS_LOG(LOG_VERB, "To %s in %"SCNu64": %s\n", to, room_id, message);
+				janus_textroom_participant *top = g_hash_table_lookup(textroom->participants, to);
+				if(top) {
+					gateway->relay_data(top->session->handle, msg_text, strlen(msg_text));
+					json_object_set_new(sent, to, json_true());
+				} else {
+					JANUS_LOG(LOG_WARN, "User %s is not in room %"SCNu64", failed to send message\n", to, room_id);
+					json_object_set_new(sent, to, json_false());
+				}
+			}
+			json_object_set_new(reply, "sent", sent);
+		} else {
+			/* Everybody in the room */
+			JANUS_LOG(LOG_VERB, "To everybody in %"SCNu64": %s\n", room_id, message);
+			if(textroom->participants) {
+				GHashTableIter iter;
+				gpointer value;
+				g_hash_table_iter_init(&iter, textroom->participants);
+				while(g_hash_table_iter_next(&iter, NULL, &value)) {
+					janus_textroom_participant *top = value;
+					JANUS_LOG(LOG_VERB, "  >> To %s in %"SCNu64": %s\n", top->username, room_id, message);
+					gateway->relay_data(top->session->handle, msg_text, strlen(msg_text));
+				}
+			}
+#ifdef HAVE_LIBCURL
+			/* Is there a backend waiting for this message too? */
+			if(textroom->http_backend) {
+				/* Prepare the libcurl context */
+				CURLcode res;
+				CURL *curl = curl_easy_init();
+				if(curl == NULL) {
+					JANUS_LOG(LOG_ERR, "Error initializing CURL context\n");
+				} else {
+					curl_easy_setopt(curl, CURLOPT_URL, textroom->http_backend);
+					struct curl_slist *headers = NULL;
+					headers = curl_slist_append(headers, "Accept: application/json");
+					headers = curl_slist_append(headers, "Content-Type: application/json");
+					headers = curl_slist_append(headers, "charsets: utf-8");
+					curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+					curl_easy_setopt(curl, CURLOPT_POSTFIELDS, msg_text);
+					curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, janus_textroom_write_data);
+					/* Send the request */
+					res = curl_easy_perform(curl);
+					if(res != CURLE_OK) {
+						JANUS_LOG(LOG_ERR, "Couldn't relay event to the backend: %s\n", curl_easy_strerror(res));
+					} else {
+						JANUS_LOG(LOG_DBG, "Event sent!\n");
+					}
+				}
+			}
+#endif
+		}
+		g_free(msg_text);
+		janus_mutex_unlock(&textroom->mutex);
+		if(!internal) {
+			/* Send response back */
+			char *reply_text = json_dumps(reply, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+			json_decref(reply);
+			gateway->relay_data(handle, reply_text, strlen(reply_text));
+			g_free(reply_text);
+		}
+	} else if(!strcasecmp(request_text, "join")) {
+		JANUS_VALIDATE_JSON_OBJECT(root, join_parameters,
+			error_code, error_cause, TRUE,
+			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
+		if(error_code != 0)
+			goto error;
+		json_t *room = json_object_get(root, "room");
+		guint64 room_id = json_integer_value(room);
+		janus_mutex_lock(&rooms_mutex);
+		janus_textroom_room *textroom = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+		if(textroom == NULL) {
+			janus_mutex_unlock(&rooms_mutex);
+			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
+			error_code = JANUS_TEXTROOM_ERROR_NO_SUCH_ROOM;
+			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
+			goto error;
+		}
+		janus_mutex_lock(&textroom->mutex);
+		janus_mutex_unlock(&rooms_mutex);
+		janus_mutex_lock(&session->mutex);
+		if(g_hash_table_lookup(session->rooms, GUINT_TO_POINTER(room_id)) != NULL) {
+			janus_mutex_unlock(&session->mutex);
+			janus_mutex_unlock(&textroom->mutex);
+			JANUS_LOG(LOG_ERR, "Already in room %"SCNu64"\n", room_id);
+			error_code = JANUS_TEXTROOM_ERROR_ALREADY_IN_ROOM;
+			g_snprintf(error_cause, 512, "Already in room %"SCNu64, room_id);
+			goto error;
+		}
+		json_t *username = json_object_get(root, "username");
+		const char *username_text = json_string_value(username);
+		janus_textroom_participant *participant = g_hash_table_lookup(textroom->participants, username_text);
+		if(participant != NULL) {
+			janus_mutex_unlock(&session->mutex);
+			janus_mutex_unlock(&textroom->mutex);
+			JANUS_LOG(LOG_ERR, "Username already taken\n");
+			error_code = JANUS_TEXTROOM_ERROR_USERNAME_EXISTS;
+			g_snprintf(error_cause, 512, "Username already taken");
+			goto error;
+		}
+		json_t *display = json_object_get(root, "display");
+		const char *display_text = json_string_value(display);
+		/* Create a participant instance */
+		participant = g_malloc0(sizeof(janus_textroom_participant));
+		participant->session = session;
+		participant->room = textroom;
+		participant->username = g_strdup(username_text);
+		participant->display = display_text ? g_strdup(display_text) : NULL;
+		participant->destroyed = 0;
+		janus_mutex_init(&participant->mutex);
+		g_hash_table_insert(session->rooms, GUINT_TO_POINTER(room_id), participant);
+		g_hash_table_insert(textroom->participants, participant->username, participant);
+		/* Notify all participants */
+		JANUS_LOG(LOG_VERB, "Notifying all participants about the new join\n");
+		json_t *list = json_array();
+		if(textroom->participants) {
+			/* Prepare event */
+			json_t *event = json_object();
+			json_object_set_new(event, "textroom", json_string("join"));
+			json_object_set_new(event, "room", json_integer(textroom->room_id));
+			json_object_set_new(event, "username", json_string(username_text));
+			if(display_text != NULL)
+				json_object_set_new(event, "display", json_string(display_text));
+			char *event_text = json_dumps(event, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+			json_decref(event);
+			gateway->relay_data(handle, event_text, strlen(event_text));
+			/* Broadcast */
+			GHashTableIter iter;
+			gpointer value;
+			g_hash_table_iter_init(&iter, textroom->participants);
+			while(g_hash_table_iter_next(&iter, NULL, &value)) {
+				janus_textroom_participant *top = value;
+				if(top == participant)
+					continue;	/* Skip us */
+				JANUS_LOG(LOG_VERB, "  >> To %s in %"SCNu64"\n", top->username, room_id);
+				gateway->relay_data(top->session->handle, event_text, strlen(event_text));
+				/* Take note of this user */
+				json_t *p = json_object();
+				json_object_set_new(p, "username", json_string(top->username));
+				if(top->display != NULL)
+					json_object_set_new(p, "display", json_string(top->display));
+				json_array_append_new(list, p);
+			}
+			g_free(event_text);
+		}
+		janus_mutex_unlock(&session->mutex);
+		janus_mutex_unlock(&textroom->mutex);
+		if(!internal) {
+			/* Send response back */
+			json_t *reply = json_object();
+			json_object_set_new(reply, "textroom", json_string("success"));
+			json_object_set_new(reply, "transaction", json_string(transaction_text));
+			json_object_set_new(reply, "participants", list);
+			char *reply_text = json_dumps(reply, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+			json_decref(reply);
+			gateway->relay_data(handle, reply_text, strlen(reply_text));
+			g_free(reply_text);
+		}
+	} else if(!strcasecmp(request_text, "leave")) {
+		JANUS_VALIDATE_JSON_OBJECT(root, room_parameters,
+			error_code, error_cause, TRUE,
+			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
+		if(error_code != 0)
+			goto error;
+		json_t *room = json_object_get(root, "room");
+		guint64 room_id = json_integer_value(room);
+		janus_mutex_lock(&rooms_mutex);
+		janus_textroom_room *textroom = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+		if(textroom == NULL) {
+			janus_mutex_unlock(&rooms_mutex);
+			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
+			error_code = JANUS_TEXTROOM_ERROR_NO_SUCH_ROOM;
+			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
+			goto error;
+		}
+		janus_mutex_lock(&textroom->mutex);
+		janus_mutex_unlock(&rooms_mutex);
+		janus_mutex_lock(&session->mutex);
+		janus_textroom_participant *participant = g_hash_table_lookup(session->rooms, GUINT_TO_POINTER(room_id));
+		if(participant == NULL) {
+			janus_mutex_unlock(&session->mutex);
+			janus_mutex_unlock(&textroom->mutex);
+			JANUS_LOG(LOG_ERR, "Not in room %"SCNu64"\n", room_id);
+			error_code = JANUS_TEXTROOM_ERROR_NOT_IN_ROOM;
+			g_snprintf(error_cause, 512, "Not in room %"SCNu64, room_id);
+			goto error;
+		}
+		g_hash_table_remove(session->rooms, GUINT_TO_POINTER(room_id));
+		g_hash_table_remove(textroom->participants, participant->username);
+		participant->session = NULL;
+		participant->room = NULL;
+		/* Notify all participants */
+		JANUS_LOG(LOG_VERB, "Notifying all participants about the new leave\n");
+		if(textroom->participants) {
+			/* Prepare event */
+			json_t *event = json_object();
+			json_object_set_new(event, "textroom", json_string("leave"));
+			json_object_set_new(event, "room", json_integer(textroom->room_id));
+			json_object_set_new(event, "username", json_string(participant->username));
+			char *event_text = json_dumps(event, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+			json_decref(event);
+			gateway->relay_data(handle, event_text, strlen(event_text));
+			/* Broadcast */
+			GHashTableIter iter;
+			gpointer value;
+			g_hash_table_iter_init(&iter, textroom->participants);
+			while(g_hash_table_iter_next(&iter, NULL, &value)) {
+				janus_textroom_participant *top = value;
+				if(top == participant)
+					continue;	/* Skip us */
+				JANUS_LOG(LOG_VERB, "  >> To %s in %"SCNu64"\n", top->username, room_id);
+				gateway->relay_data(top->session->handle, event_text, strlen(event_text));
+			}
+			g_free(event_text);
+		}
+		g_free(participant->username);
+		g_free(participant->display);
+		g_free(participant);
+		janus_mutex_unlock(&session->mutex);
+		janus_mutex_unlock(&textroom->mutex);
+		if(!internal) {
+			/* Send response back */
+			json_t *reply = json_object();
+			json_object_set_new(reply, "textroom", json_string("success"));
+			json_object_set_new(reply, "transaction", json_string(transaction_text));
+			char *reply_text = json_dumps(reply, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+			json_decref(reply);
+			gateway->relay_data(handle, reply_text, strlen(reply_text));
+			g_free(reply_text);
+		}
+	} else if(!strcasecmp(request_text, "list")) {
+		/* List all rooms (but private ones) and their details (except for the secret, of course...) */
+		json_t *list = json_array();
+		JANUS_LOG(LOG_VERB, "Request for the list for all video rooms\n");
+		janus_mutex_lock(&rooms_mutex);
+		GHashTableIter iter;
+		gpointer value;
+		g_hash_table_iter_init(&iter, rooms);
+		while(g_hash_table_iter_next(&iter, NULL, &value)) {
+			janus_textroom_room *room = value;
+			if(!room)
+				continue;
+			janus_mutex_lock(&room->mutex);
+			if(room->is_private) {
+				/* Skip private room */
+				JANUS_LOG(LOG_VERB, "Skipping private room '%s'\n", room->room_name);
+				janus_mutex_unlock(&room->mutex);
+				continue;
+			}
+			json_t *rl = json_object();
+			json_object_set_new(rl, "room", json_integer(room->room_id));
+			json_object_set_new(rl, "description", json_string(room->room_name));
+			/* TODO: Possibly list participant details... or make it a separate API call for a specific room */
+			json_object_set_new(rl, "num_participants", json_integer(g_hash_table_size(room->participants)));
+			json_array_append_new(list, rl);
+			janus_mutex_unlock(&room->mutex);
+		}
+		janus_mutex_unlock(&rooms_mutex);
+		if(!internal) {
+			/* Send response back */
+			json_t *reply = json_object();
+			json_object_set_new(reply, "textroom", json_string("success"));
+			json_object_set_new(reply, "transaction", json_string(transaction_text));
+			json_object_set_new(reply, "list", list);
+			char *reply_text = json_dumps(reply, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+			json_decref(reply);
+			gateway->relay_data(handle, reply_text, strlen(reply_text));
+			g_free(reply_text);
+		}
+	} else if(!strcasecmp(request_text, "create")) {
+		JANUS_VALIDATE_JSON_OBJECT(root, create_parameters,
+			error_code, error_cause, TRUE,
+			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
+		if(error_code != 0)
+			goto error;
+		json_t *room = json_object_get(root, "room");
+		json_t *desc = json_object_get(root, "description");
+		json_t *is_private = json_object_get(root, "is_private");
+		json_t *secret = json_object_get(root, "secret");
+		json_t *pin = json_object_get(root, "pin");
+		json_t *post = json_object_get(root, "post");
+		json_t *permanent = json_object_get(root, "permanent");
+		gboolean save = permanent ? json_is_true(permanent) : FALSE;
+		if(save && config == NULL) {
+			JANUS_LOG(LOG_ERR, "No configuration file, can't create permanent room\n");
+			error_code = JANUS_TEXTROOM_ERROR_UNKNOWN_ERROR;
+			g_snprintf(error_cause, 512, "No configuration file, can't create permanent room");
+			goto error;
+		}
+		guint64 room_id = 0;
+		room_id = json_integer_value(room);
+		if(room_id == 0) {
+			JANUS_LOG(LOG_WARN, "Desired room ID is 0, which is not allowed... picking random ID instead\n");
+		}
+		janus_mutex_lock(&rooms_mutex);
+		if(room_id > 0) {
+			/* Let's make sure the room doesn't exist already */
+			if(g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id)) != NULL) {
+				/* It does... */
+				janus_mutex_unlock(&rooms_mutex);
+				JANUS_LOG(LOG_ERR, "Room %"SCNu64" already exists!\n", room_id);
+				error_code = JANUS_TEXTROOM_ERROR_ROOM_EXISTS;
+				g_snprintf(error_cause, 512, "Room %"SCNu64" already exists", room_id);
+				goto error;
+			}
+		}
+		/* Create the text room */
+		janus_textroom_room *textroom = g_malloc0(sizeof(janus_textroom_room));
+		/* Generate a random ID */
+		if(room_id == 0) {
+			while(room_id == 0) {
+				room_id = g_random_int();
+				if(g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id)) != NULL) {
+					/* Room ID already taken, try another one */
+					room_id = 0;
+				}
+			}
+		}
+		textroom->room_id = room_id;
+		char *description = NULL;
+		if(desc != NULL && strlen(json_string_value(desc)) > 0) {
+			description = g_strdup(json_string_value(desc));
+		} else {
+			char roomname[255];
+			g_snprintf(roomname, 255, "Room %"SCNu64"", textroom->room_id);
+			description = g_strdup(roomname);
+		}
+		textroom->room_name = description;
+		textroom->is_private = is_private ? json_is_true(is_private) : FALSE;
+		if(secret)
+			textroom->room_secret = g_strdup(json_string_value(secret));
+		if(pin)
+			textroom->room_pin = g_strdup(json_string_value(pin));
+		if(post) {
+#ifdef HAVE_LIBCURL	
+			/* FIXME Should we check if this is a valid HTTP address? */
+			textroom->http_backend = g_strdup(json_string_value(post));
+#else
+			JANUS_LOG(LOG_WARN, "HTTP backend specified, but libcurl support was not built in...\n");
+#endif
+		}
+		textroom->participants = g_hash_table_new(g_str_hash, g_str_equal);
+		textroom->destroyed = 0;
+		janus_mutex_init(&textroom->mutex);
+		g_hash_table_insert(rooms, GUINT_TO_POINTER(textroom->room_id), textroom);
+		JANUS_LOG(LOG_VERB, "Created textroom: %"SCNu64" (%s, %s, secret: %s, pin: %s)\n",
+			textroom->room_id, textroom->room_name,
+			textroom->is_private ? "private" : "public",
+			textroom->room_secret ? textroom->room_secret : "no secret",
+			textroom->room_pin ? textroom->room_pin : "no pin");
+		if(save) {
+			/* This room is permanent: save to the configuration file too
+			 * FIXME: We should check if anything fails... */
+			JANUS_LOG(LOG_VERB, "Saving room %"SCNu64" permanently in config file\n", textroom->room_id);
+			janus_mutex_lock(&config_mutex);
+			char cat[BUFSIZ];
+			/* The room ID is the category */
+			g_snprintf(cat, BUFSIZ, "%"SCNu64, textroom->room_id);
+			janus_config_add_category(config, cat);
+			/* Now for the values */
+			janus_config_add_item(config, cat, "description", textroom->room_name);
+			if(textroom->is_private)
+				janus_config_add_item(config, cat, "is_private", "yes");
+			if(textroom->room_secret)
+				janus_config_add_item(config, cat, "secret", textroom->room_secret);
+			if(textroom->room_pin)
+				janus_config_add_item(config, cat, "pin", textroom->room_pin);
+			if(textroom->http_backend)
+				janus_config_add_item(config, cat, "post", textroom->http_backend);
+			/* Save modified configuration */
+			janus_config_save(config, config_folder, JANUS_TEXTROOM_PACKAGE);
+			janus_mutex_unlock(&config_mutex);
+		}
+		/* Show updated rooms list */
+		GHashTableIter iter;
+		gpointer value;
+		g_hash_table_iter_init(&iter, rooms);
+		while (g_hash_table_iter_next(&iter, NULL, &value)) {
+			janus_textroom_room *tr = value;
+			JANUS_LOG(LOG_VERB, "  ::: [%"SCNu64"][%s]\n", tr->room_id, tr->room_name);
+		}
+		janus_mutex_unlock(&rooms_mutex);
+		if(!internal) {
+			/* Send response back */
+			json_t *reply = json_object();
+			json_object_set_new(reply, "textroom", json_string("success"));
+			json_object_set_new(reply, "transaction", json_string(transaction_text));
+			json_object_set_new(reply, "room", json_integer(textroom->room_id));
+			char *reply_text = json_dumps(reply, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+			json_decref(reply);
+			gateway->relay_data(handle, reply_text, strlen(reply_text));
+			g_free(reply_text);
+		}
+	} else if(!strcasecmp(request_text, "destroy")) {
+		JANUS_VALIDATE_JSON_OBJECT(root, room_parameters,
+			error_code, error_cause, TRUE,
+			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
+		if(error_code != 0)
+			goto error;
+		json_t *room = json_object_get(root, "room");
+		json_t *permanent = json_object_get(root, "permanent");
+		gboolean save = permanent ? json_is_true(permanent) : FALSE;
+		if(save && config == NULL) {
+			JANUS_LOG(LOG_ERR, "No configuration file, can't destroy room permanently\n");
+			error_code = JANUS_TEXTROOM_ERROR_UNKNOWN_ERROR;
+			g_snprintf(error_cause, 512, "No configuration file, can't destroy room permanently");
+			goto error;
+		}
+		guint64 room_id = json_integer_value(room);
+		janus_mutex_lock(&rooms_mutex);
+		janus_textroom_room *textroom = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+		if(textroom == NULL) {
+			janus_mutex_unlock(&rooms_mutex);
+			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
+			error_code = JANUS_TEXTROOM_ERROR_NO_SUCH_ROOM;
+			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
+			goto error;
+		}
+		janus_mutex_lock(&textroom->mutex);
+		/* A secret may be required for this action */
+		JANUS_CHECK_SECRET(textroom->room_secret, root, "secret", error_code, error_cause,
+			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT, JANUS_TEXTROOM_ERROR_UNAUTHORIZED);
+		if(error_code != 0) {
+			janus_mutex_unlock(&textroom->mutex);
+			janus_mutex_unlock(&rooms_mutex);
+			goto error;
+		}
+		/* Remove room */
+		g_hash_table_remove(rooms, GUINT_TO_POINTER(room_id));
+		if(save) {
+			/* This change is permanent: save to the configuration file too
+			 * FIXME: We should check if anything fails... */
+			JANUS_LOG(LOG_VERB, "Destroying room %"SCNu64" permanently in config file\n", room_id);
+			janus_mutex_lock(&config_mutex);
+			char cat[BUFSIZ];
+			/* The room ID is the category */
+			g_snprintf(cat, BUFSIZ, "%"SCNu64, room_id);
+			janus_config_remove_category(config, cat);
+			/* Save modified configuration */
+			janus_config_save(config, config_folder, JANUS_TEXTROOM_PACKAGE);
+			janus_mutex_unlock(&config_mutex);
+		}
+		/* Notify all participants */
+		JANUS_LOG(LOG_VERB, "Notifying all participants about the destroy\n");
+		if(textroom->participants) {
+			/* Prepare event */
+			json_t *event = json_object();
+			json_object_set_new(event, "textroom", json_string("destroyed"));
+			json_object_set_new(event, "room", json_integer(textroom->room_id));
+			char *event_text = json_dumps(event, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+			json_decref(event);
+			gateway->relay_data(handle, event_text, strlen(event_text));
+			/* Broadcast */
+			GHashTableIter iter;
+			gpointer value;
+			g_hash_table_iter_init(&iter, textroom->participants);
+			while(g_hash_table_iter_next(&iter, NULL, &value)) {
+				janus_textroom_participant *top = value;
+				JANUS_LOG(LOG_VERB, "  >> To %s in %"SCNu64"\n", top->username, room_id);
+				gateway->relay_data(top->session->handle, event_text, strlen(event_text));
+				janus_mutex_unlock(&top->session->mutex);
+				g_hash_table_remove(top->session->rooms, GUINT_TO_POINTER(room_id));
+				janus_mutex_unlock(&top->session->mutex);
+				g_free(top->username);
+				g_free(top->display);
+				g_free(top);
+			}
+			g_free(event_text);
+		}
+		janus_mutex_unlock(&textroom->mutex);
+		janus_mutex_unlock(&rooms_mutex);
+		if(!internal) {
+			/* Send response back */
+			json_t *reply = json_object();
+			json_object_set_new(reply, "textroom", json_string("success"));
+			json_object_set_new(reply, "transaction", json_string(transaction_text));
+			char *reply_text = json_dumps(reply, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+			json_decref(reply);
+			gateway->relay_data(handle, reply_text, strlen(reply_text));
+			g_free(reply_text);
+		}
+		/* We'll let the watchdog worry about freeing resources */
+		old_rooms = g_list_append(old_rooms, textroom);
+	} else {
+		JANUS_LOG(LOG_ERR, "Unsupported request %s\n", request_text);
+		error_code = JANUS_TEXTROOM_ERROR_INVALID_REQUEST;
+		g_snprintf(error_cause, 512, "Unsupported request %s", request_text);
+		goto error;
+	}
+
+	json_decref(root);
+	return;
+
+error:
+		{
+			if(!internal) {
+				/* Prepare JSON error response */
+				json_t *reply = json_object();
+				json_object_set_new(reply, "textroom", json_string("error"));
+				if(transaction_text)
+					json_object_set_new(reply, "transaction", json_string(transaction_text));
+				json_object_set_new(reply, "error_code", json_integer(error_code));
+				json_object_set_new(reply, "error", json_string(error_cause));
+				char *reply_text = json_dumps(reply, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+				json_decref(reply);
+				gateway->relay_data(handle, reply_text, strlen(reply_text));
+				g_free(reply_text);
+			}
+			if(root != NULL)
+				json_decref(root);
+		}
+}
+
+void janus_textroom_slow_link(janus_plugin_session *handle, int uplink, int video) {
+	/* We don't do audio/video */
+}
+
+void janus_textroom_hangup_media(janus_plugin_session *handle) {
+	JANUS_LOG(LOG_INFO, "No WebRTC media anymore\n");
+	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
+		return;
+	janus_textroom_session *session = (janus_textroom_session *)handle->plugin_handle;
+	if(!session) {
+		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
+		return;
+	}
+	if(session->destroyed)
+		return;
+	if(g_atomic_int_add(&session->hangingup, 1))
+		return;
+	/* Get rid of all participants */
+	janus_mutex_lock(&session->mutex);
+	GList *list = NULL;
+	if(session->rooms) {
+		GHashTableIter iter;
+		gpointer value;
+		g_hash_table_iter_init(&iter, session->rooms);
+		while(g_hash_table_iter_next(&iter, NULL, &value)) {
+			janus_textroom_participant *p = value;
+			janus_mutex_lock(&p->mutex);
+			if(p->room)
+				list = g_list_append(list, GUINT_TO_POINTER(p->room->room_id));
+			janus_mutex_unlock(&p->mutex);
+		}
+		janus_mutex_unlock(&rooms_mutex);
+	}
+	janus_mutex_unlock(&session->mutex);
+	JANUS_LOG(LOG_VERB, "Leaving %d rooms\n", g_list_length(list));
+	char request[100];
+	while(list) {
+		guint64 room_id = GPOINTER_TO_UINT(list->data);
+		g_snprintf(request, sizeof(request), "{\"textroom\":\"leave\",\"transaction\":\"internal\",\"room\":%"SCNu64"}", room_id);
+		janus_textroom_handle_incoming_request(handle, g_strdup(request), TRUE);
+		list = g_list_remove_link(list, list);
+	}
+}
+
+/* Thread to handle incoming messages */
+static void *janus_textroom_handler(void *data) {
+	JANUS_LOG(LOG_VERB, "Joining TextRoom handler thread\n");
+	janus_textroom_message *msg = NULL;
+	int error_code = 0;
+	char *error_cause = g_malloc0(512);
+	json_t *root = NULL;
+	gboolean do_offer = FALSE;
+	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
+		msg = g_async_queue_pop(messages);
+		if(msg == NULL)
+			continue;
+		if(msg == &exit_message)
+			break;
+		if(msg->handle == NULL) {
+			janus_textroom_message_free(msg);
+			continue;
+		}
+		janus_textroom_session *session = NULL;
+		janus_mutex_lock(&sessions_mutex);
+		if(g_hash_table_lookup(sessions, msg->handle) != NULL ) {
+			session = (janus_textroom_session *)msg->handle->plugin_handle;
+		}
+		janus_mutex_unlock(&sessions_mutex);
+		if(!session) {
+			JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
+			janus_textroom_message_free(msg);
+			continue;
+		}
+		if(session->destroyed) {
+			janus_textroom_message_free(msg);
+			continue;
+		}
+		/* Handle request */
+		error_code = 0;
+		root = NULL;
+		JANUS_LOG(LOG_VERB, "Handling message: %s\n", msg->message);
+		if(msg->message == NULL) {
+			JANUS_LOG(LOG_ERR, "No message??\n");
+			error_code = JANUS_TEXTROOM_ERROR_NO_MESSAGE;
+			g_snprintf(error_cause, 512, "%s", "No message??");
+			goto error;
+		}
+		json_error_t error;
+		root = json_loads(msg->message, 0, &error);
+		if(!root) {
+			JANUS_LOG(LOG_ERR, "JSON error: on line %d: %s\n", error.line, error.text);
+			error_code = JANUS_TEXTROOM_ERROR_INVALID_JSON;
+			g_snprintf(error_cause, 512, "JSON error: on line %d: %s", error.line, error.text);
+			goto error;
+		}
+		if(!json_is_object(root)) {
+			JANUS_LOG(LOG_ERR, "JSON error: not an object\n");
+			error_code = JANUS_TEXTROOM_ERROR_INVALID_JSON;
+			g_snprintf(error_cause, 512, "JSON error: not an object");
+			goto error;
+		}
+		/* Parse request */
+		JANUS_VALIDATE_JSON_OBJECT(root, request_parameters,
+			error_code, error_cause, TRUE,
+			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
+		if(error_code != 0)
+			goto error;
+		json_t *request = json_object_get(root, "request");
+		const char *request_text = json_string_value(request);
+		if(!strcasecmp(request_text, "setup")) {
+			if(!g_atomic_int_compare_and_exchange(&session->setup, 0, 1)) {
+				JANUS_LOG(LOG_ERR, "PeerConnection already setup\n");
+				error_code = JANUS_TEXTROOM_ERROR_ALREADY_SETUP;
+				g_snprintf(error_cause, 512, "PeerConnection already setup");
+				goto error;
+			}
+			do_offer = TRUE;
+		} else if(!strcasecmp(request_text, "ack")) {
+			/* The peer send their answer back: do nothing */
+			do_offer = FALSE;
+		} else {
+			JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
+			error_code = JANUS_TEXTROOM_ERROR_INVALID_REQUEST;
+			g_snprintf(error_cause, 512, "Unknown request '%s'", request_text);
+			goto error;
+		}
+
+		json_decref(root);
+		/* Prepare JSON event */
+		json_t *event = json_object();
+		json_object_set_new(event, "textroom", json_string("event"));
+		json_object_set_new(event, "result", json_string("ok"));
+		char *event_text = json_dumps(event, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+		json_decref(event);
+		JANUS_LOG(LOG_VERB, "Pushing event: %s\n", event_text);
+		if(!do_offer) {
+			int ret = gateway->push_event(msg->handle, &janus_textroom_plugin, msg->transaction, event_text, NULL, NULL);
+			JANUS_LOG(LOG_VERB, "  >> %d (%s)\n", ret, janus_get_api_error(ret));
+		} else {
+			/* Send an offer */
+			char sdp[500];
+			g_snprintf(sdp, sizeof(sdp), sdp_template,
+				janus_get_real_time(),			/* We need current time here */
+				janus_get_real_time());			/* We need current time here */
+			/* How long will the gateway take to push the event? */
+			g_atomic_int_set(&session->hangingup, 0);
+			gint64 start = janus_get_monotonic_time();
+			int res = gateway->push_event(msg->handle, &janus_textroom_plugin, msg->transaction, event_text, "offer", sdp);
+			JANUS_LOG(LOG_VERB, "  >> Pushing event: %d (took %"SCNu64" us)\n",
+				res, janus_get_monotonic_time()-start);
+		}
+		g_free(event_text);
+		janus_textroom_message_free(msg);
+		continue;
+		
+error:
+		{
+			if(root != NULL)
+				json_decref(root);
+			/* Prepare JSON error event */
+			json_t *event = json_object();
+			json_object_set_new(event, "textroom", json_string("error"));
+			json_object_set_new(event, "error_code", json_integer(error_code));
+			json_object_set_new(event, "error", json_string(error_cause));
+			char *event_text = json_dumps(event, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+			json_decref(event);
+			JANUS_LOG(LOG_VERB, "Pushing event: %s\n", event_text);
+			int ret = gateway->push_event(msg->handle, &janus_textroom_plugin, msg->transaction, event_text, NULL, NULL);
+			JANUS_LOG(LOG_VERB, "  >> %d (%s)\n", ret, janus_get_api_error(ret));
+			g_free(event_text);
+			janus_textroom_message_free(msg);
+		}
+	}
+	g_free(error_cause);
+	JANUS_LOG(LOG_VERB, "Leaving TextRoom handler thread\n");
+	return NULL;
+}


### PR DESCRIPTION
Hi all,

this PR adds a new plugin that implements a feature a few people have been asking about. This plugin allows you to exchange text-based public and private messages via datachannels within the context of text rooms. More precisely, it works this way:

1. you attach to the plugin;
2. you ask for a PeerConnection (`request:"setup"`);
3. you get an SDP offer from the plugin which only contains data channels;
4. you send your SDP answer (`request:"ack"`);
5. after that, you only send and receive JSON messages through this data channel.

Within the context of the plugin, you can create/destroy/join/leave multiple rooms at the same time, and send/receive public/private messages while in them. You can send messages either to the whole room, to a single participant, or to multiple recipient in the room. Messages addressed to the room itself can also be forwarded to external applications via HTTP POST, if so configured.

The following are a few examples of messages you can send, as how you create a room:

    {
        textroom: "create",
        transaction: "123"
        room: 1234,
        description: "My room"
    }

How you join:

    {
        textroom: "join",
        transaction: "123"
        room: 1234,
        username: "a1b2c3d4",
        display: "Lorenzo Miniero"
    }

Sending a message to the whole room:

    {
        textroom: "message",
        transaction: "123"
        room: 1234,
        text: "Hey there"
    }

Sending a whisper to a single user:

    {
        textroom: "message",
        transaction: "123"
        room: 1234,
        to: "e5f6g7h8",
        text: "Hey there"
    }

Sending a whisper to multiple users:

    {
        textroom: "message",
        transaction: "123"
        room: 1234,
        tos: [ "e5f6g7h8", "i9j0k1l2" ],
        text: "Hey there"
    }

etc., quite simple, you can figure out more by looking at the code or the demo.

The demo itself is basically a very simple chatroom: you join a preconfigured room, can chat publicly, and send/receive whispers. Nothing fancy, but it's functional, and will hopefully provide people with more interesting ideas on how the plugin can be used.

The main idea is of course not to have yet another way of doing chat in a browser (there are better tools for the purpose, although this might be useful for that too in case you want to just use Janus and nothing else), but rather to provide an easy way to bridge data channel content with external applications. Right now you can only pass messages addressed to the room to an HTTP backend, so it's a start, but in the future I'd like to allow bidirectional communication, e.g., allow external applications to inject text addressed to one or more recipients in a room. This should allow for a very easy interaction with applications that are not WebRTC compliant.

Any feedback on this? The idea is to merge this soon, so please play with it and let me know what you feel.