### PR TITLE
RTP Extensions support

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -96,6 +96,14 @@ gboolean janus_ice_is_bundle_forced(void) {
 	return janus_force_bundle;
 }
 
+static gboolean janus_extmap;
+void janus_ice_extmap_support(gboolean extmap) {
+	janus_extmap = extmap;
+	JANUS_LOG(LOG_INFO, "EXTMAP %s going to be enabled\n", janus_extmap ? "is" : "is NOT");
+}
+gboolean janus_ice_is_extmap_enabled(void) {
+	return janus_extmap;
+}
 /* Whether rtcp-mux support is mandatory or not (false by default) */
 static gboolean janus_force_rtcpmux;
 static gint janus_force_rtcpmux_blackhole_port = 1234;
@@ -2712,6 +2720,8 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 		audio_stream->audio_rtcp_ctx->tb = 48000;	/* May change later */
 		audio_stream->video_rtcp_ctx = g_malloc0(sizeof(rtcp_context));
 		audio_stream->video_rtcp_ctx->tb = 90000;
+		memset(audio_stream->aextmaps, 0x00, sizeof(audio_stream->aextmaps));
+		memset(audio_stream->vextmaps, 0x00, sizeof(audio_stream->vextmaps));
 		janus_mutex_init(&audio_stream->mutex);
 		audio_stream->components = g_hash_table_new(NULL, NULL);
 		g_hash_table_insert(handle->streams, GUINT_TO_POINTER(handle->audio_id), audio_stream);
@@ -2865,6 +2875,8 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 		video_stream->video_rtcp_ctx = g_malloc0(sizeof(rtcp_context));
 		video_stream->video_rtcp_ctx->tb = 90000;
 		video_stream->components = g_hash_table_new(NULL, NULL);
+		memset(video_stream->aextmaps, 0x00, sizeof(video_stream->aextmaps));
+		memset(video_stream->vextmaps, 0x00, sizeof(video_stream->vextmaps));
 		janus_mutex_init(&video_stream->mutex);
 		g_hash_table_insert(handle->streams, GUINT_TO_POINTER(handle->video_id), video_stream);
 		if(!have_turnrest_credentials) {

--- a/ice.h
+++ b/ice.h
@@ -136,6 +136,8 @@ void janus_ice_debugging_enable(void);
 /*! \brief Method to disable libnice debugging (the default) */
 void janus_ice_debugging_disable(void);
 
+void janus_ice_extmap_support(gboolean extmap);
+gboolean janus_ice_is_extmap_enabled(void);
 
 /*! \brief Helper method to get a string representation of a libnice ICE state
  * @param[in] state The libnice ICE state
@@ -151,6 +153,8 @@ typedef struct janus_ice_stream janus_ice_stream;
 typedef struct janus_ice_component janus_ice_component;
 /*! \brief Helper to handle pending trickle candidates (e.g., when we're still waiting for an offer) */
 typedef struct janus_ice_trickle janus_ice_trickle;
+/*! \brief Helper */
+typedef struct janus_ice_extmap janus_ice_extmap;
 
 
 #define JANUS_ICE_HANDLE_WEBRTC_PROCESSING_OFFER	(1 << 0)
@@ -170,6 +174,28 @@ typedef struct janus_ice_trickle janus_ice_trickle;
 #define JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO			(1 << 14)
 #define JANUS_ICE_HANDLE_WEBRTC_GOT_OFFER			(1 << 15)
 #define JANUS_ICE_HANDLE_WEBRTC_GOT_ANSWER			(1 << 16)
+
+/*FIXME move to appropriate position */
+/* SDP extmap */
+#define EXTMAP_AUDIO_LEVEL			"urn:ietf:params:rtp-hdrext:ssrc-audio-level"
+#define EXTMAP_TOFFSET				"urn:ietf:params:rtp-hdrext:toffset"
+#define EXTMAP_ABS_SEND_TIME		"http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+#define EXTMAP_VIDEO_ORIENTATION	"urn:3gpp:video-orientation"
+#define EXTMAP_PLAYOUT_DELAY		"http://www.webrtc.org/experiments/rtp-hdrext/playout-delay"
+
+
+enum sdp_direction {
+	SDP_SENDRECV = 0x1,
+	SDP_SENDONLY = 0x2,
+	SDP_RECVONLY = 0x3,
+};
+
+struct janus_ice_extmap {
+	gboolean active;
+	uint8_t id;
+	enum sdp_direction direction;
+	enum extmap_uri_id uri_id;
+};
 
 
 /*! \brief Janus media statistics
@@ -366,6 +392,10 @@ struct janus_ice_stream {
 	janus_ice_component *rtp_component;
 	/*! \brief RTCP component */
 	janus_ice_component *rtcp_component;
+	/*! \brief array of audio extmaps */
+	janus_ice_extmap aextmaps[16];
+	/*! \brief array of video extmaps */
+	janus_ice_extmap vextmaps[16];
 	/*! \brief Helper flag to avoid flooding the console with the same error all over again */
 	gint noerrorlog:1;
 	/*! \brief Mutex to lock/unlock this stream */

--- a/janus.c
+++ b/janus.c
@@ -3497,13 +3497,16 @@ gint main(int argc, char *argv[])
 		}
 	}
 	/* Are we going to force BUNDLE and/or rtcp-mux? */
