### PR TITLE
Optional forcing of private IDs for subscriptions for better kick in VideoRoom

### DIFF
--- a/conf/janus.plugin.videoroom.cfg.sample
+++ b/conf/janus.plugin.videoroom.cfg.sample
@@ -3,6 +3,8 @@
 ; is_private = yes|no (whether this room should be in the public list, default=yes)
 ; secret = <optional password needed for manipulating (e.g. destroying) the room>
 ; pin = <optional password needed for joining the room>
+; require_pvtid = yes|no (whether subscriptions are required to provide a valid
+;			a valid private_id to associate with a publisher, default=no)
 ; publishers = <max number of concurrent senders> (e.g., 6 for a video
 ;              conference or 1 for a webinar)
 ; bitrate = <max video bitrate for senders> (e.g., 128000)

--- a/ice.c
+++ b/ice.c
@@ -397,9 +397,9 @@ static GHashTable *old_plugin_sessions;
 static janus_mutex old_plugin_sessions_mutex;
 gboolean janus_plugin_session_is_alive(janus_plugin_session *plugin_session) {
 	/* Make sure this plugin session is still alive */
-	janus_mutex_lock(&old_plugin_sessions_mutex);
+	janus_mutex_lock_nodebug(&old_plugin_sessions_mutex);
 	janus_plugin_session *result = g_hash_table_lookup(old_plugin_sessions, plugin_session);
-	janus_mutex_unlock(&old_plugin_sessions_mutex);
+	janus_mutex_unlock_nodebug(&old_plugin_sessions_mutex);
 	if(result != NULL) {
 		JANUS_LOG(LOG_ERR, "Invalid plugin session (%p)\n", plugin_session);
 	}

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1915,19 +1915,18 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 			goto plugin_response;
 		}
 		janus_mutex_lock(&videoroom->participants_mutex);
+		janus_mutex_unlock(&rooms_mutex);
 		/* A secret may be required for this action */
 		JANUS_CHECK_SECRET(videoroom->room_secret, root, "secret", error_code, error_cause,
 			JANUS_VIDEOROOM_ERROR_MISSING_ELEMENT, JANUS_VIDEOROOM_ERROR_INVALID_ELEMENT, JANUS_VIDEOROOM_ERROR_UNAUTHORIZED);
 		if(error_code != 0) {
 			janus_mutex_unlock(&videoroom->participants_mutex);
-			janus_mutex_unlock(&rooms_mutex);
 			goto plugin_response;
 		}
 		guint64 user_id = json_integer_value(id);
 		janus_videoroom_participant *participant = g_hash_table_lookup(videoroom->participants, &user_id);
 		if(participant == NULL) {
 			janus_mutex_unlock(&videoroom->participants_mutex);
-			janus_mutex_unlock(&rooms_mutex);
 			JANUS_LOG(LOG_ERR, "No such user %"SCNu64" in room %"SCNu64"\n", user_id, room_id);
 			error_code = JANUS_VIDEOROOM_ERROR_NO_SUCH_FEED;
 			g_snprintf(error_cause, 512, "No such user %"SCNu64" in room %"SCNu64, user_id, room_id);
@@ -1970,7 +1969,6 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		response = json_object();
 		json_object_set_new(response, "videoroom", json_string("success"));
 		/* Done */
-		janus_mutex_unlock(&rooms_mutex);
 		goto plugin_response;
 	} else if(!strcasecmp(request_text, "listparticipants")) {
 		/* List all participants in a room, specifying whether they're publishers or just attendees */	


### PR DESCRIPTION
This PR addresses the discussion we had in #745.

The motivation comes from the fact that, when you kick a user, normally their subscriptions still live in the room and they keep on getting media: that's expected as we kick a publisher, but listeners don't necessarily have a context, as we don't mandate them to be associated to any publisher at all.

This PR allows for this association to be optionally mandated, based on the `private_id` property we introduced recently. The idea is the following:

1. When you join as a publisher, you're returned a unique `private_id` by the plugin: you're not supposed to share this.
2. When you start subscribing to another participant, you can pass this `private_id` as part of the request, to allow the plugin to know this was originated by you. The VideoRoom demo already does that. Anyway, this parameter is entirely optional, for reasons explained in #745 (we still want to support listeners that are created out of context or with no associated publisher handle present).
3. If the room was created with a `require_pvtid:true`, then the `private_id` part when subscribing is mandatory, and it must match one of the existing publishers: if it's missing, or it's invalid, the subscription fails.
4. When a user is kicked, we check his `private_id`, and so close all listeners with the same `private_id` too. Of course, this is only guaranteed to succeed if `require_pvtid:true`, as otherwise nothing prevents listeners to be created without a `private_id`.

Tested briefly with three participants and seems to work. Please test carefully to check if it works and if it doesn't introduce any regression or problem/crash.