### PR TITLE
Fix: broken check for whether or not data channels are needed

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -724,7 +724,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					continue;
 				}
 #ifndef HAVE_SCTP
-				if(data) {
+				if(dodata) {
 					JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream '%s': no datachannels support......\n", cat->name);
 					cl = cl->next;
 					continue;


### PR DESCRIPTION
Fix: broken check for whether or not data channels were actually requested.

Previously, explicitly deconfigured data=no streams would trigger a false positive here if Janus was compiled without support for SCTP.