### PR TITLE
Added audio output device selection, if available, to devicetest demo

### DIFF
--- a/html/devicetest.html
+++ b/html/devicetest.html
@@ -67,11 +67,11 @@
 				<div class="row hide" id="devices">
 					<form class="form-inline">
 						<div class="form-group" style="margin-right: 20px;">
-							<label for="audio-device">Audio device:</label>
+							<label for="audio-device">Audio device (input):</label>
 							<select id="audio-device" class="form-control"></select>
 						</div>
 						<div class="form-group" style="margin-right: 20px;">
-							<label for="video-device">Video device:</label>
+							<label for="video-device">Video device (input):</label>
 							<select id="video-device" class="form-control"></select>
 						</div>
 						<div class="form-group">
@@ -115,7 +115,19 @@
 					<div class="col-md-6">
 						<div class="panel panel-default">
 							<div class="panel-heading">
-								<h3 class="panel-title">Remote Stream <span class="label label-primary hide" id="curres"></span> <span class="label label-info hide" id="curbitrate"></span></h3>
+								<h3 class="panel-title">Remote Stream
+									<span class="label label-primary hide" id="curres"></span>
+									<span class="label label-info hide" id="curbitrate"></span>
+									<div class="btn-group btn-group-xs pull-right hide" id="output-devices">
+										<div class="btn-group btn-group-xs">
+											<button id="outputdeviceset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+												Output device<span class="caret"></span>
+											</button>
+											<ul id="audiooutput" class="dropdown-menu" role="menu">
+											</ul>
+										</div>
+									</div>
+								</h3>
 							</div>
 							<div class="panel-body" id="videoright"></div>
 						</div>

--- a/html/echotest.js
+++ b/html/echotest.js
@@ -289,7 +289,7 @@ $(document).ready(function() {
 										} else {
 											Janus.log("Capping bandwidth to " + bitrate + " via REMB");
 										}
-										$('#bitrateset').html($(this).html()).parent().removeClass('open');
+										$('#bitrateset').html($(this).html() + '<span class="caret"></span>').parent().removeClass('open');
 										echotest.send({"message": { "bitrate": bitrate }});
 										return false;
 									});


### PR DESCRIPTION
Will fix #869, when merged. Notice that this will only work on Chrome >= 49: apparently it's not available anywhere else (not even Firefox). Couldn't test much as I don't have other output devices to choose from.