### PR TITLE
Allow some TextRoom commands to be sent via Janus API

### DIFF
--- a/html/textroomtest.js
+++ b/html/textroomtest.js
@@ -205,6 +205,8 @@ $(document).ready(function() {
 											});
 										}
 									} else if(what === "destroyed") {
+										if(json["room"] !== myroom)
+											return;
 										// Room was destroyed, goodbye!
 										Janus.warn("The room has been destroyed!");
 										bootbox.alert("The room has been destroyed", function() {

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -1525,7 +1525,8 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 		if(!internal) {
 			/* Send response back */
 			reply = json_object();
-			json_object_set_new(reply, "textroom", json_string("success"));
+			/* Notice that we reply differently if the request came via Janus API */
+			json_object_set_new(reply, "textroom", json_string(json == NULL ? "success" : "created"));
 			json_object_set_new(reply, "room", json_integer(textroom->room_id));
 			json_object_set_new(reply, "permanent", save ? json_true() : json_false());
 		}
@@ -1635,7 +1636,8 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 		if(!internal) {
 			/* Send response back */
 			reply = json_object();
-			json_object_set_new(reply, "textroom", json_string("success"));
+			/* Notice that we reply differently if the request came via Janus API */
+			json_object_set_new(reply, "textroom", json_string(json == NULL ? "success" : "destroyed"));
 		}
 		/* We'll let the watchdog worry about freeing resources */
 		old_rooms = g_list_append(old_rooms, textroom);

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -11,10 +11,13 @@
  * used within the context of any application that needs real-time text
  * broadcasting (e.g., chatrooms, but not only).
  *
- * The only message that is sent to the plugin through the Janus API is
+ * The only message that is typically sent to the plugin through the Janus API is
  * a "setup" message, by which the user initializes the PeerConnection
- * itself. Apart from that, all other messages are exchanged directly
- * via Data Channels.
+ * itself. Apart from that, all other messages can be exchanged directly
+ * via Data Channels. For room management purposes, though, requests like
+ * "create", "destroy", "list" and "exists" are available through the
+ * Janus API as well: notice that in this case you'll have to use "request"
+ * and not "textroom" as the name of the request.
  *
  * Each room can also be configured with an HTTP backend to contact for
  * incoming messages. If configured, messages addressed to that room will
@@ -358,7 +361,16 @@ static size_t janus_textroom_write_data(void *buffer, size_t size, size_t nmemb,
 }
 #endif
 
-void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *text, gboolean internal);
+/* We use this method to handle incoming requests. Since most of the requests 
+ * will arrive from data channels, but some may also arrive from the regular
+ * plugin messaging (e.g., room management), we have the ability to pass
+ * parsed JSON objects instead of strings, which explains why we specify a
+ * janus_plugin_result pointer as a return value; messages handles via
+ * datachannels would simply return NULL. Besides, some requests are actually
+ * originated internally, and don't need any response to be sent to anyone,
+ * which is what the additional boolean "internal" value is for */
+janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session *handle,
+	char *text, json_t *json, gboolean internal);
 
 
 /* Plugin implementation */
@@ -637,15 +649,111 @@ json_t *janus_textroom_query_session(janus_plugin_session *handle) {
 struct janus_plugin_result *janus_textroom_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
-	janus_textroom_message *msg = g_malloc0(sizeof(janus_textroom_message));
-	msg->handle = handle;
-	msg->transaction = transaction;
-	msg->message = message;
-	msg->jsep = jsep;
-	g_async_queue_push(messages, msg);
 
-	/* All the requests to this plugin are handled asynchronously */
-	return janus_plugin_result_new(JANUS_PLUGIN_OK_WAIT, "I'm taking my time!", NULL);
+	/* Pre-parse the message */
+	int error_code = 0;
+	char error_cause[512];
+	json_t *root = message;
+	json_t *response = NULL;
+
+	if(message == NULL) {
+		JANUS_LOG(LOG_ERR, "No message??\n");
+		error_code = JANUS_TEXTROOM_ERROR_NO_MESSAGE;
+		g_snprintf(error_cause, 512, "%s", "No message??");
+		goto plugin_response;
+	}
+
+	janus_textroom_session *session = (janus_textroom_session *)handle->plugin_handle;
+	if(!session) {
+		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
+		error_code = JANUS_TEXTROOM_ERROR_UNKNOWN_ERROR;
+		g_snprintf(error_cause, 512, "%s", "session associated with this handle...");
+		goto plugin_response;
+	}
+	if(session->destroyed) {
+		JANUS_LOG(LOG_ERR, "Session has already been destroyed...\n");
+		error_code = JANUS_TEXTROOM_ERROR_UNKNOWN_ERROR;
+		g_snprintf(error_cause, 512, "%s", "Session has already been destroyed...");
+		goto plugin_response;
+	}
+	if(!json_is_object(root)) {
+		JANUS_LOG(LOG_ERR, "JSON error: not an object\n");
+		error_code = JANUS_TEXTROOM_ERROR_INVALID_JSON;
+		g_snprintf(error_cause, 512, "JSON error: not an object");
+		goto plugin_response;
+	}
+	/* Get the request first */
+	JANUS_VALIDATE_JSON_OBJECT(root, request_parameters,
+		error_code, error_cause, TRUE,
+		JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
+	if(error_code != 0)
+		goto plugin_response;
+	json_t *request = json_object_get(root, "request");
+	/* Some requests (e.g., 'create' and 'destroy') can be handled synchronously */
+	const char *request_text = json_string_value(request);
+	if(!strcasecmp(request_text, "list")
+			|| !strcasecmp(request_text, "exists")
+			|| !strcasecmp(request_text, "create")
+			|| !strcasecmp(request_text, "destroy")) {
+		/* These requests typically only belong to the datachannel
+		 * messaging, but for admin purposes we might use them on
+		 * the Janus API as well: add the properties the datachannel
+		 * processor would expect and handle everything there */
+		json_object_set_new(root, "textroom", json_string(request_text));
+		json_object_set_new(root, "transaction", json_string(transaction));
+		janus_plugin_result *result = janus_textroom_handle_incoming_request(session->handle, NULL, root, FALSE);
+		if(result == NULL) {
+			JANUS_LOG(LOG_ERR, "JSON error: not an object\n");
+			error_code = JANUS_TEXTROOM_ERROR_INVALID_JSON;
+			g_snprintf(error_cause, 512, "JSON error: not an object");
+			goto plugin_response;
+		}
+		if(root != NULL)
+			json_decref(root);
+		if(jsep != NULL)
+			json_decref(jsep);
+		g_free(transaction);
+		return result;
+	} else if(!strcasecmp(request_text, "setup") || !strcasecmp(request_text, "ack")) {
+		/* These messages are handled asynchronously */
+		janus_textroom_message *msg = g_malloc0(sizeof(janus_textroom_message));
+		msg->handle = handle;
+		msg->transaction = transaction;
+		msg->message = root;
+		msg->jsep = jsep;
+
+		g_async_queue_push(messages, msg);
+
+		return janus_plugin_result_new(JANUS_PLUGIN_OK_WAIT, NULL, NULL);
+	} else {
+		JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
+		error_code = JANUS_TEXTROOM_ERROR_INVALID_REQUEST;
+		g_snprintf(error_cause, 512, "Unknown request '%s'", request_text);
+	}
+
+plugin_response:
+		{
+			if(error_code == 0 && !response) {
+				error_code = JANUS_TEXTROOM_ERROR_UNKNOWN_ERROR;
+				g_snprintf(error_cause, 512, "Invalid response");
+			}
+			if(error_code != 0) {
+				/* Prepare JSON error event */
+				json_t *event = json_object();
+				json_object_set_new(event, "textroom", json_string("event"));
+				json_object_set_new(event, "error_code", json_integer(error_code));
+				json_object_set_new(event, "error", json_string(error_cause));
+				response = event;
+			}
+			if(root != NULL)
+				json_decref(root);
+			if(jsep != NULL)
+				json_decref(jsep);
+			g_free(transaction);
+
+			return janus_plugin_result_new(JANUS_PLUGIN_OK, NULL, response);
+		}
+
 }
 
 void janus_textroom_setup_media(janus_plugin_session *handle) {
@@ -687,19 +795,19 @@ void janus_textroom_incoming_data(janus_plugin_session *handle, char *buf, int l
 	memcpy(text, buf, len);
 	*(text+len) = '\0';
 	JANUS_LOG(LOG_VERB, "Got a DataChannel message (%zu bytes): %s\n", strlen(text), text);
-	janus_textroom_handle_incoming_request(handle, text, FALSE);
+	janus_textroom_handle_incoming_request(handle, text, NULL, FALSE);
 }
 
 /* Helper method to handle incoming messages from the data channel */
-void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *text, gboolean internal) {
+janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *text, json_t *json, gboolean internal) {
 	janus_textroom_session *session = (janus_textroom_session *)handle->plugin_handle;
-	/* Parse JSON */
+	/* Parse JSON, if needed */
 	json_error_t error;
-	json_t *root = json_loads(text, 0, &error);
+	json_t *root = text ? json_loads(text, 0, &error) : json;
 	g_free(text);
 	if(!root) {
 		JANUS_LOG(LOG_ERR, "Error parsing data channel message (JSON error: on line %d: %s)\n", error.line, error.text);
-		return;
+		return NULL;
 	}
 	/* Handle request */
 	int error_code = 0;
@@ -709,17 +817,18 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
 	const char *transaction_text = NULL;
 	if(error_code != 0)
-		goto error;
+		goto msg_response;
 	json_t *request = json_object_get(root, "textroom");
 	json_t *transaction = json_object_get(root, "transaction");
 	const char *request_text = json_string_value(request);
 	transaction_text = json_string_value(transaction);
+	json_t *reply = NULL;
 	if(!strcasecmp(request_text, "message")) {
 		JANUS_VALIDATE_JSON_OBJECT(root, message_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto error;
+			goto msg_response;
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -729,7 +838,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_TEXTROOM_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto error;
+			goto msg_response;
 		}
 		janus_mutex_lock(&textroom->mutex);
 		janus_mutex_unlock(&rooms_mutex);
@@ -739,7 +848,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "Not in room %"SCNu64"\n", room_id);
 			error_code = JANUS_TEXTROOM_ERROR_NOT_IN_ROOM;
 			g_snprintf(error_cause, 512, "Not in room %"SCNu64, room_id);
-			goto error;
+			goto msg_response;
 		}
 		json_t *username = json_object_get(root, "to");
 		json_t *usernames = json_object_get(root, "tos");
@@ -748,7 +857,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "Both to and tos array provided\n");
 			error_code = JANUS_TEXTROOM_ERROR_INVALID_ELEMENT;
 			g_snprintf(error_cause, 512, "Both to and tos array provided");
-			goto error;
+			goto msg_response;
 		}
 		json_t *text = json_object_get(root, "text");
 		const char *message = json_string_value(text);
