### PR TITLE
IInclude publisher's audio_ssrc and video_ssrc in plugin_videoroom listparticipants

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1717,6 +1717,10 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 			if(p->display)
 				json_object_set_new(pl, "display", json_string(p->display));
 			json_object_set_new(pl, "publisher", (p->sdp && p->session->started) ? json_true() : json_false());
+			if ((p->sdp && p->session->started)) {
+				json_object_set_new(pl, "internal_audio_ssrc", json_integer(p->audio_ssrc));
+				json_object_set_new(pl, "internal_video_ssrc", json_integer(p->video_ssrc));
+			}
 			json_array_append_new(list, pl);
 		}
 		janus_mutex_unlock(&videoroom->participants_mutex);


### PR DESCRIPTION
Right now I have each user join a room 1 publisher only, no other participants. Then they choose to forward RTP traffic as they please. The destination box has just a single audio and a single video listener, and I use the ssrc to filter streams (instead of managed ports)

I couldn't find another way to get the ssrc, and this seemed the most sensible place to put it (I think).