### PR TITLE
Add missing dependency libavformat-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ On Ubuntu or Debian, it would require something like this:
 	aptitude install libmicrohttpd-dev libjansson-dev libnice-dev \
 		libssl-dev libsrtp-dev libsofia-sip-ua-dev libglib2.0-dev \
 		libopus-dev libogg-dev libcurl4-openssl-dev pkg-config gengetopt \
-		libtool automake
+		libtool automake libavformat-dev
 
 * *Note:* please notice that libopus may not be available out of the box
 on Ubuntu or Debian, unless you're using a recent version (e.g., Ubuntu


### PR DESCRIPTION
Hi,

I saw following error

```configure: error: Package requirements (
                           glib-2.0,
                           jansson,
                           libavutil,
                           libavcodec,
                           libavformat,
                           ogg
                         ) were not met:

No package 'libavutil' found
No package 'libavcodec' found
No package 'libavformat' found```
```

To resolve this, I needed to install `libavformat-dev`