### PR TITLE
MacOS endianness issue on RTP header

### DIFF
--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -50,7 +50,11 @@
  */
 
 #include <arpa/inet.h>
+#ifdef __MACH__
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <inttypes.h>
 #include <string.h>
 #include <stdlib.h>

--- a/postprocessing/pp-g711.c
+++ b/postprocessing/pp-g711.c
@@ -10,7 +10,11 @@
  */
 
 #include <arpa/inet.h>
+#ifdef __MACH__
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <inttypes.h>
 #include <string.h>
 #include <stdlib.h>

--- a/postprocessing/pp-h264.c
+++ b/postprocessing/pp-h264.c
@@ -10,7 +10,11 @@
  */
 
 #include <arpa/inet.h>
+#ifdef __MACH__
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <inttypes.h>
 #include <string.h>
 #include <stdlib.h>

--- a/postprocessing/pp-opus.c
+++ b/postprocessing/pp-opus.c
@@ -10,7 +10,11 @@
  */
 
 #include <arpa/inet.h>
+#ifdef __MACH__
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <inttypes.h>
 #include <string.h>
 #include <stdlib.h>

--- a/postprocessing/pp-srt.c
+++ b/postprocessing/pp-srt.c
@@ -10,7 +10,11 @@
  */
 
 #include <arpa/inet.h>
+#ifdef __MACH__
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <inttypes.h>
 #include <string.h>
 #include <stdlib.h>

--- a/postprocessing/pp-webm.c
+++ b/postprocessing/pp-webm.c
@@ -10,7 +10,11 @@
  */
 
 #include <arpa/inet.h>
+#ifdef __MACH__
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <inttypes.h>
 #include <string.h>
 #include <stdlib.h>

--- a/rtp.h
+++ b/rtp.h
@@ -16,6 +16,9 @@
 #include <arpa/inet.h>
 #ifdef __MACH__
 #include <machine/endian.h>
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
 #else
 #include <endian.h>
 #endif


### PR DESCRIPTION
Hi,

this patch fixes RTP header endianness issue on MacOSx. This is the reason why for instance videoroom plugin is not working on MacOSx (all the plugins that do modify the first bytes of the RTP header are failing). This is related to the issue described in this post:
https://groups.google.com/forum/#!searchin/meetecho-janus/mac$20no$20video%7Csort:relevance/meetecho-janus/9hP72hTTKk0/_ujmXPJPPAAJ

We actually experienced exactly the same problem on our macosx (v10.11.6) and this fix solved the problem for us. It also fixes all the dropping errors ("Not video and not audio, dropping (SSRC ...").
Only rtp.h needs to be modified, other changes in this pull request are related to postprocessing tool.
The problem with rtp.h is due to the fact that __{BYTE_ORDER, LITTLE_ENDIAN, BIG_ENDIAN} are not defined on MacOS.

Thanks,

Emmanuel.