### PR TITLE
Option to add temporary extension while recording

### DIFF
--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -39,6 +39,16 @@ admin_secret = janusoverlord	; String that all Janus requests must contain
 ;								  in any of the available transports.
 ;server_name = MyJanusInstance	; Public name of this Janus instance
 ;								  as it will appear in an info request
+;recordings_tmp_ext = tmp	; The extension for recordings, in Janus, is
+;							.mjr, a custom format we devised ourselves.
+;							By default, we save to .mjr directly. If you'd
+;							rather the recording filename have a temporary
+;							extension while it's being saved, and only
+;							have the .mjr extension when the recording
+;							is over (e.g., to automatically trigger some
+;							external scripts), then uncomment and set the
+;							recordings_tmp_ext property to the extension
+;							to add to the base (e.g., tmp --> .mjr.tmp).
 
 
 ; Certificate and key to use for DTLS.

--- a/janus.c
+++ b/janus.c
@@ -33,6 +33,7 @@
 #include "debug.h"
 #include "rtcp.h"
 #include "auth.h"
+#include "record.h"
 #include "events.h"
 
 
@@ -3494,6 +3495,14 @@ gint main(int argc, char *argv[])
 	item = janus_config_get_item_drilldown(config, "general", "token_auth");
 	janus_auth_init(item && item->value && janus_is_true(item->value));
 
+	/* Initialize the recorder code */
+	item = janus_config_get_item_drilldown(config, "general", "recordings_tmp_ext");
+	if(item && item->value) {
+		janus_recorder_init(TRUE, item->value);
+	} else {
+		janus_recorder_init(FALSE, NULL);
+	}
+
 	/* Setup ICE stuff (e.g., checking if the provided STUN server is correct) */
 	char *stun_server = NULL, *turn_server = NULL;
 	uint16_t stun_port = 0, turn_port = 0;
@@ -4172,6 +4181,8 @@ gint main(int argc, char *argv[])
 		g_hash_table_foreach(eventhandlers_so, janus_eventhandlerso_close, NULL);
 		g_hash_table_destroy(eventhandlers_so);
 	}
+
+	janus_recorder_deinit();
 
 	JANUS_PRINT("Bye!\n");
 

--- a/record.c
+++ b/record.c
@@ -36,6 +36,30 @@ static const char *header = "MJR00001";
 /* Frame header in the structured recording */
 static const char *frame_header = "MEETECHO";
 
+/* Whether the filenames should have a temporary extension, while saving, or not (default=false) */
+static gboolean rec_tempname = FALSE;
+/* Extension to add in case tempnames is true (default="tmp" --> ".tmp") */
+static char *rec_tempext = NULL;
+
+void janus_recorder_init(gboolean tempnames, const char *extension) {
+	JANUS_LOG(LOG_INFO, "Initializing recorder code\n");
+	if(tempnames) {
+		rec_tempname = TRUE;
+		if(extension == NULL) {
+			rec_tempext = g_strdup("tmp");
+			JANUS_LOG(LOG_INFO, "  -- No extension provided, using default one (tmp)");
+		} else {
+			rec_tempext = g_strdup(extension);
+			JANUS_LOG(LOG_INFO, "  -- Using temporary extension .%s", rec_tempext);
+		}
+	}
+}
+
+void janus_recorder_deinit(void) {
+	rec_tempname = FALSE;
+	g_free(rec_tempext);
+}
+
 
 janus_recorder *janus_recorder_create(const char *dir, const char *codec, const char *filename) {
 	janus_recorder_medium type = JANUS_RECORDER_AUDIO;
@@ -101,10 +125,22 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	memset(newname, 0, 1024);
 	if(filename == NULL) {
 		/* Choose a random username */
-		g_snprintf(newname, 1024, "janus-recording-%"SCNu32".mjr", janus_random_uint32());
+		if(!rec_tempname) {
+			/* Use .mjr as an extension right away */
+			g_snprintf(newname, 1024, "janus-recording-%"SCNu32".mjr", janus_random_uint32());
+		} else {
+			/* Append the temporary extension to .mjr, we'll rename when closing */
+			g_snprintf(newname, 1024, "janus-recording-%"SCNu32".mjr.%s", janus_random_uint32(), rec_tempext);
+		}
 	} else {
 		/* Just append the extension */
-		g_snprintf(newname, 1024, "%s.mjr", filename);
+		if(!rec_tempname) {
+			/* Use .mjr as an extension right away */
+			g_snprintf(newname, 1024, "%s.mjr", filename);
+		} else {
+			/* Append the temporary extension to .mjr, we'll rename when closing */
+			g_snprintf(newname, 1024, "%s.mjr.%s", filename, rec_tempext);
+		}
 	}
 	/* Try opening the file now */
 	if(dir == NULL) {
@@ -207,6 +243,19 @@ int janus_recorder_close(janus_recorder *recorder) {
 		size_t fsize = ftell(recorder->file);
 		fseek(recorder->file, 0L, SEEK_SET);
 		JANUS_LOG(LOG_INFO, "File is %zu bytes: %s\n", fsize, recorder->filename);
+	}
+	if(rec_tempname) {
+		/* We need to rename the file, to remove the temporary extension */
+		char newname[1024];
+		memset(newname, 0, 1024);
+		g_snprintf(newname, strlen(recorder->filename)-strlen(rec_tempext), "%s", recorder->filename);
+		if(rename(recorder->filename, newname) != 0) {
+			JANUS_LOG(LOG_ERR, "Error renaming %s to %s...\n", recorder->filename, newname);
+		} else {
+			JANUS_LOG(LOG_INFO, "Recording renamed: %s\n", newname);
+			g_free(recorder->filename);
+			recorder->filename = g_strdup(newname);
+		}
 	}
 	janus_mutex_unlock_nodebug(&recorder->mutex);
 	return 0;

--- a/record.h
+++ b/record.h
@@ -56,6 +56,12 @@ typedef struct janus_recorder {
 	janus_mutex mutex;
 } janus_recorder;
 
+/*! \brief Initialize the recorder code
+ * @param[in] tempnames Whether the filenames should have a temporary extension, while saving, or not
+ * @param[in] extension Extension to add in case tempnames is true */
+void janus_recorder_init(gboolean tempnames, const char *extension);
+/*! \brief De-initialize the recorder code */
+void janus_recorder_deinit(void);
 
 /*! \brief Create a new recorder
  * \note If no target directory is provided, the current directory will be used. If no filename


### PR DESCRIPTION
@Horsetopus expressed this request in #729, as it would make it easier for him to monitor the state of recording in external scripts. Rather than forcing it for everybody, I thought I'd make this an option available in `janus.cfg`. If you set `recordings_tmp_ext` to something, e.g.:

    recordings_tmp_ext = tmp

then while recording the `.mjr` file will also have an additional `.tmp` extension. When the recording is closed, the extra extension is removed. Without that option, the file has the `.mjr` extension since the beginning.

Tested briefly and it seems to do the job. Anyway, I noticed that in some cases, if recordings are not closed normally (e.g., PeerConnection just closed in the EchoTest), the extra extensions are never removed. The more you test this and spot inconsistencies like these, the sooner we can get these sorted out and merge.