@@ -769,9 +878,8 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		char *msg_text = json_dumps(msg, json_format);
 		json_decref(msg);
 		/* Start preparing the response too */
-		json_t *reply = json_object();
+		reply = json_object();
 		json_object_set_new(reply, "textroom", json_string("success"));
-		json_object_set_new(reply, "transaction", json_string(transaction_text));
 		/* Who should we send this message to? */
 		if(username) {
 			/* A single user */
@@ -855,17 +963,17 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		json_t *ack = json_object_get(root, "ack");
 		if(!internal && (ack == NULL || json_is_true(ack))) {
 			/* Send response back */
-			char *reply_text = json_dumps(reply, json_format);
-			gateway->relay_data(handle, reply_text, strlen(reply_text));
-			free(reply_text);
+		} else {
+			internal = TRUE;
+			json_decref(reply);
+			reply = NULL;
 		}
-		json_decref(reply);
 	} else if(!strcasecmp(request_text, "join")) {
 		JANUS_VALIDATE_JSON_OBJECT(root, join_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto error;
+			goto msg_response;
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -875,7 +983,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_TEXTROOM_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto error;
+			goto msg_response;
 		}
 		janus_mutex_lock(&textroom->mutex);
 		janus_mutex_unlock(&rooms_mutex);
@@ -886,7 +994,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "Already in room %"SCNu64"\n", room_id);
 			error_code = JANUS_TEXTROOM_ERROR_ALREADY_IN_ROOM;
 			g_snprintf(error_cause, 512, "Already in room %"SCNu64, room_id);
