### PR TITLE
Bug in janus_sip.c when the sip stack receives an INVITE with no SDP

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -2253,7 +2253,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				break;
 			}
 			if (!sip->sip_payload) {
-				JANUS_LOG(LOG_ERR,"\tReceived re-invite without SDP - responding 200 OK\n");
+				JANUS_LOG(LOG_WARN,"\tReceived re-invite without SDP - responding 200 OK\n");
 				nua_respond(nh, 200, sip_status_phrase(200), TAG_END());
 				break;
 			}

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -2252,6 +2252,11 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				nua_respond(nh, 500, sip_status_phrase(500), TAG_END());
 				break;
 			}
+			if (!sip->sip_payload) {
+				JANUS_LOG(LOG_ERR,"\tReceived re-invite without SDP - responding 200 OK\n");
+				nua_respond(nh, 200, sip_status_phrase(200), TAG_END());
+				break;
+			}
 			sdp_parser_t *parser = sdp_parse(ssip->s_home, sip->sip_payload->pl_data, sip->sip_payload->pl_len, 0);
 			if(!sdp_session(parser)) {
 				JANUS_LOG(LOG_ERR, "\tError parsing SDP!\n");


### PR DESCRIPTION
Found a bug in janus_sip.c when the sip stack receives an INVITE without SDP after the initial invite.  In this call flow, Janus was assuming the invite would always have an SDP and would segfault when receiving an invite without one.

Added this quick patch to check if the received invite actually has an SDP before attempting to parse it, and if it doesn't, just respond 200 OK and let the call continue.

Basic testing shows that this solves the issue and prevents the segfault.
