### PR TITLE
Add support of MQTT transport

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -179,6 +179,16 @@ conf_DATA += conf/janus.transport.rabbitmq.cfg.sample
 EXTRA_DIST += conf/janus.transport.rabbitmq.cfg.sample
 endif
 
+if ENABLE_MQTT
+transport_LTLIBRARIES += transports/libjanus_mqtt.la
+transports_libjanus_mqtt_la_SOURCES = transports/janus_mqtt.c
+transports_libjanus_mqtt_la_CFLAGS = $(transports_cflags)
+transports_libjanus_mqtt_la_LDFLAGS = $(transports_ldflags) -lpaho-mqtt3a
+transports_libjanus_mqtt_la_LIBADD = $(transports_libadd)
+conf_DATA += conf/janus.transport.mqtt.cfg.sample
+EXTRA_DIST += conf/janus.transport.mqtt.cfg.sample
+endif
+
 if ENABLE_PFUNIX
 transport_LTLIBRARIES += transports/libjanus_pfunix.la
 transports_libjanus_pfunix_la_SOURCES = transports/janus_pfunix.c

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ you are interested in WebSockets support for the Janus API)
 WebSockets and/or BoringSSL support, as they make use of it)
 * [rabbitmq-c](https://github.com/alanxz/rabbitmq-c) (only needed if
 you are interested in RabbitMQ support for the Janus API)
+* [paho.mqtt.c](https://eclipse.org/paho/clients/c) (only needed if
+you are interested in MQTT support for the Janus API)
 
 A couple of plugins depend on a few more libraries:
 
@@ -139,6 +141,19 @@ HTTP REST API, you'll have to install it manually:
 the first line with this:
 
 	git clone https://github.com/warmcat/libwebsockets.git
+
+The same applies for Eclipse Paho MQTT C client library, which is needed
+for the optional MQTT support. If you're interested in integrating MQTT
+queues as an alternative (or replacement) to HTTP and/or WebSockets
+to control Janus, you can install the latest version with the
+following steps:
+
+	git clone https://github.com/eclipse/paho.mqtt.c.git
+	cd paho.mqtt.c
+	make && sudo make install
+
+* *Note:* you may want to set up a different install path for the library,
+to achieve that, replace the last command by 'sudo prefix=/usr make install'.
 
 Finally, the same can be said for rabbitmq-c as well, which is needed
 for the optional RabbitMQ support. In fact, several different versions

--- a/conf/janus.transport.mqtt.cfg.sample
+++ b/conf/janus.transport.mqtt.cfg.sample
@@ -1,0 +1,24 @@
+; Configuration of the MQTT additional transport for the Janus API.
+[general]
+enable = no												; Whether the support must be enabled
+json = indented										; Whether the JSON messages should be indented (default),
+																	; plain (no indentation) or compact (no indentation and no spaces)
+
+url = tcp://localhost:1883				; The connection URL of the MQTT broker
+;client_id = guest								; Client identifier
+;username = guest									; Username to use to authenticate, if needed
+;password = guest									; Password to use to authenticate, if needed
+;keep_alive_interval = 20					; Keep connection for N seconds
+;cleansession = 0									; Clean session flag
+;disconnect_timeout = 100					; Seconds to wait before destroying client
+subscribe_topic = to-janus				; Topic for incoming messages
+;subscribe_qos = 1								; QoS for incoming messages
+publish_topic = from-janus				; Topic for outgoing messages
+;publish_qos = 1									; QoS for outgoing messages
+
+[admin]
+;admin_enable = no								; Whether the support must be enabled
+subscribe_topic = to-janus-admin	; Topic for incoming admin messages
+;subscribe_qos = 1								; QoS for incoming admin messages
+publish_topic = from-janus-admin	; Topic for outgoing admin messages
+;publish_qos = 1									; QoS for outgoing admin messages

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,12 @@ AC_ARG_ENABLE([rabbitmq],
               [],
               [enable_rabbitmq=yes])
 
+AC_ARG_ENABLE([mqtt],
+              [AS_HELP_STRING([--disable-mqtt],
+                              [Disable MQTT integration])],
+              [],
+              [enable_mqtt=yes])
+
 AC_ARG_ENABLE([unix-sockets],
               [AS_HELP_STRING([--disable-unix-sockets],
                               [Disable Unix Sockets integration])],
@@ -258,7 +264,20 @@ AC_CHECK_LIB([rabbitmq],
                AS_IF([test "x$enable_rabbitmq" = "xyes"],
                      [AC_MSG_ERROR([rabbitmq-c not found. See README.md for installation instructions or use --disable-rabbitmq])])
              ])
+AC_CHECK_LIB([paho-mqtt3a],
+             [MQTTAsync_create],
+             [
+               AS_IF([test "x$enable_mqtt" = "xyes"],
+               [
+                  AC_DEFINE(HAVE_MQTT)
+               ])
+             ],
+             [
+               AS_IF([test "x$enable_mqtt" = "xyes"],
+                     [AC_MSG_ERROR([paho c client not found. See README.md for installation instructions or use --disable-mqtt])])
+             ])
 AM_CONDITIONAL([ENABLE_RABBITMQ], [test "x$enable_rabbitmq" = "xyes"])