-			goto error;
+			goto msg_response;
 		}
 		json_t *username = json_object_get(root, "username");
 		const char *username_text = json_string_value(username);
@@ -897,7 +1005,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "Username already taken\n");
 			error_code = JANUS_TEXTROOM_ERROR_USERNAME_EXISTS;
 			g_snprintf(error_cause, 512, "Username already taken");
-			goto error;
+			goto msg_response;
 		}
 		json_t *display = json_object_get(root, "display");
 		const char *display_text = json_string_value(display);
@@ -948,14 +1056,9 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		janus_mutex_unlock(&textroom->mutex);
 		if(!internal) {
 			/* Send response back */
-			json_t *reply = json_object();
+			reply = json_object();
 			json_object_set_new(reply, "textroom", json_string("success"));
-			json_object_set_new(reply, "transaction", json_string(transaction_text));
 			json_object_set_new(reply, "participants", list);
-			char *reply_text = json_dumps(reply, json_format);
-			json_decref(reply);
-			gateway->relay_data(handle, reply_text, strlen(reply_text));
-			free(reply_text);
 		}
 		/* Also notify event handlers */
 		if(notify_events && gateway->events_is_enabled()) {
@@ -972,7 +1075,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			error_code, error_cause, TRUE,
 			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto error;
+			goto msg_response;
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -982,7 +1085,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_TEXTROOM_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto error;
+			goto msg_response;
 		}
 		janus_mutex_lock(&textroom->mutex);
 		janus_mutex_unlock(&rooms_mutex);
