### PR TITLE
check for existence of peerconnection object in oniceconnectionstatechange callback

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1253,7 +1253,9 @@ function Janus(gatewayCallbacks) {
 		}
 		Janus.log("Preparing local SDP and gathering candidates (trickle=" + config.trickle + ")");
 		config.pc.oniceconnectionstatechange = function(e) {
-			pluginHandle.iceState(config.pc.iceConnectionState);
+			if(config.pc !== undefined && config.pc !== null) {
+				pluginHandle.iceState(config.pc.iceConnectionState);
+			}
 		};
 		config.pc.onicecandidate = function(event) {
 			if (event.candidate == null ||

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -1291,7 +1291,9 @@ function Janus(gatewayCallbacks) {
 		}
 		Janus.log("Preparing local SDP and gathering candidates (trickle=" + config.trickle + ")");
 		config.pc.oniceconnectionstatechange = function(e) {
-			pluginHandle.iceState(config.pc.iceConnectionState);
+			if(config.pc !== undefined && config.pc !== null) {
+				pluginHandle.iceState(config.pc.iceConnectionState);
+			}
 		};
 		config.pc.onicecandidate = function(event) {
 			if (event.candidate == null ||


### PR DESCRIPTION
It's possible for the ```oniceconnectionstatechange``` callback to be fired
after the ```janus.js``` library has already cleaned up its peer connection
object, so check for its existence before accessing it.