### PR TITLE
wrap janus[.nojquery].js in a Universal Module definition

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -22,186 +22,39 @@
 	OTHER DEALINGS IN THE SOFTWARE.
  */
 
-// List of sessions
-Janus.sessions = {};
-
-// Screensharing Chrome Extension ID
-Janus.extensionId = "hapfgfdkleiggjjpfpenajgdnfckjpaj";
-Janus.isExtensionEnabled = function() {
-	if(window.navigator.userAgent.match('Chrome')) {
-		var chromever = parseInt(window.navigator.userAgent.match(/Chrome\/(.*) /)[1], 10);
-		var maxver = 33;
-		if(window.navigator.userAgent.match('Linux'))
-			maxver = 35;	// "known" crash in chrome 34 and 35 on linux
-		if(chromever >= 26 && chromever <= maxver) {
-			// Older versions of Chrome don't support this extension-based approach, so lie
-			return true;
-		}
-		return ($('#janus-extension-installed').length > 0);
+/**
+ * UMD wrapper.
+ */
+(function (root, factory) {
+	if (typeof define === "function" && define.amd) {
+		define([
+			"adapter",
+			"jquery",
+		], function(adapter, jQuery) {
+			return (root.Janus = factory(adapter, jQuery));
+		});
+	} else if (typeof module === "object" && module.exports) {
+		module.exports = (root.Janus = factory(require("adapter"), require("jquery")));
 	} else {
-		// Firefox of others, no need for the extension (but this doesn't mean it will work)
-		return true;
+		root.Janus = factory(root.adapter, root.jQuery);
 	}
-};
+}(this, function(adapter, jQuery) {
+var Janus;
+/**
+ * UMD wrapper.
+ */
 
-Janus.noop = function() {};
+/**
+ * jQuery wrapper.
+ * Allows $ to be used with proper namespacing.
+ */
+(function($) {
+/**
+ * jQuery wrapper.
+ */
 
-// Initialization
-Janus.init = function(options) {
-	options = options || {};
-	options.callback = (typeof options.callback == "function") ? options.callback : Janus.noop;
-	if(Janus.initDone === true) {
-		// Already initialized
-		options.callback();
-	} else {
-		if(typeof console == "undefined" || typeof console.log == "undefined")
-			console = { log: function() {} };
-		// Console logging (all debugging disabled by default)
-		Janus.trace = Janus.noop;
-		Janus.debug = Janus.noop;
-		Janus.vdebug = Janus.noop;
-		Janus.log = Janus.noop;
-		Janus.warn = Janus.noop;
-		Janus.error = Janus.noop;
-		if(options.debug === true || options.debug === "all") {
-			// Enable all debugging levels
-			Janus.trace = console.trace.bind(console);
-			Janus.debug = console.debug.bind(console);
-			Janus.vdebug = console.debug.bind(console);
-			Janus.log = console.log.bind(console);
-			Janus.warn = console.warn.bind(console);
-			Janus.error = console.error.bind(console);
-		} else if(Array.isArray(options.debug)) {
-			for(var i in options.debug) {
-				var d = options.debug[i];
-				switch(d) {
-					case "trace":
-						Janus.trace = console.trace.bind(console);
-						break;
-					case "debug":
-						Janus.debug = console.debug.bind(console);
-						break;
-					case "vdebug":
-						Janus.vdebug = console.debug.bind(console);
-						break;
-					case "log":
-						Janus.log = console.log.bind(console);
-						break;
-					case "warn":
-						Janus.warn = console.warn.bind(console);
-						break;
-					case "error":
-						Janus.error = console.error.bind(console);
-						break;
-					default:
-						console.error("Unknown debugging option '" + d + "' (supported: 'trace', 'debug', 'vdebug', 'log', warn', 'error')");
-						break;
-				}
-			}
-		}
-		Janus.log("Initializing library");
-		// Helper method to enumerate devices
-		Janus.listDevices = function(callback, config) {
-			callback = (typeof callback == "function") ? callback : Janus.noop;
-			if (config == null) config = { audio: true, video: true };
-			if(navigator.mediaDevices) {
-				navigator.mediaDevices.getUserMedia(config)
-				.then(function(stream) {
-					navigator.mediaDevices.enumerateDevices().then(function(devices) {
-						Janus.debug(devices);
-						callback(devices);
-						// Get rid of the now useless stream
-						try {
-							stream.stop();
-						} catch(e) {}
-						try {
-							var tracks = stream.getTracks();
-							for(var i in tracks) {
-								var mst = tracks[i];
-								if(mst !== null && mst !== undefined)
-									mst.stop();
-							}
-						} catch(e) {}
-					});
-				})
-				.catch(function(err) {
-					Janus.error(err);
-					callback([]);
-				});
-			} else {
-				Janus.warn("navigator.mediaDevices unavailable");
-				callback([]);
-			}
-		}
-		// Helper methods to attach/reattach a stream to a video element (previously part of adapter.js)
-		Janus.attachMediaStream = function(element, stream) {
-			if(adapter.browserDetails.browser === 'chrome') {
-				var chromever = adapter.browserDetails.version;
-				if(chromever >= 43) {
-					element.srcObject = stream;
-				} else if(typeof element.src !== 'undefined') {
-					element.src = URL.createObjectURL(stream);
-				} else {
-					Janus.error("Error attaching stream to element");
-				}
-			} else if(adapter.browserDetails.browser === 'safari' || window.navigator.userAgent.match(/iPad/i) || window.navigator.userAgent.match(/iPhone/i)) {
-				element.src = URL.createObjectURL(stream);
-			} else {
-				element.srcObject = stream;
-			}
-		};
-		Janus.reattachMediaStream = function(to, from) {
-			if(adapter.browserDetails.browser === 'chrome') {
-				var chromever = adapter.browserDetails.version;
-				if(chromever >= 43) {
-					to.srcObject = from.srcObject;
-				} else if(typeof to.src !== 'undefined') {
-					to.src = from.src;
-				}
-			} else if(adapter.browserDetails.browser === 'safari' || window.navigator.userAgent.match(/iPad/i) || window.navigator.userAgent.match(/iPhone/i)) {
-				to.src = from.src;
-			} else {
-				to.srcObject = from.srcObject;
-			}
-		};
-		// Detect tab close: make sure we don't loose existing onbeforeunload handlers
-		var oldOBF = window.onbeforeunload;
-		window.onbeforeunload = function() {
-			Janus.log("Closing window");
-			for(var s in Janus.sessions) {
-				if(Janus.sessions[s] !== null && Janus.sessions[s] !== undefined &&
-						Janus.sessions[s].destroyOnUnload) {
-					Janus.log("Destroying session " + s);
-					Janus.sessions[s].destroy({asyncRequest: false});
-				}
-			}
-			if(oldOBF && typeof oldOBF == "function")
-				oldOBF();
-		}
-		Janus.initDone = true;
-		options.callback();
-	}
-};
-
-// Helper method to check whether WebRTC is supported by this browser
-Janus.isWebrtcSupported = function() {
-	return window.RTCPeerConnection !== undefined && window.RTCPeerConnection !== null &&
-		navigator.getUserMedia !== undefined && navigator.getUserMedia !== null;
-};
-
-// Helper method to create random identifiers (e.g., transaction)
-Janus.randomString = function(len) {
-	var charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-	var randomString = '';
-	for (var i = 0; i < len; i++) {
-		var randomPoz = Math.floor(Math.random() * charSet.length);
-		randomString += charSet.substring(randomPoz,randomPoz+1);
-	}
-	return randomString;
-}
-
-
-function Janus(gatewayCallbacks) {
+// Janus session object
+Janus = function(gatewayCallbacks) {
 	if(Janus.initDone === undefined) {
 		gatewayCallbacks.error("Library not initialized");
 		return {};
@@ -2243,3 +2096,197 @@ function Janus(gatewayCallbacks) {
 		return (trickle === true);
 	}
 };
+
+// List of sessions
+Janus.sessions = {};
+
+// Screensharing Chrome Extension ID
+Janus.extensionId = "hapfgfdkleiggjjpfpenajgdnfckjpaj";
+Janus.isExtensionEnabled = function() {
+	if(window.navigator.userAgent.match('Chrome')) {
+		var chromever = parseInt(window.navigator.userAgent.match(/Chrome\/(.*) /)[1], 10);
+		var maxver = 33;
+		if(window.navigator.userAgent.match('Linux'))
+			maxver = 35;	// "known" crash in chrome 34 and 35 on linux
+		if(chromever >= 26 && chromever <= maxver) {
+			// Older versions of Chrome don't support this extension-based approach, so lie
+			return true;
+		}
+		return ($('#janus-extension-installed').length > 0);
+	} else {
+		// Firefox of others, no need for the extension (but this doesn't mean it will work)
+		return true;
+	}
+};
+
+Janus.noop = function() {};
+
+// Initialization
+Janus.init = function(options) {
+	options = options || {};
+	options.callback = (typeof options.callback == "function") ? options.callback : Janus.noop;
+	if(Janus.initDone === true) {
+		// Already initialized
+		options.callback();
+	} else {
+		if(typeof console == "undefined" || typeof console.log == "undefined")
+			console = { log: function() {} };
+		// Console logging (all debugging disabled by default)
+		Janus.trace = Janus.noop;
+		Janus.debug = Janus.noop;
+		Janus.vdebug = Janus.noop;
+		Janus.log = Janus.noop;
+		Janus.warn = Janus.noop;
+		Janus.error = Janus.noop;
+		if(options.debug === true || options.debug === "all") {
+			// Enable all debugging levels
+			Janus.trace = console.trace.bind(console);
+			Janus.debug = console.debug.bind(console);
+			Janus.vdebug = console.debug.bind(console);
+			Janus.log = console.log.bind(console);
+			Janus.warn = console.warn.bind(console);
+			Janus.error = console.error.bind(console);
+		} else if(Array.isArray(options.debug)) {
+			for(var i in options.debug) {
+				var d = options.debug[i];
+				switch(d) {
+					case "trace":
+						Janus.trace = console.trace.bind(console);
+						break;
+					case "debug":
+						Janus.debug = console.debug.bind(console);
+						break;
+					case "vdebug":
+						Janus.vdebug = console.debug.bind(console);
+						break;
+					case "log":
+						Janus.log = console.log.bind(console);
+						break;
+					case "warn":
+						Janus.warn = console.warn.bind(console);
+						break;
+					case "error":
+						Janus.error = console.error.bind(console);
+						break;
+					default:
+						console.error("Unknown debugging option '" + d + "' (supported: 'trace', 'debug', 'vdebug', 'log', warn', 'error')");
+						break;
+				}
+			}
+		}
+		Janus.log("Initializing library");
+		// Helper method to enumerate devices
+		Janus.listDevices = function(callback, config) {
+			callback = (typeof callback == "function") ? callback : Janus.noop;
+			if(navigator.mediaDevices) {
+				navigator.mediaDevices.getUserMedia(config)
+				.then(function(stream) {
+					navigator.mediaDevices.enumerateDevices().then(function(devices) {
+						Janus.debug(devices);
+						callback(devices);
+						// Get rid of the now useless stream
+						try {
+							stream.stop();
+						} catch(e) {}
+						try {
+							var tracks = stream.getTracks();
+							for(var i in tracks) {
+								var mst = tracks[i];
+								if(mst !== null && mst !== undefined)
+									mst.stop();
+							}
+						} catch(e) {}
+					});
+				})
+				.catch(function(err) {
+					Janus.error(err);
+					callback([]);
+				});
+			} else {
+				Janus.warn("navigator.mediaDevices unavailable");
+				callback([]);
+			}
+		}
+		// Helper methods to attach/reattach a stream to a video element (previously part of adapter.js)
+		Janus.attachMediaStream = function(element, stream) {
+			if(adapter.browserDetails.browser === 'chrome') {
+				var chromever = adapter.browserDetails.version;
+				if(chromever >= 43) {
+					element.srcObject = stream;
+				} else if(typeof element.src !== 'undefined') {
+					element.src = URL.createObjectURL(stream);
+				} else {
+					Janus.error("Error attaching stream to element");
+				}
+			} else if(adapter.browserDetails.browser === 'safari' || window.navigator.userAgent.match(/iPad/i) || window.navigator.userAgent.match(/iPhone/i)) {
+				element.src = URL.createObjectURL(stream);
+			} else {
+				element.srcObject = stream;
+			}
+		};
+		Janus.reattachMediaStream = function(to, from) {
+			if(adapter.browserDetails.browser === 'chrome') {
+				var chromever = adapter.browserDetails.version;
+				if(chromever >= 43) {
+					to.srcObject = from.srcObject;
+				} else if(typeof to.src !== 'undefined') {
+					to.src = from.src;
+				}
+			} else if(adapter.browserDetails.browser === 'safari' || window.navigator.userAgent.match(/iPad/i) || window.navigator.userAgent.match(/iPhone/i)) {
+				to.src = from.src;
+			} else {
+				to.srcObject = from.srcObject;
+			}
+		};
+		// Detect tab close: make sure we don't loose existing onbeforeunload handlers
+		var oldOBF = window.onbeforeunload;
+		window.onbeforeunload = function() {
+			Janus.log("Closing window");
+			for(var s in Janus.sessions) {
+				if(Janus.sessions[s] !== null && Janus.sessions[s] !== undefined &&
+						Janus.sessions[s].destroyOnUnload) {
+					Janus.log("Destroying session " + s);
+					Janus.sessions[s].destroy({asyncRequest: false});
+				}
+			}
+			if(oldOBF && typeof oldOBF == "function")
+				oldOBF();
+		}
+		Janus.initDone = true;
+		options.callback();
+	}
+};
+
+// Helper method to check whether WebRTC is supported by this browser
+Janus.isWebrtcSupported = function() {
+	return window.RTCPeerConnection !== undefined && window.RTCPeerConnection !== null &&
+		navigator.getUserMedia !== undefined && navigator.getUserMedia !== null;
+};
+
+// Helper method to create random identifiers (e.g., transaction)
+Janus.randomString = function(len) {
+	var charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	var randomString = '';
+	for (var i = 0; i < len; i++) {
+		var randomPoz = Math.floor(Math.random() * charSet.length);
+		randomString += charSet.substring(randomPoz,randomPoz+1);
+	}
+	return randomString;
+}
+
+/**
+ * jQuery wrapper.
+ */
+})(jQuery);
+/**
+ * jQuery wrapper.
+ */
+
+/**
+ * UMD wrapper.
+ */
+return Janus;
+}));
+/**
+ * UMD wrapper.
+ */


### PR DESCRIPTION
This is a draft PR to illustrate wrapping the janus[.nojquery].js library in a Univeral Module Definition: https://github.com/umdjs/umd

There are various definition patterns, I chose what I believe is the most common: allowing users to consume the library as an AMD module, a Node.js-like module, or the old school global.

Although there is a high line count to this patch, the changes are actually quite simple:

1. Make the Janus object local to the module definition (this involved moving all the object properties hung off the Janus function object to after its declaration)
2. Wrap that in a self executing function that allows jQuery to be used locally as either $ or jQuery (this could be eliminated if one or the other was used exclusively)
3. Wrap all that in the UMD, which is basically just a few lines of environment detection code inside a self-executing function, and should hardly ever be expected to change (only if a new loading environment became popular).

The way adapter.js is currently loaded is weird, and doesn't work well with the scoping, so I included it specifically in the videoroom demo HTML for example purposes -- I believe this weirdness is already being addressed in the web-refs branch.

Taking this approach will ease consumption of this library for more modern tooling, ala Webpack/Browserify, without compromising it's traditional use case.

If this draft is acceptable, I'll wait until the web-refs branch is merged, clean it up, and also convert janus.nojquery.js, which will be straightforward.