### PR TITLE
enhancements to BoringSSL handling in autoconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ to manually install it to a specific location. Use the following steps:
 Once the library is installed, you'll have to pass an additional
 ```--enable-boringssl``` flag to the configure script, as by default
 Janus will be built assuming OpenSSL will be used. By default, Janus
-expects BoringSSL to be installed in ```/opt/local``` -- if it's
+expects BoringSSL to be installed in ```/opt/boringssl``` -- if it's
 installed in another location, pass the path to the configure script
 as such: ```--enable-boringssl=/path/to/boringssl``` If you were using
 OpenSSL and want to switch to BoringSSL, make sure you also do a

--- a/README.md
+++ b/README.md
@@ -129,7 +129,10 @@ to manually install it to a specific location. Use the following steps:
 
 Once the library is installed, you'll have to pass an additional
 ```--enable-boringssl``` flag to the configure script, as by default
-Janus will be build assuming OpenSSL will be used. If you were using
+Janus will be built assuming OpenSSL will be used. By default, Janus
+expects BoringSSL to be installed in ```/opt/local``` -- if it's
+installed in another location, pass the path to the configure script
+as such: ```--enable-boringssl=/path/to/boringssl``` If you were using
 OpenSSL and want to switch to BoringSSL, make sure you also do a
 ```make clean``` in the Janus folder before compiling with the new
 BoringSSL support.

--- a/configure.ac
+++ b/configure.ac
@@ -85,8 +85,14 @@ AC_ARG_ENABLE([sample-event-handler],
 AC_ARG_ENABLE([boringssl],
               [AS_HELP_STRING([--enable-boringssl],
                               [Use BoringSSL instead of OpenSSL])],
-              [],
-              [enable_boringssl=no])
+              [
+                case "${enableval}" in
+                  yes) boringssl_dir=/opt/boringssl ;;
+                  no)  boringssl_dir= ;;
+                  *) boringssl_dir=${enableval} ;;
+                esac
+              ],
+              [boringssl_dir=])
 
 AC_ARG_ENABLE([libsrtp2],
               [AS_HELP_STRING([--enable-libsrtp2],
@@ -117,18 +123,19 @@ PKG_CHECK_MODULES([JANUS],
 JANUS_MANUAL_LIBS+=" -lm"
 AC_SUBST(JANUS_MANUAL_LIBS)
 
-AS_IF([test "x$enable_boringssl" = "xyes"],
+AS_IF([test "x${boringssl_dir}" != "x"],
 	  [echo "Trying to use BoringSSL instead of OpenSSL...";
-	   CFLAGS="$CFLAGS -I/opt/boringssl/include";
-	   BORINGSSL_CFLAGS=" -I/opt/boringssl/include";
+	   AC_MSG_NOTICE([BoringSSL directory is ${boringssl_dir}])
+	   CFLAGS="$CFLAGS -I${boringssl_dir}/include";
+	   BORINGSSL_CFLAGS=" -I${boringssl_dir}/include";
        AC_SUBST(BORINGSSL_CFLAGS)
-	   BORINGSSL_LIBS=" -L/opt/boringssl/lib";
+	   BORINGSSL_LIBS=" -L${boringssl_dir}/lib";
        AC_SUBST(BORINGSSL_LIBS)
-	   AC_CHECK_HEADERS([openssl/opensslconf.h],
+	   AC_CHECK_HEADERS([${boringssl_dir}/include/openssl/opensslconf.h],
 	                    [AC_DEFINE(HAVE_BORINGSSL)],
-	                    [AC_MSG_ERROR([BoringSSL headers not found in /opt/boringssl, use --disable-boringssl if you want to use OpenSSL instead])])
+	                    [AC_MSG_ERROR([BoringSSL headers not found in ${boringssl_dir}, use --disable-boringssl if you want to use OpenSSL instead])])
       ])
-AM_CONDITIONAL([ENABLE_BORINGSSL], [test "x$enable_boringssl" = "xyes"])
+AM_CONDITIONAL([ENABLE_BORINGSSL], [test "x${boringssl_dir}" != "x"])
 
 AS_IF([test "x$enable_dtls_settimeout" = "xyes"],
       [


### PR DESCRIPTION
- The BoringSSL header check didn't work at all, it just looked
  for OpenSSL headers in their standard install location. Now the
  check specifically looks in the include directory of the
  BoringSSL installation directory.

- Allows a custom location to be passed for the installation, eg.
  --enable-boringssl=/path/to/boringssl

- Document custom location feature in README

I'm far from an autoconf expert -- these changes are based on the autoconf documentation I read and some examples I found online. I tested all cases (disable/enable/custom install location), and they work correctly, including properly erroring out the configure script if BoringSSL can't be found. Even if it's not perfect, it's certainly an improvement over what's there now :)