### PR TITLE
fix adapter loaded logic to properly report errors

### DIFF
--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -252,7 +252,10 @@ Janus.init = function(options) {
 					done();
 					return;
 				}
-			} catch(e) {};
+			} catch(e) {
+        Janus.error('Init error:', e);
+        return;
+			};
 			var oHead = document.getElementsByTagName('head').item(0);
 			var oScript = document.createElement("script");
 			oScript.type = "text/javascript";


### PR DESCRIPTION
the callback for the scenario where adapter.js is already loaded eventually
executes the Janus.init callback -- if any errors are thrown the load sequence
should abort and report the error, instead of trying to load another script.