### PR TITLE
Fix test pipeline for the streams plugin

### DIFF
--- a/plugins/streams/test_gstreamer_1.sh
+++ b/plugins/streams/test_gstreamer_1.sh
@@ -7,5 +7,5 @@ gst-launch-1.0 \
   videotestsrc ! \
     video/x-raw,width=320,height=240,framerate=15/1 ! \
     videoscale ! videorate ! videoconvert ! timeoverlay ! \
-    vp8enc error-resilient=true ! \
+    vp8enc error-resilient=1 ! \
       rtpvp8pay ! udpsink host=127.0.0.1 port=5004


### PR DESCRIPTION
error-resilient expect a flag, not a boolean.