-	gboolean force_bundle = FALSE, force_rtcpmux = FALSE;
+	gboolean force_bundle = FALSE, force_rtcpmux = FALSE, extmap_support = FALSE;
 	item = janus_config_get_item_drilldown(config, "media", "force-bundle");
 	force_bundle = (item && item->value) ? janus_is_true(item->value) : FALSE;
 	janus_ice_force_bundle(force_bundle);
 	item = janus_config_get_item_drilldown(config, "media", "force-rtcp-mux");
 	force_rtcpmux = (item && item->value) ? janus_is_true(item->value) : FALSE;
 	janus_ice_force_rtcpmux(force_rtcpmux);
+	item = janus_config_get_item_drilldown(config, "media", "extmap-support");
+	extmap_support = (item && item->value) ? janus_is_true(item->value) : FALSE;
+	janus_ice_extmap_support(extmap_support);
 	/* NACK related stuff */
 	item = janus_config_get_item_drilldown(config, "media", "max_nack_queue");
 	if(item && item->value) {

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -1914,13 +1914,56 @@ void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, int video, cha
 		}
 		/* Decode frame (Opus -> slinear) */
 		rtp_header *rtp = (rtp_header *)buf;
+		int rtp_header_len = 12;
+		if(rtp->csrccount) {
+                        rtp_header_len += rtp->csrccount * 4;
+                }
+		if(rtp->extension) {
+                        janus_rtp_header_extension *ext = (janus_rtp_header_extension*) (buf+rtp_header_len);
+                        int rtp_ext_len = ntohs(ext->length) * 4; /* 32-bit words */
+                        rtp_header_len += 4; /* Extension Header */
+                        //JANUS_LOG(LOG_ERR, "[Opus:2] seq:%d t:%u len:%d hlen:%d elen:%d \n", ntohs(rtp->seq_number), ntohl(rtp->timestamp), len, rtp_header_len, rtp_ext_len);
+                        if(len > (rtp_header_len + rtp_ext_len)) {
+                                /* 1-Byte extenstion */
+                                if(ntohs(ext->type) == 0xBEDE) {
+                                        const uint8_t padding = 0x00, reserved = 0xF;
+                                        uint8_t _id, _len;
+                                        uint32_t _val;
+                                        int i = 0;
+                                        while(i < rtp_ext_len) {
+                                                _id = buf[rtp_header_len + i]  >> 4;
+                                                if(_id == reserved) {
+                                                        break;
+                                                } else if(_id == padding) {
+                                                        i++;
+                                                        continue;
+                                                }
+                                                _len = (buf[rtp_header_len + i] & 0xF) + 1;
+                                                /*FIXME: Maintain extmap[id]=uri */
+                                                if(_id == 1) { /* a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level */
+                                                        //_len == 1
+                                                        _val = buf[rtp_header_len + i + 1];
+                                                        //JANUS_LOG(LOG_ERR, " id: %d len:%d _val:%d v:%d level:%d i:%d \n", _id, _len, _val, ((_val >> 7) & 0x1), (_val & 0x7F), i);
+                                                } else if(_id == 3) { /* a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time */
+                                                        //_len == 3
+                                                        _val = 0x00FFFFFF & ntohl(*(uint32_t *)(buf+rtp_header_len + i));
+                                                        //JANUS_LOG(LOG_ERR, " id: %d len:%d _val:%d =%p  in:%p  i:%d \n", _id, _len, _val, _val, *(uint32_t *)(buf+rtp_header_len + i), i);
+                                                }
+                                                i += 1 + _len;
+                                        }
+
+                                } /* else ?? currently no one is supporting 2-Byte extenstions */
+
+                                rtp_header_len += rtp_ext_len;
+                        }
+                }
 		janus_audiobridge_rtp_relay_packet *pkt = g_malloc0(sizeof(janus_audiobridge_rtp_relay_packet));
 		pkt->data = g_malloc0(BUFFER_SAMPLES*sizeof(opus_int16));
 		pkt->ssrc = 0;
 		pkt->timestamp = ntohl(rtp->timestamp);
 		pkt->seq_number = ntohs(rtp->seq_number);
 		participant->working = TRUE;
