### PR TITLE
Configurable timeout for the 'not receiving audio/video' events

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,8 +342,11 @@ or on the command line:
                                   (default=off)
 	-u, --rtcp-mux                Whether to force rtcp-mux or not (whether RTP
                                   and RTCP will always be muxed)  (default=off)
-	-q, --max-nack-queue=number   Maximum size of the NACK queue per user for
-                                  retransmissions
+	-q, --max-nack-queue=number   Maximum size of the NACK queue (in ms) per user
+                                  for retransmissions
+	-t, --no-media-timer=number   Time (in s) that should pass with no media
+                                  (audio or video) being received before Janus
+                                  notifies you about this
 	-r, --rtp-port-range=min-max  Port range to use for RTP/RTCP (only available
 								  if the installed libnice supports it)
 	-d, --debug-level=1-7         Debug/logging level (0=disable debugging,

--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -53,7 +53,9 @@ cert_key = @certdir@/mycert.key
 ; range of ports to use for RTP and RTCP (by default, no range is envisaged), the
 ; starting MTU for DTLS (1472 by default, it adapts automatically),
 ; if BUNDLE should be forced (defaults to false) and if RTCP muxing should
-; be forced (defaults to false).
+; be forced (defaults to false), and finally how much time, in seconds,
+; should pass with no media (audio or video) being received before Janus
+; notifies you about this (default=1s, 0 disables these events entirely).
 [media]
 ;ipv6 = true
 ;max_nack_queue = 1000
@@ -61,6 +63,7 @@ cert_key = @certdir@/mycert.key
 ;dtls_mtu = 1200
 ;force-bundle = true
 ;force-rtcp-mux = true
+;no_media_timer = 1
 
 
 ; NAT-related stuff: specifically, you can configure the STUN/TURN

--- a/html/admin.js
+++ b/html/admin.js
@@ -199,6 +199,22 @@ function updateSettings() {
 							setMaxNackQueue(result);
 						});
 					});
+				} else if(k === 'no_media_timer') {
+					$('#'+k).append('<button id="' + k + '_button" type="button" class="btn btn-xs btn-primary">Edit no-media timer value</button>');
+					$('#'+k + "_button").click(function() {
+						bootbox.prompt("Set the new desired no-media timer value (in seconds, currently " + settings["no_media_timer"] + ")", function(result) {
+							if(isNaN(result)) {
+								bootbox.alert("Invalid no-media timer (should be a positive integer)");
+								return;
+							}
+							result = parseInt(result);
+							if(result < 0) {
+								bootbox.alert("Invalid no-media timer (should be a positive integer)");
+								return;
+							}
+							setNoMediaTimer(result);
+						});
+					});
 				} else if(k === 'locking_debug') {
 					$('#'+k).append('<button id="' + k + '_button" type="button" class="btn btn-xs"></button>');
 					$('#'+k + "_button")
@@ -294,6 +310,11 @@ function setLibniceDebug(enable) {
 
 function setMaxNackQueue(queue) {
 	var request = { "janus": "set_max_nack_queue", "max_nack_queue": queue, "transaction": randomString(12), "admin_secret": secret };
+	sendSettingsRequest(request);
+}
+
+function setNoMediaTimer(timer) {
+	var request = { "janus": "set_no_media_timer", "no_media_timer": timer, "transaction": randomString(12), "admin_secret": secret };
 	sendSettingsRequest(request);
 }
 

--- a/ice.h
+++ b/ice.h
@@ -128,6 +128,12 @@ void janus_set_max_nack_queue(uint mnq);
 /*! \brief Method to get the current max NACK value (i.e., the number of packets per handle to store for retransmissions)
  * @returns The current max NACK value */
 uint janus_get_max_nack_queue(void);
+/*! \brief Method to modify the no-media event timer (i.e., the number of seconds where no media arrives before Janus notifies this)
+ * @param[in] timer The new timer value, in seconds */
+void janus_set_no_media_timer(uint timer);
+/*! \brief Method to get the current no-media event timer (see above)
+ * @returns The current no-media event timer */
+uint janus_get_no_media_timer(void);
 /*! \brief Method to check whether libnice debugging has been enabled (http://nice.freedesktop.org/libnice/libnice-Debug-messages.html)
  * @returns True if libnice debugging is enabled, FALSE otherwise */
 gboolean janus_ice_is_ice_debugging_enabled(void);

--- a/janus.ggo
+++ b/janus.ggo
@@ -18,7 +18,8 @@ option "ice-lite" I "Whether to enable the ICE Lite mode or not" flag off
 option "ice-tcp" T "Whether to enable ICE-TCP or not (warning: only works with ICE Lite)" flag off
 option "force-bundle" U "Whether to force BUNDLE or not (whether audio, video and data will always be bundled)" flag off
 option "force-rtcp-mux" u "Whether to force rtcp-mux or not (whether RTP and RTCP will always be muxed)" flag off
-option "max-nack-queue" q "Maximum size of the NACK queue per user for retransmissions" int typestr="number" optional
+option "max-nack-queue" q "Maximum size of the NACK queue (in ms) per user for retransmissions" int typestr="number" optional
+option "no-media-timer" t "Time (in s) that should pass with no media (audio or video) being received before Janus notifies you about this" int typestr="number" optional
 option "rtp-port-range" r "Port range to use for RTP/RTCP" string typestr="min-max" optional
 option "server-name" n "Public name of this Janus instance (default=MyJanusInstance)" string typestr="name" optional
 option "debug-level" d "Debug/logging level (0=disable debugging, 7=maximum debug level; default=4)" int typestr="1-7" optional

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -1680,6 +1680,15 @@ var websocket = new WebSocket('ws://1.2.3.4:8188', 'janus-protocol');
  * - \c set_locking_debug: selectively enable/disable a live debugging of
  * the locks in Janus on the fly (useful if you're experiencing deadlocks
  * and want to investigate them);
+ * - \c set_libnice_debug: selectively enable/disable libnice debugging;
+ * - \c set_log_timestamps: selectively enable/disable adding a timestamp
+ * to all log lines Janus writes on the console and/or to file;
+ * - \c set_log_colors: selectively enable/disable using colors in all
+ * log lines Janus writes on the console and/or to file;
+ * - \c set_max_nack_queue: change the value of the max NACK queue window
+ * on the fly;
+ * - \c set_no_media_timer: change the value of the no-media timer value
+ * on the fly;
  * - \c add_token: add a valid token (only available if you enabled the \ref token);
  * - \c allow_token: give a token access to a plugin (only available if you enabled the \ref token);
  * - \c disallow_token: remove a token access from a plugin (only available if you enabled the \ref token);


### PR DESCRIPTION
This PR allows for a configuration of the timeout value for the "not receiving audio/video" events. By default, these events are kicked after 1 seconds of no media being received (`{janus:"media", .. , receiving:false}`): a new event of the same type is notified only when media is being received again  (`{janus:"media", .. , receiving:true}`).

This patch allows you to change that value of 1 seconds, which was hardcoded in the core, to something else. A value of 0 disables the "not receiving..." events entirely (but not the "now receiving.." ones). The configuration can be done in `janus.cfg`, command line, or even in real-time using the Admin API.

Addresses #771, feedback welcome.