@@ -994,7 +1097,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "Not in room %"SCNu64"\n", room_id);
 			error_code = JANUS_TEXTROOM_ERROR_NOT_IN_ROOM;
 			g_snprintf(error_cause, 512, "Not in room %"SCNu64, room_id);
-			goto error;
+			goto msg_response;
 		}
 		g_hash_table_remove(session->rooms, &room_id);
 		g_hash_table_remove(textroom->participants, participant->username);
@@ -1039,13 +1142,8 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		janus_mutex_unlock(&textroom->mutex);
 		if(!internal) {
 			/* Send response back */
-			json_t *reply = json_object();
+			reply = json_object();
 			json_object_set_new(reply, "textroom", json_string("success"));
-			json_object_set_new(reply, "transaction", json_string(transaction_text));
-			char *reply_text = json_dumps(reply, json_format);
-			json_decref(reply);
-			gateway->relay_data(handle, reply_text, strlen(reply_text));
-			free(reply_text);
 		}
 	} else if(!strcasecmp(request_text, "list")) {
 		/* List all rooms (but private ones) and their details (except for the secret, of course...) */
@@ -1077,14 +1175,9 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		janus_mutex_unlock(&rooms_mutex);
 		if(!internal) {
 			/* Send response back */
-			json_t *reply = json_object();
+			reply = json_object();
 			json_object_set_new(reply, "textroom", json_string("success"));
-			json_object_set_new(reply, "transaction", json_string(transaction_text));
 			json_object_set_new(reply, "list", list);
-			char *reply_text = json_dumps(reply, json_format);
-			json_decref(reply);
-			gateway->relay_data(handle, reply_text, strlen(reply_text));
-			free(reply_text);
 		}
 	} else if(!strcasecmp(request_text, "allowed")) {
 		JANUS_LOG(LOG_VERB, "Attempt to edit the list of allowed participants in an existing textroom room\n");
@@ -1092,7 +1185,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			error_code, error_cause, TRUE,
 			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto error;
+			goto msg_response;
 		json_t *action = json_object_get(root, "action");
 		json_t *room = json_object_get(root, "room");
 		json_t *allowed = json_object_get(root, "allowed");
@@ -1102,7 +1195,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "Unsupported action '%s' (allowed)\n", action_text);
 			error_code = JANUS_TEXTROOM_ERROR_INVALID_ELEMENT;
 			g_snprintf(error_cause, 512, "Unsupported action '%s' (allowed)", action_text);
-			goto error;
+			goto msg_response;
 		}
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -1112,7 +1205,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_TEXTROOM_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto error;
+			goto msg_response;
 		}
 		janus_mutex_lock(&textroom->mutex);
 		/* A secret may be required for this action */