-		pkt->length = opus_decode(participant->decoder, (const unsigned char *)buf+12, len-12, (opus_int16 *)pkt->data, BUFFER_SAMPLES, USE_FEC);
+		pkt->length = opus_decode(participant->decoder, (const unsigned char *)buf+rtp_header_len, len-rtp_header_len, (opus_int16 *)pkt->data, BUFFER_SAMPLES, USE_FEC);
 		participant->working = FALSE;
 		if(pkt->length < 0) {
 			JANUS_LOG(LOG_ERR, "[Opus] Ops! got an error decoding the Opus frame: %d (%s)\n", pkt->length, opus_strerror(pkt->length));

--- a/plugins/janus_voicemail.c
+++ b/plugins/janus_voicemail.c
@@ -569,7 +569,21 @@ void janus_voicemail_incoming_rtp(janus_plugin_session *handle, int video, char 
 	uint16_t seq = ntohs(rtp->seq_number);
 	if(session->seq == 0)
 		session->seq = seq;
-	ogg_packet *op = op_from_pkt((const unsigned char *)(buf+12), len-12);	/* TODO Check RTP extensions... */
+	int rtp_header_len = 12; 
+        if(rtp->csrccount) {
+                rtp_header_len += rtp->csrccount * 4;
+        }   
+        if(rtp->extension) {
+                janus_rtp_header_extension *ext = (janus_rtp_header_extension*) (buf+rtp_header_len);
+                int rtp_ext_len = ntohs(ext->length) * 4; /* 32-bit words */
+                rtp_header_len += 4; /* Extenstion Header */
+                if(len > (rtp_header_len + rtp_ext_len)) {
+                        rtp_header_len += rtp_ext_len;
+                }   
+        }
+	
+        ogg_packet *op = op_from_pkt((const unsigned char *)(buf+rtp_header_len), len-rtp_header_len);
+	
 	//~ JANUS_LOG(LOG_VERB, "\tWriting at position %d (%d)\n", seq-session->seq+1, 960*(seq-session->seq+1));
 	op->granulepos = 960*(seq-session->seq+1); // FIXME: get this from the toc byte
 	ogg_stream_packetin(session->stream, op);

--- a/plugins/janus_voicemail.c
+++ b/plugins/janus_voicemail.c
@@ -569,21 +569,20 @@ void janus_voicemail_incoming_rtp(janus_plugin_session *handle, int video, char 
 	uint16_t seq = ntohs(rtp->seq_number);
 	if(session->seq == 0)
 		session->seq = seq;
-	int rtp_header_len = 12; 
-        if(rtp->csrccount) {
-                rtp_header_len += rtp->csrccount * 4;
-        }   
-        if(rtp->extension) {
-                janus_rtp_header_extension *ext = (janus_rtp_header_extension*) (buf+rtp_header_len);
-                int rtp_ext_len = ntohs(ext->length) * 4; /* 32-bit words */
-                rtp_header_len += 4; /* Extenstion Header */
-                if(len > (rtp_header_len + rtp_ext_len)) {
-                        rtp_header_len += rtp_ext_len;
-                }   
-        }
-	
-        ogg_packet *op = op_from_pkt((const unsigned char *)(buf+rtp_header_len), len-rtp_header_len);
-	
+	int rtp_header_len = 12;
+	if(rtp->csrccount) {
+		rtp_header_len += rtp->csrccount * 4;
+	}
+
+	if(rtp->extension) {
+		janus_rtp_header_extension *ext = (janus_rtp_header_extension*) (buf+rtp_header_len);
+		int rtp_ext_len = ntohs(ext->length) * 4; /* 32-bit words */
+		rtp_header_len += 4; /* Extenstion Header */
+		if(len > (rtp_header_len + rtp_ext_len)) {
+			rtp_header_len += rtp_ext_len;
+		}
+	}
+	ogg_packet *op = op_from_pkt((const unsigned char *)(buf+rtp_header_len), len-rtp_header_len);
 	//~ JANUS_LOG(LOG_VERB, "\tWriting at position %d (%d)\n", seq-session->seq+1, 960*(seq-session->seq+1));
 	op->granulepos = 960*(seq-session->seq+1); // FIXME: get this from the toc byte
 	ogg_stream_packetin(session->stream, op);

--- a/sdp.c
+++ b/sdp.c
@@ -308,6 +308,10 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp) {
 					JANUS_LOG(LOG_VERB, "Got a sctpmap attribute: %s\n", a->value);
 				}
 #endif
+				if(!strcasecmp(a->name, "extmap")) {
+					/* FIXME Negotiate extmap uri's */
+                                        //JANUS_LOG(LOG_VERB, "[%"SCNu64"] Got a extmap: %s  \n", handle->handle_id, a->value);
+                                }
 			}
 			tempA = tempA->next;
 		}
