### PR TITLE
Use g_file_get_contents instead of fopen/fseek/fread, using the former causes AddressSanitizer to report a heap-buffer-overflow

### DIFF
--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -403,35 +403,9 @@ static struct MHD_Daemon *janus_http_create_daemon(gboolean admin, char *path,
 		}
 	} else {
 		/* HTTPS web server, read certificate and key */
-		FILE *pem = fopen(server_pem, "rb");
-		if(pem) {
-			fseek(pem, 0L, SEEK_END);
-			size_t size = ftell(pem);
-			fseek(pem, 0L, SEEK_SET);
-			cert_pem_bytes = g_malloc0(size+1);
-			char *index = cert_pem_bytes;
-			int read = 0, tot = size;
-			while((read = fread(index, sizeof(char), tot, pem)) > 0) {
-				tot -= read;
-				index += read;
-			}
-			fclose(pem);
-			cert_pem_bytes[size] = '\0';
-		}
-		FILE *key = fopen(server_key, "rb");
-		if(key) {
-			fseek(key, 0L, SEEK_END);
-			size_t size = ftell(key);
-			fseek(key, 0L, SEEK_SET);
-			cert_key_bytes = g_malloc0(size);
-			char *index = cert_key_bytes;
-			int read = 0, tot = size;
-			while((read = fread(index, sizeof(char), tot, key)) > 0) {
-				tot -= read;
-				index += read;
-			}
-			fclose(key);
-		}
+		g_file_get_contents(server_pem, &cert_pem_bytes, NULL, NULL);
+		g_file_get_contents(server_key, &cert_key_bytes, NULL, NULL);
+
 		/* Start webserver */
 		if(threads == 0) {
 			JANUS_LOG(LOG_VERB, "Using a thread per connection for the %s API %s webserver\n",


### PR DESCRIPTION
I can fix the current implementation instead of you prefer, but it is nice to have terser code :)

```
==27171==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61c00000ef0b at pc 0x7fdbb308120b bp 0x7ffd0992ec80 sp 0x7ffd099
READ of size 1676 at 0x61c00000ef0b thread T0
    #0 0x7fdbb308120a in __interceptor_strlen (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x7020a)
    #1 0x7fdb9cbac6e3 in MHD_init_daemon_certificate /home/ubuntu/src/libmicrohttpd-0.9.50/src/microhttpd/daemon.c:596
    #2 0x7fdb9cbac6e3 in MHD_TLS_init /home/ubuntu/src/libmicrohttpd-0.9.50/src/microhttpd/daemon.c:655
    #3 0x7fdb9cbac6e3 in MHD_start_daemon_va /home/ubuntu/src/libmicrohttpd-0.9.50/src/microhttpd/daemon.c:4292
    #4 0x7fdb9cbad259 in MHD_start_daemon /home/ubuntu/src/libmicrohttpd-0.9.50/src/microhttpd/daemon.c:3125
    #5 0x7fdb9cdc3b8b in janus_http_create_daemon transports/janus_http.c:443
    #6 0x7fdb9cdc8473 in janus_http_init transports/janus_http.c:747
    #7 0x4a0ed9 in main /home/ubuntu/src/janus-gateway/janus.c:4133
    #8 0x7fdbb0d8b82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #9 0x40ce38 in _start (/opt/janus/bin/janus+0x40ce38)

0x61c00000ef0b is located 0 bytes to the right of 1675-byte region [0x61c00000e880,0x61c00000ef0b)
allocated by thread T0 here:
    #0 0x7fdbb30a979a in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x9879a)
    #1 0x7fdbb28b5770 in g_malloc0 (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4f770)
    #2 0x7fdb9cdc8473 in janus_http_init transports/janus_http.c:747
    #3 0x4a0ed9 in main /home/ubuntu/src/janus-gateway/janus.c:4133
    #4 0x7fdbb0d8b82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)

SUMMARY: AddressSanitizer: heap-buffer-overflow ??:0 __interceptor_strlen
Shadow bytes around the buggy address:
  0x0c387fff9d90: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c387fff9da0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c387fff9db0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c387fff9dc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c387fff9dd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c387fff9de0: 00[03]fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c387fff9df0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c387fff9e00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c387fff9e10: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c387fff9e20: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c387fff9e30: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
==27171==ABORTING
```