### PR TITLE
Include refcount.h in files that use janus_refcount.

### DIFF
--- a/dtls.h
+++ b/dtls.h
@@ -20,6 +20,7 @@
 #include <srtp/srtp.h>
 
 #include "sctp.h"
+#include "refcount.h"
 #include "dtls-bio.h"
 
 /*! \brief DTLS stuff initialization

--- a/janus.h
+++ b/janus.h
@@ -30,6 +30,7 @@
 
 #include "mutex.h"
 #include "ice.h"
+#include "refcount.h"
 #include "transports/transport.h"
 #include "plugins/plugin.h"
 


### PR DESCRIPTION
For #403, I found two header files that use `janus_refcount` but do not include `refcount.h` (one already reported by @cacheworks).  `dtls.h` could get it via `sctp.h` but only if `HAVE_SCTP` is defined.  `janus.h` always includes `refcount.h` indirectly via `ice.h` but I think that a direct inclusion is less error prone. 