@@ -1121,7 +1214,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		if(error_code != 0) {
 			janus_mutex_unlock(&textroom->mutex);
 			janus_mutex_unlock(&rooms_mutex);
-			goto error;
+			goto msg_response;
 		}
 		if(!strcasecmp(action_text, "enable")) {
 			JANUS_LOG(LOG_VERB, "Enabling the check on allowed authorization tokens for room %"SCNu64"\n", room_id);
@@ -1150,7 +1243,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 					g_snprintf(error_cause, 512, "Invalid element in the allowed array (not a string)");
 					janus_mutex_unlock(&textroom->mutex);
 					janus_mutex_unlock(&rooms_mutex);
-					goto error;
+					goto msg_response;
 				}
 				size_t i = 0;
 				for(i=0; i<json_array_size(allowed); i++) {
@@ -1166,7 +1259,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		}
 		if(!internal) {
 			/* Send response back */
-			json_t *reply = json_object();
+			reply = json_object();
 			json_object_set_new(reply, "textroom", json_string("success"));
 			json_object_set_new(reply, "room", json_integer(textroom->room_id));
 			json_t *list = json_array();
@@ -1185,10 +1278,6 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			janus_mutex_unlock(&textroom->mutex);
 			janus_mutex_unlock(&rooms_mutex);
 			JANUS_LOG(LOG_VERB, "TextRoom room allowed list updated\n");
-			char *reply_text = json_dumps(reply, json_format);
-			json_decref(reply);
-			gateway->relay_data(handle, reply_text, strlen(reply_text));
-			free(reply_text);
 		}
 	} else if(!strcasecmp(request_text, "kick")) {
 		JANUS_LOG(LOG_VERB, "Attempt to kick a participant from an existing textroom room\n");
@@ -1196,7 +1285,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			error_code, error_cause, TRUE,
 			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto error;
+			goto msg_response;
 		json_t *room = json_object_get(root, "room");
 		json_t *username = json_object_get(root, "username");
 		guint64 room_id = json_integer_value(room);
@@ -1207,7 +1296,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_TEXTROOM_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto error;
+			goto msg_response;
 		}
 		janus_mutex_lock(&textroom->mutex);
 		/* A secret may be required for this action */
@@ -1216,7 +1305,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		if(error_code != 0) {
 			janus_mutex_unlock(&textroom->mutex);
 			janus_mutex_unlock(&rooms_mutex);
-			goto error;
+			goto msg_response;
 		}
 		const char *user_id = json_string_value(username);
 		janus_textroom_participant *participant = g_hash_table_lookup(textroom->participants, user_id);
@@ -1226,7 +1315,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "No such participant %s in room %"SCNu64"\n", user_id, room_id);
 			error_code = JANUS_TEXTROOM_ERROR_NO_SUCH_USER;
 			g_snprintf(error_cause, 512, "No such user %s in room %"SCNu64, user_id, room_id);
-			goto error;
+			goto msg_response;
 		}
 		/* Notify all participants */
 		JANUS_LOG(LOG_VERB, "Notifying all participants about the new kick\n");
@@ -1270,31 +1359,26 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		janus_mutex_unlock(&rooms_mutex);
 		if(!internal) {
 			/* Send response back */
-			json_t *reply = json_object();
+			reply = json_object();
 			json_object_set_new(reply, "textbridge", json_string("success"));
-			json_object_set_new(reply, "transaction", json_string(transaction_text));
-			char *reply_text = json_dumps(reply, json_format);
-			json_decref(reply);
-			gateway->relay_data(handle, reply_text, strlen(reply_text));
-			free(reply_text);
 		}
 	} else if(!strcasecmp(request_text, "create")) {
 		JANUS_VALIDATE_JSON_OBJECT(root, create_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto error;
+			goto msg_response;
 		if(admin_key != NULL) {
 			/* An admin key was specified: make sure it was provided, and that it's valid */
 			JANUS_VALIDATE_JSON_OBJECT(root, adminkey_parameters,
 				error_code, error_cause, TRUE,
 				JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
 			if(error_code != 0)
-				goto error;
+				goto msg_response;
 			JANUS_CHECK_SECRET(admin_key, root, "admin_key", error_code, error_cause,
 				JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT, JANUS_TEXTROOM_ERROR_UNAUTHORIZED);
 			if(error_code != 0)
-				goto error;
+				goto msg_response;
 		}
 		json_t *room = json_object_get(root, "room");
 		json_t *desc = json_object_get(root, "description");
@@ -1321,7 +1405,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 				JANUS_LOG(LOG_ERR, "Invalid element in the allowed array (not a string)\n");
 				error_code = JANUS_TEXTROOM_ERROR_INVALID_ELEMENT;
 				g_snprintf(error_cause, 512, "Invalid element in the allowed array (not a string)");
-				goto error;
+				goto msg_response;
 			}
 		}
 		gboolean save = permanent ? json_is_true(permanent) : FALSE;
@@ -1329,7 +1413,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "No configuration file, can't create permanent room\n");
 			error_code = JANUS_TEXTROOM_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "No configuration file, can't create permanent room");
