### PR TITLE
Opaque identifier to contextualise handles

### DIFF
--- a/events.c
+++ b/events.c
@@ -111,6 +111,11 @@ void janus_events_notify_handlers(int type, guint64 session_id, ...) {
 			json_object_set_new(body, "name", json_string(name));
 			char *plugin = va_arg(args, char *);
 			json_object_set_new(body, "plugin", json_string(plugin));
+			/* Handle-related events may include an opaque ID provided by who's using the plugin:
+			 * in event handlers, it may be useful for inter-handle mappings or other things */
+			char *opaque_id = va_arg(args, char *);
+			if(opaque_id != NULL)
+				json_object_set_new(body, "opaque_id", json_string(opaque_id));
 			break;
 		}
 		case JANUS_EVENT_TYPE_JSEP: {

--- a/html/janus.js
+++ b/html/janus.js
@@ -792,8 +792,9 @@ function Janus(gatewayCallbacks) {
 			callbacks.error("Invalid plugin");
 			return;
 		}
+		var opaqueId = callbacks.opaqueId;
 		var transaction = randomString(12);
-		var request = { "janus": "attach", "plugin": plugin, "transaction": transaction };
+		var request = { "janus": "attach", "plugin": plugin, "opaque_id": opaqueId, "transaction": transaction };
 		if(token !== null && token !== undefined)
 			request["token"] = token;
 		if(apisecret !== null && apisecret !== undefined)

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -834,8 +834,9 @@ function Janus(gatewayCallbacks) {
 			callbacks.error("Invalid plugin");
 			return;
 		}
+		var opaqueId = callbacks.opaqueId;
 		var transaction = randomString(12);
-		var request = { "janus": "attach", "plugin": plugin, "transaction": transaction };
+		var request = { "janus": "attach", "plugin": plugin, "opaque_id": opaqueId, "transaction": transaction };
 		if(token !== null && token !== undefined)
 			request["token"] = token;
 		if(apisecret !== null && apisecret !== undefined)

--- a/ice.c
+++ b/ice.c
@@ -924,7 +924,7 @@ void janus_ice_stats_reset(janus_ice_stats *stats) {
 
 
 /* ICE Handles */
-janus_ice_handle *janus_ice_handle_create(void *gateway_session) {
+janus_ice_handle *janus_ice_handle_create(void *gateway_session, const char *opaque_id) {
 	if(gateway_session == NULL)
 		return NULL;
 	janus_session *session = (janus_session *)gateway_session;
@@ -943,6 +943,8 @@ janus_ice_handle *janus_ice_handle_create(void *gateway_session) {
 		return NULL;
 	}
 	handle->session = gateway_session;
+	if(opaque_id)
+		handle->opaque_id = g_strdup(opaque_id);
 	handle->created = janus_get_monotonic_time();
 	handle->handle_id = handle_id;
 	handle->app = NULL;
@@ -1009,7 +1011,8 @@ gint janus_ice_handle_attach_plugin(void *gateway_session, guint64 handle_id, ja
 	janus_mutex_unlock(&session->mutex);
 	/* Notify event handlers */
 	if(janus_events_is_enabled())
-		janus_events_notify_handlers(JANUS_EVENT_TYPE_HANDLE, session->session_id, handle_id, "attached", plugin->get_package());
+		janus_events_notify_handlers(JANUS_EVENT_TYPE_HANDLE,
+			session->session_id, handle_id, "attached", plugin->get_package(), handle->opaque_id);
 	return 0;
 }
 
@@ -1092,7 +1095,8 @@ gint janus_ice_handle_destroy(void *gateway_session, guint64 handle_id) {
 	janus_mutex_unlock(&old_handles_mutex);
 	/* Notify event handlers as well */
 	if(janus_events_is_enabled())
-		janus_events_notify_handlers(JANUS_EVENT_TYPE_HANDLE, session->session_id, handle_id, "detached", plugin_t->get_package());
+		janus_events_notify_handlers(JANUS_EVENT_TYPE_HANDLE,
+			session->session_id, handle_id, "detached", plugin_t->get_package(), NULL);
 	return error;
 }
 

--- a/ice.h
+++ b/ice.h
@@ -254,6 +254,8 @@ struct janus_ice_handle {
 	void *session;
 	/*! \brief Handle identifier, guaranteed to be non-zero */
 	guint64 handle_id;
+	/*! \brief Opaque identifier, e.g., to provide inter-handle relationships to external tools */
+	char *opaque_id;
 	/*! \brief Monotonic time of when the handle has been created */
 	gint64 created;
 	/*! \brief Opaque application (plugin) pointer */
@@ -461,8 +463,9 @@ void janus_ice_trickle_destroy(janus_ice_trickle *trickle);
 ///@{
 /*! \brief Method to create a new Janus ICE handle
  * @param[in] gateway_session The gateway/peer session this ICE handle will belong to
+ * @param[in] opaque_id The opaque identifier provided by the creator, if any (optional)
  * @returns The created Janus ICE handle if successful, NULL otherwise */
-janus_ice_handle *janus_ice_handle_create(void *gateway_session);
+janus_ice_handle *janus_ice_handle_create(void *gateway_session, const char *opaque_id);
 /*! \brief Method to find an existing Janus ICE handle from its ID
  * @param[in] gateway_session The gateway/peer session this ICE handle belongs to
  * @param[in] handle_id The Janus ICE handle ID

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -270,7 +270,8 @@ var janus = new Janus(
  * properties and callbacks:
  *
  * - \c plugin: the unique package name of the plugin (e.g., \c janus.plugin.echotest );
- * will be used if you skip this property)
+ * - \c opaqueId: an optional opaque string meaningful to your application (e.g., to map all the handles of the same user);
+ * - \c token , \c apisecret: optional parameters only needed in case you're \ref auth ;
  * - a set of callbacks to be notified about events, namely:
  * 		- \c success: the handle was successfully created and is ready to be used;
  * 		- \c error: the handle was NOT successfully created;
@@ -844,6 +845,9 @@ GET http://host:port/janus/<sessionid>?maxev=5
 }
 \endverbatim
  *
+ * Notice that you can also provide an optional \c opaque_id string
+ * identifier (for more details on why this might be useful, read more
+ * <a href="https://github.com/meetecho/janus-gateway/pull/748">here</a>).
  * If the request is successful, you'll receive the unique plugin handle
  * identifier in a response formatted the same way as the session create
  * one, that is like this:


### PR DESCRIPTION
This PR continues the discussion started in #741.

More precisely, it adds another property you can set when creating a handle and attaching to a plugin, namely a opaque string that can be used for different purposes: it may be used to aggregate handles of the same user or type, for instance, or to uniquely identify a user across different sessions, depending what you need to do in terms of monitoring and debugging. A very simple use cases is modifying the VideoRoom demo so that a unique random ID is generated everytime the page is loaded, and you pass it to every handle you create for the participant (the one they use to publish and to subscribe): this way, when debugging you know all those handles belong to the same person. The same approach could be used in other applications or for different purposes (e.g., to identify in event handlers or admin API a specific user using your own service identifiers).

This opaque identifier is simply a string, and Janus never uses it for anything: it just saves it, and returns it when handle info is requested via the Admin API or handle attach events are triggered to event handlers. As such, they're only useful if you plan to use those features for your own monitoring and troubleshooting applications. It's a generic string, meaning that you can put whatever you want in it: a number formatted as a string, a base64 encoded piece of information, or xml/json/whatever as long as you serialize that to a string.

I've modified the `janus.js` and `janus.nojquery.js` libraries so that you can specify it by adding a `opaqueId: "<string>"` property when attaching, so it should be very straightforward to use and test.

Just as #741, I plan to merge this very soon, so feedback before that happens is welcome.