### PR TITLE
Changes to DTLS BIO filter for OpenSSL 1.1.0

### DIFF
--- a/dtls-bio.c
+++ b/dtls-bio.c
@@ -35,6 +35,8 @@ long janus_dtls_bio_filter_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 int janus_dtls_bio_filter_new(BIO *h);
 int janus_dtls_bio_filter_free(BIO *data);
 
+/* Filter initialization */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 static BIO_METHOD janus_dtls_bio_filter_methods = {
 	BIO_TYPE_FILTER,
 	"janus filter",
@@ -47,10 +49,30 @@ static BIO_METHOD janus_dtls_bio_filter_methods = {
 	janus_dtls_bio_filter_free,
 	NULL
 };
-BIO_METHOD *BIO_janus_dtls_filter(void) {
-	return(&janus_dtls_bio_filter_methods);
+#else
+static BIO_METHOD *janus_dtls_bio_filter_methods = NULL;
+#endif
+int janus_dtls_bio_filter_init(void) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	/* No initialization needed for OpenSSL pre-1.1.0 */
+#else
+	janus_dtls_bio_filter_methods = BIO_meth_new(BIO_TYPE_FILTER | BIO_get_new_index(), "janus filter");
+	if(!janus_dtls_bio_filter_methods)
+		return -1;
+	BIO_meth_set_write(janus_dtls_bio_filter_methods, janus_dtls_bio_filter_write);
+	BIO_meth_set_ctrl(janus_dtls_bio_filter_methods, janus_dtls_bio_filter_ctrl);
+	BIO_meth_set_create(janus_dtls_bio_filter_methods, janus_dtls_bio_filter_new);
+	BIO_meth_set_destroy(janus_dtls_bio_filter_methods, janus_dtls_bio_filter_free);
+#endif
+	return 0;
 }
-
+BIO_METHOD *BIO_janus_dtls_filter(void) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	return(&janus_dtls_bio_filter_methods);
+#else
+	return janus_dtls_bio_filter_methods;
+#endif
+}
 
 /* Helper struct to keep the filter state */
 typedef struct janus_dtls_bio_filter {
@@ -66,9 +88,14 @@ int janus_dtls_bio_filter_new(BIO *bio) {
 	janus_mutex_init(&filter->mutex);
 	
 	/* Set the BIO as initialized */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	bio->init = 1;
 	bio->ptr = filter;
 	bio->flags = 0;
+#else
+	BIO_set_init(bio, 1);
+	BIO_set_data(bio, filter);
+#endif
 	
 	return 1;
 }
@@ -78,26 +105,43 @@ int janus_dtls_bio_filter_free(BIO *bio) {
 		return 0;
 		
 	/* Get rid of the filter state */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	janus_dtls_bio_filter *filter = (janus_dtls_bio_filter *)bio->ptr;
+#else
+	janus_dtls_bio_filter *filter = (janus_dtls_bio_filter *)BIO_get_data(bio);
+#endif
 	if(filter != NULL) {
 		g_list_free(filter->packets);
 		filter->packets = NULL;
 		g_free(filter);
 	}
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	bio->ptr = NULL;
 	bio->init = 0;
 	bio->flags = 0;
+#else
+	BIO_set_data(bio, NULL);
+	BIO_set_init(bio, 0);
+#endif
 	return 1;
 }
 	
 int janus_dtls_bio_filter_write(BIO *bio, const char *in, int inl) {
 	JANUS_LOG(LOG_HUGE, "janus_dtls_bio_filter_write: %p, %d\n", in, inl);
 	/* Forward data to the write BIO */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	long ret = BIO_write(bio->next_bio, in, inl);
+#else
+	long ret = BIO_write(BIO_next(), in, inl);
+#endif
 	JANUS_LOG(LOG_HUGE, "  -- %ld\n", ret);
 	
 	/* Keep track of the packet, as we'll advertize them one by one after a pending check */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	janus_dtls_bio_filter *filter = (janus_dtls_bio_filter *)bio->ptr;
+#else
+	janus_dtls_bio_filter *filter = (janus_dtls_bio_filter *)BIO_get_data(bio);
+#endif
 	if(filter != NULL) {
 		janus_mutex_lock(&filter->mutex);
 		filter->packets = g_list_append(filter->packets, GINT_TO_POINTER(ret));
@@ -120,7 +164,11 @@ long janus_dtls_bio_filter_ctrl(BIO *bio, int cmd, long num, void *ptr) {
 			return 0L;
 		case BIO_CTRL_PENDING: {
 			/* We only advertize one packet at a time, as they may be fragmented */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 			janus_dtls_bio_filter *filter = (janus_dtls_bio_filter *)bio->ptr;
+#else
+			janus_dtls_bio_filter *filter = (janus_dtls_bio_filter *)BIO_get_data(bio);
+#endif
 			if(filter == NULL)
 				return 0;
 			janus_mutex_lock(&filter->mutex);

--- a/dtls-bio.c
+++ b/dtls-bio.c
@@ -132,7 +132,7 @@ int janus_dtls_bio_filter_write(BIO *bio, const char *in, int inl) {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 	long ret = BIO_write(bio->next_bio, in, inl);
 #else
-	long ret = BIO_write(BIO_next(), in, inl);
+	long ret = BIO_write(BIO_next(bio), in, inl);
 #endif
 	JANUS_LOG(LOG_HUGE, "  -- %ld\n", ret);
 	

--- a/dtls-bio.h
+++ b/dtls-bio.h
@@ -17,6 +17,9 @@
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 
+/*! \brief OpenSSL BIO filter for fragmentation initialization */
+int janus_dtls_bio_filter_init(void);
+
 /*! \brief OpenSSL BIO filter for fragmentation constructor */
 BIO_METHOD *BIO_janus_dtls_filter(void);
 

--- a/dtls.c
+++ b/dtls.c
@@ -318,6 +318,11 @@ error:
 
 /* DTLS-SRTP initialization */
 gint janus_dtls_srtp_init(const char* server_pem, const char* server_key) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	JANUS_LOG(LOG_WARN, "OpenSSL pre-1.1.0\n");
+#else
+	JANUS_LOG(LOG_WARN, "OpenSSL >= 1.1.0\n");
+#endif
 	/* FIXME First of all make OpenSSL thread safe (see note above on issue #316) */
 	janus_dtls_locks = g_malloc0(sizeof(*janus_dtls_locks) * CRYPTO_num_locks());
 	int l=0;

--- a/dtls.c
+++ b/dtls.c
@@ -118,8 +118,9 @@ void *janus_dtls_sctp_setup_thread(void *data);
 #endif
 
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 /*
- * FIXME DTLS locking stuff to make OpenSSL thread safe
+ * DTLS locking stuff to make OpenSSL thread safe (not needed for 1.1.0)
  *
  * Note: this is an attempt to fix the infamous issue #316:
  * 		https://github.com/meetecho/janus-gateway/issues/316
@@ -164,6 +165,7 @@ static void janus_dtls_cb_openssl_lock(int mode, int type, const char *file, int
 		janus_mutex_unlock(&janus_dtls_locks[type]);
 	}
 }
+#endif
 
 
 static int janus_dtls_generate_keys(X509** certificate, EVP_PKEY** private_key) {
@@ -320,10 +322,7 @@ error:
 gint janus_dtls_srtp_init(const char* server_pem, const char* server_key) {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 	JANUS_LOG(LOG_WARN, "OpenSSL pre-1.1.0\n");
-#else
-	JANUS_LOG(LOG_WARN, "OpenSSL >= 1.1.0\n");
-#endif
-	/* FIXME First of all make OpenSSL thread safe (see note above on issue #316) */
+	/* First of all make OpenSSL thread safe (see note above on issue #316) */
 	janus_dtls_locks = g_malloc0(sizeof(*janus_dtls_locks) * CRYPTO_num_locks());
 	int l=0;
 	for(l = 0; l < CRYPTO_num_locks(); l++) {
@@ -331,9 +330,16 @@ gint janus_dtls_srtp_init(const char* server_pem, const char* server_key) {
 	}
 	CRYPTO_THREADID_set_callback(janus_dtls_cb_openssl_threadid);
 	CRYPTO_set_locking_callback(janus_dtls_cb_openssl_lock);
+#else
+	JANUS_LOG(LOG_WARN, "OpenSSL >= 1.1.0\n");
+#endif
 
 	/* Go on and create the DTLS context */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	ssl_ctx = SSL_CTX_new(DTLSv1_method());
+#else
+	ssl_ctx = SSL_CTX_new(DTLS_method());
+#endif
 	if(!ssl_ctx) {
 		JANUS_LOG(LOG_FATAL, "Ops, error creating DTLS context?\n");
 		return -1;

--- a/dtls.c
+++ b/dtls.c
@@ -384,6 +384,11 @@ gint janus_dtls_srtp_init(const char* server_pem, const char* server_key) {
 	JANUS_LOG(LOG_INFO, "Fingerprint of our certificate: %s\n", local_fingerprint);
 	SSL_CTX_set_cipher_list(ssl_ctx, DTLS_CIPHERS);
 
+	if(janus_dtls_bio_filter_init() < 0) {
+		JANUS_LOG(LOG_FATAL, "Error initializing BIO filter\n");
+		return -8;
+	}
+
 	/* Initialize libsrtp */
 	if(srtp_init() != err_status_ok) {
 		JANUS_LOG(LOG_FATAL, "Ops, error setting up libsrtp?\n");


### PR DESCRIPTION
This is an attempt to fix #602.

OpenSSL 1.1.0, among other changes, made some structures we use opaque. This affected the DTLS BIO filter we have to handle automatic fragmentation, in `dtls-bio.c`. The OpenSSL developers were [really helpful](https://mta.openssl.org/pipermail/openssl-users/2016-September/004364.html) in providing some info on how to handle the transition, so I prepared the patch you can find in this pull request. The patch basically uses the `OPENSSL_VERSION_NUMBER` define to check if we're on OpenSSL 1.1.0 or not. If we're on an older version, we do nothing different than what we did before; if we are on 1.1.0, we use the new setters/getters instead.

I don't have OpenSSL 1.1.0 installed so I can't check if this even compiles. If you do, please compile/test and provide feedback.