### PR TITLE
Fix typo in textroom plugin log message for list command

### DIFF
--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -1050,7 +1050,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 	} else if(!strcasecmp(request_text, "list")) {
 		/* List all rooms (but private ones) and their details (except for the secret, of course...) */
 		json_t *list = json_array();
-		JANUS_LOG(LOG_VERB, "Request for the list for all video rooms\n");
+		JANUS_LOG(LOG_VERB, "Request for the list for all text rooms\n");
 		janus_mutex_lock(&rooms_mutex);
 		GHashTableIter iter;
 		gpointer value;


### PR DESCRIPTION
Says 'video room' when it should say 'text room'