### PR TITLE
fix #871 detaching of already detached plugin

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -412,6 +412,7 @@ function Janus(gatewayCallbacks) {
 				// Don't warn here because destroyHandle causes this situation.
 				return;
 			}
+			pluginHandle.detached = true;
 			pluginHandle.ondetached();
 			pluginHandle.detach();
 		} else if(json["janus"] === "media") {
@@ -781,6 +782,7 @@ function Janus(gatewayCallbacks) {
 						session : that,
 						plugin : plugin,
 						id : handleId,
+						detached : false,
 						webrtcStuff : {
 							started : false,
 							myStream : null,
@@ -867,6 +869,7 @@ function Janus(gatewayCallbacks) {
 						session : that,
 						plugin : plugin,
 						id : handleId,
+						detached : false,
 						webrtcStuff : {
 							started : false,
 							myStream : null,
@@ -1178,6 +1181,12 @@ function Janus(gatewayCallbacks) {
 			request["token"] = token;
 		if(apisecret !== null && apisecret !== undefined)
 			request["apisecret"] = apisecret;
+		if (pluginHandles[handleId].detached) {
+			// Plugin was already detached by Janus, calling detach again will return a handle not found error, so just exit here
+			delete pluginHandles[handleId];
+			callbacks.success();
+			return;
+		}
 		if(websockets) {
 			request["session_id"] = sessionId;
 			request["handle_id"] = handleId;

--- a/html/janus.js
+++ b/html/janus.js
@@ -1171,6 +1171,12 @@ function Janus(gatewayCallbacks) {
 			asyncRequest = (callbacks.asyncRequest === true);
 		Janus.log("Destroying handle " + handleId + " (async=" + asyncRequest + ")");
 		cleanupWebrtc(handleId);
+		if (pluginHandles[handleId].detached) {
+			// Plugin was already detached by Janus, calling detach again will return a handle not found error, so just exit here
+			delete pluginHandles[handleId];
+			callbacks.success();
+			return;
+		}
 		if(!connected) {
 			Janus.warn("Is the gateway down? (connected=false)");
 			callbacks.error("Is the gateway down? (connected=false)");
@@ -1181,12 +1187,6 @@ function Janus(gatewayCallbacks) {
 			request["token"] = token;
 		if(apisecret !== null && apisecret !== undefined)
 			request["apisecret"] = apisecret;
-		if (pluginHandles[handleId].detached) {
-			// Plugin was already detached by Janus, calling detach again will return a handle not found error, so just exit here
-			delete pluginHandles[handleId];
-			callbacks.success();
-			return;
-		}
 		if(websockets) {
 			request["session_id"] = sessionId;
 			request["handle_id"] = handleId;

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -473,6 +473,7 @@ function Janus(gatewayCallbacks) {
 				// Don't warn here because destroyHandle causes this situation.
 				return;
 			}
+			pluginHandle.detached = true;
 			pluginHandle.ondetached();
 			pluginHandle.detach();
 		} else if(json["janus"] === "media") {
@@ -842,6 +843,7 @@ function Janus(gatewayCallbacks) {
 						session : that,
 						plugin : plugin,
 						id : handleId,
+						detached : false,
 						webrtcStuff : {
 							started : false,
 							myStream : null,
@@ -926,6 +928,7 @@ function Janus(gatewayCallbacks) {
 						session : that,
 						plugin : plugin,
 						id : handleId,
+						detached : false,
 						webrtcStuff : {
 							started : false,
 							myStream : null,
@@ -1232,6 +1235,12 @@ function Janus(gatewayCallbacks) {
 			request["token"] = token;
 		if(apisecret !== null && apisecret !== undefined)
 			request["apisecret"] = apisecret;
+		if (pluginHandles[handleId].detached) {
+			// Plugin was already detached by Janus, calling detach again will return a handle not found error, so just exit here
+			delete pluginHandles[handleId];
+			callbacks.success();
+			return;
+		}
 		if(websockets) {
 			request["session_id"] = sessionId;
 			request["handle_id"] = handleId;

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -1225,6 +1225,12 @@ function Janus(gatewayCallbacks) {
 			asyncRequest = (callbacks.asyncRequest === true);
 		Janus.log("Destroying handle " + handleId + " (sync=" + asyncRequest + ")");
 		cleanupWebrtc(handleId);
+		if (pluginHandles[handleId].detached) {
+			// Plugin was already detached by Janus, calling detach again will return a handle not found error, so just exit here
+			delete pluginHandles[handleId];
+			callbacks.success();
+			return;
+		}
 		if(!connected) {
 			Janus.warn("Is the gateway down? (connected=false)");
 			callbacks.error("Is the gateway down? (connected=false)");
@@ -1235,12 +1241,6 @@ function Janus(gatewayCallbacks) {
 			request["token"] = token;
 		if(apisecret !== null && apisecret !== undefined)
 			request["apisecret"] = apisecret;
-		if (pluginHandles[handleId].detached) {
-			// Plugin was already detached by Janus, calling detach again will return a handle not found error, so just exit here
-			delete pluginHandles[handleId];
-			callbacks.success();
-			return;
-		}
 		if(websockets) {
 			request["session_id"] = sessionId;
 			request["handle_id"] = handleId;


### PR DESCRIPTION
Unfortunately Lorenzo's commit 8274fe87fcd8a3fbdf4ef82934edcd41828cf007 doesn't fix that problem and still calls plugin's `detach()` method on already detached plugin. At the same time, there's a WebRTC cleanup procedure inside of `destroyHandle()`, so we can't just skip `detach()` call in handling of `detached` message, so I did a small fix that works solves the issue (tested it only with REST).