### PR TITLE
Make JSON reponse for created textrooms consistent with other plugins

### DIFF
--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -1441,7 +1441,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		if(!internal) {
 			/* Send response back */
 			json_t *reply = json_object();
-			json_object_set_new(reply, "textroom", json_string("success"));
+			json_object_set_new(reply, "textroom", json_string("created"));
 			json_object_set_new(reply, "transaction", json_string(transaction_text));
 			json_object_set_new(reply, "room", json_integer(textroom->room_id));
 			json_object_set_new(reply, "permanent", save ? json_true() : json_false());


### PR DESCRIPTION
All other plugins which deal with programmatic creation of rooms
respond with the plugin name and 'created', while the textroom
plugin reponds with 'success'. This fixes the inconsistency.