### PR TITLE
Transport-related events

### DIFF
--- a/events.c
+++ b/events.c
@@ -68,10 +68,22 @@ void janus_events_notify_handlers(int type, guint64 session_id, ...) {
 			/* Core events also allocate a json_t object for its data, unref it */
 			json_t *body = va_arg(args, json_t *);
 			json_decref(body);
-		} else if(type == JANUS_EVENT_TYPE_PLUGIN || type == JANUS_EVENT_TYPE_TRANSPORT) {
+		} else if(type == JANUS_EVENT_TYPE_SESSION) {
+			/* Session events may allocate a json_t object for transport-related info, unref it */
+			va_arg(args, char *);
+			json_t *transport = va_arg(args, json_t *);
+			if(transport != NULL)
+				json_decref(transport);
+		} else if(type == JANUS_EVENT_TYPE_PLUGIN) {
 			/* Plugin originated events also allocate a json_t object for the plugin data, skip some arguments and unref it */
 			va_arg(args, guint64);
 			va_arg(args, char *);
+			json_t *data = va_arg(args, json_t *);
+			json_decref(data);
+		} else if(type == JANUS_EVENT_TYPE_TRANSPORT) {
+			/* Transport originated events also allocate a json_t object for the transport data, skip some arguments and unref it */
+			va_arg(args, char *);
+			va_arg(args, void *);
 			json_t *data = va_arg(args, json_t *);
 			json_decref(data);
 		}
