### PR TITLE
Set JANUS_THREAD_DEBUG to log the number of threads

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -2494,17 +2494,26 @@ gboolean janus_transport_is_auth_token_valid(janus_transport *plugin, const char
 }
 
 void janus_transport_task(gpointer data, gpointer user_data) {
-	JANUS_LOG(LOG_VERB, "Transport task pool, serving request\n");
 	janus_request *request = (janus_request *)data;
 	if(request == NULL) {
-		JANUS_LOG(LOG_ERR, "Missing request\n");
+		JANUS_LOG(LOG_ERR, "Transport task pool: missing request\n");
 		return;
 	}
+#ifdef JANUS_THREAD_DEBUG
+	char* msg = json_dumps(request->message, JSON_PRESERVE_ORDER);
+	JANUS_LOG(LOG_INFO, "Transport task pool, serving request; %d; %s\n", g_thread_pool_get_num_threads (tasks), msg);
+#else
+	JANUS_LOG(LOG_VERB, "THREAD_DEBUG: Transport task pool, serving request\n");
+#endif
 	if(!request->admin)
 		janus_process_incoming_request(request);
 	else
 		janus_process_incoming_admin_request(request);
 	/* Done */
+#ifdef JANUS_THREAD_DEBUG
+	JANUS_LOG(LOG_INFO, "THREAD_DEBUG: Transport task pool, request done; %d; %s\n", g_thread_pool_get_num_threads (tasks), msg);
+	free(msg);
+#endif
 	janus_request_destroy(request);
 }
 

--- a/janus.h
+++ b/janus.h
@@ -37,6 +37,8 @@
 
 #define JANUS_BUFSIZE	8192
 
+#define JANUS_THREAD_DEBUG
+
 /*! \brief Helper to address requests and their sources (e.g., a specific HTTP connection, websocket, RabbitMQ or others) */
 typedef struct janus_request janus_request;
  

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -125,6 +125,9 @@ rec_dir = <folder where recordings should be stored, when enabled>
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#ifdef JANUS_THREAD_DEBUG
+static volatile gint handler_thread_count = 0;
+#endif
 
 /* Plugin information */
 #define JANUS_VIDEOROOM_VERSION			7
@@ -2326,7 +2329,11 @@ static void janus_videoroom_sdp_v_format(char *mline, int mline_size, janus_vide
 
 /* Thread to handle incoming messages */
 static void *janus_videoroom_handler(void *data) {
+#ifdef JANUS_THREAD_DEBUG
+	JANUS_LOG(LOG_INFO, "Joining VideoRoom handler thread; %d\n", g_atomic_int_add(&handler_thread_count, 1) + 1);
+#else
 	JANUS_LOG(LOG_VERB, "Joining VideoRoom handler thread\n");
+#endif
 	janus_videoroom_message *msg = NULL;
 	int error_code = 0;
 	char error_cause[512];
@@ -3312,7 +3319,11 @@ error:
 			janus_videoroom_message_free(msg);
 		}
 	}
+#ifdef JANUS_THREAD_DEBUG
+	JANUS_LOG(LOG_INFO, "THREAD_DEBUG: Leaving VideoRoom handler thread; %d\n", g_atomic_int_add(&handler_thread_count, -1) - 1);
+#else
 	JANUS_LOG(LOG_VERB, "Leaving VideoRoom handler thread\n");
+#endif
 	return NULL;
 }
 


### PR DESCRIPTION
This counts the number of threads and logs them to find the cause for the [crash](https://github.com/meetecho/janus-gateway/pull/403#issuecomment-253330636) reported by @cacheworks.