### PR TITLE
Increase idle time for thread pool

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -3763,6 +3763,8 @@ gint main(int argc, char *argv[])
 		JANUS_LOG(LOG_FATAL, "Got error %d (%s) trying to launch the request pool task thread...\n", error->code, error->message ? error->message : "??");
 		exit(1);
 	}
+	/* Wait 120 seconds before stopping idle threads to avoid the creation of too many threads for AddressSanitizer. */
+	g_thread_pool_set_max_idle_time(120 * 1000);
 
 	/* Load transports */
 	gboolean janus_api_enabled = FALSE, admin_api_enabled = FALSE;


### PR DESCRIPTION
Increase the idle time for the thread pool to 120 seconds (from the default of 15 seconds).  This avoids the creation of too many threads if requests arrive every 15 seconds, as reported by @cacheworks.  [g_thread_pool_set_max_idle_time](https://developer.gnome.org/glib/stable/glib-Thread-Pools.html#g-thread-pool-set-max-idle-time) sets the idle time for all thread pools but I don't see that as a major issue.