### PR TITLE
Moved most of SRTP-related stuff to rtp.h/.c (cleans dtls and janus_sip)

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -15,6 +15,7 @@
 #include "janus.h"
 #include "debug.h"
 #include "dtls.h"
+#include "rtp.h"
 #include "rtcp.h"
 #include "events.h"
 
@@ -24,69 +25,6 @@
 #include <openssl/rsa.h>
 #include <openssl/asn1.h>
 
-
-/* SRTP stuff (http://tools.ietf.org/html/rfc3711) */
-static const char *janus_srtp_error[] =
-{
-#ifdef HAVE_SRTP_2
-	"srtp_err_status_ok",
-	"srtp_err_status_fail",
-	"srtp_err_status_bad_param",
-	"srtp_err_status_alloc_fail",
-	"srtp_err_status_dealloc_fail",
-	"srtp_err_status_init_fail",
-	"srtp_err_status_terminus",
-	"srtp_err_status_auth_fail",
-	"srtp_err_status_cipher_fail",
-	"srtp_err_status_replay_fail",
-	"srtp_err_status_replay_old",
-	"srtp_err_status_algo_fail",
-	"srtp_err_status_no_such_op",
-	"srtp_err_status_no_ctx",
-	"srtp_err_status_cant_check",
-	"srtp_err_status_key_expired",
-	"srtp_err_status_socket_err",
-	"srtp_err_status_signal_err",
-	"srtp_err_status_nonce_bad",
-	"srtp_err_status_read_fail",
-	"srtp_err_status_write_fail",
-	"srtp_err_status_parse_err",
-	"srtp_err_status_encode_err",
-	"srtp_err_status_semaphore_err",
-	"srtp_err_status_pfkey_err",
-#else
-	"err_status_ok",
-	"err_status_fail",
-	"err_status_bad_param",
-	"err_status_alloc_fail",
-	"err_status_dealloc_fail",
-	"err_status_init_fail",
-	"err_status_terminus",
-	"err_status_auth_fail",
-	"err_status_cipher_fail",
-	"err_status_replay_fail",
-	"err_status_replay_old",
-	"err_status_algo_fail",
-	"err_status_no_such_op",
-	"err_status_no_ctx",
-	"err_status_cant_check",
-	"err_status_key_expired",
-	"err_status_socket_err",
-	"err_status_signal_err",
-	"err_status_nonce_bad",
-	"err_status_read_fail",
-	"err_status_write_fail",
-	"err_status_parse_err",
-	"err_status_encode_err",
-	"err_status_semaphore_err",
-	"err_status_pfkey_err",
-#endif
-};
-const gchar *janus_get_srtp_error(int error) {
-	if(error < 0 || error > 24)
-		return NULL;
-	return janus_srtp_error[error];
-}
 
 const gchar *janus_get_dtls_srtp_state(janus_dtls_state state) {
 	switch(state) {
@@ -150,11 +88,6 @@ static void janus_dtls_notify_state_change(janus_dtls_srtp *dtls) {
 #define DTLS_CIPHERS	"ALL:NULL:eNULL:aNULL"
 /* Duration for the self-generated certs: 1 year */
 #define DTLS_AUTOCERT_DURATION	60*60*24*365
-
-/* SRTP stuff (http://tools.ietf.org/html/rfc3711) */
-#define SRTP_MASTER_KEY_LENGTH	16
-#define SRTP_MASTER_SALT_LENGTH	14
-#define SRTP_MASTER_LENGTH (SRTP_MASTER_KEY_LENGTH + SRTP_MASTER_SALT_LENGTH)
 
 
 static SSL_CTX *ssl_ctx = NULL;
@@ -225,45 +158,45 @@ static void janus_dtls_cb_openssl_lock(int mode, int type, const char *file, int
 
 static int janus_dtls_generate_keys(X509** certificate, EVP_PKEY** private_key) {
 	static const int num_bits = 2048;
-	BIGNUM* bne = NULL;
-	RSA* rsa_key = NULL;
-	X509_NAME* cert_name = NULL;
+	BIGNUM *bne = NULL;
+	RSA *rsa_key = NULL;
+	X509_NAME *cert_name = NULL;
 
 	JANUS_LOG(LOG_VERB, "Generating DTLS key / cert\n");
 
 	/* Create a big number object. */
 	bne = BN_new();
-	if (!bne) {
+	if(!bne) {
 		JANUS_LOG(LOG_FATAL, "BN_new() failed\n");
 		goto error;
 	}
 
-	if (!BN_set_word(bne, RSA_F4)) {  /* RSA_F4 == 65537 */
+	if(!BN_set_word(bne, RSA_F4)) {  /* RSA_F4 == 65537 */
 		JANUS_LOG(LOG_FATAL, "BN_set_word() failed\n");
 		goto error;
 	}
 
 	/* Generate a RSA key. */
 	rsa_key = RSA_new();
-	if (!rsa_key) {
+	if(!rsa_key) {
 		JANUS_LOG(LOG_FATAL, "RSA_new() failed\n");
 		goto error;
 	}
 
 	/* This takes some time. */
-	if (!RSA_generate_key_ex(rsa_key, num_bits, bne, NULL)) {
+	if(!RSA_generate_key_ex(rsa_key, num_bits, bne, NULL)) {
 		JANUS_LOG(LOG_FATAL, "RSA_generate_key_ex() failed\n");
 		goto error;
 	}
 
 	/* Create a private key object (needed to hold the RSA key). */
 	*private_key = EVP_PKEY_new();
-	if (!*private_key) {
+	if(!*private_key) {
 		JANUS_LOG(LOG_FATAL, "EVP_PKEY_new() failed\n");
 		goto error;
 	}
 
-	if (!EVP_PKEY_assign_RSA(*private_key, rsa_key)) {
+	if(!EVP_PKEY_assign_RSA(*private_key, rsa_key)) {
 		JANUS_LOG(LOG_FATAL, "EVP_PKEY_assign_RSA() failed\n");
 		goto error;
 	}
@@ -272,7 +205,7 @@ static int janus_dtls_generate_keys(X509** certificate, EVP_PKEY** private_key) 
 
 	/* Create the X509 certificate. */
 	*certificate = X509_new();
-	if (!*certificate) {
+	if(!*certificate) {
 		JANUS_LOG(LOG_FATAL, "X509_new() failed\n");
 		goto error;
 	}
@@ -288,14 +221,14 @@ static int janus_dtls_generate_keys(X509** certificate, EVP_PKEY** private_key) 
 	X509_gmtime_adj(X509_get_notAfter(*certificate), DTLS_AUTOCERT_DURATION);  /* 1 year */
 
 	/* Set the public key for the certificate using the key. */
-	if (!X509_set_pubkey(*certificate, *private_key)) {
+	if(!X509_set_pubkey(*certificate, *private_key)) {
 		JANUS_LOG(LOG_FATAL, "X509_set_pubkey() failed\n");
 		goto error;
 	}
 
 	/* Set certificate fields. */
 	cert_name = X509_get_subject_name(*certificate);
-	if (!cert_name) {
+	if(!cert_name) {
 		JANUS_LOG(LOG_FATAL, "X509_get_subject_name() failed\n");
 		goto error;
 	}
@@ -303,13 +236,13 @@ static int janus_dtls_generate_keys(X509** certificate, EVP_PKEY** private_key) 
 	X509_NAME_add_entry_by_txt(cert_name, "CN", MBSTRING_ASC, (const unsigned char*)"Janus", -1, -1, 0);
 
 	/* It is self-signed so set the issuer name to be the same as the subject. */
-	if (!X509_set_issuer_name(*certificate, cert_name)) {
+	if(!X509_set_issuer_name(*certificate, cert_name)) {
 		JANUS_LOG(LOG_FATAL, "X509_set_issuer_name() failed\n");
 		goto error;
 	}
 
 	/* Sign the certificate with the private key. */
-	if (!X509_sign(*certificate, *private_key, EVP_sha1())) {
+	if(!X509_sign(*certificate, *private_key, EVP_sha1())) {
 		JANUS_LOG(LOG_FATAL, "X509_sign() failed\n");
 		goto error;
 	}
@@ -319,13 +252,13 @@ static int janus_dtls_generate_keys(X509** certificate, EVP_PKEY** private_key) 
 	return 0;
 
 error:
-	if (bne)
+	if(bne)
 		BN_free(bne);
-	if (rsa_key && !*private_key)
+	if(rsa_key && !*private_key)
 		RSA_free(rsa_key);
-	if (*private_key)
+	if(*private_key)
 		EVP_PKEY_free(*private_key);  /* This also frees the RSA key. */
-	if (*certificate)
+	if(*certificate)
 		X509_free(*certificate);
 	return -1;
 }
@@ -335,24 +268,24 @@ static int janus_dtls_load_keys(const char* server_pem, const char* server_key, 
 	FILE* f = NULL;
 
 	f = fopen(server_pem, "r");
-	if (!f) {
+	if(!f) {
 		JANUS_LOG(LOG_FATAL, "Error opening certificate file\n");
 		goto error;
 	}
 	*certificate = PEM_read_X509(f, NULL, NULL, NULL);
-	if (!*certificate) {
+	if(!*certificate) {
 		JANUS_LOG(LOG_FATAL, "PEM_read_X509 failed\n");
 		goto error;
 	}
 	fclose(f);
 
 	f = fopen(server_key, "r");
-	if (!f) {
+	if(!f) {
 		JANUS_LOG(LOG_FATAL, "Error opening key file\n");
 		goto error;
 	}
 	*private_key = PEM_read_PrivateKey(f, NULL, NULL, NULL);
-	if (!*private_key) {
+	if(!*private_key) {
 		JANUS_LOG(LOG_FATAL, "PEM_read_PrivateKey failed\n");
 		goto error;
 	}
@@ -361,11 +294,11 @@ static int janus_dtls_load_keys(const char* server_pem, const char* server_key, 
 	return 0;
 
 error:
-	if (*certificate) {
+	if(*certificate) {
 		X509_free(*certificate);
 		*certificate = NULL;
 	}
-	if (*private_key) {
+	if(*private_key) {
 		EVP_PKEY_free(*private_key);
 		*private_key = NULL;
 	}
@@ -407,16 +340,16 @@ gint janus_dtls_srtp_init(const char* server_pem, const char* server_key) {
 	SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, janus_dtls_verify_callback);
 	SSL_CTX_set_tlsext_use_srtp(ssl_ctx, "SRTP_AES128_CM_SHA1_80");	/* FIXME Should we support something else as well? */
 
-	if (!server_pem && !server_key) {
+	if(!server_pem && !server_key) {
 		JANUS_LOG(LOG_WARN, "No cert/key specified, autogenerating some...\n");
-		if (janus_dtls_generate_keys(&ssl_cert, &ssl_key) != 0) {
+		if(janus_dtls_generate_keys(&ssl_cert, &ssl_key) != 0) {
 			JANUS_LOG(LOG_FATAL, "Error generating DTLS key/certificate\n");
 			return -2;
 		}
-	} else if (!server_pem || !server_key) {
+	} else if(!server_pem || !server_key) {
 		JANUS_LOG(LOG_FATAL, "DTLS certificate and key must be specified\n");
 		return -2;
-	} else if (janus_dtls_load_keys(server_pem, server_key, &ssl_cert, &ssl_key) != 0) {
+	} else if(janus_dtls_load_keys(server_pem, server_key, &ssl_cert, &ssl_key) != 0) {
 		return -3;
 	}
 
@@ -465,15 +398,15 @@ gint janus_dtls_srtp_init(const char* server_pem, const char* server_key) {
 
 
 void janus_dtls_srtp_cleanup(void) {
-	if (ssl_cert != NULL) {
+	if(ssl_cert != NULL) {
 		X509_free(ssl_cert);
 		ssl_cert = NULL;
 	}
-	if (ssl_key != NULL) {
+	if(ssl_key != NULL) {
 		EVP_PKEY_free(ssl_key);
 		ssl_key = NULL;
 	}
-	if (ssl_ctx != NULL) {
+	if(ssl_ctx != NULL) {
 		SSL_CTX_free(ssl_ctx);
 		ssl_ctx = NULL;
 	}
@@ -716,7 +649,7 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 					unsigned char material[SRTP_MASTER_LENGTH*2];
 					unsigned char *local_key, *local_salt, *remote_key, *remote_salt;
 					/* Export keying material for SRTP */
-					if (!SSL_export_keying_material(dtls->ssl, material, SRTP_MASTER_LENGTH*2, "EXTRACTOR-dtls_srtp", 19, NULL, 0, 0)) {
+					if(!SSL_export_keying_material(dtls->ssl, material, SRTP_MASTER_LENGTH*2, "EXTRACTOR-dtls_srtp", 19, NULL, 0, 0)) {
 						/* Oops... */
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Oops, couldn't extract SRTP keying material for component %d in stream %d?? (%s)\n",
 							handle->handle_id, component->component_id, stream->stream_id, ERR_reason_error_string(ERR_get_error()));
@@ -766,7 +699,7 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 					if(res != srtp_err_status_ok) {
 						/* Something went wrong... */
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Oops, error creating inbound SRTP session for component %d in stream %d??\n", handle->handle_id, component->component_id, stream->stream_id);
-						JANUS_LOG(LOG_ERR, "[%"SCNu64"]  -- %d (%s)\n", handle->handle_id, res, janus_get_srtp_error(res));
+						JANUS_LOG(LOG_ERR, "[%"SCNu64"]  -- %d (%s)\n", handle->handle_id, res, janus_srtp_error_str(res));
 						goto done;
 					}
 					JANUS_LOG(LOG_VERB, "[%"SCNu64"] Created inbound SRTP session for component %d in stream %d\n", handle->handle_id, component->component_id, stream->stream_id);
@@ -774,7 +707,7 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 					if(res != srtp_err_status_ok) {
 						/* Something went wrong... */
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Oops, error creating outbound SRTP session for component %d in stream %d??\n", handle->handle_id, component->component_id, stream->stream_id);
-						JANUS_LOG(LOG_ERR, "[%"SCNu64"]  -- %d (%s)\n", handle->handle_id, res, janus_get_srtp_error(res));
+						JANUS_LOG(LOG_ERR, "[%"SCNu64"]  -- %d (%s)\n", handle->handle_id, res, janus_srtp_error_str(res));
 						goto done;
 					}
 					dtls->srtp_valid = 1;
@@ -863,7 +796,7 @@ void janus_dtls_srtp_destroy(janus_dtls_srtp *dtls) {
 /* DTLS alert callback */
 void janus_dtls_callback(const SSL *ssl, int where, int ret) {
 	/* We only care about alerts */
-	if (!(where & SSL_CB_ALERT)) {
+	if(!(where & SSL_CB_ALERT)) {
 		return;
 	}
 	janus_dtls_srtp *dtls = SSL_get_ex_data(ssl, 0);

--- a/dtls.h
+++ b/dtls.h
@@ -18,18 +18,7 @@
 #include <inttypes.h>
 #include <glib.h>
 
-#ifdef HAVE_SRTP_2
-#include <srtp2/srtp.h>
-#else
-#include <srtp/srtp.h>
-#define srtp_err_status_t err_status_t
-#define srtp_err_status_ok err_status_ok
-#define srtp_err_status_replay_fail err_status_replay_fail
-#define srtp_err_status_replay_old err_status_replay_old
-#define srtp_crypto_policy_set_rtp_default crypto_policy_set_rtp_default
-#define srtp_crypto_policy_set_rtcp_default crypto_policy_set_rtcp_default
-#endif
-
+#include "rtp.h"
 #include "sctp.h"
 #include "dtls-bio.h"
 
@@ -163,12 +152,6 @@ void janus_dtls_notify_data(janus_dtls_srtp *dtls, char *buf, int len);
  * @param[in] stack Opaque pointer to the janus_dtls_srtp instance to use
  * @returns true if a retransmission is still needed, false otherwise */
 gboolean janus_dtls_retry(gpointer stack);
-
-
-/*! \brief Helper method to get a string representation of a libsrtp error code
- * @param[in] error The libsrtp error code
- * @returns A string representation of the error code */
-const gchar *janus_get_srtp_error(int error);
 
 /*! \brief Helper method to get a string representation of a Janus DTLS state
  * @param[in] state The Janus DTLS state

--- a/ice.c
+++ b/ice.c
@@ -1917,7 +1917,7 @@ void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint component_i
 					rtp_header *header = (rtp_header *)buf;
 					guint32 timestamp = ntohl(header->timestamp);
 					guint16 seq = ntohs(header->seq_number);
-					JANUS_LOG(LOG_ERR, "[%"SCNu64"]     SRTP unprotect error: %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")\n", handle->handle_id, janus_get_srtp_error(res), len, buflen, timestamp, seq);
+					JANUS_LOG(LOG_ERR, "[%"SCNu64"]     SRTP unprotect error: %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")\n", handle->handle_id, janus_srtp_error_str(res), len, buflen, timestamp, seq);
 				}
 			} else {
 				if(video) {
@@ -2093,7 +2093,7 @@ void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint component_i
 			int buflen = len;
 			srtp_err_status_t res = srtp_unprotect_rtcp(component->dtls->srtp_in, buf, &buflen);
 			if(res != srtp_err_status_ok) {
-				JANUS_LOG(LOG_ERR, "[%"SCNu64"]     SRTCP unprotect error: %s (len=%d-->%d)\n", handle->handle_id, janus_get_srtp_error(res), len, buflen);
+				JANUS_LOG(LOG_ERR, "[%"SCNu64"]     SRTCP unprotect error: %s (len=%d-->%d)\n", handle->handle_id, janus_srtp_error_str(res), len, buflen);
 			} else {
 				/* Is this audio or video? */
 				int video = 0;
@@ -3523,9 +3523,9 @@ void *janus_ice_send_thread(void *data) {
 					res = srtp_protect_rtcp(component->dtls->srtp_out, sbuf, &protected);
 					janus_mutex_unlock(&component->dtls->srtp_mutex);
 				}
-				//~ JANUS_LOG(LOG_VERB, "[%"SCNu64"] ... SRTCP protect %s (len=%d-->%d)...\n", handle->handle_id, janus_get_srtp_error(res), pkt->length, protected);
+				//~ JANUS_LOG(LOG_VERB, "[%"SCNu64"] ... SRTCP protect %s (len=%d-->%d)...\n", handle->handle_id, janus_srtp_error_str(res), pkt->length, protected);
 				if(res != srtp_err_status_ok) {
-					JANUS_LOG(LOG_ERR, "[%"SCNu64"] ... SRTCP protect error... %s (len=%d-->%d)...\n", handle->handle_id, janus_get_srtp_error(res), pkt->length, protected);
+					JANUS_LOG(LOG_ERR, "[%"SCNu64"] ... SRTCP protect error... %s (len=%d-->%d)...\n", handle->handle_id, janus_srtp_error_str(res), pkt->length, protected);
 				} else {
 					/* Shoot! */
 					//~ JANUS_LOG(LOG_VERB, "[%"SCNu64"] ... Sending SRTCP packet (pt=%u, seq=%u, ts=%u)...\n", handle->handle_id,
@@ -3603,12 +3603,12 @@ void *janus_ice_send_thread(void *data) {
 					}
 					int protected = pkt->length;
 					int res = srtp_protect(component->dtls->srtp_out, sbuf, &protected);
-					//~ JANUS_LOG(LOG_VERB, "[%"SCNu64"] ... SRTP protect %s (len=%d-->%d)...\n", handle->handle_id, janus_get_srtp_error(res), pkt->length, protected);
+					//~ JANUS_LOG(LOG_VERB, "[%"SCNu64"] ... SRTP protect %s (len=%d-->%d)...\n", handle->handle_id, janus_srtp_error_str(res), pkt->length, protected);
 					if(res != srtp_err_status_ok) {
 						rtp_header *header = (rtp_header *)sbuf;
 						guint32 timestamp = ntohl(header->timestamp);
 						guint16 seq = ntohs(header->seq_number);
-						JANUS_LOG(LOG_ERR, "[%"SCNu64"] ... SRTP protect error... %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")...\n", handle->handle_id, janus_get_srtp_error(res), pkt->length, protected, timestamp, seq);
+						JANUS_LOG(LOG_ERR, "[%"SCNu64"] ... SRTP protect error... %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")...\n", handle->handle_id, janus_srtp_error_str(res), pkt->length, protected, timestamp, seq);
 					} else {
 						/* Shoot! */
 						//~ JANUS_LOG(LOG_VERB, "[%"SCNu64"] ... Sending SRTP packet (pt=%u, ssrc=%u, seq=%u, ts=%u)...\n", handle->handle_id,

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -73,35 +73,6 @@
 #include "../sdp-utils.h"
 #include "../utils.h"
 
-#ifdef HAVE_SRTP_2
-#include <srtp2/srtp.h>
-#include <openssl/rand.h>
-#include <openssl/err.h>
-static int srtp_crypto_get_random(uint8_t *key, int len) {
-	/* libsrtp 2.0 doesn't have crypto_get_random, we use OpenSSL's RAND_* to replace it:
-	 * 		https://wiki.openssl.org/index.php/Random_Numbers */
-	int rc = RAND_bytes(key, len);
-	if(rc != 1) {
-		/* Error generating */
-		JANUS_LOG(LOG_ERR, "RAND_bytes failes: %s\n", ERR_reason_error_string(ERR_get_error()));
-		return -1;
-	}
-	return 0;
-}
-#else
-#include <srtp/srtp.h>
-#include <srtp/crypto_kernel.h>
-#define srtp_err_status_t err_status_t
-#define srtp_err_status_ok err_status_ok
-#define srtp_err_status_replay_fail err_status_replay_fail
-#define srtp_err_status_replay_old err_status_replay_old
-#define srtp_crypto_policy_set_rtp_default crypto_policy_set_rtp_default
-#define srtp_crypto_policy_set_rtcp_default crypto_policy_set_rtcp_default
-#define srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32 crypto_policy_set_aes_cm_128_hmac_sha1_32
-#define srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80 crypto_policy_set_aes_cm_128_hmac_sha1_80
-#define srtp_crypto_get_random crypto_get_random
-#endif
-
 
 /* Plugin information */
 #define JANUS_SIP_VERSION			6
@@ -405,42 +376,6 @@ struct ssip_s {
 
 
 /* SRTP stuff (in case we need SDES) */
-#define SRTP_MASTER_KEY_LENGTH	16
-#define SRTP_MASTER_SALT_LENGTH	14
-#define SRTP_MASTER_LENGTH (SRTP_MASTER_KEY_LENGTH + SRTP_MASTER_SALT_LENGTH)
-static const char *janus_sip_srtp_error[] =
-{
-	"srtp_err_status_ok",
-	"srtp_err_status_fail",
-	"srtp_err_status_bad_param",
-	"srtp_err_status_alloc_fail",
-	"srtp_err_status_dealloc_fail",
-	"srtp_err_status_init_fail",
-	"srtp_err_status_terminus",
-	"srtp_err_status_auth_fail",
-	"srtp_err_status_cipher_fail",
-	"srtp_err_status_replay_fail",
-	"srtp_err_status_replay_old",
-	"srtp_err_status_algo_fail",
-	"srtp_err_status_no_such_op",
-	"srtp_err_status_no_ctx",
-	"srtp_err_status_cant_check",
-	"srtp_err_status_key_expired",
-	"srtp_err_status_socket_err",
-	"srtp_err_status_signal_err",
-	"srtp_err_status_nonce_bad",
-	"srtp_err_status_read_fail",
-	"srtp_err_status_write_fail",
-	"srtp_err_status_parse_err",
-	"srtp_err_status_encode_err",
-	"srtp_err_status_semaphore_err",
-	"srtp_err_status_pfkey_err",
-};
-static const gchar *janus_sip_get_srtp_error(int error) {
-	if(error < 0 || error > 24)
-		return NULL;
-	return janus_sip_srtp_error[error];
-}
 static int janus_sip_srtp_set_local(janus_sip_session *session, gboolean video, char **crypto) {
 	if(session == NULL)
 		return -1;
@@ -458,7 +393,7 @@ static int janus_sip_srtp_set_local(janus_sip_session *session, gboolean video, 
 	srtp_err_status_t res = srtp_create(video ? &session->media.video_srtp_out : &session->media.audio_srtp_out, policy);
 	if(res != srtp_err_status_ok) {
 		/* Something went wrong... */
-		JANUS_LOG(LOG_ERR, "Oops, error creating outbound SRTP session: %d (%s)\n", res, janus_sip_get_srtp_error(res));
+		JANUS_LOG(LOG_ERR, "Oops, error creating outbound SRTP session: %d (%s)\n", res, janus_srtp_error_str(res));
 		g_free(key);
 		policy->key = NULL;
 		return -2;
@@ -499,7 +434,7 @@ static int janus_sip_srtp_set_remote(janus_sip_session *session, gboolean video,
 	srtp_err_status_t res = srtp_create(video ? &session->media.video_srtp_in : &session->media.audio_srtp_in, policy);
 	if(res != srtp_err_status_ok) {
 		/* Something went wrong... */
-		JANUS_LOG(LOG_ERR, "Oops, error creating inbound SRTP session: %d (%s)\n", res, janus_sip_get_srtp_error(res));
+		JANUS_LOG(LOG_ERR, "Oops, error creating inbound SRTP session: %d (%s)\n", res, janus_srtp_error_str(res));
 		g_free(decoded);
 		policy->key = NULL;
 		return -2;
@@ -1266,7 +1201,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 						guint32 timestamp = ntohl(header->timestamp);
 						guint16 seq = ntohs(header->seq_number);
 						JANUS_LOG(LOG_ERR, "[SIP-%s] Video SRTP protect error... %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")...\n",
-							session->account.username, janus_sip_get_srtp_error(res), len, protected, timestamp, seq);
+							session->account.username, janus_srtp_error_str(res), len, protected, timestamp, seq);
 					} else {
 						/* Forward the frame to the peer */
 						send(session->media.video_rtp_fd, sbuf, protected, 0);
@@ -1300,7 +1235,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 						guint32 timestamp = ntohl(header->timestamp);
 						guint16 seq = ntohs(header->seq_number);
 						JANUS_LOG(LOG_ERR, "[SIP-%s] Audio SRTP protect error... %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")...\n",
-							session->account.username, janus_sip_get_srtp_error(res), len, protected, timestamp, seq);
+							session->account.username, janus_srtp_error_str(res), len, protected, timestamp, seq);
 					} else {
 						/* Forward the frame to the peer */
 						send(session->media.audio_rtp_fd, sbuf, protected, 0);
@@ -1340,7 +1275,7 @@ void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf,
 					int res = srtp_protect_rtcp(session->media.video_srtp_out, &sbuf, &protected);
 					if(res != srtp_err_status_ok) {
 						JANUS_LOG(LOG_ERR, "[SIP-%s] Video SRTCP protect error... %s (len=%d-->%d)...\n",
-							session->account.username, janus_sip_get_srtp_error(res), len, protected);
+							session->account.username, janus_srtp_error_str(res), len, protected);
 					} else {
 						/* Forward the message to the peer */
 						send(session->media.video_rtcp_fd, sbuf, protected, 0);
@@ -1364,7 +1299,7 @@ void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf,
 					int res = srtp_protect_rtcp(session->media.audio_srtp_out, &sbuf, &protected);
 					if(res != srtp_err_status_ok) {
 						JANUS_LOG(LOG_ERR, "[SIP-%s] Audio SRTCP protect error... %s (len=%d-->%d)...\n",
-							session->account.username, janus_sip_get_srtp_error(res), len, protected);
+							session->account.username, janus_srtp_error_str(res), len, protected);
 					} else {
 						/* Forward the message to the peer */
 						send(session->media.audio_rtcp_fd, sbuf, protected, 0);
@@ -3420,7 +3355,7 @@ static void *janus_sip_relay_thread(void *data) {
 							guint32 timestamp = ntohl(header->timestamp);
 							guint16 seq = ntohs(header->seq_number);
 							JANUS_LOG(LOG_ERR, "[SIP-%s] Audio SRTP unprotect error: %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")\n",
-								session->account.username, janus_sip_get_srtp_error(res), bytes, buflen, timestamp, seq);
+								session->account.username, janus_srtp_error_str(res), bytes, buflen, timestamp, seq);
 							continue;
 						}
 						bytes = buflen;
@@ -3468,7 +3403,7 @@ static void *janus_sip_relay_thread(void *data) {
 						srtp_err_status_t res = srtp_unprotect_rtcp(session->media.audio_srtp_in, buffer, &buflen);
 						if(res != srtp_err_status_ok && res != srtp_err_status_replay_fail && res != srtp_err_status_replay_old) {
 							JANUS_LOG(LOG_ERR, "[SIP-%s] Audio SRTCP unprotect error: %s (len=%d-->%d)\n",
-								session->account.username, janus_sip_get_srtp_error(res), bytes, buflen);
+								session->account.username, janus_srtp_error_str(res), bytes, buflen);
 							continue;
 						}
 						bytes = buflen;
@@ -3497,7 +3432,7 @@ static void *janus_sip_relay_thread(void *data) {
 							guint32 timestamp = ntohl(header->timestamp);
 							guint16 seq = ntohs(header->seq_number);
 							JANUS_LOG(LOG_ERR, "[SIP-%s] Video SRTP unprotect error: %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")\n",
-								session->account.username, janus_sip_get_srtp_error(res), bytes, buflen, timestamp, seq);
+								session->account.username, janus_srtp_error_str(res), bytes, buflen, timestamp, seq);
 							continue;
 						}
 						bytes = buflen;
@@ -3544,7 +3479,7 @@ static void *janus_sip_relay_thread(void *data) {
 						srtp_err_status_t res = srtp_unprotect_rtcp(session->media.video_srtp_in, buffer, &buflen);
 						if(res != srtp_err_status_ok && res != srtp_err_status_replay_fail && res != srtp_err_status_replay_old) {
 							JANUS_LOG(LOG_ERR, "[SIP-%s] Video SRTP unprotect error: %s (len=%d-->%d)\n",
-								session->account.username, janus_sip_get_srtp_error(res), bytes, buflen);
+								session->account.username, janus_srtp_error_str(res), bytes, buflen);
 							continue;
 						}
 						bytes = buflen;

--- a/rtp.c
+++ b/rtp.c
@@ -195,3 +195,79 @@ int janus_rtp_header_extension_parse_playout_delay(char *buf, int len, int id,
 		*max_delay = max;
 	return 0;
 }
+
+/* SRTP stuff: we may need our own randomizer */
+#ifdef HAVE_SRTP_2
+int srtp_crypto_get_random(uint8_t *key, int len) {
+	/* libsrtp 2.0 doesn't have crypto_get_random, we use OpenSSL's RAND_* to replace it:
+	 * 		https://wiki.openssl.org/index.php/Random_Numbers */
+	int rc = RAND_bytes(key, len);
+	if(rc != 1) {
+		/* Error generating */
+		return -1;
+	}
+	return 0;
+}
+#endif
+/* SRTP error codes as a string array */
+static const char *janus_srtp_error[] =
+{
+#ifdef HAVE_SRTP_2
+	"srtp_err_status_ok",
+	"srtp_err_status_fail",
+	"srtp_err_status_bad_param",
+	"srtp_err_status_alloc_fail",
+	"srtp_err_status_dealloc_fail",
+	"srtp_err_status_init_fail",
+	"srtp_err_status_terminus",
+	"srtp_err_status_auth_fail",
+	"srtp_err_status_cipher_fail",
+	"srtp_err_status_replay_fail",
+	"srtp_err_status_replay_old",
+	"srtp_err_status_algo_fail",
+	"srtp_err_status_no_such_op",
+	"srtp_err_status_no_ctx",
+	"srtp_err_status_cant_check",
+	"srtp_err_status_key_expired",
+	"srtp_err_status_socket_err",
+	"srtp_err_status_signal_err",
+	"srtp_err_status_nonce_bad",
+	"srtp_err_status_read_fail",
+	"srtp_err_status_write_fail",
+	"srtp_err_status_parse_err",
+	"srtp_err_status_encode_err",
+	"srtp_err_status_semaphore_err",
+	"srtp_err_status_pfkey_err",
+#else
+	"err_status_ok",
+	"err_status_fail",
+	"err_status_bad_param",
+	"err_status_alloc_fail",
+	"err_status_dealloc_fail",
+	"err_status_init_fail",
+	"err_status_terminus",
+	"err_status_auth_fail",
+	"err_status_cipher_fail",
+	"err_status_replay_fail",
+	"err_status_replay_old",
+	"err_status_algo_fail",
+	"err_status_no_such_op",
+	"err_status_no_ctx",
+	"err_status_cant_check",
+	"err_status_key_expired",
+	"err_status_socket_err",
+	"err_status_signal_err",
+	"err_status_nonce_bad",
+	"err_status_read_fail",
+	"err_status_write_fail",
+	"err_status_parse_err",
+	"err_status_encode_err",
+	"err_status_semaphore_err",
+	"err_status_pfkey_err",
+#endif
+};
+const char *janus_srtp_error_str(int error) {
+	if(error < 0 || error > 24)
+		return NULL;
+	return janus_srtp_error[error];
+}

--- a/rtp.h
+++ b/rtp.h
@@ -26,7 +26,31 @@
 #include <string.h>
 #include <glib.h>
 
+#ifdef HAVE_SRTP_2
+#include <srtp2/srtp.h>
+#include <openssl/rand.h>
+#include <openssl/err.h>
+int srtp_crypto_get_random(uint8_t *key, int len);
+#else
+#include <srtp/srtp.h>
+#include <srtp/crypto_kernel.h>
+#define srtp_err_status_t err_status_t
+#define srtp_err_status_ok err_status_ok
+#define srtp_err_status_replay_fail err_status_replay_fail
+#define srtp_err_status_replay_old err_status_replay_old
+#define srtp_crypto_policy_set_rtp_default crypto_policy_set_rtp_default
+#define srtp_crypto_policy_set_rtcp_default crypto_policy_set_rtcp_default
+#define srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32 crypto_policy_set_aes_cm_128_hmac_sha1_32
+#define srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80 crypto_policy_set_aes_cm_128_hmac_sha1_80
+#define srtp_crypto_get_random crypto_get_random
+#endif
+
 #define RTP_HEADER_SIZE	12
+
+/* SRTP stuff (http://tools.ietf.org/html/rfc3711) */
+#define SRTP_MASTER_KEY_LENGTH	16
+#define SRTP_MASTER_SALT_LENGTH	14
+#define SRTP_MASTER_LENGTH (SRTP_MASTER_KEY_LENGTH + SRTP_MASTER_SALT_LENGTH)
 
 /*! \brief RTP Header (http://tools.ietf.org/html/rfc3550#section-5.1) */
 typedef struct rtp_header
@@ -128,5 +152,10 @@ int janus_rtp_header_extension_parse_video_orientation(char *buf, int len, int i
  * @returns 0 if found, -1 otherwise */
 int janus_rtp_header_extension_parse_playout_delay(char *buf, int len, int id,
 	uint16_t *min_delay, uint16_t *max_delay);
+
+/*! \brief Helper method to get a string representation of a libsrtp error code
+ * @param[in] error The libsrtp error code
+ * @returns A string representation of the error code */
+const char *janus_srtp_error_str(int error);
 
 #endif


### PR DESCRIPTION
This PR is motivated by the efforts in #799, where the NoSIP plugin shares a lot of code with the SIP plugin. It moves a few SRTP-related things around, specifically by putting it all in `rtp.h` and `rtp.c` (where it probably belongs) rather than in the DTLS code or the SIP plugin (where we duplicated a lot of stuff).

I guess that the `srtp_policy_t` stuff the SIP plugin does could be moved too in the future (we do something similar, although not the same thing, in `dtls.c`) but for now I think this is enough.

Should be harmless and I don't expect this to break anything, so I plan to merge soon.