### PR TITLE
Configurable session timeout value

### DIFF
--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -39,6 +39,15 @@ admin_secret = janusoverlord	; String that all Janus requests must contain
 ;								  in any of the available transports.
 ;server_name = MyJanusInstance	; Public name of this Janus instance
 ;								  as it will appear in an info request
+;session_timeout = 60		; How long (in seconds) we should wait before
+;							deciding a Janus session has timed out. A
+;							session times out when no request is received
+;							for session_timeout seconds (default=60s).
+;							Setting this to 0 will disable the timeout
+;							mechanism, which is NOT suggested as it may
+;							risk having orphaned sessions (sessions not
+;							controlled by any transport and never freed).
+;							To avoid timeouts, keep-alives can be used.
 
 
 ; Certificate and key to use for DTLS.

--- a/html/admin.js
+++ b/html/admin.js
@@ -164,7 +164,25 @@ function updateSettings() {
 					'	<td>' + settings[k] + '</td>' +
 					'	<td id="' + k + '"></td>' +
 					'</tr>');
-				if(k === 'log_level') {
+				if(k === 'session_timeout') {
+					$('#'+k).append('<button id="' + k + '_button" type="button" class="btn btn-xs btn-primary">Edit session timeout value</button>');
+					$('#'+k + "_button").click(function() {
+						bootbox.prompt("Set the new session timeout value (in seconds, currently " + settings["session_timeout"] + ")", function(result) {
+							if(isNaN(result)) {
+								bootbox.alert("Invalid session timeout value");
+								return;
+							}
+							result = parseInt(result);
+							if(result < 0) {
+								console.log(isNaN(result));
+								console.log(result < 0);
+								bootbox.alert("Invalid session timeout value");
+								return;
+							}
+							setSessionTimeoutValue(result);
+						});
+					});
+				} else if(k === 'log_level') {
 					$('#'+k).append('<button id="' + k + '_button" type="button" class="btn btn-xs btn-primary">Edit log level</button>');
 					$('#'+k + "_button").click(function() {
 						bootbox.prompt("Set the new desired log level (0-7, currently " + settings["log_level"] + ")", function(result) {
@@ -265,6 +283,11 @@ function updateSettings() {
 		},
 		dataType: "json"
 	});
+}
+
+function setSessionTimeoutValue(timeout) {
+	var request = { "janus": "set_session_timeout", "timeout": timeout, "transaction": randomString(12), "admin_secret": secret };
+	sendSettingsRequest(request);
 }
 
 function setLogLevel(level) {

--- a/janus.ggo
+++ b/janus.ggo
@@ -21,6 +21,7 @@ option "force-rtcp-mux" u "Whether to force rtcp-mux or not (whether RTP and RTC
 option "max-nack-queue" q "Maximum size of the NACK queue per user for retransmissions" int typestr="number" optional
 option "rtp-port-range" r "Port range to use for RTP/RTCP" string typestr="min-max" optional
 option "server-name" n "Public name of this Janus instance (default=MyJanusInstance)" string typestr="name" optional
+option "session-timeout" s "Session timeout value, in seconds (default=60)" int typestr="number" optional
 option "debug-level" d "Debug/logging level (0=disable debugging, 7=maximum debug level; default=4)" int typestr="1-7" optional
 option "debug-timestamps" D "Enable debug/logging timestamps" flag off
 option "disable-colors" o "Disable color in the logging" flag off

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -1676,6 +1676,7 @@ var websocket = new WebSocket('ws://1.2.3.4:8188', 'janus-protocol');
  * - \c list_handles: list all the ICE handles currently active in a Janus
  * session (returns an array of handle identifiers);
  * - \c handle_info: list all the available info on a specific ICE handle;
+ * - \c set_session_timeout: change the session timeout value in Janus on the fly;
  * - \c set_log_level: change the log level in Janus on the fly;
  * - \c set_locking_debug: selectively enable/disable a live debugging of
  * the locks in Janus on the fly (useful if you're experiencing deadlocks


### PR DESCRIPTION
The value of the session timeout dictates how long we should tolerate inactivity (as in no Janus API messages received) on a session. If no messages were received for a number of seconds that exceeds the timeout, we assume the session is dead and so we free the resources.

Time and again I've been asked to make the session timeout configurable (by default it was hardcoded to 60 seconds). This PR addresses that, and makes it configurable in `janus.cfg`, command line, and even via Admin API.

A value of `0` is possible, and completely disables session timeout checking. Anyway, you don't want that, as that will easily cause orphaned sessions (clients that died and didn't clean up) whose resources are never freed.

Feedback welcome, as I hope to merge soon.