### PR TITLE
Support for setting an iceTransportPolicy

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -272,6 +272,7 @@ function Janus(gatewayCallbacks) {
 	var iceServers = gatewayCallbacks.iceServers;
 	if(iceServers === undefined || iceServers === null)
 		iceServers = [{urls: "stun:stun.l.google.com:19302"}];
+	var iceTransportPolicy = gatewayCallbacks.iceTransportPolicy;
 	// Whether IPv6 candidates should be gathered
 	var ipv6Support = gatewayCallbacks.ipv6;
 	if(ipv6Support === undefined || ipv6Support === null)
@@ -1237,7 +1238,7 @@ function Janus(gatewayCallbacks) {
 		var config = pluginHandle.webrtcStuff;
 		Janus.debug("streamsDone:", stream);
 		config.myStream = stream;
-		var pc_config = {"iceServers": iceServers};
+		var pc_config = {"iceServers": iceServers, "iceTransportPolicy": iceTransportPolicy};
 		//~ var pc_constraints = {'mandatory': {'MozDontOfferDataChannel':true}};
 		var pc_constraints = {
 			"optional": [{"DtlsSrtpKeyAgreement": true}]

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -318,6 +318,7 @@ function Janus(gatewayCallbacks) {
 	var iceServers = gatewayCallbacks.iceServers;
 	if(iceServers === undefined || iceServers === null)
 		iceServers = [{urls: "stun:stun.l.google.com:19302"}];
+	var iceTransportPolicy = gatewayCallbacks.iceTransportPolicy;
 	// Whether IPv6 candidates should be gathered
 	var ipv6Support = gatewayCallbacks.ipv6;
 	if(ipv6Support === undefined || ipv6Support === null)
@@ -1283,7 +1284,7 @@ function Janus(gatewayCallbacks) {
 		var config = pluginHandle.webrtcStuff;
 		Janus.debug("streamsDone:", stream);
 		config.myStream = stream;
-		var pc_config = {"iceServers": iceServers};
+		var pc_config = {"iceServers": iceServers, "iceTransportPolicy": iceTransportPolicy};
 		//~ var pc_constraints = {'mandatory': {'MozDontOfferDataChannel':true}};
 		var pc_constraints = {
 			"optional": [{"DtlsSrtpKeyAgreement": true}]


### PR DESCRIPTION
Introduces support for setting an iceTransportPolicy parameter on gatewayCallbacks to force a specific policy, such as "relay" which would require the use of a TURN relay. In some restrictive environments, STUN might return ICE candidates that can't successfully receive audio/video. If no parameter is specified, there is no change to the existing behavior.