### PR TITLE
Fix on nasty race condition (SRTP contexts for outgoing traffic)

### DIFF
--- a/ice.h
+++ b/ice.h
@@ -176,6 +176,7 @@ typedef struct janus_ice_trickle janus_ice_trickle;
 #define JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO			(1 << 14)
 #define JANUS_ICE_HANDLE_WEBRTC_GOT_OFFER			(1 << 15)
 #define JANUS_ICE_HANDLE_WEBRTC_GOT_ANSWER			(1 << 16)
+#define JANUS_ICE_HANDLE_WEBRTC_HAS_AGENT			(1 << 17)
 
 
 /*! \brief Janus media statistics


### PR DESCRIPTION
This PR aims at fixing a nasty race condition we only recently found out about, after a deep investigation on reports mostly related to #751.

The issue was basically that, at times, Janus would crash when encrypting traffic with SRTP, apparently deep within the crypto code, e.g., when hashing the packets via OpenSSL. After a lot of debugging, and messing with the libraries a lot for more meaningful information, we found out that the cause was the SRTP context being messed with while it was used. At first we thought it was because of the call being hung up while in use, but we confirmed it was not the case. Besides, all outgoing traffic for a specific user has a dedicated thread, which meant there could be no concurrent access to the libsrtp encrypting features from separate threads, which would indeed break libsrtp (you need to do your own locking for that).

It turned out that this concurrent access was indeed what was happening: at times, the above mentioned outgoing-traffic thread for the user was not properly shut down, and so, even though we had checks in place, when creating a new PeerConnection on the same handle you could end up with a new thread for the user accessing the same stuff. Since they'd both share the same queue, they could both end up encrypting SRTP traffic from the same context, and cause the crash we experienced.

This PR modifies the way the outgoing-traffic is managed. Now, the outgoing-traffic thread is created the first time you create a PC just as before, but is not shutdown when you close the PC. It stays idle instead, and is re-used for any further PC you create on the same handle (e.g., publish/unpublish/publish again in the videoroom, or other SIP calls after you end the first one). This way, the concurrent access can never happen, and the start of the media exchange is actually faster after the first time, as you already have a thread available and don't have to wait for it to spawn.

We tried this patch in some dedicated tests and it seems to be working as expected for us, and it does fix the crash in the scenario I described. Anyway, since it touches a delicate part of the core, I'd ask you all to also test this patch themselves, especially with own applications. As soon as I get feedback that it works as expected and doesn't break anything, I'd like to merge, which should hopefully happen soon as it fixes a serious issue. As usual, if I don't get any feedback I'll go on merge, so it's in your best interest to make sure you're not surprised :wink:.

Thanks!