### PR TITLE
Added support for (some) RTP extensions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,6 +96,7 @@ janus_SOURCES = \
 	record.h \
 	rtcp.c \
 	rtcp.h \
+	rtp.c \
 	rtp.h \
 	sctp.c \
 	sctp.h \

--- a/conf/janus.plugin.audiobridge.cfg.sample
+++ b/conf/janus.plugin.audiobridge.cfg.sample
@@ -4,6 +4,8 @@
 ; secret = <optional password needed for manipulating (e.g. destroying) the room>
 ; pin = <optional password needed for joining the room>
 ; sampling_rate = <sampling rate> (e.g., 16000 for wideband mixing)
+; audiolevel_ext = yes|no (whether the ssrc-audio-level RTP extension must
+;		be negotiated/used or not for new joins, default=yes)
 ; record = true|false (whether this room should be recorded, default=false)
 ; record_file = /path/to/recording.wav (where to save the recording)
 

--- a/conf/janus.plugin.videoroom.cfg.sample
+++ b/conf/janus.plugin.videoroom.cfg.sample
@@ -9,6 +9,12 @@
 ; fir_freq = <send a FIR to publishers every fir_freq seconds> (0=disable)
 ; audiocodec = opus|isac32|isac16|pcmu|pcma (audio codec to force on publishers, default=opus)
 ; videocodec = vp8|vp9|h264 (video codec to force on publishers, default=vp8)
+; audiolevel_ext = yes|no (whether the ssrc-audio-level RTP extension must
+;		be negotiated/used or not for new publishers, default=yes)
+; videoorient_ext = yes|no (whether the video-orientation RTP extension must
+;		be negotiated/used or not for new publishers, default=yes)
+; playoutdelay_ext = yes|no (whether the playout-delay RTP extension must
+;		be negotiated/used or not for new publishers, default=yes)
 ; record = true|false (whether this room should be recorded, default=false)
 ; rec_dir = <folder where recordings should be stored, when enabled>
 

--- a/plugins/janus_voicemail.c
+++ b/plugins/janus_voicemail.c
@@ -569,7 +569,13 @@ void janus_voicemail_incoming_rtp(janus_plugin_session *handle, int video, char 
 	uint16_t seq = ntohs(rtp->seq_number);
 	if(session->seq == 0)
 		session->seq = seq;
-	ogg_packet *op = op_from_pkt((const unsigned char *)(buf+12), len-12);	/* TODO Check RTP extensions... */
+	int plen = 0;
+	const unsigned char *payload = (const unsigned char *)janus_rtp_payload(buf, len, &plen);
+	if(!payload) {
+		JANUS_LOG(LOG_ERR, "Ops! got an error accessing the RTP payload\n");
+		return;
+	}
+	ogg_packet *op = op_from_pkt(payload, plen);
 	//~ JANUS_LOG(LOG_VERB, "\tWriting at position %d (%d)\n", seq-session->seq+1, 960*(seq-session->seq+1));
 	op->granulepos = 960*(seq-session->seq+1); // FIXME: get this from the toc byte
 	ogg_stream_packetin(session->stream, op);

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -374,10 +374,14 @@ int main(int argc, char *argv[])
 		janus_pp_rtp_header *rtp = (janus_pp_rtp_header *)prebuffer;
 		JANUS_LOG(LOG_VERB, "  -- RTP packet (ssrc=%"SCNu32", pt=%"SCNu16", ext=%"SCNu16", seq=%"SCNu16", ts=%"SCNu32")\n",
 				ntohl(rtp->ssrc), rtp->type, rtp->extension, ntohs(rtp->seq_number), ntohl(rtp->timestamp));
+		if(rtp->csrccount) {
+			JANUS_LOG(LOG_VERB, "  -- -- Skipping CSRC list\n");
+			skip += rtp->csrccount*4;
+		}
 		if(rtp->extension) {
 			janus_pp_rtp_header_extension *ext = (janus_pp_rtp_header_extension *)(prebuffer+12);
-		JANUS_LOG(LOG_VERB, "  -- -- RTP extension (type=%"SCNu16", length=%"SCNu16")\n",
-				ntohs(ext->type), ntohs(ext->length)); 
+			JANUS_LOG(LOG_VERB, "  -- -- RTP extension (type=%"SCNu16", length=%"SCNu16")\n",
+				ntohs(ext->type), ntohs(ext->length));
 			skip = 4 + ntohs(ext->length)*4;
 		}
 		/* Generate frame packet and insert in the ordered list */

--- a/postprocessing/pp-webm.c
+++ b/postprocessing/pp-webm.c
@@ -219,7 +219,6 @@ int janus_pp_webm_preprocess(FILE *file, janus_pp_frame_packet *list, int vp8) {
 					}
 				}
 			}
