### PR TITLE
Fix processing SDPs with value-less attributes

### DIFF
--- a/sdp.c
+++ b/sdp.c
@@ -706,7 +706,7 @@ char *janus_sdp_anonymize(const char *sdp) {
 				GList *ptypes = NULL;
 				sdp_attribute_t *a = m->m_attributes;
 				while(a) {
-					if(strstr(a->a_value, "red/90000") || strstr(a->a_value, "ulpfec/90000") || strstr(a->a_value, "rtx/90000")) {
+					if(a->a_value && (strstr(a->a_value, "red/90000") || strstr(a->a_value, "ulpfec/90000") || strstr(a->a_value, "rtx/90000"))) {
 						int ptype = atoi(a->a_value);
 						ptypes = g_list_append(ptypes, GINT_TO_POINTER(ptype));
 						JANUS_LOG(LOG_VERB, "Will remove payload type %d\n", ptype);
@@ -739,7 +739,7 @@ char *janus_sdp_anonymize(const char *sdp) {
 						a = m->m_attributes;
 						sdp_attribute_t *old = NULL;
 						while(a) {
-							int a_pt = atoi(a->a_value);
+							int a_pt = a->a_value ? atoi(a->a_value) : -1;
 							if(a_pt == ptype) {
 								if(!old) {
 									m->m_attributes = a->a_next;


### PR DESCRIPTION
I ran into a crash because the SDP which was arriving at Janus had no value, so check for that.

On a related note, I think Janus is acting incorrectly here:

~~~~
[saghul][nua_i_invite]: 100 Trying
Someone is inviting us in a call:
v=0
o=- 3682855815 3682855815 IN IP4 192.168.0.38
s=Blink 2.0.0 (Linux)
t=0 0
m=message 2855 TCP/TLS/MSRP *
c=IN IP4 192.168.0.38
a=path:msrps://192.168.0.38:2855/da0f915e81b25560966a;tcp
a=sendonly
a=accept-types:*
a=setup:active
a=file-selector:name:"rpi.png" type:image/png size:28232 hash:sha-1:5F:2C:08:A1:80:E2:0D:B4:BF:85:0C:54:9C:27:36:EC:54:4B:CD:BF
a=x-file-offset
a=file-transfer-id:3dbbaf32-a33e-4bac-8dda-30a075594629
  >> Media lines:
[WARN]        Unsupported media line (not audio/video)
[3275171040507450] Audio has NOT been negotiated
[3275171040507450] Video has NOT been negotiated
[3275171040507450] SCTP/DataChannels have NOT been negotiated
[3275171040507450] Setting ICE locally: got ANSWER (0 audios, 0 videos)
[3275171040507450] Creating ICE agent (ICE Full mode, controlling)
[3275171040507450] ICE thread started
[3275171040507450] Adding 192.168.0.156 to the addresses to gather candidates for
 -------------------------------------------
  >> Anonymized (444 --> 420 bytes)
 -------------------------------------------
v=0
o=- 3682855815 3682855815 IN IP4 192.168.0.38
s=Blink 2.0.0 (Linux)
t=0 0
m=message 0 TCP/TLS/MSRP *
c=IN IP4 1.1.1.1
a=sendonly
a=path:msrps://192.168.0.38:2855/da0f915e81b25560966a;tcp
a=accept-types:*
a=file-selector:name:"rpi.png" type:image/png size:28232 hash:sha-1:5F:2C:08:A1:80:E2:0D:B4:BF:85:0C:54:9C:27:36:EC:54:4B:CD:BF
a=x-file-offset
a=file-transfer-id:3dbbaf32-a33e-4bac-8dda-30a075594629

[WARN] [3275171040507450] Skipping disabled/unsupported media line...
 -------------------------------------------
  >> Merged (420 --> 176 bytes)
 -------------------------------------------
v=0
o=- 3682855815 3682855815 IN IP4 192.168.0.156
s=Blink 2.0.0 (Linux)
t=0 0
a=group:BUNDLE
a=msid-semantic: WMS janus
m=message 0 RTP/SAVPF 0
c=IN IP4 192.168.0.156

[3275171040507450] Sending event to transport...
~~~~

That was an SDP for an MSRP file transfer.  I see a number of things wrong:

- the anonymization is wrong
- the SIP plugin should probably return 488 because there is no way a browser can work with that

Thoughts? I'll get to fixing the remaining issues next week.