### PR TITLE
First take at supporting re-invites/updates in SIP plugin (uses #578)

### DIFF
--- a/html/siptest.js
+++ b/html/siptest.js
@@ -156,6 +156,14 @@ $(document).ready(function() {
 											$('#password').removeAttr('disabled');
 											$('#register').removeAttr('disabled').click(registerUsername);
 											$('#registerset').removeAttr('disabled');
+										} else {
+											// Reset status
+											sipcall.hangup();
+											$('#dovideo').removeAttr('disabled').val('');
+											$('#peer').removeAttr('disabled').val('');
+											$('#call').removeAttr('disabled').html('Call')
+												.removeClass("btn-danger").addClass("btn-success")
+												.unbind('click').click(doCall);
 										}
 										bootbox.alert(error);
 										return;

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -3012,7 +3012,7 @@ static void *janus_sip_relay_thread(void *data) {
 	socklen_t addrlen;
 	struct sockaddr_in remote;
 	int resfd = 0, bytes = 0;
-	struct pollfd fds[4];
+	struct pollfd fds[5];
 	int pipe_fd = session->media.pipefd[0];
 	char buffer[1500];
 	memset(buffer, 0, 1500);

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -2359,6 +2359,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				break;
 			}
 			/* Send SDP to the browser */
+			char *fixed_sdp = g_strdup(sip->sip_payload->pl_data);
 			json_t *jsep = json_pack("{ssss}", "type", "offer", "sdp", fixed_sdp);
 			json_t *call = json_object();
 			json_object_set_new(call, "sip", json_string("event"));

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -295,6 +295,14 @@ typedef struct janus_sip_account {
 	janus_sip_registration_status registration_status;
 } janus_sip_account;
 
+typedef struct janus_sip_rtp_context {
+	/* Needed to fix seq and ts in case of re-INVITEs/UPDATEs that result in a RTP stream */
+	uint32_t a_last_ssrc, a_last_ts, a_base_ts, a_base_ts_prev,
+			v_last_ssrc, v_last_ts, v_base_ts, v_base_ts_prev;
+	uint16_t a_last_seq, a_base_seq, a_base_seq_prev,
+			v_last_seq, v_base_seq, v_base_seq_prev;
+} janus_sip_rtp_context;
+
 typedef struct janus_sip_media {
 	char *remote_ip;
 	int ready:1;
@@ -310,6 +318,7 @@ typedef struct janus_sip_media {
 	srtp_t audio_srtp_in, audio_srtp_out;
 	srtp_policy_t audio_remote_policy, audio_local_policy;
 	int audio_srtp_suite_in, audio_srtp_suite_out;
+	gboolean audio_send;
 	int has_video:1;
 	int video_rtp_fd, video_rtcp_fd;
 	int local_video_rtp_port, remote_video_rtp_port;
@@ -320,6 +329,10 @@ typedef struct janus_sip_media {
 	srtp_t video_srtp_in, video_srtp_out;
 	srtp_policy_t video_remote_policy, video_local_policy;
 	int video_srtp_suite_in, video_srtp_suite_out;
+	gboolean video_send;
+	janus_sip_rtp_context context;
+	int pipefd[2];
+	gboolean updated;
 } janus_sip_media;
 
 typedef struct janus_sip_session {
@@ -330,6 +343,7 @@ typedef struct janus_sip_session {
 	janus_sip_media media;
 	char *transaction;
 	char *callee;
+	janus_sdp *sdp;				/* The SDP this user sent */
 	janus_recorder *arc;		/* The Janus recorder instance for this user's audio, if enabled */
 	janus_recorder *arc_peer;	/* The Janus recorder instance for the peer's audio, if enabled */
 	janus_recorder *vrc;		/* The Janus recorder instance for this user's video, if enabled */
@@ -506,7 +520,7 @@ gpointer janus_sip_sofia_thread(gpointer user_data);
 /* Sofia callbacks */
 void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase, nua_t *nua, nua_magic_t *magic, nua_handle_t *nh, nua_hmagic_t *hmagic, sip_t const *sip, tagi_t tags[]);
 /* SDP parsing and manipulation */
-void janus_sip_sdp_process(janus_sip_session *session, janus_sdp *sdp, gboolean answer);
+void janus_sip_sdp_process(janus_sip_session *session, janus_sdp *sdp, gboolean answer, gboolean update, gboolean *changed);
 char *janus_sip_sdp_manipulate(janus_sip_session *session, janus_sdp *sdp, gboolean answer);
 /* Media */
 static int janus_sip_allocate_local_ports(janus_sip_session *session);
@@ -610,6 +624,10 @@ void *janus_sip_watchdog(void *data) {
 					if (session->callee) {
 					    g_free(session->callee);
 					    session->callee = NULL;
+					}
+					if (session->sdp) {
+					    janus_sdp_free(session->sdp);
+					    session->sdp = NULL;
 					}
 					if (session->transaction) {
 					    g_free(session->transaction);
@@ -866,6 +884,7 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->stack = NULL;
 	session->transaction = NULL;
 	session->callee = NULL;
+	session->sdp = NULL;
 	session->media.remote_ip = NULL;
 	session->media.ready = 0;
 	session->media.autoack = TRUE;
@@ -885,6 +904,7 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.audio_pt_name = NULL;
 	session->media.audio_srtp_suite_in = 0;
 	session->media.audio_srtp_suite_out = 0;
+	session->media.audio_send = TRUE;
 	session->media.has_video = 0;
 	session->media.video_rtp_fd = -1;
 	session->media.video_rtcp_fd= -1;
@@ -898,6 +918,26 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.video_pt_name = NULL;
 	session->media.video_srtp_suite_in = 0;
 	session->media.video_srtp_suite_out = 0;
+	session->media.video_send = TRUE;
+	/* Initialize the RTP context */
+	session->media.context.a_last_ssrc = 0;
+	session->media.context.a_last_ssrc = 0;
+	session->media.context.a_last_ts = 0;
+	session->media.context.a_base_ts = 0;
+	session->media.context.a_base_ts_prev = 0;
+	session->media.context.v_last_ssrc = 0;
+	session->media.context.v_last_ts = 0;
+	session->media.context.v_base_ts = 0;
+	session->media.context.v_base_ts_prev = 0;
+	session->media.context.a_last_seq = 0;
+	session->media.context.a_base_seq = 0;
+	session->media.context.a_base_seq_prev = 0;
+	session->media.context.v_last_seq = 0;
+	session->media.context.v_base_seq = 0;
+	session->media.context.v_base_seq_prev = 0;
+	session->media.pipefd[0] = -1;
+	session->media.pipefd[1] = -1;
+	session->media.updated = FALSE;
 	janus_mutex_init(&session->rec_mutex);
 	session->destroyed = 0;
 	g_atomic_int_set(&session->hangingup, 0);
@@ -1027,6 +1067,10 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 			return;
 		/* Forward to our SIP peer */
 		if(video) {
+			if(!session->media.video_send) {
+				/* Dropping video packet, peer doesn't want to receive it */
+				return;
+			}
 			if(session->media.video_ssrc == 0) {
 				rtp_header *header = (rtp_header *)buf;
 				session->media.video_ssrc = ntohl(header->ssrc);
@@ -1057,6 +1101,10 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 				}
 			}
 		} else {
+			if(!session->media.audio_send) {
+				/* Dropping audio packet, peer doesn't want to receive it */
+				return;
+			}
 			if(session->media.audio_ssrc == 0) {
 				rtp_header *header = (rtp_header *)buf;
 				session->media.audio_ssrc = ntohl(header->ssrc);
@@ -1615,6 +1663,12 @@ static void *janus_sip_handler(void *data) {
 				g_snprintf(error_cause, 512, "Missing SDP");
 				goto error;
 			}
+			if(strstr(msg->sdp, "m=application")) {
+				JANUS_LOG(LOG_ERR, "The SIP plugin does not support DataChannels\n");
+				error_code = JANUS_SIP_ERROR_MISSING_SDP;
+				g_snprintf(error_cause, 512, "The SIP plugin does not support DataChannels");
+				goto error;
+			}
 			JANUS_LOG(LOG_VERB, "%s is calling %s\n", session->account.username, uri_text);
 			JANUS_LOG(LOG_VERB, "This is involving a negotiation (%s) as well:\n%s\n", msg->sdp_type, msg->sdp);
 			/* Clean up SRTP stuff from before first, in case it's still needed */
@@ -1657,7 +1711,9 @@ static void *janus_sip_handler(void *data) {
 				g_snprintf(error_cause, 512, "Could not allocate RTP/RTCP ports");
 				goto error;
 			}
-			janus_sdp_free(parsed_sdp);
+			/* Take note of the SDP (may be useful for UPDATEs or re-INVITEs) */
+			janus_sdp_free(session->sdp);
+			session->sdp = parsed_sdp;
 			JANUS_LOG(LOG_VERB, "Prepared SDP for INVITE:\n%s", sdp);
 			/* Prepare the From header */
 			char from_hdr[1024];
@@ -1673,6 +1729,7 @@ static void *janus_sip_handler(void *data) {
 			if(session->stack->s_nh_i == NULL) {
 				JANUS_LOG(LOG_WARN, "NUA Handle for INVITE still null??\n");
 				g_free(sdp);
+				session->sdp = NULL;
 				janus_sdp_free(parsed_sdp);
 				error_code = JANUS_SIP_ERROR_LIBSOFIA_ERROR;
 				g_snprintf(error_cause, 512, "Invalid NUA Handle");
@@ -1789,7 +1846,6 @@ static void *janus_sip_handler(void *data) {
 				g_snprintf(error_cause, 512, "Could not allocate RTP/RTCP ports");
 				goto error;
 			}
-			janus_sdp_free(parsed_sdp);
 			if(session->media.audio_pt > -1) {
 				session->media.audio_pt_name = janus_get_codec_from_pt(sdp, session->media.audio_pt);
 				JANUS_LOG(LOG_VERB, "Detected audio codec: %d (%s)\n", session->media.audio_pt, session->media.audio_pt_name);
@@ -1798,6 +1854,9 @@ static void *janus_sip_handler(void *data) {
 				session->media.video_pt_name = janus_get_codec_from_pt(sdp, session->media.video_pt);
 				JANUS_LOG(LOG_VERB, "Detected video codec: %d (%s)\n", session->media.video_pt, session->media.video_pt_name);
 			}
+			/* Take note of the SDP (may be useful for UPDATEs or re-INVITEs) */
+			janus_sdp_free(session->sdp);
+			session->sdp = parsed_sdp;
 			JANUS_LOG(LOG_VERB, "Prepared SDP for 200 OK:\n%s", sdp);
 			/* Send 200 OK */
 			g_atomic_int_set(&session->hangingup, 0);
@@ -2277,10 +2336,12 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				nua_respond(nh, 488, sip_status_phrase(488), TAG_END());
 				break;
 			}
+			gboolean reinvite = FALSE;
 			if(session->stack->s_nh_i != NULL) {
 				if(session->stack->s_nh_i == nh) {
-					/* re-INVITE, we don't support those. */
-					nua_respond(nh, 488, sip_status_phrase(488), TAG_END());
+					/* re-INVITE, we'll check what changed later */
+					reinvite = TRUE;
+					JANUS_LOG(LOG_VERB, "Got a re-INVITE...\n");
 				} else if(session->status >= janus_sip_call_status_inviting) {
 					/* Busy with another call */
 					JANUS_LOG(LOG_VERB, "\tAlready in a call (busy, status=%s)\n", janus_sip_call_status_string(session->status));
@@ -2303,19 +2364,30 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 					int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, missed_text, NULL, NULL);
 					JANUS_LOG(LOG_VERB, "  >> %d (%s)\n", ret, janus_get_api_error(ret));
 					g_free(missed_text);
+					/* Done */
+					janus_sdp_free(sdp);
+					break;
 				}
+			}
+			if(!reinvite) {
+				/* New incoming call */
+				session->callee = g_strdup(url_as_string(session->stack->s_home, sip->sip_from->a_url));
+				session->status = janus_sip_call_status_invited;
+				/* Clean up SRTP stuff from before first, in case it's still needed */
+				janus_sip_srtp_cleanup(session);
+			}
+			/* Parse SDP */
+			JANUS_LOG(LOG_VERB, "Someone is %s a call:\n%s",
+				reinvite ? "updating" : "inviting us in",
+				sip->sip_payload->pl_data);
+			gboolean changed = FALSE;
+			janus_sip_sdp_process(session, sdp, FALSE, reinvite, &changed);
+			if(reinvite) {
+				/* No need to involve the browser: we reply ourselves */
+				nua_respond(nh, 200, sip_status_phrase(200), TAG_END());
 				janus_sdp_free(sdp);
 				break;
 			}
-			/* New incoming call */
-			session->callee = g_strdup(url_as_string(session->stack->s_home, sip->sip_from->a_url));
-			session->status = janus_sip_call_status_invited;
-			/* Clean up SRTP stuff from before first, in case it's still needed */
-			janus_sip_srtp_cleanup(session);
-			/* Parse SDP */
-			char *fixed_sdp = g_strdup(sip->sip_payload->pl_data);
-			JANUS_LOG(LOG_VERB, "Someone is inviting us in a call:\n%s", sip->sip_payload->pl_data);
-			janus_sip_sdp_process(session, sdp, FALSE);
 			/* Send SDP to the browser */
 			json_t *call = json_object();
 			json_object_set_new(call, "sip", json_string("event"));
@@ -2333,10 +2405,9 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			char *call_text = json_dumps(call, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
 			json_decref(call);
 			JANUS_LOG(LOG_VERB, "Pushing event to peer: %s\n", call_text);
-			int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, call_text, "offer", fixed_sdp);
+			int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, call_text, "offer", sip->sip_payload->pl_data);
 			JANUS_LOG(LOG_VERB, "  >> %d (%s)\n", ret, janus_get_api_error(ret));
 			g_free(call_text);
-			g_free(fixed_sdp);
 			janus_sdp_free(sdp);
 			/* Send a Ringing back */
 			nua_respond(nh, 180, sip_status_phrase(180), TAG_END());
@@ -2444,7 +2515,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			JANUS_LOG(LOG_VERB, "Peer accepted our call:\n%s", sip->sip_payload->pl_data);
 			session->status = janus_sip_call_status_incall;
 			char *fixed_sdp = g_strdup(sip->sip_payload->pl_data);
-			janus_sip_sdp_process(session, sdp, TRUE);
+			janus_sip_sdp_process(session, sdp, TRUE, FALSE, NULL);
 			/* If we asked for SRTP and are not getting it, fail */
 			if(session->media.require_srtp && !session->media.has_srtp_remote) {
 				JANUS_LOG(LOG_ERR, "\tWe asked for mandatory SRTP but didn't get any in the reply!\n");
@@ -2554,55 +2625,81 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 	}
 }
 
-void janus_sip_sdp_process(janus_sip_session *session, janus_sdp *sdp, gboolean answer) {
+void janus_sip_sdp_process(janus_sip_session *session, janus_sdp *sdp, gboolean answer, gboolean update, gboolean *changed) {
 	if(!session || !sdp)
 		return;
 	/* c= */
 	if(sdp->c_addr) {
+		if(update && strcmp(sdp->c_addr, session->media.remote_ip)) {
+			/* This is an update and an address changed */
+			if(changed)
+				*changed = TRUE;
+		}
 		g_free(session->media.remote_ip);
 		session->media.remote_ip = g_strdup(sdp->c_addr);
-		JANUS_LOG(LOG_VERB, "  >> Media connection:\n");
-		JANUS_LOG(LOG_VERB, "       %s\n", session->media.remote_ip);
 	}
-	JANUS_LOG(LOG_VERB, "  >> Media lines:\n");
 	GList *temp = sdp->m_lines;
 	while(temp) {
 		janus_sdp_mline *m = (janus_sdp_mline *)temp->data;
 		session->media.require_srtp = session->media.require_srtp || (m->proto && !strcasecmp(m->proto, "RTP/SAVP"));
 		if(m->type == JANUS_SDP_AUDIO) {
-			JANUS_LOG(LOG_VERB, "       Audio: %"SCNu16"\n", m->port);
 			if(m->port) {
+				if(m->port != session->media.remote_audio_rtp_port) {
+					/* This is an update and an address changed */
+					if(changed)
+						*changed = TRUE;
+				}
 				session->media.has_audio = 1;
 				session->media.remote_audio_rtp_port = m->port;
 				session->media.remote_audio_rtcp_port = m->port+1;	/* FIXME We're assuming RTCP is on the next port */
+				if(m->direction == JANUS_SDP_SENDONLY || m->direction == JANUS_SDP_INACTIVE)
+					session->media.audio_send = FALSE;
+				else
+					session->media.audio_send = TRUE;
+			} else {
+				session->media.audio_send = FALSE;
 			}
 		} else if(m->type == JANUS_SDP_VIDEO) {
-			JANUS_LOG(LOG_VERB, "       Video: %"SCNu16"\n", m->port);
 			if(m->port) {
+				if(m->port != session->media.remote_video_rtp_port) {
+					/* This is an update and an address changed */
+					if(changed)
+						*changed = TRUE;
+				}
 				session->media.has_video = 1;
 				session->media.remote_video_rtp_port = m->port;
 				session->media.remote_video_rtcp_port = m->port+1;	/* FIXME We're assuming RTCP is on the next port */
+				if(m->direction == JANUS_SDP_SENDONLY || m->direction == JANUS_SDP_INACTIVE)
+					session->media.video_send = FALSE;
+				else
+					session->media.video_send = TRUE;
+			} else {
+				session->media.video_send = FALSE;
 			}
 		} else {
-			JANUS_LOG(LOG_WARN, "       Unsupported media line (not audio/video)\n");
+			JANUS_LOG(LOG_WARN, "Unsupported media line (not audio/video)\n");
 			temp = temp->next;
 			continue;
 		}
-		JANUS_LOG(LOG_VERB, "       Media connections:\n");
 		if(m->c_addr) {
+			if(update && strcmp(m->c_addr, session->media.remote_ip)) {
+				/* This is an update and an address changed */
+				if(changed)
+					*changed = TRUE;
+			}
 			g_free(session->media.remote_ip);
 			session->media.remote_ip = g_strdup(m->c_addr);
-			JANUS_LOG(LOG_VERB, "         [%s]\n", session->media.remote_ip);
 		}
-		JANUS_LOG(LOG_VERB, "       Media attributes:\n");
+		if(update) {
+			/* FIXME This is a session update, we only accept changes in IP/ports */
+			temp = temp->next;
+			continue;
+		}
 		GList *tempA = m->attributes;
 		while(tempA) {
 			janus_sdp_attribute *a = (janus_sdp_attribute *)tempA->data;
 			if(a->name) {
-				if(!strcasecmp(a->name, "rtpmap")) {
-					JANUS_LOG(LOG_VERB, "         RTP Map:     %s\n", a->value);
-				} else if(!strcasecmp(a->name, "crypto")) {
-					JANUS_LOG(LOG_VERB, "         Crypto:      %s\n", a->value);
+				if(!strcasecmp(a->name, "crypto")) {
 					if(m->type == JANUS_SDP_AUDIO || m->type == JANUS_SDP_VIDEO) {
 						gint32 tag = 0;
 						int suite;
@@ -2646,6 +2743,17 @@ void janus_sip_sdp_process(janus_sip_session *session, janus_sdp *sdp, gboolean 
 			}
 		}
 		temp = temp->next;
+	}
+	if(changed && *changed) {
+		/* Something changed: mark this on the session, so that the thread can update the sockets */
+		session->media.updated = TRUE;
+		if(session->media.pipefd[1] > 0) {
+			int code = 1;
+			ssize_t res = 0;
+			do {
+				res = write(session->media.pipefd[1], &code, sizeof(int));
+			} while(res == -1 && errno == EINTR);
+		}
 	}
 }
 
@@ -2732,6 +2840,14 @@ static int janus_sip_allocate_local_ports(janus_sip_session *session) {
 	session->media.local_video_rtp_port = 0;
 	session->media.local_video_rtcp_port = 0;
 	session->media.video_ssrc = 0;
+	if(session->media.pipefd[0] > 0) {
+		close(session->media.pipefd[0]);
+		session->media.pipefd[0] = -1;
+	}
+	if(session->media.pipefd[1] > 0) {
+		close(session->media.pipefd[1]);
+		session->media.pipefd[1] = -1;
+	}
 	/* Start */
 	int attempts = 100;	/* FIXME Don't retry forever */
 	if(session->media.has_audio) {
@@ -2816,7 +2932,50 @@ static int janus_sip_allocate_local_ports(janus_sip_session *session) {
 			session->media.local_video_rtcp_port = rtcp_port;
 		}
 	}
+	/* We need this to quickly interrupt the poll when it's time to update a session or wrap up */
+	pipe(session->media.pipefd);
 	return 0;
+}
+
+/* Helper method to (re)connect RTP/RTCP sockets */
+static void janus_sip_connect_sockets(janus_sip_session *session, struct sockaddr_in *server_addr) {
+	if(!session || !server_addr)
+		return;
+
+	if(session->media.updated) {
+		JANUS_LOG(LOG_VERB, "Updating session sockets\n");
+	}
+
+	/* Connect peers (FIXME This pretty much sucks right now) */
+	if(session->media.remote_audio_rtp_port) {
+		server_addr->sin_port = htons(session->media.remote_audio_rtp_port);
+		if(connect(session->media.audio_rtp_fd, (struct sockaddr *)server_addr, sizeof(struct sockaddr)) == -1) {
+			JANUS_LOG(LOG_ERR, "[SIP-%s] Couldn't connect audio RTP? (%s:%d)\n", session->account.username, session->media.remote_ip, session->media.remote_audio_rtp_port);
+			JANUS_LOG(LOG_ERR, "[SIP-%s]   -- %d (%s)\n", session->account.username, errno, strerror(errno));
+		}
+	}
+	if(session->media.remote_audio_rtcp_port) {
+		server_addr->sin_port = htons(session->media.remote_audio_rtcp_port);
+		if(connect(session->media.audio_rtcp_fd, (struct sockaddr *)server_addr, sizeof(struct sockaddr)) == -1) {
+			JANUS_LOG(LOG_ERR, "[SIP-%s] Couldn't connect audio RTCP? (%s:%d)\n", session->account.username, session->media.remote_ip, session->media.remote_audio_rtcp_port);
+			JANUS_LOG(LOG_ERR, "[SIP-%s]   -- %d (%s)\n", session->account.username, errno, strerror(errno));
+		}
+	}
+	if(session->media.remote_video_rtp_port) {
+		server_addr->sin_port = htons(session->media.remote_video_rtp_port);
+		if(connect(session->media.video_rtp_fd, (struct sockaddr *)server_addr, sizeof(struct sockaddr)) == -1) {
+			JANUS_LOG(LOG_ERR, "[SIP-%s] Couldn't connect video RTP? (%s:%d)\n", session->account.username, session->media.remote_ip, session->media.remote_video_rtp_port);
+			JANUS_LOG(LOG_ERR, "[SIP-%s]   -- %d (%s)\n", session->account.username, errno, strerror(errno));
+		}
+	}
+	if(session->media.remote_video_rtcp_port) {
+		server_addr->sin_port = htons(session->media.remote_video_rtcp_port);
+		if(connect(session->media.video_rtcp_fd, (struct sockaddr *)server_addr, sizeof(struct sockaddr)) == -1) {
+			JANUS_LOG(LOG_ERR, "[SIP-%s] Couldn't connect video RTCP? (%s:%d)\n", session->account.username, session->media.remote_ip, session->media.remote_video_rtcp_port);
+			JANUS_LOG(LOG_ERR, "[SIP-%s]   -- %d (%s)\n", session->account.username, errno, strerror(errno));
+		}
+	}
+
 }
 
 /* Thread to relay RTP/RTCP frames coming from the SIP peer */
@@ -2841,36 +3000,8 @@ static void *janus_sip_relay_thread(void *data) {
 			server_addr.sin_addr = *(struct in_addr *)host->h_addr_list;
 		}
 	}
-
-	/* Connect peers (FIXME This pretty much sucks right now) */
-	if(have_server_ip && session->media.remote_audio_rtp_port) {
-		server_addr.sin_port = htons(session->media.remote_audio_rtp_port);
-		if(connect(session->media.audio_rtp_fd, (struct sockaddr *)&server_addr, sizeof(struct sockaddr)) == -1) {
-			JANUS_LOG(LOG_ERR, "[SIP-%s] Couldn't connect audio RTP? (%s:%d)\n", session->account.username, session->media.remote_ip, session->media.remote_audio_rtp_port);
-			JANUS_LOG(LOG_ERR, "[SIP-%s]   -- %d (%s)\n", session->account.username, errno, strerror(errno));
-		}
-	}
-	if(have_server_ip && session->media.remote_audio_rtcp_port) {
-		server_addr.sin_port = htons(session->media.remote_audio_rtcp_port);
-		if(connect(session->media.audio_rtcp_fd, (struct sockaddr *)&server_addr, sizeof(struct sockaddr)) == -1) {
-			JANUS_LOG(LOG_ERR, "[SIP-%s] Couldn't connect audio RTCP? (%s:%d)\n", session->account.username, session->media.remote_ip, session->media.remote_audio_rtcp_port);
-			JANUS_LOG(LOG_ERR, "[SIP-%s]   -- %d (%s)\n", session->account.username, errno, strerror(errno));
-		}
-	}
-	if(have_server_ip && session->media.remote_video_rtp_port) {
-		server_addr.sin_port = htons(session->media.remote_video_rtp_port);
-		if(connect(session->media.video_rtp_fd, (struct sockaddr *)&server_addr, sizeof(struct sockaddr)) == -1) {
-			JANUS_LOG(LOG_ERR, "[SIP-%s] Couldn't connect video RTP? (%s:%d)\n", session->account.username, session->media.remote_ip, session->media.remote_video_rtp_port);
-			JANUS_LOG(LOG_ERR, "[SIP-%s]   -- %d (%s)\n", session->account.username, errno, strerror(errno));
-		}
-	}
-	if(have_server_ip && session->media.remote_video_rtcp_port) {
-		server_addr.sin_port = htons(session->media.remote_video_rtcp_port);
-		if(connect(session->media.video_rtcp_fd, (struct sockaddr *)&server_addr, sizeof(struct sockaddr)) == -1) {
-			JANUS_LOG(LOG_ERR, "[SIP-%s] Couldn't connect video RTCP? (%s:%d)\n", session->account.username, session->media.remote_ip, session->media.remote_video_rtcp_port);
-			JANUS_LOG(LOG_ERR, "[SIP-%s]   -- %d (%s)\n", session->account.username, errno, strerror(errno));
-		}
-	}
+	if(have_server_ip)
+		janus_sip_connect_sockets(session, &server_addr);
 
 	if(!session->callee) {
 		JANUS_LOG(LOG_VERB, "[SIP-%s] Leaving thread, no callee...\n", session->account.username);
@@ -2882,14 +3013,25 @@ static void *janus_sip_relay_thread(void *data) {
 	struct sockaddr_in remote;
 	int resfd = 0, bytes = 0;
 	struct pollfd fds[4];
+	int pipe_fd = session->media.pipefd[0];
 	char buffer[1500];
 	memset(buffer, 0, 1500);
 	/* Loop */
 	int num = 0;
 	gboolean goon = TRUE;
+	int astep = 0, vstep = 0;
+	guint32 ats = 0, vts = 0;
 	while(goon && session != NULL && !session->destroyed &&
 			session->status > janus_sip_call_status_idle &&
 			session->status < janus_sip_call_status_closing) {	/* FIXME We need a per-call watchdog as well */
+
+		if(session->media.updated) {
+			/* Apparently there was a session update */
+			if(have_server_ip)
+				janus_sip_connect_sockets(session, &server_addr);
+			session->media.updated = FALSE;
+		}
+
 		/* Prepare poll */
 		num = 0;
 		if(session->media.audio_rtp_fd != -1) {
@@ -2916,6 +3058,12 @@ static void *janus_sip_relay_thread(void *data) {
 			fds[num].revents = 0;
 			num++;
 		}
+		if(pipe_fd != -1) {
+			fds[num].fd = pipe_fd;
+			fds[num].events = POLLIN;
+			fds[num].revents = 0;
+			num++;
+		}
 		/* Wait for some data */
 		resfd = poll(fds, num, 1000);
 		if(resfd < 0) {
@@ -2937,6 +3085,8 @@ static void *janus_sip_relay_thread(void *data) {
 				JANUS_LOG(LOG_ERR, "[SIP-%s] Error polling: %s...\n", session->account.username,
 					fds[i].revents & POLLERR ? "POLLERR" : "POLLHUP");
 				JANUS_LOG(LOG_ERR, "[SIP-%s]   -- %d (%s)\n", session->account.username, errno, strerror(errno));
+				if(session->media.updated)
+					break;
 				goon = FALSE;	/* Can we assume it's pretty much over, after a POLLERR? */
 				/* FIXME Simulate a "hangup" coming from the browser */
 				janus_sip_message *msg = g_malloc0(sizeof(janus_sip_message));
@@ -2948,15 +3098,17 @@ static void *janus_sip_relay_thread(void *data) {
 				g_async_queue_push(messages, msg);
 				break;
 			} else if(fds[i].revents & POLLIN) {
+				if(pipe_fd != -1 && fds[i].fd == pipe_fd) {
+					/* Poll interrupted for a reason, go on */
+					int code = 0;
+					bytes = read(pipe_fd, &code, sizeof(int));
+					break;
+				}
 				/* Got an RTP/RTCP packet */
 				if(session->media.audio_rtp_fd != -1 && fds[i].fd == session->media.audio_rtp_fd) {
 					/* Got something audio (RTP) */
 					addrlen = sizeof(remote);
 					bytes = recvfrom(session->media.audio_rtp_fd, buffer, 1500, 0, (struct sockaddr*)&remote, &addrlen);
-					//~ JANUS_LOG(LOG_VERB, "************************\nGot %d bytes on the audio RTP channel...\n", bytes);
-					//~ rtp_header_t *rtp = (rtp_header_t *)buffer;
-					//~ JANUS_LOG(LOG_VERB, " ... parsed RTP packet (ssrc=%u, pt=%u, seq=%u, ts=%u)...\n",
-						//~ ntohl(rtp->ssrc), rtp->type, ntohs(rtp->seq_number), ntohl(rtp->timestamp));
 					if(session->media.audio_ssrc_peer == 0) {
 						rtp_header *header = (rtp_header *)buffer;
 						session->media.audio_ssrc_peer = ntohl(header->ssrc);
@@ -2975,6 +3127,34 @@ static void *janus_sip_relay_thread(void *data) {
 							continue;
 						}
 						bytes = buflen;
+					}
+					/* Check if the SSRC changed (e.g., after a re-INVITE or UPDATE) */
+					rtp_header *header = (rtp_header *)buffer;
+					guint32 ssrc = ntohl(header->ssrc);
+					guint32 timestamp = ntohl(header->timestamp);
+					guint16 seq = ntohs(header->seq_number);
+					if(ssrc != session->media.context.a_last_ssrc) {
+						JANUS_LOG(LOG_VERB, "Audio SSRC changed (re-INVITE?), %"SCNu32" --> %"SCNu32"\n",
+							session->media.context.a_last_ssrc, ssrc);
+						session->media.context.a_last_ssrc = ssrc;
+						session->media.context.a_base_ts_prev = session->media.context.a_last_ts;
+						session->media.context.a_base_ts = timestamp;
+						session->media.context.a_base_seq_prev = session->media.context.a_last_seq;
+						session->media.context.a_base_seq = seq;
+					}
+					/* Compute a coherent timestamp and sequence number */
+					session->media.context.a_last_ts = (timestamp-session->media.context.a_base_ts)
+						+ session->media.context.a_base_ts_prev+(astep ? astep : 960);	/* FIXME */
+					session->media.context.a_last_seq = (seq-session->media.context.a_base_seq)+session->media.context.a_base_seq_prev+1;
+					/* Update the timestamp and sequence number in the RTP packet, and send it */
+					header->timestamp = htonl(session->media.context.a_last_ts);
+					header->seq_number = htons(session->media.context.a_last_seq);
+					if(ats == 0) {
+						ats = timestamp;
+					} else if(astep == 0) {
+						astep = timestamp-ats;
+						if(astep < 0)
+							astep = 0;
 					}
 					/* Save the frame if we're recording */
 					janus_recorder_save_frame(session->arc_peer, buffer, bytes);
@@ -3027,6 +3207,33 @@ static void *janus_sip_relay_thread(void *data) {
 						}
 						bytes = buflen;
 					}
+					/* Check if the SSRC changed (e.g., after a re-INVITE or UPDATE) */
+					rtp_header *header = (rtp_header *)buffer;
+					guint32 ssrc = ntohl(header->ssrc);
+					guint32 timestamp = ntohl(header->timestamp);
+					guint16 seq = ntohs(header->seq_number);
+					if(ssrc != session->media.context.v_last_ssrc) {
+						JANUS_LOG(LOG_VERB, "Video SSRC changed (re-INVITE?)\n");
+						session->media.context.v_last_ssrc = ssrc;
+						session->media.context.v_base_ts_prev = session->media.context.v_last_ts;
+						session->media.context.v_base_ts = timestamp;
+						session->media.context.v_base_seq_prev = session->media.context.v_last_seq;
+						session->media.context.v_base_seq = seq;
+					}
+					/* Compute a coherent timestamp and sequence number */
+					session->media.context.v_last_ts = (timestamp-session->media.context.v_base_ts)
+						+ session->media.context.v_base_ts_prev+(vstep ? vstep : 4500);	/* FIXME */
+					session->media.context.v_last_seq = (seq-session->media.context.v_base_seq)+session->media.context.v_base_seq_prev+1;
+					/* Update the timestamp and sequence number in the RTP packet, and send it */
+					header->timestamp = htonl(session->media.context.v_last_ts);
+					header->seq_number = htons(session->media.context.v_last_seq);
+					if(vts == 0) {
+						vts = timestamp;
+					} else if(vstep == 0) {
+						vstep = timestamp-vts;
+						if(vstep < 0)
+							vstep = 0;
+					}
 					/* Save the frame if we're recording */
 					janus_recorder_save_frame(session->vrc_peer, buffer, bytes);
 					/* Relay to browser */
@@ -3077,6 +3284,14 @@ static void *janus_sip_relay_thread(void *data) {
 	session->media.local_video_rtp_port = 0;
 	session->media.local_video_rtcp_port = 0;
 	session->media.video_ssrc = 0;
+	if(session->media.pipefd[0] > 0) {
+		close(session->media.pipefd[0]);
+		session->media.pipefd[0] = -1;
+	}
+	if(session->media.pipefd[1] > 0) {
+		close(session->media.pipefd[1]);
+		session->media.pipefd[1] = -1;
+	}
 	/* Clean up SRTP stuff, if needed */
 	janus_sip_srtp_cleanup(session);
 	/* Done */
@@ -3116,7 +3331,7 @@ gpointer janus_sip_sofia_thread(gpointer user_data) {
 	session->stack->s_nua = nua_create(session->stack->s_root,
 				janus_sip_sofia_callback,
 				session,
-				SIPTAG_ALLOW_STR("INVITE, ACK, BYE, CANCEL, OPTIONS"),
+				SIPTAG_ALLOW_STR("INVITE, ACK, BYE, CANCEL, OPTIONS, UPDATE"),
 				NUTAG_M_USERNAME(session->account.username),
 				NUTAG_URL(sip_url),
 				TAG_IF(session->account.sips, NUTAG_SIPS_URL(sips_url)),


### PR DESCRIPTION
As @saghul suggested, SIP re-INVITE support is added as a separate pull request that is based on #578. Copying text I wrote there here.

It basically updates the socket connections after the peer re-invites us, and makes sure no media is forwarded from the browser to the SIP peer if the media direction changed. Still no way for the browser to trigger a re-invite as we don't support renegotiation on the Janus core side yet.

This seems to work for me, but I only tried with Asterisk and forwards (Asterisk answering and playing something back, and then forwarding the call to a SIP endpoint), so you guys may want to make further tests to make sure this works as expected. Mentioning @tuijldert in particular as he worked on #577 in master.

Still incomplete as this does NOT renegotiate SRTP contexts too if renegotiated: it currently only works with plain RTP. Updating a session with new crypto stuff will require more work. _Note:_ although just tried and with Asterisk it worked nevertheless: since SRTP is involved, Asterisk doesn't force media end-to-end after in the re-INVITE, but stays on the media path to ensure secure media between Janus and itself, and allowing plain RTP on the other end. Anyway, with proxies that behave differently this is still something that needs effort on our end.

Feedback welcome!