### PR TITLE
Put the mutex for websockets into janus_transport_session

### DIFF
--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -979,8 +979,6 @@ static int janus_websockets_common_callback(
 {
 	const char *log_prefix = admin ? "AdminWSS" : "WSS";
 	janus_websockets_client *ws_client = (janus_websockets_client *)user;
-	if(reason != LWS_CALLBACK_ESTABLISHED && g_atomic_int_get(&ws_client->destroyed))
-		return 0;
 	switch(reason) {
 		case LWS_CALLBACK_ESTABLISHED: {
 			/* Is there any filtering we should apply? */
@@ -1038,6 +1036,8 @@ static int janus_websockets_common_callback(
 				JANUS_LOG(LOG_ERR, "[%s-%p] Invalid WebSocket client instance...\n", log_prefix, wsi);
 				return -1;
 			}
+			if(g_atomic_int_get(&ws_client->destroyed))
+				return 0;
 			/* Is this a new message, or part of a fragmented one? */
 #ifdef HAVE_LIBWEBSOCKETS_NEWAPI
 			const size_t remaining = lws_remaining_packet_payload(wsi);

--- a/transports/transport.c
+++ b/transports/transport.c
@@ -27,6 +27,7 @@ janus_transport_session *janus_transport_session_create(void *transport_p, void 
 	tp->p_free = p_free;
 	g_atomic_int_set(&tp->destroyed, 0);
 	janus_refcount_init(&tp->ref, janus_transport_session_free);
+	janus_mutex_init(&tp->mutex);
 	return tp;
 }
 

--- a/transports/transport.h
+++ b/transports/transport.h
@@ -147,6 +147,8 @@ struct janus_transport_session {
 	/*! \brief Whether this mapping has been destroyed definitely or not: if so,
 	 * the transport shouldn't make use of it anymore */
 	volatile gint destroyed;
+	/*! \brief Mutex to protect changes to transport_p */
+	janus_mutex mutex;
 	/*! \brief Reference counter for this instance */
 	janus_refcount ref;
 };


### PR DESCRIPTION
This is an attempt to fix the [race condition](https://github.com/meetecho/janus-gateway/pull/643#issuecomment-252447843) in websockets.  By putting the mutex into `janus_transport_session`, `janus_websockets_client` can be freed by libwebsockets without causing access to freed memory.  As there is no `janus_transport_session` in master, this PR wouldn't apply there.

The change from `g_free(message)` to `json_decref(message)` in `janus_websockets_send_message` should be made in any case.
