### PR TITLE
Matching VideoRoom subscribers to participants

### DIFF
--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -55,6 +55,8 @@ var started = false;
 var myusername = null;
 var myid = null;
 var mystream = null;
+// We use this other ID just to map our subscriptions to us
+var mypvtid = null;
 
 var feeds = [];
 var bitrateTimer = [];
@@ -138,6 +140,7 @@ $(document).ready(function() {
 										if(event === "joined") {
 											// Publisher/manager created, negotiate WebRTC and attach to existing feeds, if any
 											myid = msg["id"];
+											mypvtid = msg["private_id"];
 											Janus.log("Successfully joined room " + msg["room"] + " with ID " + myid);
 											publishOwnFeed(true);
 											// Any new feed to attach to?
@@ -381,7 +384,7 @@ function newRemoteFeed(id, display) {
 				Janus.log("Plugin attached! (" + remoteFeed.getPlugin() + ", id=" + remoteFeed.getId() + ")");
 				Janus.log("  -- This is a subscriber");
 				// We wait for the plugin to send us an offer
-				var listen = { "request": "join", "room": 1234, "ptype": "listener", "feed": id };
+				var listen = { "request": "join", "room": 1234, "ptype": "listener", "feed": id, "private_id": mypvtid };
 				remoteFeed.send({"message": listen});
 			},
 			error: function(error) {


### PR DESCRIPTION
One thing I noticed when playing with event handlers and plugins is that there sometime is some missing context information that would be helpful to have instead. Among this, we currently have no way to understand who a specific viewer handle in a VideoRoom belongs to: we do know who they are subscribed to, but not if it's a watch stream I created or somebody else. Relying on the session alone doesn't help, as there are applications that aggregate handles from different users in the same sessions (e.g., server side applications).

This PR tries to address this, adding a new private identifier that the participant can use to clarify a subscription belongs to them. Besides providing a better overview of how a VideoRoom is happening (who's publishing, and who's getting/not getting who?), this way if there's any trouble, e.g., ICE failures and things like that, you have more context too.

You may be wondering why not re-use the already existing participant ID for the purpose. The reason for this is is that the participant ID is known to everybody in the room, and I wanted something harder to "abuse" (not that there may be any particular reason to abuse the feature, if not to be annoying...). As such, the idea is that when you join as a participant, you get your ID as before, and you also get a new ID back called `private_id`. Then, if you want, every time you subscribe to somebody else in the room you add the same `private_id` in the request as well. The plugin does nothing with this identifier (no validation), but only stores it, and uses it when notifying handlers. This way, handlers and related applications can use this private identifier to know which handles belong to you as a participant in the room.

This feature is absolutely optional: passing the `private_id` or not when subscribing results in no change at all in the user experience. As anticipated, it's just a feature that allows for a better matching of some of the handles in the VideoRoom, something I believe would definitely help in monitoring and troubleshooting based on handlers. I plan to merge this soon, since this is pretty harmless, and the idea is to write a new blog post on event handlers soon to show this in use to debug a VideoRoom live.

Feedback welcome!