### PR TITLE
Use g_clear_pointer to decrease refcounts

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -2376,8 +2376,10 @@ static void *janus_videoroom_handler(void *data) {
 				JANUS_VALIDATE_JSON_OBJECT(root, publisher_parameters,
 					error_code, error_cause, TRUE,
 					JANUS_VIDEOROOM_ERROR_MISSING_ELEMENT, JANUS_VIDEOROOM_ERROR_INVALID_ELEMENT);
-				if(error_code != 0)
+				if(error_code != 0) {
+					g_clear_pointer(&videoroom, janus_videoroom_room_dereference);
 					goto error;
+				}
 				json_t *display = json_object_get(root, "display");
 				const char *display_text = display ? json_string_value(display) : NULL;
 				guint64 user_id = 0;


### PR DESCRIPTION
I replaced almost all calls to `janus_refcount_decrease` with `g_clear_pointer` with the appropriate `GDestroyNotify`.

I see that every time a subscriber is added, the refcount for `publisher->session` is increased (and decreased when the subscriber is removed).  I don't know why that happens because I don't see a reference from the subscriber to the publisher's session.

Even if this is needed, I would suggest that both subscriber and publisher should increase the refcount for their own session when they get created.  That should happen anyway to avoid having an uncounted reference.