### PR TITLE
add ssl support for the rabbitmq transport

### DIFF
--- a/conf/janus.transport.rabbitmq.cfg.sample
+++ b/conf/janus.transport.rabbitmq.cfg.sample
@@ -25,6 +25,13 @@ host = localhost			; The address of the RabbitMQ server
 ;vhost = /					; Virtual host to specify when logging in, if needed
 to_janus = to-janus			; Name of the queue for incoming messages
 from_janus = from-janus		; Name of the queue for outgoing messages
+;ssl_enable = no			; Whether ssl support must be enabled
+;ssl_verify_peer = yes		; Whether peer verification must be enabled
+;ssl_verify_hostname = yes	; Whether hostname verification must be enabled
+; certificates to use when SSL support is enabled, if needed
+;ssl_cacert = /path/to/cacert.pem
+;ssl_cert = /path/to/cert.pem
+;ssl_key = /path/to/key.pem
 
 ; If you want to expose the Admin API via RabbitMQ as well, you need to
 ; specify a different set of queues, as you cannot mix Janus API and

--- a/transports/janus_rabbitmq.c
+++ b/transports/janus_rabbitmq.c
@@ -36,6 +36,7 @@
 #include <amqp.h>
 #include <amqp_framing.h>
 #include <amqp_tcp_socket.h>
+#include <amqp_ssl_socket.h>
 
 #include "../debug.h"
 #include "../apierror.h"
@@ -222,6 +223,35 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 	else
 		password = g_strdup("guest");
 
+	/* SSL config*/
+	const char *ssl_cacert_file = NULL;
+	const char *ssl_cert_file = NULL;
+	const char *ssl_key_file = NULL;
+	gboolean ssl_enable = FALSE;
+	gboolean ssl_verify_peer = FALSE;
+	gboolean ssl_verify_hostname = FALSE;
+	item = janus_config_get_item_drilldown(config, "general", "ssl_enable");
+	if(!item || !item->value || !janus_is_true(item->value)) {
+		JANUS_LOG(LOG_INFO, "RabbitMQ SSL support disabled\n");
+	} else {
+		ssl_enable = TRUE;
+		item = janus_config_get_item_drilldown(config, "general", "ssl_cacert");
+		if(item && item->value)
+			ssl_cacert_file = g_strdup(item->value);
+		item = janus_config_get_item_drilldown(config, "general", "ssl_cert");
+		if(item && item->value)
+			ssl_cert_file = g_strdup(item->value);
+		item = janus_config_get_item_drilldown(config, "general", "ssl_key");
+		if(item && item->value)
+			ssl_key_file = g_strdup(item->value);
+		item = janus_config_get_item_drilldown(config, "general", "ssl_verify_peer");
+		if(item && item->value && janus_is_true(item->value))
+			ssl_verify_peer = TRUE;
+		item = janus_config_get_item_drilldown(config, "general", "ssl_verify_hostname");
+		if(item && item->value && janus_is_true(item->value))
+			ssl_verify_hostname = TRUE;
+	}
+
 	/* Now check if the Janus API must be supported */
 	const char *to_janus = NULL, *from_janus = NULL;
 	const char *to_janus_admin = NULL, *from_janus_admin = NULL;
@@ -278,14 +308,48 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 		}
 		/* Connect */
 		rmq_client->rmq_conn = amqp_new_connection();
+		amqp_socket_t *socket = NULL;
+		int status;
 		JANUS_LOG(LOG_VERB, "Creating RabbitMQ socket...\n");
-		amqp_socket_t *socket = amqp_tcp_socket_new(rmq_client->rmq_conn);
-		if(socket == NULL) {
-			JANUS_LOG(LOG_FATAL, "Can't connect to RabbitMQ server: error creating socket...\n");
-			goto error;
+		if (ssl_enable) {
+			socket = amqp_ssl_socket_new(rmq_client->rmq_conn);
+			if(socket == NULL) {
+				JANUS_LOG(LOG_FATAL, "Can't connect to RabbitMQ server: error creating socket...\n");
+				goto error;
+			}
+			if(ssl_verify_peer) {
+				amqp_ssl_socket_set_verify_peer(socket, 1);
+			} else {
+				amqp_ssl_socket_set_verify_peer(socket, 0);
+			}
+			if(ssl_verify_hostname) {
+				amqp_ssl_socket_set_verify_hostname(socket, 1);
+			} else {
+				amqp_ssl_socket_set_verify_hostname(socket, 0);
+			}
+			if(ssl_cacert_file) {
+				status = amqp_ssl_socket_set_cacert(socket, ssl_cacert_file);
+				if(status != AMQP_STATUS_OK) {
+					JANUS_LOG(LOG_FATAL, "Can't connect to RabbitMQ server: error setting CA certificate... (%s)\n", amqp_error_string2(status));
+					goto error;
+				}
+			}
+			if(ssl_cert_file && ssl_key_file) {
+				amqp_ssl_socket_set_key(socket, ssl_cert_file, ssl_key_file);
+				if(status != AMQP_STATUS_OK) {
+					JANUS_LOG(LOG_FATAL, "Can't connect to RabbitMQ server: error setting key... (%s)\n", amqp_error_string2(status));
+					goto error;
+				}
+			}
+		} else {
+			socket = amqp_tcp_socket_new(rmq_client->rmq_conn);
+			if(socket == NULL) {
+				JANUS_LOG(LOG_FATAL, "Can't connect to RabbitMQ server: error creating socket...\n");
+				goto error;
+			}
 		}
 		JANUS_LOG(LOG_VERB, "Connecting to RabbitMQ server...\n");
-		int status = amqp_socket_open(socket, rmqhost, rmqport);
+		status = amqp_socket_open(socket, rmqhost, rmqport);
 		if(status != AMQP_STATUS_OK) {
 			JANUS_LOG(LOG_FATAL, "Can't connect to RabbitMQ server: error opening socket... (%s)\n", amqp_error_string2(status));
 			goto error;
@@ -414,6 +478,12 @@ error:
 		g_free((char *)to_janus_admin);
 	if(from_janus_admin)
 		g_free((char *)from_janus_admin);
+	if(ssl_cacert_file)
+		g_free((char *)ssl_cacert_file);
+	if(ssl_cert_file)
+		g_free((char *)ssl_cert_file);
+	if(ssl_key_file)
+		g_free((char *)ssl_key_file);
 	if(config)
 		janus_config_destroy(config);
 	return -1;


### PR DESCRIPTION
This pull request adds ssl support for the rabbitmq transport.

It introduces a few new configuration keys (only taken into consideration if ssl is enabled) and uses them when doing the amqp socket setup.