+AM_CONDITIONAL([ENABLE_MQTT], [test "x$enable_mqtt" = "xyes"])
 
 AC_TRY_COMPILE([
                #include <stdlib.h>
@@ -442,6 +461,9 @@ AM_COND_IF([ENABLE_WEBSOCKETS],
 AM_COND_IF([ENABLE_RABBITMQ],
 	[echo "    RabbitMQ:              yes"],
 	[echo "    RabbitMQ:              no"])
+AM_COND_IF([ENABLE_MQTT],
+	[echo "    MQTT:                  yes"],
+	[echo "    MQTT:                  no"])
 AM_COND_IF([ENABLE_PFUNIX],
 	[echo "    Unix Sockets:          yes"],
 	[echo "    Unix Sockets:          no"])

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -91,6 +91,7 @@
  * - \b libmicrohttpd: http://www.gnu.org/software/libmicrohttpd/ (\c optional, Web server)
  * - \b libwebsockets: https://libwebsockets.org/ (\c optional, WebSockets)
  * - \b rabbitmq-c: https://github.com/alanxz/rabbitmq-c (\c optional, v1.0.4, RabbitMQ)
+ * - \b paho.mqtt.c: https://eclipse.org/paho/clients/c (\c optional, v1.1.0, MQTT)
  * - \b libopus: http://opus-codec.org/ (\c optional, only needed for the bridge plugin)
  * - \b libogg: http://xiph.org/ogg/ (\c optional, only needed for the voicemail plugin)
  *
@@ -98,10 +99,10 @@
 
 /*! \page JS JavaScript API
  * The gateway exposes, assuming the HTTP transport has been compiled, a
- * pseudo-RESTful interface, and optionally also WebSocket/RabbitMQ/UnixSockets interfaces
- * as well, all of which based on JSON messages. These
+ * pseudo-RESTful interface, and optionally also WebSocket/RabbitMQ/MQTT/UnixSockets
+ * interfaces as well, all of which based on JSON messages. These
  * interfaces are described in more detail in the \ref plainhttp \ref WS
- * \ref rabbit and \ref unix documentation respectively, and all allow clients to
+ * \ref rabbit \ref mqtt and \ref unix documentation respectively, and all allow clients to
  * take advantage of the features provided by Janus and the functionality
  * made available by its plugins. Considering most clients will be web browsers,
  * a common choice will be to rely on either the REST or the WebSockets
@@ -538,14 +539,14 @@ janus.attach(
  *
  */
 
-/*! \page rest RESTful, WebSockets, RabbitMQ and UnixSockets API
+/*! \page rest RESTful, WebSockets, RabbitMQ, MQTT and UnixSockets API
  *
  * Since version \c 0.0.6, there are three different ways to interact with a
- * Janus instance: a \ref plainhttp (the default), a \ref WS, a \ref rabbit and a \ref unix
- * (both optional, need an external library to be available). All of
+ * Janus instance: a \ref plainhttp (the default), a \ref WS, a \ref rabbit, \ref mqtt
+ * and a \ref unix (both optional, need an external library to be available). All of
  * the interfaces use the same messages (in terms of requests, responses
  * and notifications), so almost all the concepts described in the
- * \ref plainhttp section apply to the WebSocket/RabbitMQ/UnixSockets interfaces as well.
+ * \ref plainhttp section apply to the WebSocket/RabbitMQ/MQTT/UnixSockets interfaces as well.
  * Besides, since version \c 0.1.0 the transport mechanism for the Janus API
  * has been made modular, which means other protocols for transporting
  * Janus API messages might become available in the future: considering the
@@ -556,8 +557,8 @@ janus.attach(
  * As it will be explained later in the \ref WS, \ref rabbit and \ref unix sections
  * below, the only differences come when addressing specific sessions/handles
  * and in part in how you handle notifications using something different than
- * the REST interface: in fact, since with WebSockets, RabbitMQ and UnixSockets (and, as
- * anticipated, with other protocols that may be added in the future too)
+ * the REST interface: in fact, since with WebSockets, RabbitMQ, MQTT and UnixSockets
+ * (and, as anticipated, with other protocols that may be added in the future too)
  * there's no REST-based path involved, you'll need a couple of additional
  * identifiers to bridge the gap.
  * Some details are also provided in case you're interested in \ref auth.
@@ -1301,10 +1302,10 @@ var websocket = new WebSocket('ws://1.2.3.4:8188', 'janus-protocol');
  *
  * \section rabbit RabbitMQ interface
  * The semantics of how the requests have to be built, when compared to
- * the usage of plain HTTP, is exactly the same as for WebSockets, so 
+ * the usage of plain HTTP, is exactly the same as for WebSockets, so
  * refer to the \ref WS documentation for details about that.
  *
- * Of course, there are other aspects that differ when making use of 
+ * Of course, there are other aspects that differ when making use of
  * RabbitMQ messaging to talk to Janus, rather than using HTTP messages
  * or WebSockets. Specifically, RabbitMQ just basically forwards messages
  * on queues, and as such implementing a pseudo-bidirectional channel
@@ -1335,10 +1336,30 @@ var websocket = new WebSocket('ws://1.2.3.4:8188', 'janus-protocol');
  * implemented to do so, by looking at the Janus-level \c transaction
  * identifier.
  *
+ * \section mqtt MQTT interface
+ * The semantics of how the requests have to be built, when compared to
+ * the usage of plain HTTP, is exactly the same as for WebSockets, so
+ * refer to the \ref WS documentation for details about that.
+ *
+ * Of course, there are other aspects that differ when making use of
+ * MQTT messaging to talk to Janus, rather than using HTTP messages
+ * or WebSockets. Similar to RabbitMQ, MQTT just basically forwards messages
+ * on queues, and as such implementing a pseudo-bidirectional channel
+ * as the Janus API requires needs some precaution.
+ *
+ * In particular, when configuring Janus to use MQTT you'll have to
+ * specify \b two \b queues:
+ *
+ * - a queue for \b incoming messages (application -> Janus);
+ * - a queue for \b outgoing messages (Janus -> application).
+ *
+ * The proper usage of these queues will allow you to implement the kind
+ * of bidirectional channel Janus needs.
+ *
  * \section unix UnixSockets interface
  * The semantics of how the requests have to be built, when compared to
- * the usage of plain HTTP, is exactly the same as for WebSockets and
- * RabbitMQ, so refer to the \ref WS documentation for details about that.
+ * the usage of plain HTTP, is exactly the same as for WebSockets, RabbitMQ
+ * and MQTT, so refer to the \ref WS documentation for details about that.
  *
  * Apart from that, the only configuration needed is related to the path
  * the client and server will be sharing, and the socket type. Notice that only the
@@ -1765,7 +1786,7 @@ POST /admin
  * To conclude, all of the above mentioned examples have assumed an usage
  * of HTTP to interact with the Admin API. The same considerations already
  * made for the Janus API as to the usage of different transports (WebSockets,
- * RabbitMQ or others) apply here as well, particularly with respect to
+ * RabbitMQ, MQTT or others) apply here as well, particularly with respect to
  * the explicit \c session_id and \c handle_id in the JSON payload. Besides,
  * to use the Admin API over WebSockets you'll have to use <code>janus-admin-protocol</code>
  * as the subprotocol, instead of the <code>janus-protocol</code> of the

--- a/transports/janus_mqtt.c
+++ b/transports/janus_mqtt.c
@@ -1,0 +1,637 @@
+/*! \file   janus_mqtt.c
+ * \author Andrei Nesterov <ae.nesterov@gmail.com>
+ * \copyright GNU General Public License v3
+ * \brief  Janus MQTT transport plugin
+ * \details  This is an implementation of a MQTT transport for the Janus API,
+ * using the Eclipse Paho C Client library (https://eclipse.org/paho/clients/c).
+ * This means that this module adds support for MQTT based messaging as
+ * an alternative "transport" for API requests, responses and notifications.
+ * This is only useful when you're handling the communication with
+ * clients your own way. Right now, you can only configure
+ * the address of the MQTT broker to use, and the queues to
+ * make use of to receive (to-janus) and send (from-janus) messages
+ * from/to an external application. As with WebSockets, considering that
+ * requests wouldn't include a path to address some mandatory information,
+ * these requests addressed to Janus should include as part of their payload,
+ * when needed, additional pieces of information like \c session_id and
+ * \c handle_id. That is, where you'd send a Janus request related to a
+ * specific session to the \c /janus/<session> path, with RabbitMQ
+ * you'd have to send the same request with an additional \c session_id
+ * field in the JSON payload.
+ * \note When you create a session using RabbitMQ, a subscription to the
+ * events related to it is done automatically through the outgoing queue,
+ * so no need for an explicit request as the GET in the plain HTTP API.
+ *
+ * \ingroup transports
+ * \ref transports
+ */
+
+#include "transport.h"
+
+#include <MQTTAsync.h>
+
+#include "../debug.h"
+#include "../config.h"
+#include "../utils.h"
+
+/* Transport plugin information */
+#define JANUS_MQTT_VERSION        1
+#define JANUS_MQTT_VERSION_STRING "0.0.1"
+#define JANUS_MQTT_DESCRIPTION    "This transport plugin adds MQTT support to the Janus API via Paho client library."
+#define JANUS_MQTT_NAME           "JANUS MQTT transport plugin"
+#define JANUS_MQTT_AUTHOR         "Andrei Nesterov <ae.nesterov@gmail.com>"
+#define JANUS_MQTT_PACKAGE        "janus.transport.mqtt"
+
+/* Transport methods */
+janus_transport *create(void);
+int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path);
+void janus_mqtt_destroy(void);
+int janus_mqtt_get_api_compatibility(void);
+int janus_mqtt_get_version(void);
+const char *janus_mqtt_get_version_string(void);
+const char *janus_mqtt_get_description(void);
+const char *janus_mqtt_get_name(void);
+const char *janus_mqtt_get_author(void);
+const char *janus_mqtt_get_package(void);
+gboolean janus_mqtt_is_janus_api_enabled(void);
+gboolean janus_mqtt_is_admin_api_enabled(void);
+int janus_mqtt_send_message(void *context, void *request_id, gboolean admin, json_t *message);
+void janus_mqtt_session_created(void *context, guint64 session_id);
+void janus_mqtt_session_over(void *context, guint64 session_id, gboolean timeout);
+
+/* Transport setup */
+static janus_transport janus_mqtt_transport_ =
+	JANUS_TRANSPORT_INIT (
+		.init = janus_mqtt_init,
+		.destroy = janus_mqtt_destroy,
+
+		.get_api_compatibility = janus_mqtt_get_api_compatibility,
+		.get_version = janus_mqtt_get_version,
+		.get_version_string = janus_mqtt_get_version_string,
+		.get_description = janus_mqtt_get_description,
+		.get_name = janus_mqtt_get_name,
+		.get_author = janus_mqtt_get_author,
+		.get_package = janus_mqtt_get_package,
+
+		.is_janus_api_enabled = janus_mqtt_is_janus_api_enabled,
+		.is_admin_api_enabled = janus_mqtt_is_admin_api_enabled,
+
+		.send_message = janus_mqtt_send_message,
+		.session_created = janus_mqtt_session_created,
+		.session_over = janus_mqtt_session_over,
+	);
+
+/* Transport creator */
+janus_transport *create(void) {
+	JANUS_LOG(LOG_VERB, "%s created!\n", JANUS_MQTT_NAME);
+	return &janus_mqtt_transport_;
+}
+
+/* API flags */
+static gboolean janus_mqtt_api_enabled_ = FALSE;
+static gboolean janus_mqtt_admin_api_enabled_ = FALSE;
+
+/* JSON serialization options */
+static size_t json_format_ = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+
+/* MQTT client context */
+typedef struct janus_mqtt_context {
+	janus_transport_callbacks *gateway;
+	MQTTAsync client;
+	struct {
+		int keep_alive_interval;
+		int cleansession;
+	} connect;
+	struct {
+		int timeout;
+	} disconnect;
+	struct {
+		char *topic;
+		int qos;
+	} subscribe;
+	struct {
+		char *topic;
+		int qos;
+	} publish;
+	struct {
+		struct {
+			char *topic;
+			int qos;
+		} subscribe;
+		struct {
+			char *topic;
+			int qos;
+		} publish;
+	} admin;
+} janus_mqtt_context;
+
+/* Transport client methods */
+void janus_mqtt_client_connection_lost(void *context, char *cause);
+int janus_mqtt_client_message_arrived(void *context, char *topicName, int topicLen, MQTTAsync_message *message);
+void janus_mqtt_client_delivery_complete(void *context, MQTTAsync_token token);
+int janus_mqtt_client_connect(janus_mqtt_context *ctx);
+void janus_mqtt_client_connect_success(void *context, MQTTAsync_successData *response);
+void janus_mqtt_client_connect_failure(void *context, MQTTAsync_failureData *response);
+int janus_mqtt_client_reconnect(janus_mqtt_context *ctx);
+void janus_mqtt_client_reconnect_success(void *context, MQTTAsync_successData *response);
+void janus_mqtt_client_reconnect_failure(void *context, MQTTAsync_failureData *response);
+int janus_mqtt_client_disconnect(janus_mqtt_context *ctx);
+void janus_mqtt_client_disconnect_success(void *context, MQTTAsync_successData *response);
+void janus_mqtt_client_disconnect_failure(void *context, MQTTAsync_failureData *response);
+int janus_mqtt_client_subscribe(janus_mqtt_context *ctx, gboolean admin);
+void janus_mqtt_client_subscribe_success(void *context, MQTTAsync_successData *response);
+void janus_mqtt_client_subscribe_failure(void *context, MQTTAsync_failureData *response);
+void janus_mqtt_client_admin_subscribe_success(void *context, MQTTAsync_successData *response);
+void janus_mqtt_client_admin_subscribe_failure(void *context, MQTTAsync_failureData *response);
+int janus_mqtt_client_publish_message(janus_mqtt_context *ctx, char *payload, gboolean admin);
+void janus_mqtt_client_publish_janus_success(void *context, MQTTAsync_successData *response);
+void janus_mqtt_client_publish_janus_failure(void *context, MQTTAsync_failureData *response);
+void janus_mqtt_client_publish_admin_success(void *context, MQTTAsync_successData *response);
+void janus_mqtt_client_publish_admin_failure(void *context, MQTTAsync_failureData *response);
+void janus_mqtt_client_destroy_context(janus_mqtt_context **ctx);
+
+/* We only handle a single client */
+static janus_mqtt_context *context_ = NULL;
+
+int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path) {
+	if(callback == NULL || config_path == NULL) {
+		/* Invalid arguments */
+		return -1;
+	}
+
+	/* Initializing context */
+	janus_mqtt_context *ctx = g_malloc0(sizeof(struct janus_mqtt_context));
+	ctx->gateway = callback;
+	context_ = ctx;
+
+	/* Read configuration */
+	char filename[255];
+	g_snprintf(filename, 255, "%s/%s.cfg", config_path, JANUS_MQTT_PACKAGE);
+	JANUS_LOG(LOG_VERB, "Configuration file: %s\n", filename);
+	janus_config *config = janus_config_parse(filename);
+	if(config != NULL) {
+		janus_config_print(config);
+	}
+
+	/* Handle configuration */
+	janus_config_item *url_item = janus_config_get_item_drilldown(config, "general", "url");
+	const char *url = g_strdup((url_item && url_item->value) ? url_item->value : "tcp://localhost:1883");
+
+	janus_config_item *client_id_item = janus_config_get_item_drilldown(config, "general", "client_id");
+	const char *client_id = g_strdup((client_id_item && client_id_item->value) ? client_id_item->value : "guest");
+
+	janus_config_item *username_item = janus_config_get_item_drilldown(config, "general", "username");
+	const char *username = g_strdup((username_item && username_item->value) ? username_item->value : "guest");
+	
+	janus_config_item *password_item = janus_config_get_item_drilldown(config, "general", "password");
+	const char *password = g_strdup((password_item && password_item->value) ? password_item->value : "guest");
+
+	janus_config_item *json_item = janus_config_get_item_drilldown(config, "general", "json");
+	if(json_item && json_item->value) {
+		/* Check how we need to format/serialize the JSON output */
+		if(!strcasecmp(json_item->value, "indented")) {
+			/* Default: indented, we use three spaces for that */
+			json_format_ = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+		} else if(!strcasecmp(json_item->value, "plain")) {
+			/* Not indented and no new lines, but still readable */
+			json_format_ = JSON_INDENT(0) | JSON_PRESERVE_ORDER;
+		} else if(!strcasecmp(json_item->value, "compact")) {
+			/* Compact, so no spaces between separators */
+			json_format_ = JSON_COMPACT | JSON_PRESERVE_ORDER;
+		} else {
+			JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", json_item->value);
+			json_format_ = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+		}
+	}
+
+	/* Connect configuration */
+	janus_config_item *keep_alive_interval_item = janus_config_get_item_drilldown(config, "general", "keep_alive_interval");
+	ctx->connect.keep_alive_interval = (keep_alive_interval_item && keep_alive_interval_item->value) ? atoi(keep_alive_interval_item->value) : 20;
+
+	janus_config_item *cleansession_item = janus_config_get_item_drilldown(config, "general", "cleansession");
+	ctx->connect.cleansession = (cleansession_item && cleansession_item->value) ? atoi(cleansession_item->value) : 0;
+
+	/* Disconnect configuration */
+	janus_config_item *disconnect_timeout_item = janus_config_get_item_drilldown(config, "general", "disconnect_timeout");
+	ctx->disconnect.timeout = (disconnect_timeout_item && disconnect_timeout_item->value) ? atoi(disconnect_timeout_item->value) : 100;
+
+	janus_config_item *enable_item = janus_config_get_item_drilldown(config, "general", "enable");
+	if(enable_item && enable_item->value && janus_is_true(enable_item->value)) {
+		janus_mqtt_api_enabled_ = TRUE;
+
+		/* Subscribe configuration */
+		{
+			janus_config_item *topic_item = janus_config_get_item_drilldown(config, "general", "subscribe_topic");
+			if(!topic_item || !topic_item->value) {
+				JANUS_LOG(LOG_FATAL, "Missing topic for incoming messages for MQTT integration...\n");
+				goto error;
+			}
+			ctx->subscribe.topic = g_strdup(topic_item->value);
+
+			janus_config_item *qos_item = janus_config_get_item_drilldown(config, "general", "subscribe_qos");
+			ctx->subscribe.qos = (qos_item && qos_item->value) ? atoi(qos_item->value) : 1;
+		}
+
+		/* Publish configuration */
+		{
+			janus_config_item *topic_item = janus_config_get_item_drilldown(config, "general", "publish_topic");
+			if(!topic_item || !topic_item->value) {
+				JANUS_LOG(LOG_FATAL, "Missing topic for outgoing messages for MQTT integration...\n");
+				goto error;
+			}
+			ctx->publish.topic = g_strdup(topic_item->value);
+
+			janus_config_item *qos_item = janus_config_get_item_drilldown(config, "general", "publish_qos");
+			ctx->publish.qos = (qos_item && qos_item->value) ? atoi(qos_item->value) : 1;
+		}
+	}
+	else {
+		janus_mqtt_api_enabled_ = FALSE;
+		ctx->subscribe.topic = NULL;
+		ctx->publish.topic = NULL;
+	}
+
+	/* Admin configuration */
+	janus_config_item *admin_enable_item = janus_config_get_item_drilldown(config, "admin", "admin_enable");
+	if(admin_enable_item && admin_enable_item->value && janus_is_true(admin_enable_item->value)) {
+		janus_mqtt_admin_api_enabled_ = TRUE;
+
+		/* Admin subscribe configuration */
+		{
+			janus_config_item *topic_item = janus_config_get_item_drilldown(config, "admin", "subscribe_topic");
+			if(!topic_item || !topic_item->value) {
+				JANUS_LOG(LOG_FATAL, "Missing topic for incoming admin messages for MQTT integration...\n");
+				goto error;
+			}
+			ctx->admin.subscribe.topic = g_strdup(topic_item->value);
+
+			janus_config_item *qos_item = janus_config_get_item_drilldown(config, "admin", "subscribe_qos");
+			ctx->admin.subscribe.qos = (qos_item && qos_item->value) ? atoi(qos_item->value) : 1;
+		}
+
+		/* Admin publish configuration */
+		{
+			janus_config_item *topic_item = janus_config_get_item_drilldown(config, "admin", "publish_topic");
+			if(!topic_item || !topic_item->value) {
+				JANUS_LOG(LOG_FATAL, "Missing topic for outgoing admin messages for MQTT integration...\n");
+				goto error;
+			}
+			ctx->admin.publish.topic = g_strdup(topic_item->value);
+
+			janus_config_item *qos_item = janus_config_get_item_drilldown(config, "admin", "publish_qos");
+			ctx->admin.publish.qos = (qos_item && qos_item->value) ? atoi(qos_item->value) : 1;
+		}
+	}
+	else {
+		janus_mqtt_admin_api_enabled_ = FALSE;
+		ctx->admin.subscribe.topic = NULL;
+		ctx->admin.publish.topic = NULL;
+	}
+
+	if(!janus_mqtt_api_enabled_ && !janus_mqtt_admin_api_enabled_) {
+		JANUS_LOG(LOG_WARN, "MQTT support disabled for both Janus and Admin API, giving up\n");
+		goto error;
+	}
+
+	/* Creating a client */
+	if(MQTTAsync_create(
+			&ctx->client,
+			url,
+			client_id,
+			MQTTCLIENT_PERSISTENCE_NONE,
+			NULL) != MQTTASYNC_SUCCESS) {
+		JANUS_LOG(LOG_FATAL, "Can't connect to MQTT broker: error creating client...\n");
+		goto error;
+	}
+	if(MQTTAsync_setCallbacks(
+			ctx->client,
+			ctx,
+			janus_mqtt_client_connection_lost,
+			janus_mqtt_client_message_arrived,
+			janus_mqtt_client_delivery_complete) != MQTTASYNC_SUCCESS) {
+		JANUS_LOG(LOG_FATAL, "Can't connect to MQTT broker: error setting up callbacks...\n");
+		goto error;
+	}
+
+	/* Connecting to the broker */
+	int rc = janus_mqtt_client_connect(ctx);
+	if(rc != MQTTASYNC_SUCCESS) {
+		JANUS_LOG(LOG_FATAL, "Can't connect to MQTT broker, return code: %d\n", rc);
+		goto error;
+	}
+
+	return 0;
+
+error:
+	/* If we got here, something went wrong */
+	janus_mqtt_client_destroy_context(&ctx);
+	g_free((char *)url);
+	g_free((char *)client_id);
+	g_free((char *)username);
+	g_free((char *)password);
+	g_free(config);
+
+	return -1;
+}
+
+void janus_mqtt_destroy(void) {
+	JANUS_LOG(LOG_INFO, "Disconnecting MQTT client...\n");
+
+	janus_mqtt_client_disconnect(context_);
+}
+
+int janus_mqtt_get_api_compatibility(void) {
+	return JANUS_TRANSPORT_API_VERSION;
+}
+
+int janus_mqtt_get_version(void) {
+	return JANUS_MQTT_VERSION;
+}
+
+const char *janus_mqtt_get_version_string(void) {
+	return JANUS_MQTT_VERSION_STRING;
+}
+
+const char *janus_mqtt_get_description(void) {
+	return JANUS_MQTT_DESCRIPTION;
+}
+
+const char *janus_mqtt_get_name(void) {
+	return JANUS_MQTT_NAME;
+}
+
+const char *janus_mqtt_get_author(void) {
+	return JANUS_MQTT_AUTHOR;
+}
+
+const char *janus_mqtt_get_package(void) {
+	return JANUS_MQTT_PACKAGE;
+}
+
+gboolean janus_mqtt_is_janus_api_enabled(void) {
+	return janus_mqtt_api_enabled_;
+}
+
+gboolean janus_mqtt_is_admin_api_enabled(void) {
+	return janus_mqtt_admin_api_enabled_;
+}
+
+int janus_mqtt_send_message(void *context, void *request_id, gboolean admin, json_t *message) {
+	if(message == NULL) {
+		return -1;
+	}
+	if(context == NULL) {
+		json_decref(message);
+		return -1;
+	}
+
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	char *payload = json_dumps(message, json_format_);
+	json_decref(message);
+	JANUS_LOG(LOG_HUGE, "Sending %s API message via MQTT: %s\n", admin ? "admin" : "Janus", payload);
+
+	int rc = janus_mqtt_client_publish_message(ctx, payload, admin);
+	if(rc != MQTTASYNC_SUCCESS) {
+		JANUS_LOG(LOG_ERR, "Can't publish to MQTT topic: %s, return code: %d\n", admin ? ctx->admin.publish.topic : ctx->publish.topic, rc);
+	}
+
+	return 0;
+}
+
+void janus_mqtt_session_created(void *context, guint64 session_id) {
+	/* We don't care */
+}
+
+void janus_mqtt_session_over(void *context, guint64 session_id, gboolean timeout) {
+	/* We don't care, not even if it's a timeout (should we?), our client is always up */
+}
+
+void janus_mqtt_client_connection_lost(void *context, char *cause) {
+	JANUS_LOG(LOG_INFO, "MQTT connection lost cause of %s. Reconnecting...\n", cause);
+	/* Automatic reconnect */
+}
+
+int janus_mqtt_client_message_arrived(void *context, char *topicName, int topicLen, MQTTAsync_message *message) {
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	gchar *topic = g_strndup(topicName, topicLen);
+	const gboolean janus = janus_mqtt_api_enabled_ &&  !strcasecmp(topic, ctx->subscribe.topic);
+	const gboolean admin = janus_mqtt_admin_api_enabled_ && !strcasecmp(topic, ctx->admin.subscribe.topic);
+	g_free(topic);
+
+	if((janus || admin) && message->payloadlen) {
+		JANUS_LOG(LOG_HUGE, "Receiving %s API message over MQTT: %s\n", admin ? "admin" : "Janus", (char *)message->payload);
+
+		json_error_t error;
+		json_t *root = json_loadb(message->payload, message->payloadlen, 0, &error);
+		ctx->gateway->incoming_request(&janus_mqtt_transport_, ctx, NULL, admin, root, &error);
+	}
+
+	MQTTAsync_freeMessage(&message);
+	MQTTAsync_free(topicName);
+	return TRUE;
+}
+
+void janus_mqtt_client_delivery_complete(void *context, MQTTAsync_token token) {
+}
+
+int janus_mqtt_client_connect(janus_mqtt_context *ctx) {
+	MQTTAsync_connectOptions options = MQTTAsync_connectOptions_initializer;
+	options.keepAliveInterval = ctx->connect.keep_alive_interval;
+	options.cleansession = ctx->connect.cleansession;
+	options.automaticReconnect = TRUE;
+	options.onSuccess = janus_mqtt_client_connect_success;
+	options.onFailure = janus_mqtt_client_connect_failure;
+	options.context = ctx;
+	return MQTTAsync_connect(ctx->client, &options);
+}
+
+void janus_mqtt_client_connect_success(void *context, MQTTAsync_successData *response) {
+	JANUS_LOG(LOG_INFO, "MQTT client has been successfully connected to the broker\n");
+
+	/* Subscribe to one (janus or admin) topic at the time */
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	if(janus_mqtt_api_enabled_) {
+		int rc = janus_mqtt_client_subscribe(context, FALSE);
+		if(rc != MQTTASYNC_SUCCESS) {
+			JANUS_LOG(LOG_ERR, "Can't subscribe to MQTT topic: %s, return code: %d\n", ctx->subscribe.topic, rc);
+		}
+	}
+	else if(janus_mqtt_admin_api_enabled_) {
+		int rc = janus_mqtt_client_subscribe(context, TRUE);
+		if(rc != MQTTASYNC_SUCCESS) {
+			JANUS_LOG(LOG_ERR, "Can't subscribe to MQTT admin topic: %s, return code: %d\n", ctx->admin.subscribe.topic, rc);
+		}
+	}
+}
+
+void janus_mqtt_client_connect_failure(void *context, MQTTAsync_failureData *response) {
+	int rc = response ? response->code : 0;
+	JANUS_LOG(LOG_ERR, "MQTT client has been failed connecting to the broker, return code: %d. Reconnecting...\n", rc);
+	/* Automatic reconnect */
+}
+
+int janus_mqtt_client_reconnect(janus_mqtt_context *ctx) {
+	MQTTAsync_disconnectOptions options = MQTTAsync_disconnectOptions_initializer;
+	options.onSuccess = janus_mqtt_client_reconnect_success;
+	options.onFailure = janus_mqtt_client_reconnect_failure;
+	options.context = ctx;
+	options.timeout = ctx->disconnect.timeout;
+	return MQTTAsync_disconnect(ctx->client, &options);
+}
+
+void janus_mqtt_client_reconnect_success(void *context, MQTTAsync_successData *response) {
+	JANUS_LOG(LOG_INFO, "MQTT client has been successfully disconnected. Reconnecting...\n");
+
+	int rc = janus_mqtt_client_connect(context);
+	if(rc != MQTTASYNC_SUCCESS) {
+		JANUS_LOG(LOG_FATAL, "Can't connect to MQTT broker, return code: %d\n", rc);
+	}
+}
+
+void janus_mqtt_client_reconnect_failure(void *context, MQTTAsync_failureData *response) {
+	int rc = response ? response->code : 0;
+	JANUS_LOG(LOG_ERR, "MQTT client has been failed reconnecting from MQTT broker, return code: %d\n", rc);
+}
+
+int janus_mqtt_client_disconnect(janus_mqtt_context *ctx) {
+	MQTTAsync_disconnectOptions options = MQTTAsync_disconnectOptions_initializer;
+	options.onSuccess = janus_mqtt_client_disconnect_success;
+	options.onFailure = janus_mqtt_client_disconnect_failure;
+	options.context = ctx;
+	options.timeout = ctx->disconnect.timeout;
+	return MQTTAsync_disconnect(ctx->client, &options);
+}
+
+void janus_mqtt_client_disconnect_success(void *context, MQTTAsync_successData *response) {
+	JANUS_LOG(LOG_INFO, "MQTT client has been successfully disconnected. Destroying the client...\n");
+
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	janus_mqtt_client_destroy_context(&ctx);
+}
+
+void janus_mqtt_client_disconnect_failure(void *context, MQTTAsync_failureData *response) {
+	int rc = response ? response->code : 0;
+	JANUS_LOG(LOG_ERR, "Can't disconnect from MQTT broker, return code: %d\n", rc);
+
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	janus_mqtt_client_destroy_context(&ctx);
+}
+
+int janus_mqtt_client_subscribe(janus_mqtt_context *ctx, gboolean admin) {
+	MQTTAsync_responseOptions options = MQTTAsync_responseOptions_initializer;
+	options.context = ctx;
+	if(admin) {
+		options.onSuccess = janus_mqtt_client_admin_subscribe_success;
+		options.onFailure = janus_mqtt_client_admin_subscribe_failure;
+		return MQTTAsync_subscribe(ctx->client, ctx->admin.subscribe.topic, ctx->admin.subscribe.qos, &options);
+	}
+	else {
+		options.onSuccess = janus_mqtt_client_subscribe_success;
+		options.onFailure = janus_mqtt_client_subscribe_failure;
+		return MQTTAsync_subscribe(ctx->client, ctx->subscribe.topic, ctx->subscribe.qos, &options);
+	}
+}
+
+void janus_mqtt_client_subscribe_success(void *context, MQTTAsync_successData *response) {
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	JANUS_LOG(LOG_INFO, "MQTT client has been successfully subscribed to MQTT topic: %s\n", ctx->subscribe.topic);
+
+	/* Subscribe to admin topic if we haven't done it yet */
+	if(janus_mqtt_admin_api_enabled_ && (!janus_mqtt_api_enabled_ || strcasecmp(ctx->subscribe.topic, ctx->admin.subscribe.topic))) {
+		int rc = janus_mqtt_client_subscribe(context, TRUE);
+		if(rc != MQTTASYNC_SUCCESS) {
+			JANUS_LOG(LOG_ERR, "Can't subscribe to MQTT topic: %s, return code: %d\n", ctx->subscribe.topic, rc);
+		}
+	}
+}
+
+void janus_mqtt_client_subscribe_failure(void *context, MQTTAsync_failureData *response) {
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	int rc = response ? response->code : 0;
+	JANUS_LOG(LOG_ERR, "MQTT client has been failed subscribing to MQTT topic: %s, return code: %d. Reconnecting...\n", ctx->subscribe.topic, rc);
+
+	/* Reconnect */
+	{
+		int rc = janus_mqtt_client_reconnect(context);
+		if(rc != MQTTASYNC_SUCCESS) {
+			JANUS_LOG(LOG_FATAL, "Can't reconnect to MQTT broker, return code: %d\n", rc);
+		}
+	}
+}
+
+void janus_mqtt_client_admin_subscribe_success(void *context, MQTTAsync_successData *response) {
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	JANUS_LOG(LOG_INFO, "MQTT client has been successfully subscribed to MQTT topic: %s\n", ctx->admin.subscribe.topic);
+}
+
+void janus_mqtt_client_admin_subscribe_failure(void *context, MQTTAsync_failureData *response) {
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	int rc = response ? response->code : 0;
+	JANUS_LOG(LOG_ERR, "MQTT client has been failed subscribing to MQTT topic: %s, return code: %d. Reconnecting...\n", ctx->admin.subscribe.topic, rc);
+
+	/* Reconnect */
+	{
+		int rc = janus_mqtt_client_reconnect(context);
+		if(rc != MQTTASYNC_SUCCESS) {
+			JANUS_LOG(LOG_FATAL, "Can't reconnect to MQTT broker, return code: %d\n", rc);
+		}
+	}
+}
+
+int janus_mqtt_client_publish_message(janus_mqtt_context *ctx, char *payload, gboolean admin) {
+	MQTTAsync_message msg = MQTTAsync_message_initializer;
+	msg.payload = payload;
+	msg.payloadlen = strlen(payload);
+	msg.qos = ctx->publish.qos;
+	msg.retained = 0;
+
+	MQTTAsync_responseOptions options;
+	options.context = ctx;
+	if(admin) {
+		options.onSuccess = janus_mqtt_client_publish_admin_success;
+		options.onFailure = janus_mqtt_client_publish_admin_failure;
+		return MQTTAsync_sendMessage(ctx->client, ctx->admin.publish.topic, &msg, &options);
+	}
+	else {
+		options.onSuccess = janus_mqtt_client_publish_janus_success;
+		options.onFailure = janus_mqtt_client_publish_janus_failure;
+		return MQTTAsync_sendMessage(ctx->client, ctx->publish.topic, &msg, &options);
+	}
+}
+
+void janus_mqtt_client_publish_janus_success(void *context, MQTTAsync_successData *response) {
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	JANUS_LOG(LOG_HUGE, "MQTT client has been successfully published to MQTT topic: %s\n", ctx->publish.topic);
+}
+
+void janus_mqtt_client_publish_janus_failure(void *context, MQTTAsync_failureData *response) {
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	int rc = response ? response->code : 0;
+	JANUS_LOG(LOG_ERR, "MQTT client has been failed publishing to MQTT topic: %s, return code: %d\n", ctx->publish.topic, rc);
+}
+
+void janus_mqtt_client_publish_admin_success(void *context, MQTTAsync_successData *response) {
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	JANUS_LOG(LOG_HUGE, "MQTT client has been successfully published to MQTT topic: %s\n", ctx->admin.publish.topic);
+}
+
+void janus_mqtt_client_publish_admin_failure(void *context, MQTTAsync_failureData *response) {
+	janus_mqtt_context *ctx = (janus_mqtt_context *)context;
+	int rc = response ? response->code : 0;
+	JANUS_LOG(LOG_ERR, "MQTT client has been failed publishing to MQTT topic: %s, return code: %d\n", ctx->admin.publish.topic, rc);
+}
+
+void janus_mqtt_client_destroy_context(janus_mqtt_context **ptr) {
+	janus_mqtt_context *ctx = (janus_mqtt_context *)*ptr;
+	if(ctx) {
+		MQTTAsync_destroy(&ctx->client);
+		g_free(ctx->subscribe.topic);
+		g_free(ctx->publish.topic);
+		g_free(ctx->admin.subscribe.topic);
+		g_free(ctx->admin.publish.topic);
+		g_free(ctx);
+		*ptr = NULL;
+	}
+
+	JANUS_LOG(LOG_INFO, "%s destroyed!\n", JANUS_MQTT_NAME);
+}


### PR DESCRIPTION
Message Queue Telemetry Transport (MQTT) is a popular and lightweight publish and subscribe messaging transport. It's also an open standard, and there is already exist a lot of open source brokers/clients. It would be nice to have build-in support for this protocol within Janus Gateway.

If it's ok, I could make another commit with Docker file describing a container with all needed development environment and installed dependencies including MQTT broker within it. I also would glad to fix any code-style and other issues. Just let me know about it