### PR TITLE
Safari mobile - attachMediaStream and reattachMediaStream

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -143,7 +143,7 @@ Janus.init = function(options) {
 				} else {
 					Janus.error("Error attaching stream to element");
 				}
-			} else if(navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i)) {
+			} else if(adapter.browserDetails.browser === 'safari') {
 				element.src = URL.createObjectURL(stream);
 			}
 			else {
@@ -158,7 +158,7 @@ Janus.init = function(options) {
 				} else if(typeof to.src !== 'undefined') {
 					to.src = from.src;
 				}
-			} else if(navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i)) {
+			} else if(adapter.browserDetails.browser === 'safari') {
 				to.src = from.src;
 			}
 			else {

--- a/html/janus.js
+++ b/html/janus.js
@@ -143,7 +143,10 @@ Janus.init = function(options) {
 				} else {
 					Janus.error("Error attaching stream to element");
 				}
-			} else {
+			} else if(navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i)) {
+				element.src = URL.createObjectURL(stream);
+			}
+			else {
 				element.srcObject = stream;
 			}
 		};
@@ -155,7 +158,10 @@ Janus.init = function(options) {
 				} else if(typeof to.src !== 'undefined') {
 					to.src = from.src;
 				}
-			} else {
+			} else if(navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i)) {
+				to.src = from.src;
+			}
+			else {
 				to.srcObject = from.srcObject;
 			}
 		};

--- a/html/janus.js
+++ b/html/janus.js
@@ -143,7 +143,7 @@ Janus.init = function(options) {
 				} else {
 					Janus.error("Error attaching stream to element");
 				}
-			} else if(adapter.browserDetails.browser === 'safari') {
+			} else if(adapter.browserDetails.browser === 'safari' || window.navigator.match(/iPad/i) || window.navigator.match(/iPhone/i)) {
 				element.src = URL.createObjectURL(stream);
 			}
 			else {
@@ -158,7 +158,7 @@ Janus.init = function(options) {
 				} else if(typeof to.src !== 'undefined') {
 					to.src = from.src;
 				}
-			} else if(adapter.browserDetails.browser === 'safari') {
+			} else if(adapter.browserDetails.browser === 'safari' || window.navigator.match(/iPad/i) || window.navigator.match(/iPhone/i)) {
 				to.src = from.src;
 			}
 			else {

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -143,7 +143,7 @@ Janus.init = function(options) {
 				} else {
 					Janus.error("Error attaching stream to element");
 				}
-			} else if(navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i)) {
+			} else if(adapter.browserDetails.browser === 'safari') {
 				element.src = URL.createObjectURL(stream);
 			}
 			else {
@@ -158,7 +158,7 @@ Janus.init = function(options) {
 				} else if(typeof to.src !== 'undefined') {
 					to.src = from.src;
 				}
-			} else if(navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i)) {
+			} else if(adapter.browserDetails.browser === 'safari') {
 				to.src = from.src;
 			}
 			else {

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -143,7 +143,10 @@ Janus.init = function(options) {
 				} else {
 					Janus.error("Error attaching stream to element");
 				}
-			} else {
+			} else if(navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i)) {
+				element.src = URL.createObjectURL(stream);
+			}
+			else {
 				element.srcObject = stream;
 			}
 		};
@@ -155,7 +158,10 @@ Janus.init = function(options) {
 				} else if(typeof to.src !== 'undefined') {
 					to.src = from.src;
 				}
-			} else {
+			} else if(navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i)) {
+				to.src = from.src;
+			}
+			else {
 				to.srcObject = from.srcObject;
 			}
 		};

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -143,7 +143,7 @@ Janus.init = function(options) {
 				} else {
 					Janus.error("Error attaching stream to element");
 				}
-			} else if(adapter.browserDetails.browser === 'safari') {
+			} else if(adapter.browserDetails.browser === 'safari' || window.navigator.match(/iPad/i) || window.navigator.match(/iPhone/i)) {
 				element.src = URL.createObjectURL(stream);
 			}
 			else {
@@ -158,7 +158,7 @@ Janus.init = function(options) {
 				} else if(typeof to.src !== 'undefined') {
 					to.src = from.src;
 				}
-			} else if(adapter.browserDetails.browser === 'safari') {
+			} else if(adapter.browserDetails.browser === 'safari' || window.navigator.match(/iPad/i) || window.navigator.match(/iPhone/i)) {
 				to.src = from.src;
 			}
 			else {


### PR DESCRIPTION
We have modified the `attachMediaStream` and `reattachMediaStream` methods for iOS devices.

This change has been tested over an Ionic application and `cordova-plugin-iosrtc`