@@ -863,6 +867,13 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon) {
 		if(m->type == JANUS_SDP_AUDIO) {
 			a = janus_sdp_attribute_create("mid", "%s", handle->audio_mid ? handle->audio_mid : "audio");
 			m->attributes = g_list_insert_before(m->attributes, first, a);
+			/* FIXME it should be dynamic based on Negotiated SDP */
+			/* TODO Move to separate function like https://hg.mozilla.org/integration/mozilla-inbound/rev/5e7f819ed1fe#l10.97 */
+			a  = janus_sdp_attribute_create("extmap", "1 %s", "urn:ietf:params:rtp-hdrext:ssrc-audio-level");
+                        m->attributes = g_list_insert_before(m->attributes, first, a);
+                        a  = janus_sdp_attribute_create("extmap", "3 %s", "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time");
+                        m->attributes = g_list_insert_before(m->attributes, first, a);
+
 		} else if(m->type == JANUS_SDP_VIDEO) {
 			a = janus_sdp_attribute_create("mid", "%s", handle->video_mid ? handle->video_mid : "video");
 			m->attributes = g_list_insert_before(m->attributes, first, a);

--- a/sdp.h
+++ b/sdp.h
@@ -70,6 +70,10 @@ int janus_sdp_parse_candidate(void *stream, const char *candidate, int trickle);
  * @returns 0 in case of success, a non-zero integer in case of an error */
 int janus_sdp_parse_ssrc(void *stream, const char *ssrc_attr, int video);
 
+/*!\brief Method to parse a extmap attribute
+ *  */
+int janus_sdp_parse_extmap(void *ice_stream, char *extmap_attr, int video);
+
 /*! \brief Method to strip/anonymize a session description
  * @param[in,out] sdp The Janus SDP description object to strip/anonymize
  * @returns 0 in case of success, a non-zero integer in case of an error */

--- a/utils.h
+++ b/utils.h
@@ -23,6 +23,16 @@
 #define JANUS_JSON_PARAM_POSITIVE 2
 #define JANUS_JSON_PARAM_NONEMPTY 4
 
+/*! \brief EXTENSION URI's map
+ * placed here to make visible to plugins */
+enum extmap_uri_id {
+	EXTMAP_AUDIO_LEVEL_ID	= 1,
+	EXTMAP_TOFFSET_ID		= 2,
+	EXTMAP_ABS_SEND_TIME_ID = 3,
+	EXTMAP_VIDEO_ORIENT_ID	= 4,
+	EXTMAP_PLAYOUT_DELAY_ID	= 6,
+};
+
 struct janus_json_parameter {
 	const gchar *name;
 	json_type jtype;
@@ -121,6 +131,12 @@ int janus_get_codec_pt(const char *sdp, const char *codec);
  * @param pt The payload type to look for
  * @returns The codec name, if found, NULL otherwise */
 const char *janus_get_codec_from_pt(const char *sdp, int pt);
+
+/*! \brief Ugly and dirty helper to quickly get extension uri id
+ * @param handle is gateway_handle
+ * @param ext_id is extension id 
+ * @param audio is a boolean to differentiate audio/video */
+int janus_ice_extension_id(void* handle, int ext_id, gboolean audio);
 
 /*! \brief Check if the given IP address is valid: family is set to the address family if the IP is valid
  * @param ip The IP address to check


### PR DESCRIPTION
Tried to support WebRTC RTP Extensions as explained in below links.
https://tools.ietf.org/html/rfc5285
https://tools.ietf.org/html/rfc6464
https://webrtc.org/experiments/rtp-hdrext/abs-send-time/

Currently i hard coded the extension uri's & id's,  as am unable to find the right place to do extmap negotiation.

RTP Header Extension for Client-to-Mixer Audio Level is very useful in improving audio bridge quality :+1:  