### PR TITLE
Fixes for 64-bit identifiers

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -659,7 +659,7 @@ void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean ipv6, uint16_t
 
 	/* Start the handles watchdog */
 	janus_mutex_init(&old_handles_mutex);
-	old_handles = g_hash_table_new(NULL, NULL);
+	old_handles = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free, NULL);
 	handles_watchdog_context = g_main_context_new();
 	handles_watchdog_loop = g_main_loop_new(handles_watchdog_context, FALSE);
 	GError *error = NULL;
@@ -905,7 +905,7 @@ janus_ice_handle *janus_ice_handle_create(void *gateway_session) {
 	janus_session *session = (janus_session *)gateway_session;
 	guint64 handle_id = 0;
 	while(handle_id == 0) {
-		handle_id = g_random_int();
+		handle_id = janus_random_uint64();
 		if(janus_ice_handle_find(gateway_session, handle_id) != NULL) {
 			/* Handle ID already taken, try another one */
 			handle_id = 0;
@@ -927,8 +927,8 @@ janus_ice_handle *janus_ice_handle_create(void *gateway_session) {
 	/* Set up other stuff. */
 	janus_mutex_lock(&session->mutex);
 	if(session->ice_handles == NULL)
-		session->ice_handles = g_hash_table_new(NULL, NULL);
-	g_hash_table_insert(session->ice_handles, GUINT_TO_POINTER(handle_id), handle);
+		session->ice_handles = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free, NULL);
+	g_hash_table_insert(session->ice_handles, janus_uint64_dup(handle->handle_id), handle);
 	janus_mutex_unlock(&session->mutex);
 
 	return handle;
@@ -939,7 +939,7 @@ janus_ice_handle *janus_ice_handle_find(void *gateway_session, guint64 handle_id
 		return NULL;
 	janus_session *session = (janus_session *)gateway_session;
 	janus_mutex_lock(&session->mutex);
-	janus_ice_handle *handle = session->ice_handles ? g_hash_table_lookup(session->ice_handles, GUINT_TO_POINTER(handle_id)) : NULL;
+	janus_ice_handle *handle = session->ice_handles ? g_hash_table_lookup(session->ice_handles, &handle_id) : NULL;
 	janus_mutex_unlock(&session->mutex);
 	return handle;
 }
@@ -1032,7 +1032,7 @@ gint janus_ice_handle_destroy(void *gateway_session, guint64 handle_id) {
 	/* We only actually destroy the handle later */
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Handle detached (error=%d), scheduling destruction\n", handle_id, error);
 	janus_mutex_lock(&old_handles_mutex);
-	g_hash_table_insert(old_handles, GUINT_TO_POINTER(handle_id), handle);
+	g_hash_table_insert(old_handles, janus_uint64_dup(handle->handle_id), handle);
 	janus_mutex_unlock(&old_handles_mutex);
 	return error;
 }
@@ -2642,12 +2642,12 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 		audio_stream->disabled = FALSE;
 		/* FIXME By default, if we're being called we're DTLS clients, but this may be changed by ICE... */
 		audio_stream->dtls_role = offer ? JANUS_DTLS_ROLE_CLIENT : JANUS_DTLS_ROLE_ACTPASS;
-		audio_stream->audio_ssrc = g_random_int();	/* FIXME Should we look for conflicts? */
+		audio_stream->audio_ssrc = janus_random_uint32();	/* FIXME Should we look for conflicts? */
 		audio_stream->audio_ssrc_peer = 0;	/* FIXME Right now we don't know what this will be */
 		audio_stream->video_ssrc = 0;
 		if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
 			/* If we're bundling, this stream is going to be used for video as well */
-			audio_stream->video_ssrc = g_random_int();	/* FIXME Should we look for conflicts? */
+			audio_stream->video_ssrc = janus_random_uint32();	/* FIXME Should we look for conflicts? */
 		}
 		audio_stream->video_ssrc_peer = 0;	/* FIXME Right now we don't know what this will be */
 		audio_stream->video_ssrc_peer_rtx = 0;	/* FIXME Right now we don't know what this will be */
@@ -2800,7 +2800,7 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 		video_stream->disabled = FALSE;
 		/* FIXME By default, if we're being called we're DTLS clients, but this may be changed by ICE... */
 		video_stream->dtls_role = offer ? JANUS_DTLS_ROLE_CLIENT : JANUS_DTLS_ROLE_ACTPASS;
-		video_stream->video_ssrc = g_random_int();	/* FIXME Should we look for conflicts? */
+		video_stream->video_ssrc = janus_random_uint32();	/* FIXME Should we look for conflicts? */
 		video_stream->video_ssrc_peer = 0;	/* FIXME Right now we don't know what this will be */
 		video_stream->video_ssrc_peer_rtx = 0;	/* FIXME Right now we don't know what this will be */
 		video_stream->audio_ssrc = 0;

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -770,7 +770,7 @@ int janus_audiobridge_init(janus_callbacks *callback, const char *config_path) {
 		janus_config_print(config);
 	janus_mutex_init(&config_mutex);
 	
-	rooms = g_hash_table_new(NULL, NULL);
+	rooms = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free, NULL);
 	janus_mutex_init(&rooms_mutex);
 	sessions = g_hash_table_new(NULL, NULL);
 	janus_mutex_init(&sessions_mutex);
@@ -852,7 +852,7 @@ int janus_audiobridge_init(janus_callbacks *callback, const char *config_path) {
 				audiobridge->record_file = g_strdup(recfile->value);
 			audiobridge->recording = NULL;
 			audiobridge->destroy = 0;
-			audiobridge->participants = g_hash_table_new(NULL, NULL);
+			audiobridge->participants = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free, NULL);
 			audiobridge->destroyed = 0;
 			janus_mutex_init(&audiobridge->mutex);
 			JANUS_LOG(LOG_VERB, "Created audiobridge: %"SCNu64" (%s, %s, secret: %s, pin: %s)\n",
@@ -868,7 +868,7 @@ int janus_audiobridge_init(janus_callbacks *callback, const char *config_path) {
 				JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the mixer thread...\n", error->code, error->message ? error->message : "??");
 			} else {
 				janus_mutex_lock(&rooms_mutex);
-				g_hash_table_insert(rooms, GUINT_TO_POINTER(audiobridge->room_id), audiobridge);
+				g_hash_table_insert(rooms, janus_uint64_dup(audiobridge->room_id), audiobridge);
 				janus_mutex_unlock(&rooms_mutex);
 			}
 			cl = cl->next;
@@ -1160,7 +1160,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		janus_mutex_lock(&rooms_mutex);
 		if(room_id > 0) {
 			/* Let's make sure the room doesn't exist already */
-			if(g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id)) != NULL) {
+			if(g_hash_table_lookup(rooms, &room_id) != NULL) {
 				/* It does... */
 				janus_mutex_unlock(&rooms_mutex);
 				JANUS_LOG(LOG_ERR, "Room %"SCNu64" already exists!\n", room_id);
@@ -1181,8 +1181,8 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		/* Generate a random ID */
 		if(room_id == 0) {
 			while(room_id == 0) {
-				room_id = g_random_int();
-				if(g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id)) != NULL) {
+				room_id = janus_random_uint64();
+				if(g_hash_table_lookup(rooms, &room_id) != NULL) {
 					/* Room ID already taken, try another one */
 					room_id = 0;
 				}
@@ -1236,10 +1236,10 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			audiobridge->record_file = g_strdup(json_string_value(recfile));
 		audiobridge->recording = NULL;
 		audiobridge->destroy = 0;
-		audiobridge->participants = g_hash_table_new(NULL, NULL);
+		audiobridge->participants = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free, NULL);
 		audiobridge->destroyed = 0;
 		janus_mutex_init(&audiobridge->mutex);
-		g_hash_table_insert(rooms, GUINT_TO_POINTER(audiobridge->room_id), audiobridge);
+		g_hash_table_insert(rooms, janus_uint64_dup(audiobridge->room_id), audiobridge);
 		JANUS_LOG(LOG_VERB, "Created audiobridge: %"SCNu64" (%s, %s, secret: %s, pin: %s)\n",
 			audiobridge->room_id, audiobridge->room_name,
 			audiobridge->is_private ? "private" : "public",
@@ -1260,7 +1260,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			g_free(audiobridge);
 			goto error;
 		} else {
-			g_hash_table_insert(rooms, GUINT_TO_POINTER(audiobridge->room_id), audiobridge);
+			g_hash_table_insert(rooms, janus_uint64_dup(audiobridge->room_id), audiobridge);
 		}
 		if(save) {
 			/* This room is permanent: save to the configuration file too
@@ -1313,7 +1313,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		}
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
-		janus_audiobridge_room *audiobridge = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+		janus_audiobridge_room *audiobridge = g_hash_table_lookup(rooms, &room_id);
 		if(audiobridge == NULL) {
 			janus_mutex_unlock(&rooms_mutex);
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
@@ -1331,7 +1331,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			goto error;
 		}
 		/* Remove room */
-		g_hash_table_remove(rooms, GUINT_TO_POINTER(room_id));
+		g_hash_table_remove(rooms, &room_id);
 		if(save) {
 			/* This change is permanent: save to the configuration file too
 			 * FIXME: We should check if anything fails... */
@@ -1433,7 +1433,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
-		gboolean room_exists = g_hash_table_contains(rooms, GUINT_TO_POINTER(room_id));
+		gboolean room_exists = g_hash_table_contains(rooms, &room_id);
 		janus_mutex_unlock(&rooms_mutex);
 		response = json_object();
 		json_object_set_new(response, "audiobridge", json_string("success"));
@@ -1450,7 +1450,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
-		janus_audiobridge_room *audiobridge = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+		janus_audiobridge_room *audiobridge = g_hash_table_lookup(rooms, &room_id);
 		if(audiobridge == NULL) {
 			janus_mutex_unlock(&rooms_mutex);
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
@@ -1711,7 +1711,7 @@ void janus_audiobridge_hangup_media(janus_plugin_session *handle) {
 		json_object_set_new(event, "leaving", json_integer(participant->user_id));
 		char *leaving_text = json_dumps(event, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
 		json_decref(event);
-		g_hash_table_remove(audiobridge->participants, GUINT_TO_POINTER(participant->user_id));
+		g_hash_table_remove(audiobridge->participants, &participant->user_id);
 		GHashTableIter iter;
 		gpointer value;
 		g_hash_table_iter_init(&iter, audiobridge->participants);
@@ -1834,7 +1834,7 @@ static void *janus_audiobridge_handler(void *data) {
 			json_t *room = json_object_get(root, "room");
 			guint64 room_id = json_integer_value(room);
 			janus_mutex_lock(&rooms_mutex);
-			janus_audiobridge_room *audiobridge = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+			janus_audiobridge_room *audiobridge = g_hash_table_lookup(rooms, &room_id);
 			if(audiobridge == NULL) {
 				janus_mutex_unlock(&rooms_mutex);
 				JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
@@ -1868,7 +1868,7 @@ static void *janus_audiobridge_handler(void *data) {
 			json_t *id = json_object_get(root, "id");
 			if(id) {
 				user_id = json_integer_value(id);
-				if(g_hash_table_lookup(audiobridge->participants, GUINT_TO_POINTER(user_id)) != NULL) {
+				if(g_hash_table_lookup(audiobridge->participants, &user_id) != NULL) {
 					/* User ID already taken */
 					janus_mutex_unlock(&audiobridge->mutex);
 					janus_mutex_unlock(&rooms_mutex);
@@ -1881,8 +1881,8 @@ static void *janus_audiobridge_handler(void *data) {
 			if(user_id == 0) {
 				/* Generate a random ID */
 				while(user_id == 0) {
-					user_id = g_random_int();
-					if(g_hash_table_lookup(audiobridge->participants, GUINT_TO_POINTER(user_id)) != NULL) {
+					user_id = janus_random_uint64();
+					if(g_hash_table_lookup(audiobridge->participants, &user_id) != NULL) {
 						/* User ID already taken, try another one */
 						user_id = 0;
 					}
@@ -2001,7 +2001,7 @@ static void *janus_audiobridge_handler(void *data) {
 			
 			/* Done */
 			session->participant = participant;
-			g_hash_table_insert(audiobridge->participants, GUINT_TO_POINTER(user_id), participant);
+			g_hash_table_insert(audiobridge->participants, janus_uint64_dup(participant->user_id), participant);
 			/* Notify the other participants */
 			json_t *newuser = json_object();
 			json_object_set_new(newuser, "audiobridge", json_string("joined"));
@@ -2165,7 +2165,7 @@ static void *janus_audiobridge_handler(void *data) {
 				g_snprintf(error_cause, 512, "Already in this room");
 				goto error;
 			}
-			janus_audiobridge_room *audiobridge = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+			janus_audiobridge_room *audiobridge = g_hash_table_lookup(rooms, &room_id);
 			if(audiobridge == NULL) {
 				janus_mutex_unlock(&rooms_mutex);
 				JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
@@ -2199,7 +2199,7 @@ static void *janus_audiobridge_handler(void *data) {
 			json_t *id = json_object_get(root, "id");
 			if(id) {
 				user_id = json_integer_value(id);
-				if(g_hash_table_lookup(audiobridge->participants, GUINT_TO_POINTER(user_id)) != NULL) {
+				if(g_hash_table_lookup(audiobridge->participants, &user_id) != NULL) {
 					/* User ID already taken */
 					janus_mutex_unlock(&audiobridge->mutex);
 					janus_mutex_unlock(&rooms_mutex);
@@ -2212,8 +2212,8 @@ static void *janus_audiobridge_handler(void *data) {
 			if(user_id == 0) {
 				/* Generate a random ID */
 				while(user_id == 0) {
-					user_id = g_random_int();
-					if(g_hash_table_lookup(audiobridge->participants, GUINT_TO_POINTER(user_id)) != NULL) {
+					user_id = janus_random_uint64();
+					if(g_hash_table_lookup(audiobridge->participants, &user_id) != NULL) {
 						/* User ID already taken, try another one */
 						user_id = 0;
 					}
@@ -2225,7 +2225,7 @@ static void *janus_audiobridge_handler(void *data) {
 			janus_audiobridge_room *old_audiobridge = participant->room;
 			/* Leave the old room first... */
 			janus_mutex_lock(&old_audiobridge->mutex);
-			g_hash_table_remove(old_audiobridge->participants, GUINT_TO_POINTER(participant->user_id));
+			g_hash_table_remove(old_audiobridge->participants, &participant->user_id);
 			if(old_audiobridge->sampling_rate != audiobridge->sampling_rate) {
 				/* Create a new one that takes into account the sampling rate we want now */
 				int error = 0;
@@ -2238,7 +2238,7 @@ static void *janus_audiobridge_handler(void *data) {
 					error_code = JANUS_AUDIOBRIDGE_ERROR_LIBOPUS_ERROR;
 					g_snprintf(error_cause, 512, "Error creating Opus decoder");
 					/* Join the old room again... */
-					g_hash_table_insert(audiobridge->participants, GUINT_TO_POINTER(participant->user_id), participant);
+					g_hash_table_insert(audiobridge->participants, janus_uint64_dup(participant->user_id), participant);
 					janus_mutex_unlock(&old_audiobridge->mutex);
 					janus_mutex_unlock(&audiobridge->mutex);
 					janus_mutex_unlock(&rooms_mutex);
@@ -2276,7 +2276,7 @@ static void *janus_audiobridge_handler(void *data) {
 					error_code = JANUS_AUDIOBRIDGE_ERROR_LIBOPUS_ERROR;
 					g_snprintf(error_cause, 512, "Error creating Opus decoder");
 					/* Join the old room again... */
-					g_hash_table_insert(audiobridge->participants, GUINT_TO_POINTER(participant->user_id), participant);
+					g_hash_table_insert(audiobridge->participants, janus_uint64_dup(participant->user_id), participant);
 					janus_mutex_unlock(&old_audiobridge->mutex);
 					janus_mutex_unlock(&audiobridge->mutex);
 					janus_mutex_unlock(&rooms_mutex);
@@ -2324,7 +2324,7 @@ static void *janus_audiobridge_handler(void *data) {
 				if(participant->encoder)
 					opus_encoder_ctl(participant->encoder, OPUS_SET_COMPLEXITY(participant->opus_complexity));
 			}
-			g_hash_table_insert(audiobridge->participants, GUINT_TO_POINTER(user_id), participant);
+			g_hash_table_insert(audiobridge->participants, janus_uint64_dup(participant->user_id), participant);
 			/* Notify the other participants */
 			json_t *newuser = json_object();
 			json_object_set_new(newuser, "audiobridge", json_string("joined"));
@@ -2405,7 +2405,7 @@ static void *janus_audiobridge_handler(void *data) {
 				}
 				g_free(leaving_text);
 				/* Actually leave the room... */
-				g_hash_table_remove(audiobridge->participants, GUINT_TO_POINTER(participant->user_id));
+				g_hash_table_remove(audiobridge->participants, &participant->user_id);
 				participant->room = NULL;
 			}
 			/* Get rid of queued packets */

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -1672,6 +1672,7 @@ janus_recordplay_frame_packet *janus_recordplay_get_frames(const char *dir, cons
 				json_t *type = json_object_get(info, "t");
 				if(!type || !json_is_string(type)) {
 					JANUS_LOG(LOG_WARN, "Missing/invalid recording type in info header...\n");
+					json_decref(info);
 					fclose(file);
 					return NULL;
 				}
@@ -1684,6 +1685,7 @@ janus_recordplay_frame_packet *janus_recordplay_get_frames(const char *dir, cons
 					video = 0;
 				} else {
 					JANUS_LOG(LOG_WARN, "Unsupported recording type '%s' in info header...\n", t);
+					json_decref(info);
 					fclose(file);
 					return NULL;
 				}
@@ -1691,16 +1693,19 @@ janus_recordplay_frame_packet *janus_recordplay_get_frames(const char *dir, cons
 				json_t *codec = json_object_get(info, "c");
 				if(!codec || !json_is_string(codec)) {
 					JANUS_LOG(LOG_WARN, "Missing recording codec in info header...\n");
+					json_decref(info);
 					fclose(file);
 					return NULL;
 				}
 				const char *c = json_string_value(codec);
 				if(video && strcasecmp(c, "vp8")) {
-					JANUS_LOG(LOG_WARN, "The post-processor only suupports VP8 video for now (was '%s')...\n", c);
+					JANUS_LOG(LOG_WARN, "The Record&Play plugin only supports VP8 video for now (was '%s')...\n", c);
+					json_decref(info);
 					fclose(file);
 					return NULL;
 				} else if(!video && strcasecmp(c, "opus")) {
-					JANUS_LOG(LOG_WARN, "The post-processor only suupports Opus audio for now (was '%s')...\n", c);
+					JANUS_LOG(LOG_WARN, "The Record&Play plugin only supports Opus audio for now (was '%s')...\n", c);
+					json_decref(info);
 					fclose(file);
 					return NULL;
 				}
@@ -1708,6 +1713,7 @@ janus_recordplay_frame_packet *janus_recordplay_get_frames(const char *dir, cons
 				json_t *created = json_object_get(info, "s");
 				if(!created || !json_is_integer(created)) {
 					JANUS_LOG(LOG_WARN, "Missing recording created time in info header...\n");
+					json_decref(info);
 					fclose(file);
 					return NULL;
 				}
@@ -1716,6 +1722,7 @@ janus_recordplay_frame_packet *janus_recordplay_get_frames(const char *dir, cons
 				json_t *written = json_object_get(info, "u");
 				if(!written || !json_is_integer(written)) {
 					JANUS_LOG(LOG_WARN, "Missing recording written time in info header...\n");
+					json_decref(info);
 					fclose(file);
 					return NULL;
 				}
@@ -1725,6 +1732,7 @@ janus_recordplay_frame_packet *janus_recordplay_get_frames(const char *dir, cons
 				JANUS_LOG(LOG_VERB, "  -- Codec:   %s\n", c);
 				JANUS_LOG(LOG_VERB, "  -- Created: %"SCNi64"\n", c_time);
 				JANUS_LOG(LOG_VERB, "  -- Written: %"SCNi64"\n", w_time);
+				json_decref(info);
 			}
 		} else {
 			JANUS_LOG(LOG_ERR, "Invalid header...\n");

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1414,7 +1414,7 @@ static void *janus_sip_handler(void *data) {
 			if(guest) {
 				/* Not needed, we can stop here: just pick a random username if it wasn't provided and say we're registered */
 				if(!username)
-					g_snprintf(user_id, 255, "janus-sip-%"SCNu32"", g_random_int());
+					g_snprintf(user_id, 255, "janus-sip-%"SCNu32"", janus_random_uint32());
 				JANUS_LOG(LOG_INFO, "Guest will have username %s\n", user_id);
 				send_register = FALSE;
 			} else {

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -356,7 +356,7 @@ typedef struct janus_streaming_codecs {
 } janus_streaming_codecs;
 
 typedef struct janus_streaming_mountpoint {
-	gint64 id;
+	guint64 id;
 	char *name;
 	char *description;
 	gboolean is_private;
@@ -560,7 +560,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 		janus_config_print(config);
 	janus_mutex_init(&config_mutex);
 	
-	mountpoints = g_hash_table_new(NULL, NULL);
+	mountpoints = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free, NULL);
 	janus_mutex_init(&mountpoints_mutex);
 	/* Parse configuration to populate the mountpoints */
 	if(config != NULL) {
@@ -632,7 +632,8 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					JANUS_LOG(LOG_VERB, "Missing id for stream '%s', will generate a random one...\n", cat->name);
 				} else {
 					janus_mutex_lock(&mountpoints_mutex);
-					janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(atol(id->value)));
+					guint64 mpid = g_ascii_strtoull(id->value, 0, 10);
+					janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, &mpid);
 					janus_mutex_unlock(&mountpoints_mutex);
 					if(mp != NULL) {
 						JANUS_LOG(LOG_ERR, "A stream with the provided ID %s already exists, skipping '%s'\n", id->value, cat->name);
@@ -643,7 +644,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				JANUS_LOG(LOG_VERB, "Audio %s, Video %s\n", doaudio ? "enabled" : "NOT enabled", dovideo ? "enabled" : "NOT enabled");
 				janus_streaming_mountpoint *mp = NULL;
 				if((mp = janus_streaming_create_rtp_source(
-						(id && id->value) ? atol(id->value) : 0,
+						(id && id->value) ? g_ascii_strtoull(id->value, 0, 10) : 0,
 						(char *)cat->name,
 						desc ? (char *)desc->value : NULL,
 						doaudio,
@@ -708,7 +709,8 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					JANUS_LOG(LOG_VERB, "Missing id for stream '%s', will generate a random one...\n", cat->name);
 				} else {
 					janus_mutex_lock(&mountpoints_mutex);
-					janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(atol(id->value)));
+					guint64 mpid = g_ascii_strtoull(id->value, 0, 10);
+					janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, &mpid);
 					janus_mutex_unlock(&mountpoints_mutex);
 					if(mp != NULL) {
 						JANUS_LOG(LOG_ERR, "A stream with the provided ID %s already exists, skipping '%s'\n", id->value, cat->name);
@@ -718,7 +720,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				}
 				janus_streaming_mountpoint *mp = NULL;
 				if((mp = janus_streaming_create_file_source(
-						(id && id->value) ? atol(id->value) : 0,
+						(id && id->value) ? g_ascii_strtoull(id->value, 0, 10) : 0,
 						(char *)cat->name,
 						desc ? (char *)desc->value : NULL,
 						(char *)file->value,
@@ -772,7 +774,8 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					JANUS_LOG(LOG_VERB, "Missing id for stream '%s', will generate a random one...\n", cat->name);
 				} else {
 					janus_mutex_lock(&mountpoints_mutex);
-					janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(atol(id->value)));
+					guint64 mpid = g_ascii_strtoull(id->value, 0, 10);
+					janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, &mpid);
 					janus_mutex_unlock(&mountpoints_mutex);
 					if(mp != NULL) {
 						JANUS_LOG(LOG_ERR, "A stream with the provided ID %s already exists, skipping '%s'\n", id->value, cat->name);
@@ -782,7 +785,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				}
 				janus_streaming_mountpoint *mp = NULL;
 				if((mp = janus_streaming_create_file_source(
-						(id && id->value) ? atol(id->value) : 0,
+						(id && id->value) ? g_ascii_strtoull(id->value, 0, 10) : 0,
 						(char *)cat->name,
 						desc ? (char *)desc->value : NULL,
 						(char *)file->value,
@@ -822,7 +825,8 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					JANUS_LOG(LOG_VERB, "Missing id for stream '%s', will generate a random one...\n", cat->name);
 				} else {
 					janus_mutex_lock(&mountpoints_mutex);
-					janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(atol(id->value)));
+					guint64 mpid = g_ascii_strtoull(id->value, 0, 10);
+					janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, &mpid);
 					janus_mutex_unlock(&mountpoints_mutex);
 					if(mp != NULL) {
 						JANUS_LOG(LOG_ERR, "A stream with the provided ID %s already exists, skipping '%s'\n", id->value, cat->name);
@@ -832,7 +836,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				}
 				janus_streaming_mountpoint *mp = NULL;
 				if((mp = janus_streaming_create_rtsp_source(
-						(id && id->value) ? atol(id->value) : 0,
+						(id && id->value) ? g_ascii_strtoull(id->value, 0, 10) : 0,
 						(char *)cat->name,
 						desc ? (char *)desc->value : NULL,
 						(char *)file->value, doaudio, dovideo)) == NULL) {
@@ -1148,9 +1152,9 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		if(error_code != 0)
 			goto error;
 		json_t *id = json_object_get(root, "id");
-		gint64 id_value = json_integer_value(id);
+		guint64 id_value = json_integer_value(id);
 		janus_mutex_lock(&mountpoints_mutex);
-		janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(id_value));
+		janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, &id_value);
 		if(mp == NULL) {
 			janus_mutex_unlock(&mountpoints_mutex);
 			JANUS_LOG(LOG_VERB, "No such mountpoint/stream %"SCNu64"\n", id_value);
@@ -1276,7 +1280,8 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_VERB, "Missing id, will generate a random one...\n");
 			} else {
 				janus_mutex_lock(&mountpoints_mutex);
-				mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(json_integer_value(id)));
+				guint64 mpid = json_integer_value(id);
+				mp = g_hash_table_lookup(mountpoints, &mpid);
 				janus_mutex_unlock(&mountpoints_mutex);
 				if(mp != NULL) {
 					JANUS_LOG(LOG_ERR, "A stream with the provided ID already exists\n");
@@ -1341,7 +1346,8 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_VERB, "Missing id, will generate a random one...\n");
 			} else {
 				janus_mutex_lock(&mountpoints_mutex);
-				mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(json_integer_value(id)));
+				guint64 mpid = json_integer_value(id);
+				mp = g_hash_table_lookup(mountpoints, &mpid);
 				janus_mutex_unlock(&mountpoints_mutex);
 				if(mp != NULL) {
 					JANUS_LOG(LOG_ERR, "A stream with the provided ID already exists\n");
@@ -1405,7 +1411,8 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_VERB, "Missing id, will generate a random one...\n");
 			} else {
 				janus_mutex_lock(&mountpoints_mutex);
-				mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(json_integer_value(id)));
+				guint64 mpid = json_integer_value(id);
+				mp = g_hash_table_lookup(mountpoints, &mpid);
 				janus_mutex_unlock(&mountpoints_mutex);
 				if(mp != NULL) {
 					JANUS_LOG(LOG_ERR, "A stream with the provided ID already exists\n");
@@ -1573,9 +1580,9 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			g_snprintf(error_cause, 512, "No configuration file, can't destroy mountpoint permanently");
 			goto error;
 		}
-		gint64 id_value = json_integer_value(id);
+		guint64 id_value = json_integer_value(id);
 		janus_mutex_lock(&mountpoints_mutex);
-		janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(id_value));
+		janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, &id_value);
 		if(mp == NULL) {
 			janus_mutex_unlock(&mountpoints_mutex);
 			JANUS_LOG(LOG_VERB, "No such mountpoint/stream %"SCNu64"\n", id_value);
@@ -1632,7 +1639,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		/* Remove mountpoint from the hashtable: this will get it destroyed */
 		if(!mp->destroyed) {
 			mp->destroyed = janus_get_monotonic_time();
-			g_hash_table_remove(mountpoints, GINT_TO_POINTER(id_value));
+			g_hash_table_remove(mountpoints, &id_value);
 			/* Cleaning up and removing the mountpoint is done in a lazy way */
 			old_mountpoints = g_list_append(old_mountpoints, mp);
 		}
@@ -1658,9 +1665,9 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			goto error;
 		}
 		json_t *id = json_object_get(root, "id");
-		gint64 id_value = json_integer_value(id);
+		guint64 id_value = json_integer_value(id);
 		janus_mutex_lock(&mountpoints_mutex);
-		janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(id_value));
+		janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, &id_value);
 		if(mp == NULL) {
 			janus_mutex_unlock(&mountpoints_mutex);
 			JANUS_LOG(LOG_VERB, "No such mountpoint/stream %"SCNu64"\n", id_value);
@@ -1793,9 +1800,9 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		if(error_code != 0)
 			goto error;
 		json_t *id = json_object_get(root, "id");
-		gint64 id_value = json_integer_value(id);
+		guint64 id_value = json_integer_value(id);
 		janus_mutex_lock(&mountpoints_mutex);
-		janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(id_value));
+		janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, &id_value);
 		if(mp == NULL) {
 			janus_mutex_unlock(&mountpoints_mutex);
 			JANUS_LOG(LOG_VERB, "No such mountpoint/stream %"SCNu64"\n", id_value);
@@ -2080,9 +2087,9 @@ static void *janus_streaming_handler(void *data) {
 			if(error_code != 0)
 				goto error;
 			json_t *id = json_object_get(root, "id");
-			gint64 id_value = json_integer_value(id);
+			guint64 id_value = json_integer_value(id);
 			janus_mutex_lock(&mountpoints_mutex);
-			janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(id_value));
+			janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, &id_value);
 			if(mp == NULL) {
 				janus_mutex_unlock(&mountpoints_mutex);
 				JANUS_LOG(LOG_VERB, "No such mountpoint/stream %"SCNu64"\n", id_value);
@@ -2229,9 +2236,9 @@ static void *janus_streaming_handler(void *data) {
 			if(error_code != 0)
 				goto error;
 			json_t *id = json_object_get(root, "id");
-			gint64 id_value = json_integer_value(id);
+			guint64 id_value = json_integer_value(id);
 			janus_mutex_lock(&mountpoints_mutex);
-			janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, GINT_TO_POINTER(id_value));
+			janus_streaming_mountpoint *mp = g_hash_table_lookup(mountpoints, &id_value);
 			if(mp == NULL) {
 				janus_mutex_unlock(&mountpoints_mutex);
 				JANUS_LOG(LOG_VERB, "No such mountpoint/stream %"SCNu64"\n", id_value);
@@ -2459,8 +2466,8 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 	if(id == 0) {
 		JANUS_LOG(LOG_VERB, "Missing id, will generate a random one...\n");
 		while(id == 0) {
-			id = g_random_int();
-			if(g_hash_table_lookup(mountpoints, GINT_TO_POINTER(id)) != NULL) {
+			id = janus_random_uint64();
+			if(g_hash_table_lookup(mountpoints, &id) != NULL) {
 				/* ID already in use, try another one */
 				id = 0;
 			}
@@ -2579,7 +2586,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 	live_rtp->listeners = NULL;
 	live_rtp->destroyed = 0;
 	janus_mutex_init(&live_rtp->mutex);
-	g_hash_table_insert(mountpoints, GINT_TO_POINTER(live_rtp->id), live_rtp);
+	g_hash_table_insert(mountpoints, janus_uint64_dup(live_rtp->id), live_rtp);
 	janus_mutex_unlock(&mountpoints_mutex);
 	GError *error = NULL;
 	g_thread_try_new(live_rtp->name, &janus_streaming_relay_thread, live_rtp, &error);
@@ -2613,8 +2620,8 @@ janus_streaming_mountpoint *janus_streaming_create_file_source(
 	if(id == 0) {
 		JANUS_LOG(LOG_VERB, "Missing id, will generate a random one...\n");
 		while(id == 0) {
-			id = g_random_int();
-			if(g_hash_table_lookup(mountpoints, GINT_TO_POINTER(id)) != NULL) {
+			id = janus_random_uint64();
+			if(g_hash_table_lookup(mountpoints, &id) != NULL) {
 				/* ID already in use, try another one */
 				id = 0;
 			}
@@ -2683,7 +2690,7 @@ janus_streaming_mountpoint *janus_streaming_create_file_source(
 	file_source->listeners = NULL;
 	file_source->destroyed = 0;
 	janus_mutex_init(&file_source->mutex);
-	g_hash_table_insert(mountpoints, GINT_TO_POINTER(file_source->id), file_source);
+	g_hash_table_insert(mountpoints, janus_uint64_dup(file_source->id), file_source);
 	janus_mutex_unlock(&mountpoints_mutex);
 	if(live) {
 		GError *error = NULL;
@@ -2880,8 +2887,8 @@ janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 	if(id == 0) {
 		JANUS_LOG(LOG_VERB, "Missing id, will generate a random one...\n");
 		while(id == 0) {
-			id = g_random_int();
-			if(g_hash_table_lookup(mountpoints, GINT_TO_POINTER(id)) != NULL) {
+			id = janus_random_uint64();
+			if(g_hash_table_lookup(mountpoints, &id) != NULL) {
 				/* ID already in use, try another one */
 				id = 0;
 			}
@@ -2922,7 +2929,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 		curl_easy_cleanup(curl);
 		return NULL;
 	}	
-	live_rtsp->id = id ? id : g_random_int();
+	live_rtsp->id = id ? id : janus_random_uint64();
 	live_rtsp->name = sourcename;
 	live_rtsp->description = description;
 	live_rtsp->enabled = TRUE;
@@ -2946,7 +2953,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 	live_rtsp->listeners = NULL;
 	live_rtsp->destroyed = 0;
 	janus_mutex_init(&live_rtsp->mutex);
-	g_hash_table_insert(mountpoints, GINT_TO_POINTER(live_rtsp->id), live_rtsp);
+	g_hash_table_insert(mountpoints, janus_uint64_dup(live_rtsp->id), live_rtsp);
 	janus_mutex_unlock(&mountpoints_mutex);	
 	GError *error = NULL;
 	g_thread_try_new(live_rtsp->name, &janus_streaming_relay_thread, live_rtsp, &error);	

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -362,7 +362,7 @@ int janus_textroom_init(janus_callbacks *callback, const char *config_path) {
 		janus_config_print(config);
 	janus_mutex_init(&config_mutex);
 	
-	rooms = g_hash_table_new(NULL, NULL);
+	rooms = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free, NULL);
 	janus_mutex_init(&rooms_mutex);
 	sessions = g_hash_table_new(NULL, NULL);
 	messages = g_async_queue_new_full((GDestroyNotify) janus_textroom_message_free);
@@ -422,7 +422,7 @@ int janus_textroom_init(janus_callbacks *callback, const char *config_path) {
 				textroom->is_private ? "private" : "public",
 				textroom->room_secret ? textroom->room_secret : "no secret",
 				textroom->room_pin ? textroom->room_pin : "no pin");
-			g_hash_table_insert(rooms, GUINT_TO_POINTER(textroom->room_id), textroom);
+			g_hash_table_insert(rooms, janus_uint64_dup(textroom->room_id), textroom);
 			cl = cl->next;
 		}
 		/* Done: we keep the configuration file open in case we get a "create" or "destroy" with permanent=true */
@@ -534,7 +534,7 @@ void janus_textroom_create_session(janus_plugin_session *handle, int *error) {
 	}	
 	janus_textroom_session *session = (janus_textroom_session *)g_malloc0(sizeof(janus_textroom_session));
 	session->handle = handle;
-	session->rooms = g_hash_table_new(NULL, NULL);
+	session->rooms = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free, NULL);
 	session->destroyed = 0;
 	janus_mutex_init(&session->mutex);
 	g_atomic_int_set(&session->setup, 0);
@@ -678,7 +678,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
-		janus_textroom_room *textroom = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+		janus_textroom_room *textroom = g_hash_table_lookup(rooms, &room_id);
 		if(textroom == NULL) {
 			janus_mutex_unlock(&rooms_mutex);
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
@@ -688,7 +688,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		}
 		janus_mutex_lock(&textroom->mutex);
 		janus_mutex_unlock(&rooms_mutex);
-		janus_textroom_participant *participant = g_hash_table_lookup(session->rooms, GUINT_TO_POINTER(room_id));
+		janus_textroom_participant *participant = g_hash_table_lookup(session->rooms, &room_id);
 		if(participant == NULL) {
 			janus_mutex_unlock(&textroom->mutex);
 			JANUS_LOG(LOG_ERR, "Not in room %"SCNu64"\n", room_id);
@@ -819,7 +819,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
-		janus_textroom_room *textroom = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+		janus_textroom_room *textroom = g_hash_table_lookup(rooms, &room_id);
 		if(textroom == NULL) {
 			janus_mutex_unlock(&rooms_mutex);
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
@@ -830,7 +830,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		janus_mutex_lock(&textroom->mutex);
 		janus_mutex_unlock(&rooms_mutex);
 		janus_mutex_lock(&session->mutex);
-		if(g_hash_table_lookup(session->rooms, GUINT_TO_POINTER(room_id)) != NULL) {
+		if(g_hash_table_lookup(session->rooms, &room_id) != NULL) {
 			janus_mutex_unlock(&session->mutex);
 			janus_mutex_unlock(&textroom->mutex);
 			JANUS_LOG(LOG_ERR, "Already in room %"SCNu64"\n", room_id);
@@ -859,7 +859,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		participant->display = display_text ? g_strdup(display_text) : NULL;
 		participant->destroyed = 0;
 		janus_mutex_init(&participant->mutex);
-		g_hash_table_insert(session->rooms, GUINT_TO_POINTER(room_id), participant);
+		g_hash_table_insert(session->rooms, janus_uint64_dup(textroom->room_id), participant);
 		g_hash_table_insert(textroom->participants, participant->username, participant);
 		/* Notify all participants */
 		JANUS_LOG(LOG_VERB, "Notifying all participants about the new join\n");
@@ -916,7 +916,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
-		janus_textroom_room *textroom = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+		janus_textroom_room *textroom = g_hash_table_lookup(rooms, &room_id);
 		if(textroom == NULL) {
 			janus_mutex_unlock(&rooms_mutex);
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
@@ -927,7 +927,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		janus_mutex_lock(&textroom->mutex);
 		janus_mutex_unlock(&rooms_mutex);
 		janus_mutex_lock(&session->mutex);
-		janus_textroom_participant *participant = g_hash_table_lookup(session->rooms, GUINT_TO_POINTER(room_id));
+		janus_textroom_participant *participant = g_hash_table_lookup(session->rooms, &room_id);
 		if(participant == NULL) {
 			janus_mutex_unlock(&session->mutex);
 			janus_mutex_unlock(&textroom->mutex);
@@ -936,7 +936,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			g_snprintf(error_cause, 512, "Not in room %"SCNu64, room_id);
 			goto error;
 		}
-		g_hash_table_remove(session->rooms, GUINT_TO_POINTER(room_id));
+		g_hash_table_remove(session->rooms, &room_id);
 		g_hash_table_remove(textroom->participants, participant->username);
 		participant->session = NULL;
 		participant->room = NULL;
@@ -1058,7 +1058,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		janus_mutex_lock(&rooms_mutex);
 		if(room_id > 0) {
 			/* Let's make sure the room doesn't exist already */
-			if(g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id)) != NULL) {
+			if(g_hash_table_lookup(rooms, &room_id) != NULL) {
 				/* It does... */
 				janus_mutex_unlock(&rooms_mutex);
 				JANUS_LOG(LOG_ERR, "Room %"SCNu64" already exists!\n", room_id);
@@ -1072,8 +1072,8 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		/* Generate a random ID */
 		if(room_id == 0) {
 			while(room_id == 0) {
-				room_id = g_random_int();
-				if(g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id)) != NULL) {
+				room_id = janus_random_uint64();
+				if(g_hash_table_lookup(rooms, &room_id) != NULL) {
 					/* Room ID already taken, try another one */
 					room_id = 0;
 				}
@@ -1105,7 +1105,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		textroom->participants = g_hash_table_new(g_str_hash, g_str_equal);
 		textroom->destroyed = 0;
 		janus_mutex_init(&textroom->mutex);
-		g_hash_table_insert(rooms, GUINT_TO_POINTER(textroom->room_id), textroom);
+		g_hash_table_insert(rooms, janus_uint64_dup(textroom->room_id), textroom);
 		JANUS_LOG(LOG_VERB, "Created textroom: %"SCNu64" (%s, %s, secret: %s, pin: %s)\n",
 			textroom->room_id, textroom->room_name,
 			textroom->is_private ? "private" : "public",
@@ -1171,7 +1171,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		}
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
-		janus_textroom_room *textroom = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+		janus_textroom_room *textroom = g_hash_table_lookup(rooms, &room_id);
 		if(textroom == NULL) {
 			janus_mutex_unlock(&rooms_mutex);
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
@@ -1189,7 +1189,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			goto error;
 		}
 		/* Remove room */
-		g_hash_table_remove(rooms, GUINT_TO_POINTER(room_id));
+		g_hash_table_remove(rooms, &room_id);
 		if(save) {
 			/* This change is permanent: save to the configuration file too
 			 * FIXME: We should check if anything fails... */
@@ -1222,7 +1222,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 				JANUS_LOG(LOG_VERB, "  >> To %s in %"SCNu64"\n", top->username, room_id);
 				gateway->relay_data(top->session->handle, event_text, strlen(event_text));
 				janus_mutex_unlock(&top->session->mutex);
-				g_hash_table_remove(top->session->rooms, GUINT_TO_POINTER(room_id));
+				g_hash_table_remove(top->session->rooms, &room_id);
 				janus_mutex_unlock(&top->session->mutex);
 				g_free(top->username);
 				g_free(top->display);
@@ -1302,7 +1302,7 @@ void janus_textroom_hangup_media(janus_plugin_session *handle) {
 			janus_textroom_participant *p = value;
 			janus_mutex_lock(&p->mutex);
 			if(p->room)
-				list = g_list_append(list, GUINT_TO_POINTER(p->room->room_id));
+				list = g_list_append(list, janus_uint64_dup(p->room->room_id));
 			janus_mutex_unlock(&p->mutex);
 		}
 		janus_mutex_unlock(&rooms_mutex);
@@ -1310,12 +1310,14 @@ void janus_textroom_hangup_media(janus_plugin_session *handle) {
 	janus_mutex_unlock(&session->mutex);
 	JANUS_LOG(LOG_VERB, "Leaving %d rooms\n", g_list_length(list));
 	char request[100];
+	GList *first = list;
 	while(list) {
-		guint64 room_id = GPOINTER_TO_UINT(list->data);
+		guint64 room_id = *((guint64 *)list->data);
 		g_snprintf(request, sizeof(request), "{\"textroom\":\"leave\",\"transaction\":\"internal\",\"room\":%"SCNu64"}", room_id);
 		janus_textroom_handle_incoming_request(handle, g_strdup(request), TRUE);
-		list = g_list_remove_link(list, list);
+		list = list->next;
 	}
+	g_list_free_full(first, (GDestroyNotify)g_free);
 }
 
 /* Thread to handle incoming messages */

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -594,9 +594,9 @@ static guint32 janus_rtp_forwarder_add_helper(janus_videoroom_participant *p, co
 	inet_pton(AF_INET, host, &(forward->serv_addr.sin_addr));
 	forward->serv_addr.sin_port = htons(port);
 	janus_mutex_lock(&p->rtp_forwarders_mutex);
-	guint32 stream_id = g_random_int();
+	guint32 stream_id = janus_random_uint32();
 	while(g_hash_table_lookup(p->rtp_forwarders, GUINT_TO_POINTER(stream_id)) != NULL) {
-		stream_id = g_random_int();
+		stream_id = janus_random_uint32();
 	}
 	g_hash_table_insert(p->rtp_forwarders, GUINT_TO_POINTER(stream_id), forward);
 	janus_mutex_unlock(&p->rtp_forwarders_mutex);
@@ -699,7 +699,7 @@ void *janus_videoroom_watchdog(void *data) {
 					GList *rm = rl->next;
 					old_rooms = g_list_delete_link(old_rooms, rl);
 					rl = rm;
-					g_hash_table_remove(rooms, GUINT_TO_POINTER(room->room_id));
+					g_hash_table_remove(rooms, &room->room_id);
 					continue;
 				}
 				rl = rl->next;
@@ -739,8 +739,8 @@ int janus_videoroom_init(janus_callbacks *callback, const char *config_path) {
 		janus_config_print(config);
 	janus_mutex_init(&config_mutex);
 
-	rooms = g_hash_table_new_full(NULL, NULL, NULL,
-	                              (GDestroyNotify) janus_videoroom_free);
+	rooms = g_hash_table_new_full(g_int64_hash, g_int64_equal,
+		(GDestroyNotify)g_free, (GDestroyNotify) janus_videoroom_free);
 	janus_mutex_init(&rooms_mutex);
 	sessions = g_hash_table_new(NULL, NULL);
 	janus_mutex_init(&sessions_mutex);
@@ -851,9 +851,9 @@ int janus_videoroom_init(janus_callbacks *callback, const char *config_path) {
 			}
 			videoroom->destroyed = 0;
 			janus_mutex_init(&videoroom->participants_mutex);
-			videoroom->participants = g_hash_table_new(NULL, NULL);
+			videoroom->participants = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free, NULL);
 			janus_mutex_lock(&rooms_mutex);
-			g_hash_table_insert(rooms, GUINT_TO_POINTER(videoroom->room_id), videoroom);
+			g_hash_table_insert(rooms, janus_uint64_dup(videoroom->room_id), videoroom);
 			janus_mutex_unlock(&rooms_mutex);
 			JANUS_LOG(LOG_VERB, "Created videoroom: %"SCNu64" (%s, %s, %s/%s codecs, secret: %s, pin: %s)\n",
 				videoroom->room_id, videoroom->room_name,
@@ -1030,7 +1030,7 @@ static void janus_videoroom_leave_or_unpublish(janus_videoroom_participant *part
 			janus_mutex_lock(&participant->room->participants_mutex);
 			janus_videoroom_notify_participants(participant, leaving_text);
 			if(is_leaving) {
-				g_hash_table_remove(participant->room->participants, GUINT_TO_POINTER(participant->user_id));
+				g_hash_table_remove(participant->room->participants, &participant->user_id);
 			}
 			janus_mutex_unlock(&participant->room->participants_mutex);
 		}
@@ -1159,7 +1159,7 @@ static int janus_videoroom_access_room(json_t *root, gboolean check_secret, gboo
 	int error_code = 0;
 	json_t *room = json_object_get(root, "room");
 	guint64 room_id = json_integer_value(room);
-	*videoroom = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+	*videoroom = g_hash_table_lookup(rooms, &room_id);
 	if(*videoroom == NULL) {
 		JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 		error_code = JANUS_VIDEOROOM_ERROR_NO_SUCH_ROOM;
@@ -1317,7 +1317,7 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		janus_mutex_lock(&rooms_mutex);
 		if(room_id > 0) {
 			/* Let's make sure the room doesn't exist already */
-			if(g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id)) != NULL) {
+			if(g_hash_table_lookup(rooms, &room_id) != NULL) {
 				/* It does... */
 				janus_mutex_unlock(&rooms_mutex);
 				JANUS_LOG(LOG_ERR, "Room %"SCNu64" already exists!\n", room_id);
@@ -1338,8 +1338,8 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		/* Generate a random ID */
 		if(room_id == 0) {
 			while(room_id == 0) {
-				room_id = g_random_int();
-				if(g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id)) != NULL) {
+				room_id = janus_random_uint64();
+				if(g_hash_table_lookup(rooms, &room_id) != NULL) {
 					/* Room ID already taken, try another one */
 					room_id = 0;
 				}
@@ -1420,7 +1420,7 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		}
 		videoroom->destroyed = 0;
 		janus_mutex_init(&videoroom->participants_mutex);
-		videoroom->participants = g_hash_table_new(NULL, NULL);
+		videoroom->participants = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free, NULL);
 		JANUS_LOG(LOG_VERB, "Created videoroom: %"SCNu64" (%s, %s, %s/%s codecs, secret: %s, pin: %s)\n",
 			videoroom->room_id, videoroom->room_name,
 			videoroom->is_private ? "private" : "public",
@@ -1469,7 +1469,7 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		/* Show updated rooms list */
 		GHashTableIter iter;
 		gpointer value;
-		g_hash_table_insert(rooms, GUINT_TO_POINTER(videoroom->room_id), videoroom);
+		g_hash_table_insert(rooms, janus_uint64_dup(videoroom->room_id), videoroom);
 		g_hash_table_iter_init(&iter, rooms);
 		while (g_hash_table_iter_next(&iter, NULL, &value)) {
 			janus_videoroom *vr = value;
@@ -1618,7 +1618,7 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		if(error_code != 0)
 			goto error;
 		janus_mutex_lock(&videoroom->participants_mutex);
-		janus_videoroom_participant* publisher = g_hash_table_lookup(videoroom->participants, GUINT_TO_POINTER(publisher_id));
+		janus_videoroom_participant* publisher = g_hash_table_lookup(videoroom->participants, &publisher_id);
 		if(publisher == NULL) {
 			janus_mutex_unlock(&videoroom->participants_mutex);
 			JANUS_LOG(LOG_ERR, "No such publisher (%"SCNu64")\n", publisher_id);
@@ -1693,7 +1693,7 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		if(error_code != 0)
 			goto error;
 		janus_mutex_lock(&videoroom->participants_mutex);
-		janus_videoroom_participant *publisher = g_hash_table_lookup(videoroom->participants, GUINT_TO_POINTER(publisher_id));
+		janus_videoroom_participant *publisher = g_hash_table_lookup(videoroom->participants, &publisher_id);
 		if(publisher == NULL) {
 			janus_mutex_unlock(&videoroom->participants_mutex);
 			JANUS_LOG(LOG_ERR, "No such publisher (%"SCNu64")\n", publisher_id);
@@ -1729,7 +1729,7 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
-		gboolean room_exists = g_hash_table_contains(rooms, GUINT_TO_POINTER(room_id));
+		gboolean room_exists = g_hash_table_contains(rooms, &room_id);
 		janus_mutex_unlock(&rooms_mutex);
 		response = json_object();
 		json_object_set_new(response, "videoroom", json_string("success"));
@@ -1782,7 +1782,7 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
-		janus_videoroom *videoroom = g_hash_table_lookup(rooms, GUINT_TO_POINTER(room_id));
+		janus_videoroom *videoroom = g_hash_table_lookup(rooms, &room_id);
 		if(videoroom == NULL) {
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_VIDEOROOM_ERROR_NO_SUCH_ROOM;
@@ -2536,7 +2536,7 @@ static void *janus_videoroom_handler(void *data) {
 				if(id) {
 					user_id = json_integer_value(id);
 					janus_mutex_lock(&videoroom->participants_mutex);
-					if(g_hash_table_lookup(videoroom->participants, GUINT_TO_POINTER(user_id)) != NULL) {
+					if(g_hash_table_lookup(videoroom->participants, &user_id) != NULL) {
 						janus_mutex_unlock(&videoroom->participants_mutex);
 						/* User ID already taken */
 						JANUS_LOG(LOG_ERR, "User ID %"SCNu64" already exists\n", user_id);
@@ -2550,8 +2550,8 @@ static void *janus_videoroom_handler(void *data) {
 					/* Generate a random ID */
 					janus_mutex_lock(&videoroom->participants_mutex);
 					while(user_id == 0) {
-						user_id = g_random_int();
-						if(g_hash_table_lookup(videoroom->participants, GUINT_TO_POINTER(user_id)) != NULL) {
+						user_id = janus_random_uint64();
+						if(g_hash_table_lookup(videoroom->participants, &user_id) != NULL) {
 							/* User ID already taken, try another one */
 							user_id = 0;
 						}
@@ -2632,8 +2632,8 @@ static void *janus_videoroom_handler(void *data) {
 						publisher->video_pt = VP8_PT;
 						break;
 				}
-				publisher->audio_ssrc = g_random_int();
-				publisher->video_ssrc = g_random_int();
+				publisher->audio_ssrc = janus_random_uint32();
+				publisher->video_ssrc = janus_random_uint32();
 				publisher->remb_startup = 4;
 				publisher->remb_latest = 0;
 				publisher->fir_latest = 0;
@@ -2670,7 +2670,7 @@ static void *janus_videoroom_handler(void *data) {
 				GHashTableIter iter;
 				gpointer value;
 				janus_mutex_lock(&videoroom->participants_mutex);
-				g_hash_table_insert(videoroom->participants, GUINT_TO_POINTER(user_id), publisher);
+				g_hash_table_insert(videoroom->participants, janus_uint64_dup(publisher->user_id), publisher);
 				g_hash_table_iter_init(&iter, videoroom->participants);
 				while (!videoroom->destroyed && g_hash_table_iter_next(&iter, NULL, &value)) {
 					janus_videoroom_participant *p = value;
@@ -2704,7 +2704,7 @@ static void *janus_videoroom_handler(void *data) {
 				json_t *video = json_object_get(root, "video");
 				json_t *data = json_object_get(root, "data");
 				janus_mutex_lock(&videoroom->participants_mutex);
-				janus_videoroom_participant *publisher = g_hash_table_lookup(videoroom->participants, GUINT_TO_POINTER(feed_id));
+				janus_videoroom_participant *publisher = g_hash_table_lookup(videoroom->participants, &feed_id);
 				janus_mutex_unlock(&videoroom->participants_mutex);
 				if(publisher == NULL || publisher->sdp == NULL) {
 					JANUS_LOG(LOG_ERR, "No such feed (%"SCNu64")\n", feed_id);
@@ -2810,7 +2810,7 @@ static void *janus_videoroom_handler(void *data) {
 						}
 						uint64_t feed_id = json_integer_value(feed);
 						janus_mutex_lock(&videoroom->participants_mutex);
-						janus_videoroom_participant *publisher = g_hash_table_lookup(videoroom->participants, GUINT_TO_POINTER(feed_id));
+						janus_videoroom_participant *publisher = g_hash_table_lookup(videoroom->participants, &feed_id);
 						janus_mutex_unlock(&videoroom->participants_mutex);
 						if(publisher == NULL) { //~ || publisher->sdp == NULL) {
 							/* FIXME For muxed listeners, we accept subscriptions to existing participants who haven't published yet */
@@ -3083,7 +3083,7 @@ static void *janus_videoroom_handler(void *data) {
 					goto error;
 				}
 				janus_mutex_lock(&listener->room->participants_mutex);
-				janus_videoroom_participant *publisher = g_hash_table_lookup(listener->room->participants, GUINT_TO_POINTER(feed_id));
+				janus_videoroom_participant *publisher = g_hash_table_lookup(listener->room->participants, &feed_id);
 				janus_mutex_unlock(&listener->room->participants_mutex);
 				if(publisher == NULL || publisher->sdp == NULL) {
 					JANUS_LOG(LOG_ERR, "No such feed (%"SCNu64")\n", feed_id);
@@ -3209,7 +3209,7 @@ static void *janus_videoroom_handler(void *data) {
 					}
 					uint64_t feed_id = json_integer_value(feed);
 					janus_mutex_lock(&listener->room->participants_mutex);
-					janus_videoroom_participant *publisher = g_hash_table_lookup(listener->room->participants, GUINT_TO_POINTER(feed_id));
+					janus_videoroom_participant *publisher = g_hash_table_lookup(listener->room->participants, &feed_id);
 					janus_mutex_unlock(&listener->room->participants_mutex);
 					if(publisher == NULL) { //~ || publisher->sdp == NULL) {
 						/* FIXME For muxed listeners, we accept subscriptions to existing participants who haven't published yet */
@@ -3661,7 +3661,7 @@ int janus_videoroom_muxed_subscribe(janus_videoroom_listener_muxed *muxed_listen
 	int added_feeds = 0;
 	while(ps) {
 		uint64_t feed_id = GPOINTER_TO_UINT(ps->data);
-		janus_videoroom_participant *publisher = g_hash_table_lookup(videoroom->participants, GUINT_TO_POINTER(feed_id));
+		janus_videoroom_participant *publisher = g_hash_table_lookup(videoroom->participants, &feed_id);
 		if(publisher == NULL) { //~ || publisher->sdp == NULL) {
 			/* FIXME For muxed listeners, we accept subscriptions to existing participants who haven't published yet */
 			JANUS_LOG(LOG_WARN, "No such feed (%"SCNu64"), skipping\n", feed_id);

--- a/plugins/janus_voicemail.c
+++ b/plugins/janus_voicemail.c
@@ -447,7 +447,7 @@ void janus_voicemail_create_session(janus_plugin_session *handle, int *error) {
 		return;
 	}
 	session->handle = handle;
-	session->recording_id = g_random_int();
+	session->recording_id = janus_random_uint64();
 	session->start_time = 0;
 	session->stream = NULL;
 	char f[255];

--- a/record.c
+++ b/record.c
@@ -101,7 +101,7 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	memset(newname, 0, 1024);
 	if(filename == NULL) {
 		/* Choose a random username */
-		g_snprintf(newname, 1024, "janus-recording-%"SCNu32".mjr", g_random_int());
+		g_snprintf(newname, 1024, "janus-recording-%"SCNu32".mjr", janus_random_uint32());
 	} else {
 		/* Just append the extension */
 		g_snprintf(newname, 1024, "%s.mjr", filename);

--- a/sdp.c
+++ b/sdp.c
@@ -567,7 +567,7 @@ int janus_sdp_parse_ssrc(janus_ice_stream *stream, const char *ssrc_attr, int vi
 	janus_ice_handle *handle = stream->handle;
 	if(handle == NULL)
 		return -2;
-	gint64 ssrc = atoll(ssrc_attr);
+	guint32 ssrc = atol(ssrc_attr);
 	if(ssrc == 0)
 		return -3;
 	if(video) {

--- a/utils.c
+++ b/utils.c
@@ -69,6 +69,32 @@ gboolean janus_strcmp_const_time(const void *str1, const void *str2) {
 	return result == 0;
 }
 
+guint32 janus_random_uint32(void) {
+	return g_random_int();
+}
+
+guint64 janus_random_uint64(void) {
+	/*
+	 * FIXME This needs to be improved, and use something that generates
+	 * more strongly random stuff... using /dev/urandom is probably not
+	 * a good idea, as we don't want to make it harder to cross compile Janus
+	 *
+	 * TODO Look into what libssl and/or libcrypto provide in that respect
+	 *
+	 * PS: JavaScript only supports integer up to 2^53, so we need to
+	 * make sure the number is below 9007199254740992 for safety
+	 */
+	guint64 num = g_random_int() & 0x1FFFFF;
+	num = (num << 32) | g_random_int();
+	return num;
+}
+
+guint64 *janus_uint64_dup(guint64 num) {
+	guint64 *dup = g_malloc0(sizeof(guint64));
+	memcpy(dup, &num, sizeof(num));
+	return dup;
+}
+
 void janus_flags_reset(janus_flags *flags) {
 	if(flags != NULL)
 		*flags = 0;

--- a/utils.c
+++ b/utils.c
@@ -90,9 +90,9 @@ guint64 janus_random_uint64(void) {
 }
 
 guint64 *janus_uint64_dup(guint64 num) {
-	guint64 *dup = g_malloc0(sizeof(guint64));
-	memcpy(dup, &num, sizeof(num));
-	return dup;
+	guint64 *numdup = g_malloc0(sizeof(guint64));
+	memcpy(numdup, &num, sizeof(num));
+	return numdup;
 }
 
 void janus_flags_reset(janus_flags *flags) {

--- a/utils.h
+++ b/utils.h
@@ -58,6 +58,24 @@ gboolean janus_is_true(const char *value);
  * @returns true if the strings are the same, false otherwise */
 gboolean janus_strcmp_const_time(const void *str1, const void *str2);
 
+/*! \brief Helper to generate random 32-bit unsigned integers (useful for SSRCs, etc.)
+ * @note Currently just wraps g_random_int()
+ * @returns A random 32-bit unsigned integer */
+guint32 janus_random_uint32(void);
+
+/*! \brief Helper to generate random 64-bit unsigned integers (useful for Janus IDs)
+ * @returns A random 64-bit unsigned integer */
+guint64 janus_random_uint64(void);
+
+/*! \brief Helper to generate an allocated copy of a guint64 number
+ * @note While apparently silly, this is needed in order to make sure guint64 values
+ * used as keys in GHashTable operations are not lost: using temporary guint64 numbers
+ * in a g_hash_table_insert, for instance, will cause the key to contain garbage as
+ * soon as the temporary variable is lost, and all opererations on the key to fail
+ * @param num The guint64 number to duplicate
+ * @returns A pointer to a guint64 number, if successful, NULL otherwise */
+guint64 *janus_uint64_dup(guint64 num);
+
 /** @name Flags helper methods
  */
 ///@{


### PR DESCRIPTION
Somebody recently made me notice that, although most of our identifiers are `guint64`, we use `g_random_int()` to assign them values, which is a method that only returns 32-bit unsigned integers. While this was brought to my attention as a security concern (it's easier to brute-force a 32-bit value), this actually raised some other issues when I looked into it, which is what this patch tries to address.

In fact, I soon found out it wasn't just a matter of generating actual 64-bit values. Throughout the code we often use `GHashTable` tables as maps for sessions, handles, rooms, mountpoints and so on. In order to use those numeric identifiers as keys to those maps, we used `GUINT_TO_POINTER` a lot. Unfortunately, that only works as expected for numbers as high as 2^32, and doesn't when you go beyond that. This means that when you use higher values (even when you pass a value yourself via API), assuming that a 64-bit value is ok, things go crazy, map lookups fail, and things like that.

In order to fix that, I had to do several things in the code.

1. I added two new methods, called `janus_random_uint32()` and `janus_random_uint64()`, to generate `guint32` and `guint64` random numbers respectively. `janus_random_uint32()` is simply `g_random_int()` in disguise. `janus_random_uint64()` uses `g_random_int()` twice to generate a random 64-bit unsigned integer. Besides, since JavaScript apparently can't handle any integer beyond 2^53, I had to make sure the generated value here wouldn't go beyond that (or otherwise nothing works in browsers).
2. I had to modify all the `GHashTable` management when those values were involved. Specifically, `g_int64_hash` and `g_int64_equal` are now passed as arguments when creating the table, in order to make sure keys are properly addressed and compared. All lookups and removes now address the identifiers by reference, as the key needs to be a pointer and, as anticipated, `GUINT_TO_POINTER` is a no go. Finally, for inserts we needed to duplicate (as in, allocate and copy) the identifiers in order to use them as keys. In fact, using temporary values and their references, there, would soon leave the key as garbage, rendering the respective values unreachable; using the properties of existing structs wasn't reliable either, as those could be freed before the key. In order to do so, I added a new `janus_uint64_dup` to take care of that. Of course, since these keys need to be automatically freed when they're not needed anymore, I made sure `g_free` was passed as the first `GDestroyFunction` when creating the tables.

This is basically it. If you were using 64-bit identifiers in a similar way you're encouraged to align to this patch, as soon as we merge it. This is not a direct commit as I want to make sure this doesn't break any existing app out there. In fact, we now end up often generating larger identifiers for both sessions and handles, which is something that may confuse applications that are not prepared for that (although they should be, those have always been supposed to be 64-bit).

In the future we may work on making the random generation of those identifiers more "secure". At the moment, as I said, it's still just using `g_random_int` anyway with some ands/ors to make sure it's a 0<x<2^53 value. So, no crypto or anything fancy is involved yet. 

That said, I'd like to merge this soon, so feedback on this, hints on things I may have forgotten/mistyped/whatever is more than welcome!