-			goto error;
+			goto msg_response;
 		}
 		guint64 room_id = 0;
 		room_id = json_integer_value(room);
@@ -1345,7 +1429,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 				JANUS_LOG(LOG_ERR, "Room %"SCNu64" already exists!\n", room_id);
 				error_code = JANUS_TEXTROOM_ERROR_ROOM_EXISTS;
 				g_snprintf(error_cause, 512, "Room %"SCNu64" already exists", room_id);
-				goto error;
+				goto msg_response;
 			}
 		}
 		/* Create the text room */
@@ -1440,15 +1524,10 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		janus_mutex_unlock(&rooms_mutex);
 		if(!internal) {
 			/* Send response back */
-			json_t *reply = json_object();
+			reply = json_object();
 			json_object_set_new(reply, "textroom", json_string("success"));
-			json_object_set_new(reply, "transaction", json_string(transaction_text));
 			json_object_set_new(reply, "room", json_integer(textroom->room_id));
 			json_object_set_new(reply, "permanent", save ? json_true() : json_false());
-			char *reply_text = json_dumps(reply, json_format);
-			json_decref(reply);
-			gateway->relay_data(handle, reply_text, strlen(reply_text));
-			free(reply_text);
 		}
 		/* Also notify event handlers */
 		if(notify_events && gateway->events_is_enabled()) {
@@ -1462,7 +1541,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			error_code, error_cause, TRUE,
 			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto error;
+			goto msg_response;
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -1470,22 +1549,17 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		janus_mutex_unlock(&rooms_mutex);
 		if(!internal) {
 			/* Send response back */
-			json_t *reply = json_object();
+			reply = json_object();
 			json_object_set_new(reply, "textroom", json_string("success"));
 			json_object_set_new(reply, "room", json_integer(room_id));
 			json_object_set_new(reply, "exists", room_exists ? json_true() : json_false());
-			json_object_set_new(reply, "transaction", json_string(transaction_text));
-			char *reply_text = json_dumps(reply, json_format);
-			json_decref(reply);
-			gateway->relay_data(handle, reply_text, strlen(reply_text));
-			free(reply_text);
 		}
 	} else if(!strcasecmp(request_text, "destroy")) {
 		JANUS_VALIDATE_JSON_OBJECT(root, room_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto error;
+			goto msg_response;
 		json_t *room = json_object_get(root, "room");
 		json_t *permanent = json_object_get(root, "permanent");
 		gboolean save = permanent ? json_is_true(permanent) : FALSE;
@@ -1493,7 +1567,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "No configuration file, can't destroy room permanently\n");
 			error_code = JANUS_TEXTROOM_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "No configuration file, can't destroy room permanently");
-			goto error;
+			goto msg_response;
 		}
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -1503,7 +1577,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_TEXTROOM_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto error;
+			goto msg_response;
 		}
 		janus_mutex_lock(&textroom->mutex);
 		/* A secret may be required for this action */
@@ -1512,7 +1586,7 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		if(error_code != 0) {
 			janus_mutex_unlock(&textroom->mutex);
 			janus_mutex_unlock(&rooms_mutex);
-			goto error;
+			goto msg_response;
 		}
 		/* Remove room */
 		g_hash_table_remove(rooms, &room_id);
@@ -1560,13 +1634,8 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		janus_mutex_unlock(&rooms_mutex);
 		if(!internal) {
 			/* Send response back */
-			json_t *reply = json_object();
+			reply = json_object();
 			json_object_set_new(reply, "textroom", json_string("success"));
-			json_object_set_new(reply, "transaction", json_string(transaction_text));
-			char *reply_text = json_dumps(reply, json_format);
-			json_decref(reply);
-			gateway->relay_data(handle, reply_text, strlen(reply_text));
-			free(reply_text);
 		}
 		/* We'll let the watchdog worry about freeing resources */
 		old_rooms = g_list_append(old_rooms, textroom);
@@ -1581,30 +1650,41 @@ void janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *
 		JANUS_LOG(LOG_ERR, "Unsupported request %s\n", request_text);
 		error_code = JANUS_TEXTROOM_ERROR_INVALID_REQUEST;
 		g_snprintf(error_cause, 512, "Unsupported request %s", request_text);
