### PR TITLE
Correctly handle parse error in janus.nojquery.js

### DIFF
--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -192,7 +192,13 @@ Janus.init = function(options) {
 						return;
 					}
 					// Got payload
-					params.success(JSON.parse(XHR.responseText));
+					try {
+						params.success(JSON.parse(XHR.responseText));
+					} catch(e) {
+						params.error(XHR, XHR.status, 'Could not parse response, error: ' + e +
+									 ', text: ' + XHR.responseText);
+						return;
+					}
 				};
 			}
 			try {


### PR DESCRIPTION
We are getting parse errors due to empty string being passed to JSON parse.
Added better error handling to:
a) Not fail.
b) Understand why we get empty strings there.

The error:
Uncaught SyntaxError: Unexpected end of JSON input