### PR TITLE
Better integration of new IP tools in Janus core and plugins

### DIFF
--- a/conf/janus.plugin.streaming.cfg.sample.in
+++ b/conf/janus.plugin.streaming.cfg.sample.in
@@ -36,7 +36,12 @@
 ; dataiface = network interface or IP address to bind to, if any (binds to all otherwise)
 ; databuffermsg = yes|no (whether the plugin should store the latest
 ;		message and send it immediately for new viewers)
+;
+; The following options are only valid for the 'rstp' type:
 ; url = RTSP stream URL (only for restreaming RTSP)
+; rtsp_user = RTSP authorization username (only if type=rtsp)
+; rtsp_pwd = RTSP authorization password (only if type=rtsp)
+; rtspiface = network interface or IP address to bind to, if any (binds to all otherwise), when receiving RTSP streams
 ;
 ; To test the [gstreamer-sample] example, check the test_gstreamer.sh
 ; script in the plugins/streams folder. To test the live and on-demand

--- a/ip-utils.c
+++ b/ip-utils.c
@@ -276,7 +276,7 @@ int janus_network_detect_local_ip(janus_network_query_options addr_type, janus_n
 char *janus_network_detect_local_ip_as_string(janus_network_query_options addr_type) {
 	janus_network_address addr;
 	janus_network_address_string_buffer buf;
-    int res = janus_network_detect_local_ip(addr_type, &addr) || janus_network_address_to_string_buffer(&addr, &buf);
+	int res = janus_network_detect_local_ip(addr_type, &addr) || janus_network_address_to_string_buffer(&addr, &buf);
 	if(res != 0)
 		return NULL;
 	return g_strdup(janus_network_address_string_from_buffer(&buf));

--- a/ip-utils.c
+++ b/ip-utils.c
@@ -24,33 +24,6 @@
 
 #include "ip-utils.h"
 
-int janus_network_detect_local_ip(char *buf, size_t buflen) {
-	struct sockaddr_in addr;
-	socklen_t len;
-	int fd = socket(AF_INET, SOCK_DGRAM, 0);
-	if(fd == -1)
-		goto error;
-	addr.sin_family = AF_INET;
-	addr.sin_port = htons(1);
-	inet_pton(AF_INET, "1.2.3.4", &addr.sin_addr.s_addr);
-	if(connect(fd, (const struct sockaddr*) &addr, sizeof(addr)) < 0)
-		goto error;
-	len = sizeof(addr);
-	if(getsockname(fd, (struct sockaddr*) &addr, &len) < 0)
-		goto error;
-	if(getnameinfo((const struct sockaddr*) &addr, sizeof(addr),
-			buf, buflen,
-			NULL, 0, NI_NUMERICHOST) != 0)
-		goto error;
-	close(fd);
-	return 0;
-error:
-	if(fd != -1)
-		close(fd);
-	g_strlcpy(buf, "127.0.0.1", buflen);
-	return -1;
-}
-
 static int janus_ip_compare_byte_arrays(const uint8_t *b1, const uint8_t *b2, const size_t size) {
 	size_t i;
 	for(i = 0; i < size; ++i) {
@@ -92,8 +65,7 @@ static int janus_ip_iface_matches(const struct ifaddrs *ifa, const janus_network
 			((query->mode & janus_network_query_options_ipv4) && janus_ip_iface_matches_ipv4(ifa, &query->ipv4) == 1) ||
 			((query->mode & janus_network_query_options_ipv6) && janus_ip_iface_matches_ipv6(ifa, &query->ipv6) == 1) ||
 			((query->mode & janus_network_query_options_name) && janus_ip_iface_matches_name(ifa, query->device_name) == 1) ? 1 : 0;
-	}
-	else {
+	} else {
 		return -EINVAL;
 	}
 }
@@ -126,8 +98,7 @@ int janus_network_prepare_device_query(const char *user_value, const janus_netwo
 		}
 
 		return ((query_mode == janus_network_query_options_none) == (query->mode == janus_network_query_options_none)) ? 0 : -EINVAL;
-	}
-	else {
+	} else {
 		return -EINVAL;
 	}
 }
@@ -144,8 +115,7 @@ static int janus_ip_copy_ipv4(const struct sockaddr_in *iface, struct in_addr *r
 int janus_network_get_devices_ipv4(const struct ifaddrs *ifa, const janus_network_query_config *query, struct in_addr *result) {
 	if(ifa && ifa->ifa_addr && (ifa->ifa_addr->sa_family == AF_INET) && result && query && (query->mode & janus_network_query_options_ipv4)) {
 		return janus_ip_copy_ipv4((struct sockaddr_in *) ifa->ifa_addr, result);
-	}
-	else {
+	} else {
 		return -EINVAL;
 	}
 }
@@ -163,8 +133,7 @@ static int janus_ip_copy_ipv6(const struct sockaddr_in6 *iface, struct in6_addr 
 int janus_network_get_devices_ipv6(const struct ifaddrs *ifa, const janus_network_query_config *query, struct in6_addr *result) {
 	if(ifa && ifa->ifa_addr && (ifa->ifa_addr->sa_family == AF_INET6) && result && query && (query->mode & janus_network_query_options_ipv6)) {
 		return janus_ip_copy_ipv6((struct sockaddr_in6 *) ifa->ifa_addr, result);
-	}
-	else {
+	} else {
 		return -EINVAL;
 	}
 }
@@ -181,8 +150,7 @@ int janus_network_get_device_address(const struct ifaddrs *ifa, janus_network_ad
 			default:
 				return -EINVAL;
 		}
-	}
-	else {
+	} else {
 		return -EINVAL;
 	}
 }
@@ -232,23 +200,84 @@ const char *janus_network_address_string_from_buffer(const janus_network_address
 }
 
 int janus_network_lookup_interface(const struct ifaddrs *ifas, const char *iface, janus_network_address *result) {
-	if(result == NULL)
-		return -1;
+	if(ifas == NULL || iface == NULL || result == NULL)
+		return -EINVAL;
 	janus_network_address_nullify(result);
-	if(iface == NULL)
-		return -1;
 	janus_network_query_config q;
 	/* Let's see if iface is an IPv4 address, an IPv6 address, or possibly an interface name */
-	if(janus_network_prepare_device_query(iface,
-			janus_network_query_options_ipv4 | janus_network_query_options_ipv6 | janus_network_query_options_name, &q)) {
+	int res = janus_network_prepare_device_query(iface,
+			janus_network_query_options_ipv4 | janus_network_query_options_ipv6 | janus_network_query_options_name, &q);
+	if(res != 0) {
 		/* None of them..? */
-		return -1;
+		return res;
 	}
 	const struct ifaddrs *found = janus_network_query_devices(ifas, &q);
 	if(!found || janus_network_get_device_address(found, result)) {
 		/* Couldn't find anything on iface */
-		return -1;
+		return -EINVAL;
 	}
 	/* Done */
 	return 0;
+}
+
+int janus_network_detect_local_ip(janus_network_query_options addr_type, janus_network_address *result) {
+	if(result == NULL)
+		return -EINVAL;
+	janus_network_address_nullify(result);
+	gboolean found = FALSE;
+	int fd = -1;
+	if(addr_type == janus_network_query_options_ipv4 || addr_type == janus_network_query_options_any_ip) {
+		/* Let's try IPv4 (FIXME Should probably use other internal methods) */
+		struct sockaddr_in addr;
+		socklen_t len;
+		fd = socket(AF_INET, SOCK_DGRAM, 0);
+		if(fd > -1) {
+			addr.sin_family = AF_INET;
+			addr.sin_port = htons(1);
+			inet_pton(AF_INET, "1.2.3.4", &addr.sin_addr);
+			if(connect(fd, (const struct sockaddr*)&addr, sizeof(addr)) > -1) {
+				len = sizeof(addr);
+				if(getsockname(fd, (struct sockaddr*)&addr, &len) > -1) {
+					result->family = AF_INET;
+					if(janus_ip_copy_ipv4((struct sockaddr_in *)&addr, &result->ipv4) == 0) {
+						found = TRUE;
+					}
+				}
+			}
+		}
+	}
+	if(fd != -1)
+		close(fd);
+	if(!found && (addr_type == janus_network_query_options_ipv6 || addr_type == janus_network_query_options_any_ip)) {
+		/* Let's try IPv6 (FIXME Should probably use other internal methods) */
+		struct sockaddr_in6 addr;
+		socklen_t len;
+		int fd = socket(AF_INET6, SOCK_DGRAM, 0);
+		if(fd > -1) {
+			addr.sin6_family = AF_INET6;
+			addr.sin6_port = htons(1);
+			inet_pton(AF_INET6, "::1.2.3.4", &addr.sin6_addr);
+			if(connect(fd, (const struct sockaddr*)&addr, sizeof(addr)) > -1) {
+				len = sizeof(addr);
+				if(getsockname(fd, (struct sockaddr*)&addr, &len) > -1) {
+					result->family = AF_INET6;
+					if(janus_ip_copy_ipv6((struct sockaddr_in6 *)&addr, &result->ipv6) == 0) {
+						found = TRUE;
+					}
+				}
+			}
+		}
+	}
+	if(fd != -1)
+		close(fd);
+	return found ? 0 : -EINVAL;
+}
+
+char *janus_network_detect_local_ip_as_string(janus_network_query_options addr_type) {
+	janus_network_address addr;
+	janus_network_address_string_buffer buf;
+    int res = janus_network_detect_local_ip(addr_type, &addr) || janus_network_address_to_string_buffer(&addr, &buf);
+	if(res != 0)
+		return NULL;
+	return g_strdup(janus_network_address_string_from_buffer(&buf));
 }

--- a/ip-utils.h
+++ b/ip-utils.h
@@ -21,12 +21,6 @@
 #include <netinet/in.h>
 
 
-/*! \brief Helper method to find a valid local IP address, that is an address that can be used to communicate
- * @param[in] buf An input/output buffer over which the IP address will be printed
- * @param[in] buflen The size of the input/output buffer
- * @returns 0 if found, a negative integer otherwise */
-int janus_network_detect_local_ip(char *buf, size_t buflen);
-
 /** @name Janus helper methods to match names and addresses with network interfaces/devices.
  */
 ///@{
@@ -88,7 +82,7 @@ typedef struct janus_network_address_string_buffer {
 /*!
  * \brief Initialise a network device query.
  * \param user_value The user-supplied string which is supposed to describe either the device name or its IP address.
- * \param query_mode (A mask of) Options describing the supoorted types of matches which should be accepted when performing a look up with this query.
+ * \param query_mode (A mask of) Options describing the supported types of matches which should be accepted when performing a look up with this query.
  * This can be used to restrict the query to 'by device name' or 'IPv4 only' type searches.
  * \param query The query object to configure.
  * \return 0 on success or -EINVAL if any of the arguments are NULL or the given value to look for does not correspond to a valid IPv4/IPv6 address and
@@ -197,13 +191,31 @@ int janus_network_address_string_buffer_is_null(const janus_network_address_stri
 const char *janus_network_address_string_from_buffer(const janus_network_address_string_buffer *b);
 
 /*!
- * \brief Look for an interface name to prepare a janus_network_address instance
- * \param ifas The list of interfaces to lookup into (e.g., as returned from getifaddrs)
+ * \brief Convert an interface name or IP address to a janus_network_address instance
+ * \param ifas The list of interfaces to look into (e.g., as returned from getifaddrs)
  * \param iface The interface name or IP address to look for
  * \param result Pointer to a valid janus_network_address instance that will contain the result
- * \return 0 in case of success, a negative integer otherwise
+ * \return 0 in case of success, -EINVAL otherwise otherwise
  */
 int janus_network_lookup_interface(const struct ifaddrs *ifas, const char *iface, janus_network_address *result);
+
+/*!
+ * \brief Helper method to find a valid local IP address, that is an address that can be used to communicate
+ * \param addr The type of address you're interested in (janus_network_query_options_ipv4,
+ * janus_network_query_options_ipv6 or janus_network_query_options_any_ip)
+ * \param result Pointer to a valid janus_network_address instance that will contain the result
+ * \return 0 in case of success, -EINVAL otherwise otherwise
+ */
+int janus_network_detect_local_ip(janus_network_query_options addr_type, janus_network_address *result);
+
+/*!
+ * \brief Wrapper to janus_network_detect_local_ip that returns a string instead
+ * \note The string is allocated with g_strdup and so needs to be freed by the caller
+ * \param addr The type of address you're interested in (janus_network_query_options_ipv4,
+ * janus_network_query_options_ipv6 or janus_network_query_options_any_ip)
+ * \return 0 in case of success, -EINVAL otherwise otherwise
+ */
+char *janus_network_detect_local_ip_as_string(janus_network_query_options addr_type);
 ///@}
 
 #endif

--- a/ip-utils.h
+++ b/ip-utils.h
@@ -3,10 +3,10 @@
  * \copyright GNU General Public License v3
  * \brief    IP address related utility functions (headers)
  * \details  Provides functions to query for network devices with a given device name or address.
- * \p Devices may be looked up by either a device name or by the IPv4 or IPv6 address of the configured network interface.
+ * Devices may be looked up by either a device name or by the IPv4 or IPv6 address of the configured network interface.
  * This functionality may be used to bind to user configurable network devices instead of relying on unpredictable implementation defined defaults.
  *
- * \p Parsing IPv4/IPv6 addresses is robust against malformed input.
+ * Parsing IPv4/IPv6 addresses is robust against malformed input.
  *
  * \see man 3 getifaddrs
  * \see man 3 inet_pton
@@ -20,24 +20,31 @@
 #include <ifaddrs.h>
 #include <netinet/in.h>
 
+
+/*! \brief Helper method to find a valid local IP address, that is an address that can be used to communicate
+ * @param[in] buf An input/output buffer over which the IP address will be printed
+ * @param[in] buflen The size of the input/output buffer
+ * @returns 0 if found, a negative integer otherwise */
+int janus_network_detect_local_ip(char *buf, size_t buflen);
+
 /** @name Janus helper methods to match names and addresses with network interfaces/devices.
  */
 ///@{
-typedef enum janus_ip_network_query_options {
-	janus_ip_network_query_options_none = 0,
-	janus_ip_network_query_options_name = 1,
-	janus_ip_network_query_options_ipv4 = 2,
-	janus_ip_network_query_options_ipv6 = 4,
-	janus_ip_network_query_options_any_ip = 6,
-	janus_ip_network_query_options_any = 7
-} janus_ip_network_query_options;
+typedef enum janus_network_query_options {
+	janus_network_query_options_none = 0,
+	janus_network_query_options_name = 1,
+	janus_network_query_options_ipv4 = 2,
+	janus_network_query_options_ipv6 = 4,
+	janus_network_query_options_any_ip = 6,
+	janus_network_query_options_any = 7
+} janus_network_query_options;
 
 /*!
  * \brief Internal object representation of a network device query (configuration).
  */
 typedef struct janus_network_query_config {
-	const char * device_name;
-	janus_ip_network_query_options mode;
+	const char *device_name;
+	janus_network_query_options mode;
 	struct in_addr ipv4;
 	struct in6_addr ipv6;
 } janus_network_query_config;
@@ -47,7 +54,7 @@ typedef struct janus_network_query_config {
  * Use the \c family member (either \c AF_INET or \c AF_INET6) to determine which type of address is contained.
  * \see man 7 ip
  * \see man 7 ipv6
- * \see \c janus_get_network_device_address
+ * \see \c janus_network_get_device_address
  */
 typedef struct janus_network_address {
 	/*!
@@ -86,9 +93,9 @@ typedef struct janus_network_address_string_buffer {
  * \param query The query object to configure.
  * \return 0 on success or -EINVAL if any of the arguments are NULL or the given value to look for does not correspond to a valid IPv4/IPv6 address and
  * matching by name is disabled.
- * \see \c janus_ip_network_query_options
+ * \see \c janus_network_query_options
  */
-int janus_prepare_network_device_query(const char *user_value, const janus_ip_network_query_options query_mode, janus_network_query_config *query);
+int janus_network_prepare_device_query(const char *user_value, const janus_network_query_options query_mode, janus_network_query_config *query);
 
 /*!
  * \brief Initialise a network device query with default query options.
@@ -96,9 +103,9 @@ int janus_prepare_network_device_query(const char *user_value, const janus_ip_ne
  * \param user_value The user-supplied string which is supposed to describe either the device name or its IP address.
  * \param query The query object to configure.
  * \return 0 on success, or -EINVAL if any of the arguments are NULL
- * \see \c janus_prepare_network_device_query
+ * \see \c janus_network_prepare_device_query
  */
-int janus_prepare_network_device_query_default(const char *user_value, janus_network_query_config *query);
+int janus_network_prepare_device_query_default(const char *user_value, janus_network_query_config *query);
 
 /*!
  * \brief Look up network devices matching the given query.
@@ -110,34 +117,34 @@ int janus_prepare_network_device_query_default(const char *user_value, janus_net
  * \return a pointer to a node describing the matching network interface or `NULL` if no (further) match was found.
  * \see man 3 getifaddrs
  */
-const struct ifaddrs * janus_query_network_devices(const struct ifaddrs *ifas, const janus_network_query_config *query);
+const struct ifaddrs *janus_network_query_devices(const struct ifaddrs *ifas, const janus_network_query_config *query);
 
 /*!
  * \brief Copies the IPv4 address from a network inteface description to the given result structure.
- * \param ifa The network interface description to grab the IPv4 address from. It should be obtained with `janus_query_network_devices()`.
+ * \param ifa The network interface description to grab the IPv4 address from. It should be obtained with `janus_network_query_devices()`.
  * \param result Pointer to a structure to populate with the IPv4 address of the given network interface
  * \return 0 on success, -EINVAL if any argument is NULL or the network interface description or the network device query do not correspond to an IPv4 configuration.
  * \see man 7 ip
- * \see \c janus_query_network_devices
+ * \see \c janus_network_query_devices
  */
-int janus_get_network_devices_ipv4(const struct ifaddrs *ifa, const janus_network_query_config *query, struct in_addr *result);
+int janus_network_get_devices_ipv4(const struct ifaddrs *ifa, const janus_network_query_config *query, struct in_addr *result);
 
 /*!
  * \brief Copies the IPv6 address from a network inteface description to the given result structure.
- * \param ifa The network interface description to grab the IPv6 address from. It should be obtained with `janus_query_network_devices()`.
+ * \param ifa The network interface description to grab the IPv6 address from. It should be obtained with `janus_network_query_devices()`.
  * \param result Pointer to a structure to populate with the IPv6 address of the given network interface
  * \return 0 on success, -EINVAL if any argument is NULL or the network interface description or the network device query do not correspond to an IPv6 configuration.
  * \see man 7 ipv6
- * \see \c janus_query_network_devices
+ * \see \c janus_network_query_devices
  */
-int janus_get_network_devices_ipv6(const struct ifaddrs *ifa, const janus_network_query_config *query, struct in6_addr *result);
+int janus_network_get_devices_ipv6(const struct ifaddrs *ifa, const janus_network_query_config *query, struct in6_addr *result);
 
 /*!
  * \brief Copies the IP address from a network interface description to the given result structure.
  * \return 0 on success, or -EINVAL if any argument is NULL or the given network interface does not correspond to an IP address.
  * \see \c janus_network_address
  */
-int janus_get_network_device_address(const struct ifaddrs *ifa, janus_network_address *result);
+int janus_network_get_device_address(const struct ifaddrs *ifa, janus_network_address *result);
 
 /*!
  * \brief Set the given network address to a null/nil value.
@@ -149,7 +156,7 @@ void janus_network_address_nullify(janus_network_address *a);
 /*!
  * \brief Test if a given network address is null-valued
  * \param a The address to check
- * \return some a value which is true if the given address is null-valued, false otherwise.
+ * \return A positive integer if the given address is null-valued, 0 otherwise.
  * \see \c janus_network_address_nullify
  */
 int janus_network_address_is_null(const janus_network_address *a);
@@ -176,7 +183,7 @@ void janus_network_address_string_buffer_nullify(janus_network_address_string_bu
 /*!
  * \brief Test if a given network address string buffer is null-valued
  * \param b The buffer to check
- * \return some a value which is true if the given buffer is null-valued, false otherwise.
+ * \return A positive integer if the given buffer is null-valued, 0 otherwise.
  * \see \c janus_network_address_string_buffer_nullify
  */
 int janus_network_address_string_buffer_is_null(const janus_network_address_string_buffer *b);
@@ -184,10 +191,19 @@ int janus_network_address_string_buffer_is_null(const janus_network_address_stri
 /*!
  * \brief Extract the human readable representation of a network address from a given buffer.
  * \param b The buffer containing the given network
- * \return a pointer to the human readable representation of the network address inside the given buffer, or NULL if the buffer is invalid or NULL.
+ * \return A pointer to the human readable representation of the network address inside the given buffer, or NULL if the buffer is invalid or NULL.
  * \see \c janus_network_address_to_string_buffer
  */
-const char * janus_network_address_string_from_buffer(const janus_network_address_string_buffer *b);
+const char *janus_network_address_string_from_buffer(const janus_network_address_string_buffer *b);
+
+/*!
+ * \brief Look for an interface name to prepare a janus_network_address instance
+ * \param ifas The list of interfaces to lookup into (e.g., as returned from getifaddrs)
+ * \param iface The interface name or IP address to look for
+ * \param result Pointer to a valid janus_network_address instance that will contain the result
+ * \return 0 in case of success, a negative integer otherwise
+ */
+int janus_network_lookup_interface(const struct ifaddrs *ifas, const char *iface, janus_network_address *result);
 ///@}
 
 #endif

--- a/ip-utils.h
+++ b/ip-utils.h
@@ -156,6 +156,14 @@ void janus_network_address_nullify(janus_network_address *a);
 int janus_network_address_is_null(const janus_network_address *a);
 
 /*!
+ * \brief Convert a struct sockaddr to a janus_network_address
+ * \param s The struct sockaddr to convert
+ * \param a The address to write to
+ * \return 0 on success, or -EINVAL otherwise.
+ */
+int janus_network_address_from_sockaddr(struct sockaddr *s, janus_network_address *a);
+
+/*!
  * \brief Convert the given network address to a form which can be used to extract a human readable network address from.
  * \param a The address to convert
  * \param buf A buffer to contain the human readable form.
@@ -189,6 +197,25 @@ int janus_network_address_string_buffer_is_null(const janus_network_address_stri
  * \see \c janus_network_address_to_string_buffer
  */
 const char *janus_network_address_string_from_buffer(const janus_network_address_string_buffer *b);
+
+/*!
+ * \brief Test if a given IP address string is a valid address of the specified type
+ * \param addr The type of address you're interested in (janus_network_query_options_ipv4,
+ * janus_network_query_options_ipv6 or janus_network_query_options_any_ip)
+ * \param user_value The IP address string to check
+ * \return A positive integer if the given string is a valid address, 0 otherwise.
+ */
+int janus_network_string_is_valid_address(janus_network_query_options addr_type, const char *user_value);
+
+/*!
+ * \brief Convert an IP address string to a janus_network_address instance
+ * \param addr The type of address you're interested in (janus_network_query_options_ipv4,
+ * janus_network_query_options_ipv6 or janus_network_query_options_any_ip)
+ * \param user_value The IP address string to check
+ * \param result Pointer to a valid janus_network_address instance that will contain the result
+ * \return 0 in case of success, -EINVAL otherwise otherwise
+ */
+int janus_network_string_to_address(janus_network_query_options addr_type, const char *user_value, janus_network_address *result);
 
 /*!
  * \brief Convert an interface name or IP address to a janus_network_address instance

--- a/janus.c
+++ b/janus.c
@@ -136,7 +136,7 @@ json_t *janus_admin_component_summary(janus_ice_component *component);
 
 
 /* IP addresses */
-static gchar local_ip[INET6_ADDRSTRLEN];
+static gchar *local_ip;
 gchar *janus_get_local_ip(void) {
 	return local_ip;
 }
@@ -3483,45 +3483,32 @@ gint main(int argc, char *argv[])
 	item = janus_config_get_item_drilldown(config, "general", "interface");
 	if(item && item->value) {
 		JANUS_LOG(LOG_VERB, "  -- Will try to use %s\n", item->value);
-		int family;
-		if (!janus_is_ip_valid(item->value, &family)) {
-			JANUS_LOG(LOG_WARN, "Invalid local IP specified: %s, guessing the default...\n", item->value);
+		/* Verify that the address is valid */
+		struct ifaddrs *ifas = NULL;
+		janus_network_address iface;
+		janus_network_address_string_buffer ibuf;
+		if(getifaddrs(&ifas) || ifas == NULL) {
+			JANUS_LOG(LOG_ERR, "Unable to acquire list of network devices/interfaces; some configurations may not work as expected...\n");
 		} else {
-			/* Verify that we can actually bind to that address */
-			int fd = socket(family, SOCK_DGRAM, 0);
-			if (fd == -1) {
-				JANUS_LOG(LOG_WARN, "Error creating test socket, falling back to detecting IP address...\n");
+			if(janus_network_lookup_interface(ifas, item->value, &iface) != 0) {
+				JANUS_LOG(LOG_WARN, "Error setting local IP address to %s, falling back to detecting IP address...\n", item->value);
 			} else {
-				int r;
-				struct sockaddr_storage ss;
-				socklen_t addrlen;
-				memset(&ss, 0, sizeof(ss));
-				if (family == AF_INET) {
-					struct sockaddr_in *addr4 = (struct sockaddr_in*)&ss;
-					addr4->sin_family = AF_INET;
-					addr4->sin_port = 0;
-					inet_pton(AF_INET, item->value, &(addr4->sin_addr.s_addr));
-					addrlen = sizeof(struct sockaddr_in);
+				if(janus_network_address_to_string_buffer(&iface, &ibuf) != 0 || janus_network_address_string_buffer_is_null(&ibuf)) {
+					JANUS_LOG(LOG_WARN, "Error getting local IP address from %s, falling back to detecting IP address...\n", item->value);
 				} else {
-					struct sockaddr_in6 *addr6 = (struct sockaddr_in6*)&ss;
-					addr6->sin6_family = AF_INET6;
-					addr6->sin6_port = 0;
-					inet_pton(AF_INET6, item->value, &(addr6->sin6_addr.s6_addr));
-					addrlen = sizeof(struct sockaddr_in6);
-				}
-				r = bind(fd, (const struct sockaddr*)&ss, addrlen);
-				close(fd);
-				if (r < 0) {
-					JANUS_LOG(LOG_WARN, "Error setting local IP address to %s, falling back to detecting IP address...\n", item->value);
-				} else {
-					g_strlcpy(local_ip, item->value, sizeof(local_ip));
+					local_ip = g_strdup(janus_network_address_string_from_buffer(&ibuf));
 					local_ip_set = TRUE;
 				}
 			}
 		}
 	}
-	if(!local_ip_set)
-		janus_network_detect_local_ip(local_ip, sizeof(local_ip));
+	if(!local_ip_set) {
+		local_ip = janus_network_detect_local_ip_as_string(janus_network_query_options_any_ip);
+		if(local_ip == NULL) {
+			JANUS_LOG(LOG_WARN, "Couldn't find any address! using 127.0.0.1 as the local IP... (which is NOT going to work out of your machine)\n");
+			local_ip = g_strdup("127.0.0.1");
+		}
+	}
 	JANUS_LOG(LOG_INFO, "Using %s as local IP...\n", local_ip);
 
 	/* Was a custom instance name provided? */
@@ -3680,6 +3667,7 @@ gint main(int argc, char *argv[])
 		gboolean private_address = FALSE;
 		const char *test_ip = nat_1_1_mapping ? nat_1_1_mapping : local_ip;
 		struct sockaddr_in addr;
+		/* FIXME This ugly check only works with IPv4... */
 		if(inet_pton(AF_INET, test_ip, &addr) > 0) {
 			unsigned short int ip[4];
 			sscanf(test_ip, "%hu.%hu.%hu.%hu", &ip[0], &ip[1], &ip[2], &ip[3]);
@@ -4257,6 +4245,7 @@ gint main(int argc, char *argv[])
 	}
 
 	janus_recorder_deinit();
+	g_free(local_ip);
 
 	JANUS_PRINT("Bye!\n");
 

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -176,7 +176,7 @@ static volatile gint initialized = 0, stopping = 0;
 static gboolean notify_events = TRUE;
 static janus_callbacks *gateway = NULL;
 
-static char *local_ip;
+static char *local_ip = NULL;
 static int keepalive_interval = 120;
 static gboolean behind_nat = FALSE;
 static char *user_agent;
@@ -757,7 +757,6 @@ int janus_sip_init(janus_callbacks *callback, const char *config_path) {
 	if(config != NULL) {
 		janus_config_print(config);
 
-		gboolean local_ip_set = FALSE;
 		janus_config_item *item = janus_config_get_item_drilldown(config, "general", "local_ip");
 		if(item && item->value) {
 			/* Verify that the address is valid */
@@ -774,12 +773,11 @@ int janus_sip_init(janus_callbacks *callback, const char *config_path) {
 						JANUS_LOG(LOG_WARN, "Error getting local IP address from %s, falling back to detecting IP address...\n", item->value);
 					} else {
 						local_ip = g_strdup(janus_network_address_string_from_buffer(&ibuf));
-						local_ip_set = TRUE;
 					}
 				}
 			}
 		}
-		if(!local_ip_set) {
+		if(local_ip == NULL) {
 			local_ip = janus_network_detect_local_ip_as_string(janus_network_query_options_any_ip);
 			if(local_ip == NULL) {
 				JANUS_LOG(LOG_WARN, "Couldn't find any address! using 127.0.0.1 as the local IP... (which is NOT going to work out of your machine)\n");

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2655,7 +2655,7 @@ static int janus_streaming_create_fd(int port, in_addr_t mcast, const janus_netw
 			if(!janus_network_address_is_null(iface)) {
 				if(iface->family == AF_INET) {
 					mreq.imr_interface = iface->ipv4;
-					(void) janus_network_address_to_string_buffer(iface, &address_representation); // this is OK: if we get here iface must be non-NULL
+					(void) janus_network_address_to_string_buffer(iface, &address_representation); /* This is OK: if we get here iface must be non-NULL */
 					JANUS_LOG(LOG_INFO, "[%s] %s listener using interface address: %s\n", mountpointname, listenername, janus_network_address_string_from_buffer(&address_representation));
 				} else {
 					JANUS_LOG(LOG_ERR, "[%s] %s listener: invalid multicast address type (only IPv4 is currently supported by this plugin)\n", mountpointname, listenername);
@@ -2690,7 +2690,7 @@ static int janus_streaming_create_fd(int port, in_addr_t mcast, const janus_netw
 		if(!IN_MULTICAST(ntohl(mcast)) && !janus_network_address_is_null(iface)) {
 			if(iface->family == AF_INET) {
 				address.sin_addr = iface->ipv4;
-				(void) janus_network_address_to_string_buffer(iface, &address_representation); // this is OK: if we get here iface must be non-NULL
+				(void) janus_network_address_to_string_buffer(iface, &address_representation); /* This is OK: if we get here iface must be non-NULL */
 				JANUS_LOG(LOG_INFO, "[%s] %s listener restricted to interface address: %s\n", mountpointname, listenername, janus_network_address_string_from_buffer(&address_representation));
 			} else {
 				JANUS_LOG(LOG_ERR, "[%s] %s listener: invalid address/restriction type (only IPv4 is currently supported by this plugin)\n", mountpointname, listenername);

--- a/transports/janus_pfunix.c
+++ b/transports/janus_pfunix.c
@@ -28,6 +28,8 @@
 
 #include "transport.h"
 
+#include <arpa/inet.h>
+#include <sys/socket.h>
 #include <poll.h>
 #include <sys/un.h>
 

--- a/utils.c
+++ b/utils.c
@@ -14,10 +14,8 @@
 #include <sys/stat.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <arpa/inet.h>
 #include <sys/file.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <unistd.h>
 
 #include "utils.h"
@@ -356,50 +354,6 @@ const char *janus_get_codec_from_pt(const char *sdp, int pt) {
 		line = next ? (next+1) : NULL;
 	}
 	return NULL;
-}
-
-char *janus_address_to_ip(struct sockaddr *address) {
-	if(address == NULL)
-		return NULL;
-	char addr_buf[INET6_ADDRSTRLEN];
-	const char *addr = NULL;
-	struct sockaddr_in *sin = NULL;
-	struct sockaddr_in6 *sin6 = NULL;
-
-	switch(address->sa_family) {
-		case AF_INET:
-			sin = (struct sockaddr_in *)address;
-			addr = inet_ntop(AF_INET, &sin->sin_addr, addr_buf, INET_ADDRSTRLEN);
-			break;
-		case AF_INET6:
-			sin6 = (struct sockaddr_in6 *)address;
-			addr = inet_ntop(AF_INET6, &sin6->sin6_addr, addr_buf, INET6_ADDRSTRLEN);
-			break;
-		default:
-			/* Unknown family */
-			break;
-	}
-	return addr ? g_strdup(addr) : NULL;
-}
-
-uint16_t janus_address_to_port(struct sockaddr *address) {
-	if(address == NULL)
-		return 0;
-	struct sockaddr_in *sin = NULL;
-	struct sockaddr_in6 *sin6 = NULL;
-
-	switch(address->sa_family) {
-		case AF_INET:
-			sin = (struct sockaddr_in *)address;
-			return ntohs(sin->sin_port);
-		case AF_INET6:
-			sin6 = (struct sockaddr_in6 *)address;
-			return ntohs(sin6->sin6_port);
-		default:
-			/* Unknown family */
-			break;
-	}
-	return 0;
 }
 
 /* PID file management */

--- a/utils.c
+++ b/utils.c
@@ -358,26 +358,6 @@ const char *janus_get_codec_from_pt(const char *sdp, int pt) {
 	return NULL;
 }
 
-gboolean janus_is_ip_valid(const char *ip, int *family) {
-	if(ip == NULL)
-		return FALSE;
-
-	struct sockaddr_in addr4;
-	struct sockaddr_in6 addr6;
-
-	if(inet_pton(AF_INET, ip, &addr4) > 0) {
-		if(family != NULL)
-			*family = AF_INET;
-		return TRUE;
-	} else if(inet_pton(AF_INET6, ip, &addr6) > 0) {
-		if(family != NULL)
-			*family = AF_INET6;
-		return TRUE;
-	} else {
-		return FALSE;
-	}
-}
-
 char *janus_address_to_ip(struct sockaddr *address) {
 	if(address == NULL)
 		return NULL;

--- a/utils.h
+++ b/utils.h
@@ -122,12 +122,6 @@ int janus_get_codec_pt(const char *sdp, const char *codec);
  * @returns The codec name, if found, NULL otherwise */
 const char *janus_get_codec_from_pt(const char *sdp, int pt);
 
-/*! \brief Check if the given IP address is valid: family is set to the address family if the IP is valid
- * @param ip The IP address to check
- * @param[in,out] family The address family of the address, set by the method if valid
- * @returns true if the address is valid, false otherwise */
-gboolean janus_is_ip_valid(const char *ip, int *family);
-
 /*! \brief Convert a sockaddr address to an IP string
  * \note The resulting string is allocated, which means the caller must free it itself when done
  * @param address The sockaddr address to convert

--- a/utils.h
+++ b/utils.h
@@ -14,7 +14,6 @@
 
 #include <stdint.h>
 #include <glib.h>
-#include <netinet/in.h>
 #include <jansson.h>
 
 /* Use JANUS_JSON_BOOL instead of the non-existing JSON_BOOLEAN */
@@ -121,17 +120,6 @@ int janus_get_codec_pt(const char *sdp, const char *codec);
  * @param pt The payload type to look for
  * @returns The codec name, if found, NULL otherwise */
 const char *janus_get_codec_from_pt(const char *sdp, int pt);
-
-/*! \brief Convert a sockaddr address to an IP string
- * \note The resulting string is allocated, which means the caller must free it itself when done
- * @param address The sockaddr address to convert
- * @returns A string containing the IP address, if successful, NULL otherwise */
-char *janus_address_to_ip(struct sockaddr *address);
-
-/*! \brief Get the port from a sockaddr address
- * @param address The sockaddr address to get the port from
- * @returns The port number, if successful, 0 otherwise */
-uint16_t janus_address_to_port(struct sockaddr *address);
 
 /*! \brief Create and lock a PID file
  * @param file Path to the PID file to use


### PR DESCRIPTION
This PR tries to follow up the excellent work started by @cmacq2 in #776. It renames some of the methods and stuff to have a shared prefix for everything (`janus_network_`), adds a new method to detect your local IP (basically what we already had in `janus.c` and `janus_sip.c`, can be improved), and moves `janus_streaming_lookup_network_interface` to the ip-utils instead (as `janus_network_lookup_interface`, which now tries to query IPv6 too) so that other plugins in the future will be able to use it to.

I may do some more things with this, as I'm figuring out, for instance, if the "ignore interface" stuff we have in `ice.c` can be generalized somehow and moved to the ip-utils too, but that's pretty much it. It shouldn't break anything so I plan to merge soon.