### PR TITLE
Autodetect libsrtp version (1.5.x vs 2.0.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ on Ubuntu or Debian, unless you're using a recent version (e.g., Ubuntu
 14.04 LTS). In that case, you'll have to [install it manually](http://www.opus-codec.org).
 
 If your distro ships a pre-1.5 version of libsrtp, it may be better to
-uninstall that version and [install 1.5 manually](https://github.com/cisco/libsrtp/releases).
+uninstall that version and [install 1.5 or 2.0.0 manually](https://github.com/cisco/libsrtp/releases).
 In fact, 1.4.x is known to cause several issues with WebRTC. Installation
-is quite straightforward:
+of version 1.5.4 is quite straightforward:
 
 	wget https://github.com/cisco/libsrtp/archive/v1.5.4.tar.gz
 	tar xfv v1.5.4.tar.gz
@@ -85,8 +85,21 @@ is quite straightforward:
 	./configure --prefix=/usr --enable-openssl
 	make shared_library && sudo make install
 
-* *Note:* you may need to pass --libdir=/usr/lib64 to the configure
-script if you're installing on a x86_64 distribution.
+The instructions for version 2.0.0 is practically the same:
+
+	wget https://github.com/cisco/libsrtp/archive/v2.0.0.tar.gz
+	tar xfv v2.0.0.tar.gz
+	cd libsrtp-2.0.0
+	./configure --prefix=/usr --enable-openssl
+	make shared_library && sudo make install
+
+The Janus configure script autodetects which one you have installed and
+links to the correct library automatically, choosing v2.0.0 if both are
+installed. If you want v1.5.4 to be picked, pass `--disable-libsrtp2`
+when configuring Janus to force it to use the older version instead.
+
+* *Note:* when installing libsrtp, no matter which version, you may need to pass
+--libdir=/usr/lib64 to the configure script if you're installing on a x86_64 distribution.
 
 If you want to make use of BoringSSL instead of OpenSSL (e.g., because
 you want to take advantage of `--enable-dtls-settimeout`), you'll have

--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,12 @@ AC_ARG_ENABLE([boringssl],
               [],
               [enable_boringssl=no])
 
+AC_ARG_ENABLE([libsrtp2],
+              [AS_HELP_STRING([--enable-libsrtp2],
+                              [Use libsrtp 2.0.x instead of libsrtp 1.5.x])],
+              [],
+              [enable_libsrtp2=maybe])
+
 AC_ARG_ENABLE([dtls-settimeout],
               [AS_HELP_STRING([--enable-dtls-settimeout],
                               [Use DTLSv1_set_initial_timeout_duration (only available in recent BoringSSL versions)])],
@@ -141,10 +147,42 @@ AC_CHECK_LIB([dl],
              [JANUS_MANUAL_LIBS+=" -ldl"],
              [AC_MSG_ERROR([libdl not found.])])
 
-AC_CHECK_LIB([srtp],
-             [srtp_init],
-             [JANUS_MANUAL_LIBS+=" -lsrtp"],
-             [AC_MSG_ERROR([libsrtp not found.])])
+AM_CONDITIONAL([ENABLE_LIBSRTP_2], false)
+AS_IF([test "x$enable_libsrtp2" != "xno"],
+      [AC_CHECK_LIB([srtp2],
+                    [srtp_init],
+                    [
+                      AC_CHECK_HEADER([srtp2/srtp.h],
+                                      [
+                                        AC_DEFINE(HAVE_SRTP_2)
+                                        JANUS_MANUAL_LIBS+=" -lsrtp2"
+                                        enable_libsrtp2=yes
+                                        AM_CONDITIONAL([ENABLE_LIBSRTP_2], true)
+                                      ],
+                                      [
+                                        AS_IF([test "x$enable_libsrtp2" = "xyes"],
+                                              [AC_MSG_ERROR([libsrtp2 headers not found. See README.md for installation instructions or use --disable-libsrtp-2 to try and autodetect libsrtp 1.5.x instead])])
+                                      ])
+                    ],
+                    [
+                      AS_IF([test "x$enable_libsrtp2" = "xyes"],
+                            [AC_MSG_ERROR([libsrtp2 not found. See README.md for installation instructions or use --disable-libsrtp-2 to try and autodetect libsrtp 1.5.x instead])])
+                    ])
+      ])
+AM_COND_IF([ENABLE_LIBSRTP_2],
+           [],
+           [AC_CHECK_LIB([srtp],
+                         [srtp_init],
+                         [
+                           AC_CHECK_HEADER([srtp/srtp.h],
+                                           [
+                                             JANUS_MANUAL_LIBS+=" -lsrtp"
+                                             enable_libsrtp2=no
+                                           ],
+                                           [AC_MSG_ERROR([libsrtp and libsrtp2 headers not found. See README.md for installation instructions])])
+                         ],
+                         [AC_MSG_ERROR([libsrtp and libsrtp2 not found. See README.md for installation instructions])])
+           ])
 
 AC_CHECK_LIB([usrsctp],
              [usrsctp_finish],
@@ -461,12 +499,15 @@ AC_OUTPUT
 ##
 echo
 
+AM_COND_IF([ENABLE_LIBSRTP_2],
+	[echo "libsrtp version:           2.0.x"],
+	[echo "libsrtp version:           1.5.x"])
+AM_COND_IF([ENABLE_BORINGSSL],
+	[echo "SSL/crypto library:        BoringSSL"],
+	[echo "SSL/crypto library:        OpenSSL"])
 AM_COND_IF([ENABLE_SCTP],
 	[echo "DataChannels support:      yes"],
 	[echo "DataChannels support:      no"])
-AM_COND_IF([ENABLE_BORINGSSL],
-	[echo "BoringSSL (no OpenSSL):    yes"],
-	[echo "BoringSSL (no OpenSSL):    no"])
 AM_COND_IF([ENABLE_POST_PROCESSING],
 	[echo "Recordings post-processor: yes"],
 	[echo "Recordings post-processor: no"])

--- a/dtls.c
+++ b/dtls.c
@@ -27,6 +27,33 @@
 /* SRTP stuff (http://tools.ietf.org/html/rfc3711) */
 static const char *janus_srtp_error[] =
 {
+#ifdef HAVE_SRTP_2
+	"srtp_err_status_ok",
+	"srtp_err_status_fail",
+	"srtp_err_status_bad_param",
+	"srtp_err_status_alloc_fail",
+	"srtp_err_status_dealloc_fail",
+	"srtp_err_status_init_fail",
+	"srtp_err_status_terminus",
+	"srtp_err_status_auth_fail",
+	"srtp_err_status_cipher_fail",
+	"srtp_err_status_replay_fail",
+	"srtp_err_status_replay_old",
+	"srtp_err_status_algo_fail",
+	"srtp_err_status_no_such_op",
+	"srtp_err_status_no_ctx",
+	"srtp_err_status_cant_check",
+	"srtp_err_status_key_expired",
+	"srtp_err_status_socket_err",
+	"srtp_err_status_signal_err",
+	"srtp_err_status_nonce_bad",
+	"srtp_err_status_read_fail",
+	"srtp_err_status_write_fail",
+	"srtp_err_status_parse_err",
+	"srtp_err_status_encode_err",
+	"srtp_err_status_semaphore_err",
+	"srtp_err_status_pfkey_err",
+#else
 	"err_status_ok",
 	"err_status_fail",
 	"err_status_bad_param",
@@ -52,6 +79,7 @@ static const char *janus_srtp_error[] =
 	"err_status_encode_err",
 	"err_status_semaphore_err",
 	"err_status_pfkey_err",
+#endif
 };
 const gchar *janus_get_srtp_error(int error) {
 	if(error < 0 || error > 24)
@@ -396,7 +424,11 @@ gint janus_dtls_srtp_init(const char* server_pem, const char* server_key) {
 	}
 
 	/* Initialize libsrtp */
+#ifdef HAVE_SRTP_2
+	if(srtp_init() != srtp_err_status_ok) {
+#else
 	if(srtp_init() != err_status_ok) {
+#endif
 		JANUS_LOG(LOG_FATAL, "Ops, error setting up libsrtp?\n");
 		return 5;
 	}
@@ -668,8 +700,13 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 					}
 					/* Build master keys and set SRTP policies */
 						/* Remote (inbound) */
+#ifdef HAVE_SRTP_2
+					srtp_crypto_policy_set_rtp_default(&(dtls->remote_policy.rtp));
+					srtp_crypto_policy_set_rtcp_default(&(dtls->remote_policy.rtcp));
+#else
 					crypto_policy_set_rtp_default(&(dtls->remote_policy.rtp));
 					crypto_policy_set_rtcp_default(&(dtls->remote_policy.rtcp));
+#endif
 					dtls->remote_policy.ssrc.type = ssrc_any_inbound;
 					unsigned char remote_policy_key[SRTP_MASTER_LENGTH];
 					dtls->remote_policy.key = (unsigned char *)&remote_policy_key;
@@ -681,8 +718,13 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 #endif
 					dtls->remote_policy.next = NULL;
 						/* Local (outbound) */
+#ifdef HAVE_SRTP_2
+					srtp_crypto_policy_set_rtp_default(&(dtls->local_policy.rtp));
+					srtp_crypto_policy_set_rtcp_default(&(dtls->local_policy.rtcp));
+#else
 					crypto_policy_set_rtp_default(&(dtls->local_policy.rtp));
 					crypto_policy_set_rtcp_default(&(dtls->local_policy.rtcp));
+#endif
 					dtls->local_policy.ssrc.type = ssrc_any_outbound;
 					unsigned char local_policy_key[SRTP_MASTER_LENGTH];
 					dtls->local_policy.key = (unsigned char *)&local_policy_key;
@@ -694,8 +736,13 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 #endif
 					dtls->local_policy.next = NULL;
 					/* Create SRTP sessions */
+#ifdef HAVE_SRTP_2
+					srtp_err_status_t res = srtp_create(&(dtls->srtp_in), &(dtls->remote_policy));
+					if(res != srtp_err_status_ok) {
+#else
 					err_status_t res = srtp_create(&(dtls->srtp_in), &(dtls->remote_policy));
 					if(res != err_status_ok) {
+#endif
 						/* Something went wrong... */
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Oops, error creating inbound SRTP session for component %d in stream %d??\n", handle->handle_id, component->component_id, stream->stream_id);
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"]  -- %d (%s)\n", handle->handle_id, res, janus_get_srtp_error(res));
@@ -703,7 +750,11 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 					}
 					JANUS_LOG(LOG_VERB, "[%"SCNu64"] Created inbound SRTP session for component %d in stream %d\n", handle->handle_id, component->component_id, stream->stream_id);
 					res = srtp_create(&(dtls->srtp_out), &(dtls->local_policy));
+#ifdef HAVE_SRTP_2
+					if(res != srtp_err_status_ok) {
+#else
 					if(res != err_status_ok) {
+#endif
 						/* Something went wrong... */
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Oops, error creating outbound SRTP session for component %d in stream %d??\n", handle->handle_id, component->component_id, stream->stream_id);
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"]  -- %d (%s)\n", handle->handle_id, res, janus_get_srtp_error(res));

--- a/dtls.c
+++ b/dtls.c
@@ -424,11 +424,7 @@ gint janus_dtls_srtp_init(const char* server_pem, const char* server_key) {
 	}
 
 	/* Initialize libsrtp */
-#ifdef HAVE_SRTP_2
 	if(srtp_init() != srtp_err_status_ok) {
-#else
-	if(srtp_init() != err_status_ok) {
-#endif
 		JANUS_LOG(LOG_FATAL, "Ops, error setting up libsrtp?\n");
 		return 5;
 	}
@@ -700,13 +696,8 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 					}
 					/* Build master keys and set SRTP policies */
 						/* Remote (inbound) */
-#ifdef HAVE_SRTP_2
 					srtp_crypto_policy_set_rtp_default(&(dtls->remote_policy.rtp));
 					srtp_crypto_policy_set_rtcp_default(&(dtls->remote_policy.rtcp));
-#else
-					crypto_policy_set_rtp_default(&(dtls->remote_policy.rtp));
-					crypto_policy_set_rtcp_default(&(dtls->remote_policy.rtcp));
-#endif
 					dtls->remote_policy.ssrc.type = ssrc_any_inbound;
 					unsigned char remote_policy_key[SRTP_MASTER_LENGTH];
 					dtls->remote_policy.key = (unsigned char *)&remote_policy_key;
@@ -718,13 +709,8 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 #endif
 					dtls->remote_policy.next = NULL;
 						/* Local (outbound) */
-#ifdef HAVE_SRTP_2
 					srtp_crypto_policy_set_rtp_default(&(dtls->local_policy.rtp));
 					srtp_crypto_policy_set_rtcp_default(&(dtls->local_policy.rtcp));
-#else
-					crypto_policy_set_rtp_default(&(dtls->local_policy.rtp));
-					crypto_policy_set_rtcp_default(&(dtls->local_policy.rtcp));
-#endif
 					dtls->local_policy.ssrc.type = ssrc_any_outbound;
 					unsigned char local_policy_key[SRTP_MASTER_LENGTH];
 					dtls->local_policy.key = (unsigned char *)&local_policy_key;
@@ -736,13 +722,8 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 #endif
 					dtls->local_policy.next = NULL;
 					/* Create SRTP sessions */
-#ifdef HAVE_SRTP_2
 					srtp_err_status_t res = srtp_create(&(dtls->srtp_in), &(dtls->remote_policy));
 					if(res != srtp_err_status_ok) {
-#else
-					err_status_t res = srtp_create(&(dtls->srtp_in), &(dtls->remote_policy));
-					if(res != err_status_ok) {
-#endif
 						/* Something went wrong... */
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Oops, error creating inbound SRTP session for component %d in stream %d??\n", handle->handle_id, component->component_id, stream->stream_id);
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"]  -- %d (%s)\n", handle->handle_id, res, janus_get_srtp_error(res));
@@ -750,11 +731,7 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 					}
 					JANUS_LOG(LOG_VERB, "[%"SCNu64"] Created inbound SRTP session for component %d in stream %d\n", handle->handle_id, component->component_id, stream->stream_id);
 					res = srtp_create(&(dtls->srtp_out), &(dtls->local_policy));
-#ifdef HAVE_SRTP_2
 					if(res != srtp_err_status_ok) {
-#else
-					if(res != err_status_ok) {
-#endif
 						/* Something went wrong... */
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Oops, error creating outbound SRTP session for component %d in stream %d??\n", handle->handle_id, component->component_id, stream->stream_id);
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"]  -- %d (%s)\n", handle->handle_id, res, janus_get_srtp_error(res));

--- a/dtls.h
+++ b/dtls.h
@@ -22,6 +22,12 @@
 #include <srtp2/srtp.h>
 #else
 #include <srtp/srtp.h>
+#define srtp_err_status_t err_status_t
+#define srtp_err_status_ok err_status_ok
+#define srtp_err_status_replay_fail err_status_replay_fail
+#define srtp_err_status_replay_old err_status_replay_old
+#define srtp_crypto_policy_set_rtp_default crypto_policy_set_rtp_default
+#define srtp_crypto_policy_set_rtcp_default crypto_policy_set_rtcp_default
 #endif
 
 #include "sctp.h"

--- a/dtls.h
+++ b/dtls.h
@@ -17,7 +17,12 @@
 
 #include <inttypes.h>
 #include <glib.h>
+
+#ifdef HAVE_SRTP_2
+#include <srtp2/srtp.h>
+#else
 #include <srtp/srtp.h>
+#endif
 
 #include "sctp.h"
 #include "dtls-bio.h"

--- a/ice.c
+++ b/ice.c
@@ -1838,15 +1838,9 @@ void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint component_i
 			}
 
 			int buflen = len;
-#ifdef HAVE_SRTP_2
 			srtp_err_status_t res = srtp_unprotect(component->dtls->srtp_in, buf, &buflen);
 			if(res != srtp_err_status_ok) {
 				if(res != srtp_err_status_replay_fail && res != srtp_err_status_replay_old) {
-#else
-			err_status_t res = srtp_unprotect(component->dtls->srtp_in, buf, &buflen);
-			if(res != err_status_ok) {
-				if(res != err_status_replay_fail && res != err_status_replay_old) {
-#endif
 					/* Only print the error if it's not a 'replay fail' or 'replay old' (which is probably just the result of us NACKing a packet) */
 					rtp_header *header = (rtp_header *)buf;
 					guint32 timestamp = ntohl(header->timestamp);
@@ -2025,13 +2019,8 @@ void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint component_i
 			JANUS_LOG(LOG_WARN, "[%"SCNu64"]     Missing valid SRTP session (packet arrived too early?), skipping...\n", handle->handle_id);
 		} else {
 			int buflen = len;
-#ifdef HAVE_SRTP_2
 			srtp_err_status_t res = srtp_unprotect_rtcp(component->dtls->srtp_in, buf, &buflen);
 			if(res != srtp_err_status_ok) {
-#else
-			err_status_t res = srtp_unprotect_rtcp(component->dtls->srtp_in, buf, &buflen);
-			if(res != err_status_ok) {
-#endif
 				JANUS_LOG(LOG_ERR, "[%"SCNu64"]     SRTCP unprotect error: %s (len=%d-->%d)\n", handle->handle_id, janus_get_srtp_error(res), len, buflen);
 			} else {
 				/* Is this audio or video? */
@@ -3410,11 +3399,7 @@ void *janus_ice_send_thread(void *data) {
 					janus_mutex_unlock(&component->dtls->srtp_mutex);
 				}
 				//~ JANUS_LOG(LOG_VERB, "[%"SCNu64"] ... SRTCP protect %s (len=%d-->%d)...\n", handle->handle_id, janus_get_srtp_error(res), pkt->length, protected);
-#ifdef HAVE_SRTP_2
 				if(res != srtp_err_status_ok) {
-#else
-				if(res != err_status_ok) {
-#endif
 					JANUS_LOG(LOG_ERR, "[%"SCNu64"] ... SRTCP protect error... %s (len=%d-->%d)...\n", handle->handle_id, janus_get_srtp_error(res), pkt->length, protected);
 				} else {
 					/* Shoot! */
@@ -3494,11 +3479,7 @@ void *janus_ice_send_thread(void *data) {
 					int protected = pkt->length;
 					int res = srtp_protect(component->dtls->srtp_out, sbuf, &protected);
 					//~ JANUS_LOG(LOG_VERB, "[%"SCNu64"] ... SRTP protect %s (len=%d-->%d)...\n", handle->handle_id, janus_get_srtp_error(res), pkt->length, protected);
-#ifdef HAVE_SRTP_2
 					if(res != srtp_err_status_ok) {
-#else
-					if(res != err_status_ok) {
-#endif
 						rtp_header *header = (rtp_header *)sbuf;
 						guint32 timestamp = ntohl(header->timestamp);
 						guint16 seq = ntohs(header->seq_number);

--- a/ice.c
+++ b/ice.c
@@ -1838,9 +1838,15 @@ void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint component_i
 			}
 
 			int buflen = len;
+#ifdef HAVE_SRTP_2
+			srtp_err_status_t res = srtp_unprotect(component->dtls->srtp_in, buf, &buflen);
+			if(res != srtp_err_status_ok) {
+				if(res != srtp_err_status_replay_fail && res != srtp_err_status_replay_old) {
+#else
 			err_status_t res = srtp_unprotect(component->dtls->srtp_in, buf, &buflen);
 			if(res != err_status_ok) {
 				if(res != err_status_replay_fail && res != err_status_replay_old) {
+#endif
 					/* Only print the error if it's not a 'replay fail' or 'replay old' (which is probably just the result of us NACKing a packet) */
 					rtp_header *header = (rtp_header *)buf;
 					guint32 timestamp = ntohl(header->timestamp);
@@ -2019,8 +2025,13 @@ void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint component_i
 			JANUS_LOG(LOG_WARN, "[%"SCNu64"]     Missing valid SRTP session (packet arrived too early?), skipping...\n", handle->handle_id);
 		} else {
 			int buflen = len;
+#ifdef HAVE_SRTP_2
+			srtp_err_status_t res = srtp_unprotect_rtcp(component->dtls->srtp_in, buf, &buflen);
+			if(res != srtp_err_status_ok) {
+#else
 			err_status_t res = srtp_unprotect_rtcp(component->dtls->srtp_in, buf, &buflen);
 			if(res != err_status_ok) {
+#endif
 				JANUS_LOG(LOG_ERR, "[%"SCNu64"]     SRTCP unprotect error: %s (len=%d-->%d)\n", handle->handle_id, janus_get_srtp_error(res), len, buflen);
 			} else {
 				/* Is this audio or video? */
@@ -3399,7 +3410,11 @@ void *janus_ice_send_thread(void *data) {
 					janus_mutex_unlock(&component->dtls->srtp_mutex);
 				}
 				//~ JANUS_LOG(LOG_VERB, "[%"SCNu64"] ... SRTCP protect %s (len=%d-->%d)...\n", handle->handle_id, janus_get_srtp_error(res), pkt->length, protected);
+#ifdef HAVE_SRTP_2
+				if(res != srtp_err_status_ok) {
+#else
 				if(res != err_status_ok) {
+#endif
 					JANUS_LOG(LOG_ERR, "[%"SCNu64"] ... SRTCP protect error... %s (len=%d-->%d)...\n", handle->handle_id, janus_get_srtp_error(res), pkt->length, protected);
 				} else {
 					/* Shoot! */
@@ -3479,7 +3494,11 @@ void *janus_ice_send_thread(void *data) {
 					int protected = pkt->length;
 					int res = srtp_protect(component->dtls->srtp_out, sbuf, &protected);
 					//~ JANUS_LOG(LOG_VERB, "[%"SCNu64"] ... SRTP protect %s (len=%d-->%d)...\n", handle->handle_id, janus_get_srtp_error(res), pkt->length, protected);
+#ifdef HAVE_SRTP_2
+					if(res != srtp_err_status_ok) {
+#else
 					if(res != err_status_ok) {
+#endif
 						rtp_header *header = (rtp_header *)sbuf;
 						guint32 timestamp = ntohl(header->timestamp);
 						guint16 seq = ntohs(header->seq_number);


### PR DESCRIPTION
This PR modifies the configure script to allow it to autodetect which version of libsrtp is installed (1.5.4 and/or 2.0.0), and link to the correct one. Considering both could be installed at the same time (libsrtp2 uses different folders and a different shared object name), the configure script tries to first look for libsrtp2 and, if that's not available, libsrtp. A new configure flag, `--disable-libsrtp2`, is available in case you have v2.0.0 installed but want Janus to still use v1.5.4 anyway.

Apart from that, there are no changes to the code. I was under the assumption that libsrtp 2.0.0 had introduced some API changes, but I couldn't find any in the version I got from the [releases](https://github.com/cisco/libsrtp/releases) page. Not sure if the development/master version differs substantially from that one, and if we should account for that in the code itself.

Feedback welcome, as usual, in particular if you've played with libsrtp 2.0.0 yourself.