### PR TITLE
Added git commit + compile time information to the Janus logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 cmdline.c
 cmdline.h
+version.c
 docs/html/
 
 /janus

--- a/Makefile.am
+++ b/Makefile.am
@@ -128,6 +128,8 @@ janus_SOURCES = \
 	turnrest.h \
 	utils.c \
 	utils.h \
+	version.c \
+	version.h \
 	plugins/plugin.c \
 	plugins/plugin.h \
 	transports/transport.h \
@@ -152,13 +154,20 @@ janus_LDADD = \
 
 man1_MANS = janus.1
 
-BUILT_SOURCES = cmdline.c cmdline.h
+BUILT_SOURCES = cmdline.c cmdline.h version.c
 
 cmdline.c: janus.ggo
 	gengetopt --set-package="janus" --set-version="$(VERSION)" < $^
 
+version.c: FORCE
+	`which git` rev-parse HEAD | awk 'BEGIN {print "#include \"version.h\""} {print "const char *janus_build_git_sha = \"" $$0"\";"} END {}' > version.c
+	date | awk 'BEGIN {} {print "const char *janus_build_git_time = \""$$0"\";"} END {} ' >> version.c
+
+.PHONY: FORCE
+FORCE:
+
 EXTRA_DIST += janus.ggo
-CLEANFILES += cmdline.c cmdline.h
+CLEANFILES += cmdline.c cmdline.h version.c
 
 ##
 # Transports

--- a/janus.c
+++ b/janus.c
@@ -26,6 +26,7 @@
 #include <poll.h>
 
 #include "janus.h"
+#include "version.h"
 #include "cmdline.h"
 #include "config.h"
 #include "apierror.h"
@@ -3135,6 +3136,9 @@ gint main(int argc, char *argv[])
 	struct rlimit core_limits;
 	core_limits.rlim_cur = core_limits.rlim_max = RLIM_INFINITY;
 	setrlimit(RLIMIT_CORE, &core_limits);
+
+	g_print("Janus commit: %s\n", janus_build_git_sha);
+	g_print("Compiled on:  %s\n\n", janus_build_git_time);
 
 	struct gengetopt_args_info args_info;
 	/* Let's call our cmdline parser */

--- a/version.h
+++ b/version.h
@@ -1,0 +1,19 @@
+/*! \file   version.h
+ * \author Lorenzo Miniero <lorenzo@meetecho.com>
+ * \copyright GNU General Public License v3
+ * \brief  Janus GitHub versioning (headers)
+ * \details This exposes a quick an easy way to display the commit the
+ * compiled version of Janus implements, and when it has been built. It 
+ * is based on this excellent comment: http://stackoverflow.com/a/1843783
+ *
+ * \ingroup core
+ * \ref core
+ */
+ 
+#ifndef _JANUS_VERSION_H
+#define _JANUS_VERSION_H
+
+extern const char *janus_build_git_time;
+extern const char *janus_build_git_sha;
+
+#endif


### PR DESCRIPTION
For a while I wanted to add information like which revision of Janus a specific instance was built against, or when it was built, as it's stuff that is always useful to have in the logs. I found a very useful suggestion [here](http://stackoverflow.com/a/1843783) and so implemented it, which means that now, with this patch, everytime you start Janus you should get something like this:

```
Janus commit: 10eea99203f30cd74b058f7b542439a6e03a8d59
Compiled on:  Thu  6 Apr 16:17:26 CEST 2017
```

I've published it as a pull request rather than on master directly as I want to make sure it works as expected not only on other systems (e.g., Mac OS), but also on other Linux distros besides mine (Fedora 25). The part I'm worried the most about is the way we generate the `version.c` file:

```
version.c: FORCE
	`which git` rev-parse HEAD | awk 'BEGIN {print "#include \"version.h\""} {print "const char *janus_build_git_sha = \"" $$0"\";"} END {}' > version.c
	date | awk 'BEGIN {} {print "const char *janus_build_git_time = \""$$0"\";"} END {} ' >> version.c
```

as I'm not sure the \`which git\` part fares well everywhere. Besides, both lines are probably very much bash-oriented. Can you guys please test and let me know? If you have suggestions on how to improve/fix in case I'd very much welcome it.