### PR TITLE
Allow updating display value via configure command

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -654,7 +654,8 @@ static struct janus_json_parameter configure_parameters[] = {
 	{"quality", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"volume", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"record", JANUS_JSON_BOOL, 0},
-	{"filename", JSON_STRING, 0}
+	{"filename", JSON_STRING, 0},
+	{"display", JSON_STRING, 0}
 };
 static struct janus_json_parameter rtp_forward_parameters[] = {
 	{"room", JSON_INTEGER, JANUS_JSON_PARAM_REQUIRED | JANUS_JSON_PARAM_POSITIVE},

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -2771,8 +2771,8 @@ static void *janus_audiobridge_handler(void *data) {
 					}
 				}
 				if (display) {
-					const char *display_text = json_string_value(display);
-					participant->display = g_strdup(display_text);
+				  g_free(participant->display);
+					participant->display = g_strdup(json_string_value(display));
 					JANUS_LOG(LOG_VERB, "Setting display property: %s (room %"SCNu64", user %"SCNu64")\n", participant->display, participant->room->room_id, participant->user_id);
 				}
 				/* Notify all other participants about the mute/unmute */

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -2731,6 +2731,7 @@ static void *janus_audiobridge_handler(void *data) {
 			json_t *gain = json_object_get(root, "volume");
 			json_t *record = json_object_get(root, "record");
 			json_t *recfile = json_object_get(root, "filename");
+			json_t *display = json_object_get(root, "display");
 			if(gain)
 				participant->volume_gain = json_integer_value(gain);
 			if(quality) {
@@ -2745,26 +2746,33 @@ static void *janus_audiobridge_handler(void *data) {
 				if(participant->encoder)
 					opus_encoder_ctl(participant->encoder, OPUS_SET_COMPLEXITY(participant->opus_complexity));
 			}
-			if(muted) {
-				participant->muted = json_is_true(muted);
-				JANUS_LOG(LOG_VERB, "Setting muted property: %s (room %"SCNu64", user %"SCNu64")\n", participant->muted ? "true" : "false", participant->room->room_id, participant->user_id);
-				if(participant->muted) {
-					/* Clear the queued packets waiting to be handled */
-					janus_mutex_lock(&participant->qmutex);
-					while(participant->inbuf) {
-						GList *first = g_list_first(participant->inbuf);
-						janus_audiobridge_rtp_relay_packet *pkt = (janus_audiobridge_rtp_relay_packet *)first->data;
-						participant->inbuf = g_list_remove_link(participant->inbuf, first);
-						first = NULL;
-						if(pkt == NULL)
-							continue;
-						if(pkt->data)
-							g_free(pkt->data);
-						pkt->data = NULL;
-						g_free(pkt);
-						pkt = NULL;
+			if(muted || display) {
+				if (muted) {
+					participant->muted = json_is_true(muted);
+					JANUS_LOG(LOG_VERB, "Setting muted property: %s (room %"SCNu64", user %"SCNu64")\n", participant->muted ? "true" : "false", participant->room->room_id, participant->user_id);
+					if(participant->muted) {
+						/* Clear the queued packets waiting to be handled */
+						janus_mutex_lock(&participant->qmutex);
+						while(participant->inbuf) {
+							GList *first = g_list_first(participant->inbuf);
+							janus_audiobridge_rtp_relay_packet *pkt = (janus_audiobridge_rtp_relay_packet *)first->data;
+							participant->inbuf = g_list_remove_link(participant->inbuf, first);
+							first = NULL;
+							if(pkt == NULL)
+								continue;
+							if(pkt->data)
+								g_free(pkt->data);
+							pkt->data = NULL;
+							g_free(pkt);
+							pkt = NULL;
+						}
+						janus_mutex_unlock(&participant->qmutex);
 					}
-					janus_mutex_unlock(&participant->qmutex);
+				}
+				if (display) {
+					const char *display_text = json_string_value(display);
+					participant->display = g_strdup(display_text);
+					JANUS_LOG(LOG_VERB, "Setting display property: %s (room %"SCNu64", user %"SCNu64")\n", participant->display, participant->room->room_id, participant->user_id);
 				}
 				/* Notify all other participants about the mute/unmute */
 				janus_mutex_lock(&rooms_mutex);

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -3389,8 +3389,8 @@ static void *janus_videoroom_handler(void *data) {
 				}
 				janus_mutex_unlock(&participant->rec_mutex);
 				if(display) {
-					const char *display_text = json_string_value(display);
-					participant->display = g_strdup(display_text);
+				  g_free(participant->display);
+					participant->display = g_strdup(json_string_value(display));
 					janus_mutex_lock(&participant->room->participants_mutex);
 					json_t *display_event = json_object();
 					json_object_set_new(display_event, "videoroom", json_string("event"));

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -266,7 +266,8 @@ static struct janus_json_parameter publish_parameters[] = {
 	{"data", JANUS_JSON_BOOL, 0},
 	{"bitrate", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"record", JANUS_JSON_BOOL, 0},
-	{"filename", JSON_STRING, 0}
+	{"filename", JSON_STRING, 0},
+	{"display", JSON_STRING, 0}
 };
 static struct janus_json_parameter rtp_forward_parameters[] = {
 	{"room", JSON_INTEGER, JANUS_JSON_PARAM_REQUIRED | JANUS_JSON_PARAM_POSITIVE},
@@ -3395,10 +3396,8 @@ static void *janus_videoroom_handler(void *data) {
 					json_object_set_new(display_event, "videoroom", json_string("event"));
 					json_object_set_new(display_event, "id", json_integer(participant->user_id));
 					json_object_set_new(display_event, "display", json_string(participant->display));
-					if(participant->room) {
-						if(!participant->room->destroyed) {
-							janus_videoroom_notify_participants(participant, display_event);
-						}
+					if(participant->room && !participant->room->destroyed) {
+						janus_videoroom_notify_participants(participant, display_event);
 					}
 					janus_mutex_unlock(&participant->room->participants_mutex);
 					json_decref(display_event);


### PR DESCRIPTION
This adds functionality to the audiobridge and videoroom plugins to allow updating the 'display' value that is optionally passed on registration, via the handle's 'configure' message

I hope you'll go easy on me, I'm not the strongest C programmer, and this is my first attempt to accomplish anything of substance in the Janus codebase :) I'm not clear if I took the best approach, and haven't added any doc yet, pending your feedback and possible adjustments.

I will say that I tested both of them in my local install, and they appear to work perfectly. Sending this configure command:
```javascript
      const configure = {
        "request": "configure",
        "display": "foo",
      };
      handle.send({
        "message": configure,
      });
```
Yields this response for the audiobridge:
```json
{
	"audiobridge": "event",
	"room": 3604791866433732600,
	"participants": [{
		"id": 2677844740813301,
		"display": "foo",
		"muted": false
	}]
}
```
And this for the videoroom:
```json
{
 	"videoroom": "event",
 	"id": "4708612212021077",
 	"display": "foo"
}
```