### PR TITLE
Use `var` keyword before declaring charSet var.

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -270,7 +270,7 @@ function Janus(gatewayCallbacks) {
 
 	// Private method to create random identifiers (e.g., transaction)
 	function randomString(len) {
-		charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+		var charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 		var randomString = '';
 		for (var i = 0; i < len; i++) {
 			var randomPoz = Math.floor(Math.random() * charSet.length);

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -319,7 +319,7 @@ function Janus(gatewayCallbacks) {
 
 	// Private method to create random identifiers (e.g., transaction)
 	function randomString(len) {
-		charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+		var charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 		var randomString = '';
 		for (var i = 0; i < len; i++) {
 			var randomPoz = Math.floor(Math.random() * charSet.length);


### PR DESCRIPTION
While JavaScript does not require this, if the script is merged
with other scripts that have "use strict", the code stops working.

Also there is no reason the scope of charSet is global.