-
 		} else {
 			/* https://tools.ietf.org/html/draft-ietf-payload-vp9 */
 			/* Read the first bytes of the payload, and get the first octet (VP9 Payload Descriptor) */

--- a/rtp.c
+++ b/rtp.c
@@ -1,0 +1,178 @@
+/*! \file    rtp.c
+ * \author   Lorenzo Miniero <lorenzo@meetecho.com>
+ * \copyright GNU General Public License v3
+ * \brief    RTP processing
+ * \details  Implementation of the RTP header. Since the gateway does not
+ * much more than relaying frames around, the only thing we're interested
+ * in is the RTP header and how to get its payload, and parsing extensions.
+ * 
+ * \ingroup protocols
+ * \ref protocols
+ */
+ 
+#include "rtp.h"
+#include "debug.h"
+
+char *janus_rtp_payload(char *buf, int len, int *plen) {
+	if(!buf || len < 12)
+		return NULL;
+
+	rtp_header *rtp = (rtp_header *)buf;
+	int hlen = 12;
+	if(rtp->csrccount)	/* Skip CSRC if needed */
+		hlen += rtp->csrccount*4;
+
+	if(rtp->extension) {
+		janus_rtp_header_extension *ext = (janus_rtp_header_extension*)(buf+hlen);
+		int extlen = ntohs(ext->length)*4;
+		hlen += 4;
+		if(len > (hlen + extlen))
+			hlen += extlen;
+	}
+	if(plen)
+		*plen = len-hlen;
+	return buf+hlen;
+}
+
+int janus_rtp_header_extension_get_id(const char *sdp, const char *extension) {
+	if(!sdp || !extension)
+		return -1;
+	char extmap[100];
+	g_snprintf(extmap, 100, "a=extmap:%%d %s", extension);
+	/* Look for the extmap */
+	const char *line = strstr(sdp, "m=");
+	while(line) {
+		char *next = strchr(line, '\n');
+		if(next) {
+			*next = '\0';
+			if(strstr(line, "a=extmap") && strstr(line, extension)) {
+				/* Gotcha! */
+				int id = 0;
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+				if(sscanf(line, extmap, &id) == 1) {
+#pragma GCC diagnostic warning "-Wformat-nonliteral"
+					*next = '\n';
+					return id;
+				}
+			}
+			*next = '\n';
+		}
+		line = next ? (next+1) : NULL;
+	}
+	return -2;
+}
+
+const char *janus_rtp_header_extension_get_from_id(const char *sdp, int id) {
+	if(!sdp || id < 0)
+		return NULL;
+	/* Look for the mapping */
+	char extmap[100];
+	g_snprintf(extmap, 100, "a=extmap:%d ", id);
+	const char *line = strstr(sdp, "m=");
+	while(line) {
+		char *next = strchr(line, '\n');
+		if(next) {
+			*next = '\0';
+			if(strstr(line, extmap)) {
+				/* Gotcha! */
+				char extension[100];
+				if(sscanf(line, "a=extmap:%d %s", &id, extension) == 2) {
+					*next = '\n';
+					if(strstr(extension, JANUS_RTP_EXTMAP_AUDIO_LEVEL))
+						return JANUS_RTP_EXTMAP_AUDIO_LEVEL;
+					if(strstr(extension, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION))
+						return JANUS_RTP_EXTMAP_VIDEO_ORIENTATION;
+					if(strstr(extension, JANUS_RTP_EXTMAP_PLAYOUT_DELAY))
+						return JANUS_RTP_EXTMAP_PLAYOUT_DELAY;
+					if(strstr(extension, JANUS_RTP_EXTMAP_TOFFSET))
+						return JANUS_RTP_EXTMAP_TOFFSET;
+					if(strstr(extension, JANUS_RTP_EXTMAP_ABS_SEND_TIME))
+						return JANUS_RTP_EXTMAP_ABS_SEND_TIME;
+					if(strstr(extension, JANUS_RTP_EXTMAP_CC_EXTENSIONS))
+						return JANUS_RTP_EXTMAP_CC_EXTENSIONS;
+					JANUS_LOG(LOG_ERR, "Unsupported extension '%s'\n", extension);
+					return NULL;
+				}
+			}
+			*next = '\n';
+		}
+		line = next ? (next+1) : NULL;
+	}
+	return NULL;
+}
+
+static int janus_rtp_header_extension_find(char *buf, int len, int id, uint8_t *byte) {
+	if(!buf || len < 12)
+		return -1;
+	rtp_header *rtp = (rtp_header *)buf;
+	int hlen = 12;
+	if(rtp->csrccount)	/* Skip CSRC if needed */
+		hlen += rtp->csrccount*4;
+	if(rtp->extension) {
+		janus_rtp_header_extension *ext = (janus_rtp_header_extension*)(buf+hlen);
+		int extlen = ntohs(ext->length)*4;
+		hlen += 4;
+		if(len > (hlen + extlen)) {
+			/* 1-Byte extension */
+			if(ntohs(ext->type) == 0xBEDE) {
+				const uint8_t padding = 0x00, reserved = 0xF;
+				uint8_t extid = 0, idlen;
+				int i = 0;
+				while(i < extlen) {
+					extid = buf[hlen+i] >> 4;
+					if(extid == reserved) {
+						break;
+					} else if(extid == padding) {
+						i++;
+						continue;
+					}
+					idlen = (buf[hlen+i] & 0xF)+1;
+					if(extid == id) {
+						/* Found! */
+						if(byte)
+							*byte = buf[hlen+i+1];
+						return 0;
+					}
+					i += 1 + idlen;
+				}
+			}
+			hlen += extlen;
+		}
+	}
+	return -1;
+}
+
+int janus_rtp_header_extension_parse_audio_level(char *buf, int len, int id, int *level) {
+	uint8_t byte = 0;
+	if(janus_rtp_header_extension_find(buf, len, id, &byte) < 0)
+		return -1;
+	/* a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level */
+	int v = (byte & 0x80) >> 7;
+	int value = byte & 0x7F;
+	JANUS_LOG(LOG_DBG, "%02x --> v=%d, level=%d\n", byte, v, value);
+	if(level)
+		*level = value;
+	return 0;
+}
+
+int janus_rtp_header_extension_parse_video_orientation(char *buf, int len, int id,
+		gboolean *c, gboolean *f, gboolean *r1, gboolean *r0) {
+	uint8_t byte = 0;
+	if(janus_rtp_header_extension_find(buf, len, id, &byte) < 0)
+		return -1;
+	/* a=extmap:4 urn:3gpp:video-orientation */
+	gboolean cbit = (byte & 0x08) >> 3;
+	gboolean fbit = (byte & 0x04) >> 2;
+	gboolean r1bit = (byte & 0x02) >> 1;
+	gboolean r0bit = byte & 0x01;
+	JANUS_LOG(LOG_DBG, "%02x --> c=%d, f=%d, r1=%d, r0=%d\n", byte, cbit, fbit, r1bit, r0bit);
+	if(c)
+		*c = cbit;
+	if(f)
+		*f = fbit;
+	if(r1)
+		*r1 = r1bit;
+	if(r0)
+		*r0 = r0bit;
+	return 0;
+}

--- a/rtp.h
+++ b/rtp.h
@@ -2,9 +2,9 @@
  * \author   Lorenzo Miniero <lorenzo@meetecho.com>
  * \copyright GNU General Public License v3
  * \brief    RTP processing (headers)
- * \details  Implementation the RTP header. Since the gateway does not
+ * \details  Implementation of the RTP header. Since the gateway does not
  * much more than relaying frames around, the only thing we're interested
- * in is the RTP header and how to get its payload.
+ * in is the RTP header and how to get its payload, and parsing extensions.
  * 
  * \ingroup protocols
  * \ref protocols
@@ -21,6 +21,7 @@
 #endif
 #include <inttypes.h>
 #include <string.h>
+#include <glib.h>
 
 #define RTP_HEADER_SIZE	12
 
@@ -61,5 +62,58 @@ typedef struct janus_rtp_header_extension {
 	uint16_t type;
 	uint16_t length;
 } janus_rtp_header_extension;
+
+/*! \brief a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level */
+#define JANUS_RTP_EXTMAP_AUDIO_LEVEL		"urn:ietf:params:rtp-hdrext:ssrc-audio-level"
+/*! \brief a=extmap:2 urn:ietf:params:rtp-hdrext:toffset */
+#define JANUS_RTP_EXTMAP_TOFFSET			"urn:ietf:params:rtp-hdrext:toffset"
+/*! \brief a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time */
+#define JANUS_RTP_EXTMAP_ABS_SEND_TIME		"http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+/*! \brief a=extmap:4 urn:3gpp:video-orientation */
+#define JANUS_RTP_EXTMAP_VIDEO_ORIENTATION	"urn:3gpp:video-orientation"
+/*! \brief a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01 */
+#define JANUS_RTP_EXTMAP_CC_EXTENSIONS		"http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
+/*! \brief a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay */
+#define JANUS_RTP_EXTMAP_PLAYOUT_DELAY		"http://www.webrtc.org/experiments/rtp-hdrext/playout-delay"
+
+/*! \brief Helper to quickly access the RTP payload, skipping header and extensions
+ * @param[in] buf The packet data
+ * @param[in] len The packet data length in bytes
+ * @param[out] plen The payload data length in bytes
+ * @returns A pointer to where the payload data starts, or NULL otherwise; plen is also set accordingly */
+char *janus_rtp_payload(char *buf, int len, int *plen);
+
+/*! \brief Ugly and dirty helper to quickly get the id associated with an RTP extension (extmap) in an SDP
+ * @param sdp The SDP to parse
+ * @param extension The extension namespace to look for
+ * @returns The extension id, if found, -1 otherwise */
+int janus_rtp_header_extension_get_id(const char *sdp, const char *extension);
+
+/*! \brief Ugly and dirty helper to quickly get the RTP extension namespace associated with an id (extmap) in an SDP
+ * @note This only looks for the extensions we know about, those defined in rtp.h
+ * @param sdp The SDP to parse
+ * @param id The extension id to look for
+ * @returns The extension namespace, if found, NULL otherwise */
+const char *janus_rtp_header_extension_get_from_id(const char *sdp, int id);
+
+/*! \brief Helper to parse a ssrc-audio-level RTP extension (https://tools.ietf.org/html/rfc6464)
+ * @param[in] buf The packet data
+ * @param[in] len The packet data length in bytes
+ * @param[in] id The extension ID to look for
+ * @param[out] level The level value in dBov (0=max, 127=min)
+ * @returns 0 if found, -1 otherwise */
+int janus_rtp_header_extension_parse_audio_level(char *buf, int len, int id, int *level);
+
+/*! \brief Helper to parse a video-orientation RTP extension (http://www.3gpp.org/ftp/Specs/html-info/26114.htm)
+ * @param[in] buf The packet data
+ * @param[in] len The packet data length in bytes
+ * @param[in] id The extension ID to look for
+ * @param[out] c The value of the Camera (C) bit
+ * @param[out] f The value of the Flip (F) bit
+ * @param[out] r1 The value of the first Rotation (R1) bit
+ * @param[out] r0 The value of the second Rotation (R0) bit
+ * @returns 0 if found, -1 otherwise */
+int janus_rtp_header_extension_parse_video_orientation(char *buf, int len, int id,
+	gboolean *c, gboolean *f, gboolean *r1, gboolean *r0);
 
 #endif

--- a/rtp.h
+++ b/rtp.h
@@ -116,4 +116,14 @@ int janus_rtp_header_extension_parse_audio_level(char *buf, int len, int id, int
 int janus_rtp_header_extension_parse_video_orientation(char *buf, int len, int id,
 	gboolean *c, gboolean *f, gboolean *r1, gboolean *r0);
 
+/*! \brief Helper to parse a playout-delay RTP extension (https://webrtc.org/experiments/rtp-hdrext/playout-delay)
+ * @param[in] buf The packet data
+ * @param[in] len The packet data length in bytes
+ * @param[in] id The extension ID to look for
+ * @param[out] min_delay The minimum delay value
+ * @param[out] max_delay The maximum delay value
+ * @returns 0 if found, -1 otherwise */
+int janus_rtp_header_extension_parse_playout_delay(char *buf, int len, int id,
+	uint16_t *min_delay, uint16_t *max_delay);
+
 #endif

--- a/sdp.c
+++ b/sdp.c
@@ -642,7 +642,6 @@ int janus_sdp_anonymize(janus_sdp *anon) {
 					|| !strcasecmp(a->name, "candidate")
 					|| !strcasecmp(a->name, "ssrc")
 					|| !strcasecmp(a->name, "ssrc-group")
-					|| !strcasecmp(a->name, "extmap")	/* TODO Actually implement RTP extensions */
 					|| !strcasecmp(a->name, "sctpmap")) {
 				m->attributes = g_list_remove(m->attributes, a);
 				tempA = m->attributes;


### PR DESCRIPTION
This PR revisits the effort made by @AjayChoudary in #683. Specifically, it introduces support for RTP header extensions in Janus, trying to make it a bit more integrated with what was already available.

Unlike the original patch, this PR does not keep a map/array of extension IDs, though. Just as the core doesn't mess with payload types, it doesn't interfere with extension IDs either, and leaves negotiation and management of those to plugins. An example of how this can be done is available in both the AudioBridge and VideoRoom plugins, which have been extended to negotiate a few extensions, if provided by the offerer. The AudioBridge negotiates the audio level extension to check if a frame is silence and to keep track of the current audio level. The VideoRoom plugin negotiates audio level and video orientation to just forward those to the viewer (no manipulation done on the server side).

The PR introduces a few new methods in rtp.h that plugins can use:

1. `janus_rtp_payload` allows you to quickly access the RTP payload: it automatically skips extensions and other stuff beyond the common RTP header, and so might be useful to avoid issues like assuming the data is simply 12 bytes away (which is what we did in a couple of plugins).
2. `janus_rtp_header_extension_get_id` is a quick'n'dirty method to find the extension ID associated with a namespace (e.g., `"urn:ietf:params:rtp-hdrext:ssrc-audio-level"`) from an SDP string; it might be useful as a quick alternative to parsing the SDP and traversing it using the SDP utils (which is what the VideoRoom plugin does instead) to get the ID, which is needed when you have to negotiate the feature and make sure you use the same ID in an answer.
3. `janus_rtp_header_extension_get_from_id` does the opposite: you pass the numeric ID and you get back the extension namespace (assuming the extension is defined in rtp.h, otherwise we fail).

There also are a couple of methods to actually parse an RTP extension:

1. `janus_rtp_header_extension_parse_audio_level` parses an audio level RTP extension, returning the value (in dBov) reported in there.
2. `janus_rtp_header_extension_parse_video_orientation` parses a video orientation RTP extension, returning the values (camera, flip, rotation) reported in there (couldn't test this one as even negotiating it I never got any of those, so feedback welcome on the accuracy).

I plan to merge this quite soon, so please let me know if there's anything that needs to be fixed or improved. I'm not aware of any issue with the existing demos and none should appear, but you never know if this can end up breaking something else (e.g., external applications making assumptions on the RTP they get from Janus plugins).