-		goto error;
+		goto msg_response;
 	}
 
-	json_decref(root);
-	return;
-
-error:
+msg_response:
 		{
 			if(!internal) {
-				/* Prepare JSON error response */
-				json_t *reply = json_object();
-				json_object_set_new(reply, "textroom", json_string("error"));
-				if(transaction_text)
+				if(error_code == 0 && !reply) {
+					error_code = JANUS_TEXTROOM_ERROR_UNKNOWN_ERROR;
+					g_snprintf(error_cause, 512, "Invalid response");
+				}
+				if(error_code != 0) {
+					/* Prepare JSON error event */
+					json_t *event = json_object();
+					json_object_set_new(event, "textroom", json_string("error"));
+					json_object_set_new(event, "error_code", json_integer(error_code));
+					json_object_set_new(event, "error", json_string(error_cause));
+					reply = event;
+				}
+				if(transaction_text && json == NULL)
 					json_object_set_new(reply, "transaction", json_string(transaction_text));
-				json_object_set_new(reply, "error_code", json_integer(error_code));
-				json_object_set_new(reply, "error", json_string(error_cause));
-				char *reply_text = json_dumps(reply, json_format);
-				json_decref(reply);
-				gateway->relay_data(handle, reply_text, strlen(reply_text));
-				free(reply_text);
+				if(json == NULL) {
+					/* Reply via data channels */
+					char *reply_text = json_dumps(reply, json_format);
+					json_decref(reply);
+					gateway->relay_data(handle, reply_text, strlen(reply_text));
+					free(reply_text);
+				} else {
+					/* Reply via Janus API */
+					return janus_plugin_result_new(JANUS_PLUGIN_OK, NULL, reply);
+				}
 			}
 			if(root != NULL)
 				json_decref(root);
 		}
+	return NULL;
 }
 
 void janus_textroom_slow_link(janus_plugin_session *handle, int uplink, int video) {
@@ -1647,7 +1727,7 @@ void janus_textroom_hangup_media(janus_plugin_session *handle) {
 	while(list) {
 		guint64 room_id = *((guint64 *)list->data);
 		g_snprintf(request, sizeof(request), "{\"textroom\":\"leave\",\"transaction\":\"internal\",\"room\":%"SCNu64"}", room_id);
-		janus_textroom_handle_incoming_request(handle, g_strdup(request), TRUE);
+		janus_textroom_handle_incoming_request(handle, g_strdup(request), NULL, TRUE);
 		list = list->next;
 	}
 	g_list_free_full(first, (GDestroyNotify)g_free);
@@ -1709,6 +1789,7 @@ static void *janus_textroom_handler(void *data) {
 			goto error;
 		json_t *request = json_object_get(root, "request");
 		const char *request_text = json_string_value(request);
+		do_offer = FALSE;
 		if(!strcasecmp(request_text, "setup")) {
 			if(!g_atomic_int_compare_and_exchange(&session->setup, 0, 1)) {
 				JANUS_LOG(LOG_ERR, "PeerConnection already setup\n");
@@ -1718,8 +1799,7 @@ static void *janus_textroom_handler(void *data) {
 			}
 			do_offer = TRUE;
 		} else if(!strcasecmp(request_text, "ack")) {
-			/* The peer send their answer back: do nothing */
-			do_offer = FALSE;
+			/* The peer sent their answer back: do nothing */
 		} else {
 			JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
 			error_code = JANUS_TEXTROOM_ERROR_INVALID_REQUEST;


### PR DESCRIPTION
So far, all TextRoom commands had to be sent via datachannels. As explained in #766, it might make sense to have some room-management requests available to the regular plugin messaging as well, in order to be able, e.g., to create rooms on the server side without having to create a datachannel.

This PR implements this, and allows for the usage of `create`, `destroy`, `exists` and `list` to be invoked via plugin messaging. All the other requests still need a datachannel. Notice that when using plugin messaging the syntax for the request name will have to be `request:"name"` and not `textroom:"name"` (e.g., `request:"create"` and not `textroom:"create"`); all other properties are named exactly the same.

Tested briefly and it seems to be working for me, but please play with this more than I just did, in order to make sure I didn't break anything. If everything works fine and no leaks are found (try spotting those as well), the plan is to merge soon.