### PR TITLE
RTSP PLAY request URL should not have a slash appended

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2959,8 +2959,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 	g_free(data.buffer);
 	data.buffer = g_malloc0(1);
 	data.size = 0;		
-	sprintf(uri, "%s/", url);
-	curl_easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, uri);
+	curl_easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, url);
 	curl_easy_setopt(curl, CURLOPT_RANGE, "0.000-");
 	curl_easy_setopt(curl, CURLOPT_RTSP_REQUEST, (long)CURL_RTSPREQ_PLAY);		
 	res = curl_easy_perform(curl);


### PR DESCRIPTION
While testing some RTSP streaming, I ran into [this interesting line](https://github.com/meetecho/janus-gateway/blob/master/plugins/janus_streaming.c#L2962), where a slash is being appended to the given stream URL before issuing the PLAY request. This lead to the following request/response:
```
PLAY rtsp://192.168.0.67/b5.mp4/ RTSP/1.0
CSeq: 4
Range: 0.000-
> 400 BAD REQUEST
```

Removing the slash as in the patch seemed to fix the issue, returning a 200 status code and starting playback, although I'm curious how this has been working for others. Perhaps I have a picky server! [The IETF RTSP RFC](https://www.ietf.org/rfc/rfc2326.txt) suggests there should not be a slash appended.

Let me know if you have any comments and thanks for a great piece of software!