@@ -100,6 +112,9 @@ void janus_events_notify_handlers(int type, guint64 session_id, ...) {
 			/* For sessions, there's just a generic event name (what happened) */
 			char *name = va_arg(args, char *);
 			json_object_set_new(body, "name", json_string(name));
+			json_t *transport = va_arg(args, json_t *);
+			if(transport != NULL)
+				json_object_set(body, "transport", transport);
 			break;
 		}
 		case JANUS_EVENT_TYPE_HANDLE: {
@@ -141,14 +156,25 @@ void janus_events_notify_handlers(int type, guint64 session_id, ...) {
 			body = va_arg(args, json_t *);
 			break;
 		}
-		case JANUS_EVENT_TYPE_PLUGIN:
-		case JANUS_EVENT_TYPE_TRANSPORT: {
+		case JANUS_EVENT_TYPE_PLUGIN: {
 			/* For plugin-originated events, there's the handle ID, the plugin name, and a generic, plugin specific, json_t object */
 			guint64 handle_id = va_arg(args, guint64);
 			if(handle_id > 0)	/* Plugins and transports may not specify a session and handle ID for out of context events */
 				json_object_set_new(event, "handle_id", json_integer(handle_id));
 			char *name = va_arg(args, char *);
 			json_object_set_new(body, "plugin", json_string(name));
+			json_t *data = va_arg(args, json_t *);
+			json_object_set(body, "data", data);
+			break;
+		}
+		case JANUS_EVENT_TYPE_TRANSPORT: {
+			char *name = va_arg(args, char *);
+			json_object_set_new(body, "transport", json_string(name));
+			char *instance = va_arg(args, void *);
+			char id[32];
+			memset(id, 0, sizeof(id));
+			g_snprintf(id, sizeof(id), "%p", instance);
+			json_object_set_new(body, "id", json_string(id));
 			json_t *data = va_arg(args, json_t *);
 			json_object_set(body, "data", data);
 			break;

--- a/events/janus_sampleevh.c
+++ b/events/janus_sampleevh.c
@@ -342,14 +342,24 @@ static void *janus_sampleevh_handler(void *data) {
 				switch(type) {
 					case JANUS_EVENT_TYPE_SESSION:
 						/* This is a session related event. The only info that is
-						 * provided is a name for the event itself. Here's an example
-						 * of a new session being created:
+						 * required is a name for the event itself: a "created"
+						 * event may also contain transport info, in the form of
+						 * the transport module that originated the session
+						 * (e.g., "janus.transport.http") and an internal unique
+						 * ID for the transport instance (which may be associated
+						 * to a connection or anything else within the specifics
+						 * of the transport module itself). Here's an example of
+						 * a new session being created:
 							{
 							   "type": 1,
 							   "timestamp": 3583879627,
 							   "session_id": 2004798115,
 							   "event": {
 								  "name": "created"
+							   },
+							   "transport": {
+							      "transport": "janus.transport.http",
+							      "id": "0x7fcb100008c0"
 							   }
 							}
 						*/

--- a/janus.c
+++ b/janus.c
@@ -319,6 +319,7 @@ gboolean janus_transport_is_api_secret_needed(janus_transport *plugin);
 gboolean janus_transport_is_api_secret_valid(janus_transport *plugin, const char *apisecret);
 gboolean janus_transport_is_auth_token_needed(janus_transport *plugin);
 gboolean janus_transport_is_auth_token_valid(janus_transport *plugin, const char *token);
+void janus_transport_notify_event(janus_transport *plugin, void *transport, json_t *event);
 
 static janus_transport_callbacks janus_handler_transport =
 	{
@@ -328,6 +329,8 @@ static janus_transport_callbacks janus_handler_transport =
 		.is_api_secret_valid = janus_transport_is_api_secret_valid,
 		.is_auth_token_needed = janus_transport_is_auth_token_needed,
 		.is_auth_token_valid = janus_transport_is_auth_token_valid,
+		.events_is_enabled = janus_events_is_enabled,
+		.notify_event = janus_transport_notify_event,
 	};
 GThreadPool *tasks = NULL;
 void janus_transport_task(gpointer data, gpointer user_data);
@@ -407,7 +410,7 @@ static gboolean janus_check_sessions(gpointer user_data) {
 				}
 				/* Notify event handlers as well */
 				if(janus_events_is_enabled())
-					janus_events_notify_handlers(JANUS_EVENT_TYPE_SESSION, session->session_id, "timeout");
+					janus_events_notify_handlers(JANUS_EVENT_TYPE_SESSION, session->session_id, "timeout", NULL);
 
 				/* Mark the session as over, we'll deal with it later */
 				session->timeout = 1;
@@ -470,9 +473,6 @@ janus_session *janus_session_create(guint64 session_id) {
 	janus_mutex_lock(&sessions_mutex);
 	g_hash_table_insert(sessions, janus_uint64_dup(session->session_id), session);
 	janus_mutex_unlock(&sessions_mutex);
-	/* Notify event handlers */
-	if(janus_events_is_enabled())
-		janus_events_notify_handlers(JANUS_EVENT_TYPE_SESSION, session_id, "created");
 	return session;
 }
 
@@ -675,6 +675,17 @@ int janus_process_incoming_request(janus_request *request) {
 		session->source = janus_request_new(request->transport, request->instance, NULL, FALSE, NULL);
 		/* Notify the source that a new session has been created */
 		request->transport->session_created(request->instance, session->session_id);
+		/* Notify event handlers */
+		if(janus_events_is_enabled()) {
+			/* Session created, add info on the transport that originated it */
+			json_t *transport = json_object();
+			json_object_set_new(transport, "transport", json_string(session->source->transport->get_package()));
+			char id[32];
+			memset(id, 0, sizeof(id));
+			g_snprintf(id, sizeof(id), "%p", session->source->instance);
+			json_object_set_new(transport, "id", json_string(id));
+			janus_events_notify_handlers(JANUS_EVENT_TYPE_SESSION, session_id, "created", transport);
+		}
 		/* Prepare JSON reply */
 		json_t *reply = json_object();
 		json_object_set_new(reply, "janus", json_string("success"));
@@ -846,7 +857,7 @@ int janus_process_incoming_request(janus_request *request) {
 		ret = janus_process_success(request, reply);
 		/* Notify event handlers as well */
 		if(janus_events_is_enabled())
-			janus_events_notify_handlers(JANUS_EVENT_TYPE_SESSION, session_id, "destroyed");
+			janus_events_notify_handlers(JANUS_EVENT_TYPE_SESSION, session_id, "destroyed", NULL);
 	} else if(!strcasecmp(message_text, "detach")) {
 		if(handle == NULL) {
 			/* Query is an handle-level command */
@@ -2473,6 +2484,19 @@ gboolean janus_transport_is_auth_token_valid(janus_transport *plugin, const char
 	if(!janus_auth_is_enabled())
 		return TRUE;
 	return token && janus_auth_check_token(token);
+}
+
+void janus_transport_notify_event(janus_transport *plugin, void *transport, json_t *event) {
+	/* A plugin asked to notify an event to the handlers */
+	if(!plugin || !event || !json_is_object(event))
+		return;
+	/* Notify event handlers */
+	if(janus_events_is_enabled()) {
+		janus_events_notify_handlers(JANUS_EVENT_TYPE_TRANSPORT,
+			0, plugin->get_package(), transport, event);
+	} else {
+		json_decref(event);
+	}
 }
 
 void janus_transport_task(gpointer data, gpointer user_data) {

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -103,6 +103,7 @@ static gint initialized = 0, stopping = 0;
 static janus_transport_callbacks *gateway = NULL;
 static gboolean http_janus_api_enabled = FALSE;
 static gboolean http_admin_api_enabled = FALSE;
+static gboolean notify_events = TRUE;
 
 /* JSON serialization options */
 static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
@@ -570,6 +571,14 @@ int janus_http_init(janus_transport_callbacks *callback, const char *config_path
 				JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", item->value);
 				json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
 			}
+		}
+
+		/* Check if we need to send events to handlers */
+		janus_config_item *events = janus_config_get_item_drilldown(config, "general", "events");
+		if(events != NULL && events->value != NULL)
+			notify_events = janus_is_true(events->value);
+		if(!notify_events && callback->events_is_enabled()) {
+			JANUS_LOG(LOG_WARN, "Notification of events to handlers disabled for %s\n", JANUS_REST_NAME);
 		}
 
 		/* Check the base paths */
@@ -1060,6 +1069,21 @@ int janus_http_handler(void *cls, struct MHD_Connection *connection, const char 
 		*ptr = msg;
 		MHD_get_connection_values(connection, MHD_HEADER_KIND, &janus_http_headers, msg);
 		ret = MHD_YES;
+		/* Notify handlers about this new transport instance */
+		if(notify_events && gateway->events_is_enabled()) {
+			json_t *info = json_object();
+			json_object_set_new(info, "event", json_string("request"));
+			json_object_set_new(info, "admin_api", json_false());
+			const union MHD_ConnectionInfo *conninfo = MHD_get_connection_info(connection, MHD_CONNECTION_INFO_CLIENT_ADDRESS);
+			if(conninfo != NULL) {
+				char *ip = janus_address_to_ip((struct sockaddr *)conninfo->client_addr);
+				json_object_set_new(info, "ip", json_string(ip));
+				g_free(ip);
+				uint16_t port = janus_address_to_port((struct sockaddr *)conninfo->client_addr);
+				json_object_set_new(info, "port", json_integer(port));
+			}
+			gateway->notify_event(&janus_http_transport, msg, info);
+		}
 	} else {
 		JANUS_LOG(LOG_DBG, "Processing HTTP %s request on %s...\n", method, url);
 	}
@@ -1441,6 +1465,21 @@ int janus_http_admin_handler(void *cls, struct MHD_Connection *connection, const
 		*ptr = msg;
 		MHD_get_connection_values(connection, MHD_HEADER_KIND, &janus_http_headers, msg);
 		ret = MHD_YES;
+		/* Notify handlers about this new transport instance */
+		if(notify_events && gateway->events_is_enabled()) {
+			json_t *info = json_object();
+			json_object_set_new(info, "event", json_string("request"));
+			json_object_set_new(info, "admin_api", json_true());
+			const union MHD_ConnectionInfo *conninfo = MHD_get_connection_info(connection, MHD_CONNECTION_INFO_CLIENT_ADDRESS);
+			if(conninfo != NULL) {
+				char *ip = janus_address_to_ip((struct sockaddr *)conninfo->client_addr);
+				json_object_set_new(info, "ip", json_string(ip));
+				g_free(ip);
+				uint16_t port = janus_address_to_port((struct sockaddr *)conninfo->client_addr);
+				json_object_set_new(info, "port", json_integer(port));
+			}
+			gateway->notify_event(&janus_http_transport, msg, info);
+		}
 	}
 	/* Parse request */
 	if (strcasecmp(method, "GET") && strcasecmp(method, "POST") && strcasecmp(method, "OPTIONS")) {

--- a/transports/transport.h
+++ b/transports/transport.h
@@ -94,7 +94,7 @@ janus_transport *create(void) {
 
 
 /*! \brief Version of the API, to match the one transport plugins were compiled against */
-#define JANUS_TRANSPORT_API_VERSION	5
+#define JANUS_TRANSPORT_API_VERSION	6
 
 /*! \brief Initialization of all transport plugin properties to NULL
  * 
@@ -233,6 +233,14 @@ struct janus_transport_callbacks {
 	 * @returns TRUE if the auth token is valid, FALSE otherwise */
 	gboolean (* const is_auth_token_valid)(janus_transport *plugin, const char *token);
 
+	/*! \brief Callback to check whether the event handlers mechanism is enabled
+	 * @returns TRUE if it is, FALSE if it isn't (which means notify_event should NOT be called) */
+	gboolean (* const events_is_enabled)(void);
+	/*! \brief Callback to notify an event to the registered and subscribed event handlers
+	 * \note Don't unref the event object, the core will do that for you
+	 * @param[in] plugin The transport originating the event
+	 * @param[in] event The event to notify as a Jansson json_t object */
+	void (* const notify_event)(janus_transport *plugin, void *transport, json_t *event);
 };
 
 /*! \brief The hook that transport plugins need to implement to be created from the gateway */

--- a/utils.c
+++ b/utils.c
@@ -402,6 +402,26 @@ char *janus_address_to_ip(struct sockaddr *address) {
 	return addr ? g_strdup(addr) : NULL;
 }
 
+uint16_t janus_address_to_port(struct sockaddr *address) {
+	if(address == NULL)
+		return 0;
+	struct sockaddr_in *sin = NULL;
+	struct sockaddr_in6 *sin6 = NULL;
+
+	switch(address->sa_family) {
+		case AF_INET:
+			sin = (struct sockaddr_in *)address;
+			return ntohs(sin->sin_port);
+		case AF_INET6:
+			sin6 = (struct sockaddr_in6 *)address;
+			return ntohs(sin6->sin6_port);
+		default:
+			/* Unknown family */
+			break;
+	}
+	return 0;
+}
+
 /* PID file management */
 static char *pidfile = NULL;
 static int pidfd = -1;

--- a/utils.h
+++ b/utils.h
@@ -134,6 +134,11 @@ gboolean janus_is_ip_valid(const char *ip, int *family);
  * @returns A string containing the IP address, if successful, NULL otherwise */
 char *janus_address_to_ip(struct sockaddr *address);
 
+/*! \brief Get the port from a sockaddr address
+ * @param address The sockaddr address to get the port from
+ * @returns The port number, if successful, 0 otherwise */
+uint16_t janus_address_to_port(struct sockaddr *address);
+
 /*! \brief Create and lock a PID file
  * @param file Path to the PID file to use
  * @returns 0 if successful, a negative integer otherwise */


### PR DESCRIPTION
This PR implements the transport-related events for Event Handlers, as they were the only ones left missing so far. It does this at two different levels:

1. on one side, transports themselves generate events; as different modules might implement different technologies in different ways, these events are transport- and module-specific (e.g., the HTTP transport might notify you about new HTTP requests that arrive, the WebSockets transport about connections/disconnections, etc.);
2. on another side, the existing "session created" event has been enriched with info on the transport that originated the creation.

This is a simple example of how a transport-related event for HTTP could look like:

```
   {
      "type": 128,
      "timestamp": 1484656548988936,
      "event": {
         "transport": "janus.transport.http",
         "id": "0x7f1fc00008c0",
         "data": {
            "event": "request",
            "admin_api": false,
            "ip": "::1",
            "port": 59294
         }
      }
   }
```

and this is how the new "session created" event looks like instead:

```
   {
      "type": 1,
      "timestamp": 1484656548989422,
      "session_id": 4723806468072828,
      "event": {
         "name": "created",
         "transport": {
            "transport": "janus.transport.http",
            "id": "0x7f1fc00008c0"
         }
      }
   }
```

Since the session has been created by an HTTP transport instance with ID `0x7f1fc00008c0`, you can see previous transport-related events to have an idea of where this session came from (e.g., remote address, if available).

Feedback welcome!