### PR TITLE
External token authentication and authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*~
+TAGS
+
 cmdline.c
 cmdline.h
 version.c

--- a/auth-external/.gitignore
+++ b/auth-external/.gitignore
@@ -1,0 +1,2 @@
+*~
+node_modules

--- a/auth-external/README
+++ b/auth-external/README
@@ -1,0 +1,12 @@
+###
+### To run this example authentication/authorization server...
+###
+
+# Install nodejs in whatever way your distribution provides it.
+apt-get install nodejs
+
+# Install the required sub-packages
+npm install .
+
+# Start it up!
+nodejs /authserver-example.js

--- a/auth-external/README
+++ b/auth-external/README
@@ -9,4 +9,4 @@ apt-get install nodejs
 npm install .
 
 # Start it up!
-nodejs /authserver-example.js
+nodejs ./authserver-example.js

--- a/auth-external/authserver-example.js
+++ b/auth-external/authserver-example.js
@@ -1,0 +1,142 @@
+//
+// Whhat port to listen on
+//
+var PORT = 3000;
+
+//
+// Configure (in this example, hard-coded) allowed tokens and their authorizations
+//
+var allowedTokens =
+{
+  // Token 'default' is only allowed the "standard" stuff, e.g., 
+  // not plugin-specific, or "trickle".
+  default : function(request)
+  {
+    var authenticated = allowStandard(request);
+console.log("DEFAULT: returning", authenticated);
+    return authenticated;
+  },
+
+  // Token 'echoonly' is only allowed access to the echo plugin (and the "standard" stuff)
+  echoonly : function(request)
+  {
+    var authenticated;
+
+    // Default to disallowing all requests
+    authenticated = allowStandard(request);
+
+    // Allow specific requests to the streaming plugin
+    if (request.plugin_package == "janus.plugin.echo")
+    {
+      authenticated = true;
+    }
+
+    return authenticated;
+  },
+
+  // Token 'restricted' is only allowed the following:
+  //   - Access to the streaming plugin's "list" and "start" requests;
+  //   - Access to the streaming plugin's "watch" request if the requested id is 999
+  //   - Complete access to the echo plugin
+  restricted : function(request)
+  {
+    var             authenticated;
+
+    // Default to disallowing all requests
+    authenticated = allowStandard(request);
+
+    // Allow specific requests to the streaming plugin
+    if (request.plugin_package == "janus.plugin.streaming" &&
+        request.janus == "message")
+    {
+      // Allow streaming video 999
+      if (request.body.request == "watch" && request.body.id == "999")
+      {
+        authenticated = true;
+      }
+
+      // Allow the "list" and "start" commands
+      if ( [ "list", "start" ].indexOf(request.body.request) != -1)
+      {
+        authenticated = true;
+      }
+    }
+
+    // Allow requests to the echo plugin
+    if (request.plugin_package == "janus.plugin.echo")
+    {
+      authenticated = true;
+    }
+
+    return authenticated;
+  },
+
+  // Token 'superuser' is granted unlimited access.
+  superuser : function(request)
+  {
+    return true;
+  }
+};
+
+// Prepare to create a web server
+var express = require('express');
+var bodyParser = require("body-parser");
+
+var app = express();
+
+app.use(bodyParser.json());
+
+// Authenticate when we receive a root-level POST request
+app.post(
+  "/",
+  function(req, res)
+  {
+    var             request = req.body;
+    var             authenticated = false;
+
+    console.log("authserver got request:\n" + JSON.stringify(request, null, "  "));
+
+    // Is this token recognized?
+    if (typeof allowedTokens[request.token] == "function")
+    {
+      // Yup. Authenticate/authorize based on the request and token
+      authenticated = allowedTokens[request.token](request);
+    }
+    console.log("authserver: " + (authenticated ? "allowed" : "not allowed"));
+
+    // Send back the result
+    res.writeHead(200, {'Content-Type': 'application/json'});
+    res.end(
+      JSON.stringify(
+        {
+          authenticated : authenticated
+        }));
+  });
+
+// Initialize immediately.
+var port = PORT;
+app.listen(port);
+console.log('Listening at http://localhost:' + port)
+
+
+//
+// Allow the standard requests that any valid token likely wants
+//
+function allowStandard(request)
+{
+  var authenticated = false;
+
+  // Allow trickle requests
+  if (request.janus == "trickle")
+  {
+    authenticated = true;
+  }
+
+  // Allow any request that's not to a specific plugin
+  if (! request.plugin_package)
+  {
+    authenticated = true;
+  }
+
+  return authenticated;
+}

--- a/auth-external/authserver-example.js
+++ b/auth-external/authserver-example.js
@@ -13,7 +13,6 @@ var allowedTokens =
   default : function(request)
   {
     var authenticated = allowStandard(request);
-console.log("DEFAULT: returning", authenticated);
     return authenticated;
   },
 

--- a/auth-external/package.json
+++ b/auth-external/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "authserver",
+  "version": "0.0.1",
+  "description": "Example token authentication server for Janus Gateway",
+  "main": "authserver-example.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "body-parser": "^1.17.2",
+    "express": "^4.15.3"
+  },
+  "author": "Derrell Lipman <derrell.lipman@unwireduniverse.com>",
+  "license": "GNU General Public License v3"
+}

--- a/auth.c
+++ b/auth.c
@@ -15,29 +15,64 @@
  * \ref core
  */
 
+#ifdef HAVE_LIBCURL
+#  include <curl/curl.h>
+#endif
 #include "auth.h"
 #include "debug.h"
 #include "mutex.h"
+#include "ice.h"
+#include "janus.h"
+#include "plugins/plugin.h"
 
 /* Hash table to contain the tokens to match */
 static GHashTable *tokens = NULL, *allowed_plugins = NULL;
 static gboolean auth_enabled = FALSE;
+static char auth_type = '-';
+static const void *auth_external_private_data = NULL;
 static janus_mutex mutex;
 
 static void janus_auth_free_token(char *token) {
 	g_free(token);
 }
 
+gboolean (*janus_auth_check_token_external)(const char *token, json_t *root) =
+#ifdef HAVE_LIBCURL
+        janus_auth_check_token_http;
+#else
+        janus_auth_check_token_false;
+#endif
+
+
 /* Setup */
-void janus_auth_init(gboolean enabled) {
-	if(enabled) {
-		JANUS_LOG(LOG_INFO, "Token based authentication enabled\n");
+void janus_auth_init(char type) {
+        auth_type = type;       /* save the requested authentication type */
+
+        switch(auth_type) {
+        case 'I' :              /* Internal (traditional) token authentication */
+		JANUS_LOG(LOG_INFO, "Internal token based authentication enabled\n");
 		tokens = g_hash_table_new_full(g_str_hash, g_str_equal, (GDestroyNotify)janus_auth_free_token, NULL);
 		allowed_plugins = g_hash_table_new_full(g_str_hash, g_str_equal, (GDestroyNotify)janus_auth_free_token, NULL);
 		auth_enabled = TRUE;
-	} else {
+                break;
+
+        case 'E' :              /* External token authentication */
+		JANUS_LOG(LOG_INFO, "External token based authentication enabled\n");
+                auth_enabled = TRUE;
+                break;
+
+        case '-' :
 		JANUS_LOG(LOG_WARN, "Token based authentication disabled\n");
-	}
+                auth_enabled = FALSE;
+                break;
+
+        default :
+                /* Should never occur. */
+		JANUS_LOG(LOG_ERR, "Programmer error: Unexpected auth type: %c\n", type);
+                auth_enabled = TRUE;
+                break;
+        }
+
 	janus_mutex_init(&mutex);
 }
 
@@ -76,17 +111,23 @@ gboolean janus_auth_add_token(const char *token) {
 	return TRUE;
 }
 
-gboolean janus_auth_check_token(const char *token) {
-	/* Always TRUE if the mechanism is disabled, of course */
-	if(!auth_enabled || tokens == NULL)
-		return TRUE;
-	janus_mutex_lock(&mutex);
-	if(token && g_hash_table_lookup(tokens, token)) {
-		janus_mutex_unlock(&mutex);
-		return TRUE;
-	}
-	janus_mutex_unlock(&mutex);
-	return FALSE;
+gboolean janus_auth_check_token(const char *token, json_t *root) {
+        if(!auth_enabled)
+                return TRUE;
+
+        if(auth_type == 'I') {  /* Internal authentication */
+                if(tokens == NULL)
+                        return TRUE;
+                janus_mutex_lock(&mutex);
+                if(token && g_hash_table_lookup(tokens, token)) {
+                        janus_mutex_unlock(&mutex);
+                        return TRUE;
+                }
+                janus_mutex_unlock(&mutex);
+                return FALSE;
+        } else {                /* External authentication */
+                return janus_auth_check_token_external(token, root);
+        }
 }
 
 GList *janus_auth_list_tokens(void) {
@@ -214,4 +255,178 @@ gboolean janus_auth_disallow_plugin(const char *token, void *plugin) {
 	}
 	janus_mutex_unlock(&mutex);
 	return TRUE;
+}
+
+#ifdef HAVE_LIBCURL
+
+static const char * get_plugin_name(json_t *root) {
+        const char *plugin_name = NULL;
+        guint64 session_id = 0;
+        guint64 handle_id = 0;
+	json_t *s = json_object_get(root, "session_id");
+	if(s && json_is_integer(s))
+		session_id = json_integer_value(s);
+	json_t *h = json_object_get(root, "handle_id");
+	if(h && json_is_integer(h))
+		handle_id = json_integer_value(h);
+        if(session_id > 0 && handle_id > 0) {
+                /* Look for our handle */
+                janus_session *session = janus_session_find(session_id);
+                janus_ice_handle *handle = janus_ice_handle_find(session, handle_id);
+                janus_plugin *plugin_t = (janus_plugin *)handle->app;
+                plugin_name = plugin_t->get_package();
+        }
+
+        return plugin_name;
+}
+
+
+typedef struct ResultData {
+        char *memory;
+        size_t size;
+} ResultData;
+
+
+static size_t 
+resultBytesCallback(void *contents, size_t size, size_t nmemb, void *userp) {
+        size_t realsize = size * nmemb;
+        struct ResultData *mem = userp;
+ 
+        mem->memory = realloc(mem->memory, mem->size + realsize + 1);
+        if(mem->memory == NULL) {
+                JANUS_LOG(LOG_ERR, "auth http: out of memory!\n");
+                return 0;
+        }
+ 
+        /* Copy this new data into the buffer */
+        memcpy(&mem->memory[mem->size], contents, realsize);
+        mem->size += realsize;        /* update number of bytes in buffer */
+        mem->memory[mem->size] = 0;   /* null-terminate */
+ 
+        return realsize;
+}
+
+gboolean janus_auth_check_token_http(const char *token, json_t *root) {
+        CURL *curl;
+        CURLcode res;
+        const char *plugin_name = root == NULL ? NULL : get_plugin_name(root);
+        char *message;
+        ResultData result;
+        gboolean ret;
+        struct curl_slist *list = NULL;
+
+        /* Add the plugin package name to the message */
+        json_object_set(root, "plugin_package", json_string(plugin_name));
+
+        /* Format the request message into a JSON string */
+        message = json_dumps(root, JSON_INDENT(2));
+
+        JANUS_LOG(LOG_INFO, "janus_auth_check_token_http: plugin=%s, message:\n%s\n",
+                  plugin_name == NULL ? "<null>" : plugin_name, message);
+
+        /* Ensure that a URL has been configured */
+        if(!auth_external_private_data) {
+                JANUS_LOG(LOG_ERR, "auth http: no URL has been configured\n");
+                return FALSE;
+        }
+
+        /* Prepare to receive a result */
+        if ((result.memory = malloc(1)) == NULL) { /* will grow as needed */
+                JANUS_LOG(LOG_ERR, "auth http: out of memory!\n");
+                return FALSE;
+        }
+        result.size = 0;        /* result buffer is initially empty */
+
+        /* Initialize the curl library */
+        curl_global_init(CURL_GLOBAL_ALL);
+
+        /* Get a curl handle */
+        curl = curl_easy_init();
+        if(!curl) {
+                JANUS_LOG(LOG_ERR, "auth http: could not initialize curl!\n");
+                curl_global_cleanup();
+                return FALSE;
+        }
+
+        /* Set the URL for this request */
+        curl_easy_setopt(curl, CURLOPT_URL, (char *) auth_external_private_data);
+
+        if(message) {
+                /* Add the POST data: the user's request we are processing */
+                curl_easy_setopt(curl, CURLOPT_POSTFIELDS, message);
+
+                /* Give it the data length */
+                curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, strlen(message));
+        }
+
+        /* Save the authentication request result in memory, piece-by-piece */
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, resultBytesCallback);
+
+        /* Pass our result struct to the callback function */
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&result);
+
+        /* Set the content type of the data we're sending */
+        list = curl_slist_append(list, "Content-Type: application/json");
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
+
+        /* Issue the request and get our response! */
+        res = curl_easy_perform(curl);
+
+        /* Success? */
+        if(res != CURLE_OK) {
+                JANUS_LOG(LOG_ERR, "auth http: request failed (%d) to %s\n", res, (char *) auth_external_private_data);
+                ret = FALSE;
+                goto cleanup;
+        }
+
+        JANUS_LOG(LOG_INFO, "janus_auth_check_token_http result:\n%s\n", result.memory);
+
+	/* Parse the JSON payload */
+	json_error_t error;
+        json_t *resroot;
+	resroot = json_loads(result.memory, 0, &error);
+	if(!resroot) {
+                /* could not parse JSON */
+		ret = FALSE;
+		goto cleanup;
+	}
+	if(!json_is_object(resroot)) {
+		ret = FALSE;
+		json_decref(resroot);
+		goto cleanup;
+	}
+
+        // Get the 'authenticated' value provided to us
+        json_t *authenticated = json_object_get(resroot, "authenticated");
+        ret = json_is_true(authenticated);
+        json_decref(resroot);
+
+cleanup:
+        // Free the result buffer
+        free(result.memory);
+
+        /* Clean up this curl request */
+        curl_easy_cleanup(curl);
+
+        /* Deinitialize the curl library */
+        curl_global_cleanup();
+
+        return ret;
+}
+
+#else
+gboolean janus_auth_check_token_false(const char *token, json_t *root) {
+        JANUS_LOG(LOG_INFO, "External token authentication is not available (LIBCURL was not found)\n");
+        return FALSE;
+}
+#endif
+
+void janus_auth_set_external_private_data(void * data)
+{
+        auth_external_private_data = data;
+}
+
+const char * janus_auth_get_external_private_data(void)
+{
+        return auth_external_private_data;
 }

--- a/html/echotest.js
+++ b/html/echotest.js
@@ -86,7 +86,7 @@ $(document).ready(function() {
 					//		token: "mytoken",
 					//	or
 					//		apisecret: "serversecret",
-                                        token: "mytoken",
+                                        token: "echoonly",
 					success: function() {
 						// Attach to echo test plugin
 						janus.attach(

--- a/html/echotest.js
+++ b/html/echotest.js
@@ -86,6 +86,7 @@ $(document).ready(function() {
 					//		token: "mytoken",
 					//	or
 					//		apisecret: "serversecret",
+                                        token: "mytoken",
 					success: function() {
 						// Attach to echo test plugin
 						janus.attach(

--- a/html/streamingtest.html
+++ b/html/streamingtest.html
@@ -40,6 +40,10 @@
 					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
+                        <div>
+                                <span style="padding-left: 4px;">Token:</span>
+                                <input id="token" style="padding: 4px;" type="text" />
+                        </div>
 			<div class="container" id="details">
 				<div class="row">
 					<div class="col-md-12">

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -63,6 +63,12 @@ $(document).ready(function() {
 	Janus.init({debug: "all", callback: function() {
 		// Use a button to start the demo
 		$('#start').click(function() {
+                        var token = $('#token').val();
+
+                        if(token.length === 0) {
+                                token = "default";
+                        }
+
 			if(started)
 				return;
 			started = true;
@@ -76,6 +82,7 @@ $(document).ready(function() {
 			janus = new Janus(
 				{
 					server: server,
+                                        token: token,
 					success: function() {
 						// Attach to streaming plugin
 						janus.attach(

--- a/janus.c
+++ b/janus.c
@@ -671,7 +671,7 @@ int janus_process_incoming_request(janus_request *request) {
 			if(janus_auth_is_enabled()) {
 				/* The token based authentication mechanism is enabled, check that the client provided it */
 				json_t *token = json_object_get(root, "token");
-				if(token && json_is_string(token) && janus_auth_check_token(json_string_value(token))) {
+				if(token && json_is_string(token) && janus_auth_check_token(json_string_value(token), root)) {
 					token_authorized = TRUE;
 				}
 			}
@@ -753,7 +753,7 @@ int janus_process_incoming_request(janus_request *request) {
 		if(janus_auth_is_enabled()) {
 			/* The token based authentication mechanism is enabled, check that the client provided it */
 			json_t *token = json_object_get(root, "token");
-			if(token && json_is_string(token) && janus_auth_check_token(json_string_value(token))) {
+			if(token && json_is_string(token) && janus_auth_check_token(json_string_value(token), root)) {
 				token_authorized = TRUE;
 			}
 		}
@@ -1554,6 +1554,7 @@ int janus_process_incoming_admin_request(janus_request *request) {
 			json_object_set_new(reply, "transaction", json_string(transaction_text));
 			json_t *status = json_object();
 			json_object_set_new(status, "token_auth", janus_auth_is_enabled() ? json_true() : json_false());
+			json_object_set_new(status, "token_auth_private", json_string(janus_auth_get_external_private_data()));
 			json_object_set_new(status, "session_timeout", json_integer(session_timeout));
 			json_object_set_new(status, "log_level", json_integer(janus_log_level));
 			json_object_set_new(status, "log_timestamps", janus_log_timestamps ? json_true() : json_false());
@@ -1911,7 +1912,7 @@ int janus_process_incoming_admin_request(janus_request *request) {
 			json_t *token = json_object_get(root, "token");
 			const char *token_value = json_string_value(token);
 			/* Check if the token is valid, first */
-			if(!janus_auth_check_token(token_value)) {
+			if(!janus_auth_check_token(token_value, NULL)) {
 				ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_TOKEN_NOT_FOUND, "Token %s not found", token_value);
 				goto jsondone;
 			}
@@ -1992,7 +1993,7 @@ int janus_process_incoming_admin_request(janus_request *request) {
 			json_t *token = json_object_get(root, "token");
 			const char *token_value = json_string_value(token);
 			/* Check if the token is valid, first */
-			if(!janus_auth_check_token(token_value)) {
+			if(!janus_auth_check_token(token_value, NULL)) {
 				ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_TOKEN_NOT_FOUND, "Token %s not found", token_value);
 				goto jsondone;
 			}
@@ -2558,7 +2559,7 @@ gboolean janus_transport_is_auth_token_needed(janus_transport *plugin) {
 gboolean janus_transport_is_auth_token_valid(janus_transport *plugin, const char *token) {
 	if(!janus_auth_is_enabled())
 		return TRUE;
-	return token && janus_auth_check_token(token);
+	return token && janus_auth_check_token(token, NULL);
 }
 
 void janus_transport_notify_event(janus_transport *plugin, void *transport, json_t *event) {
@@ -3372,7 +3373,13 @@ gint main(int argc, char *argv[])
 		janus_config_add_item(config, "general", "api_secret", args_info.apisecret_arg);
 	}
 	if(args_info.token_auth_given) {
-		janus_config_add_item(config, "general", "token_auth", "yes");
+                if (strlen(args_info.token_auth_arg) > 0) {
+                        janus_config_add_item(config, "general", "token_auth", "external");
+                        janus_config_add_item(config, "general", "token_auth_private", args_info.token_auth_arg);
+                } else {
+                        janus_config_add_item(config, "general", "token_auth", "yes");
+                }
+                
 	}
 	if(args_info.cert_pem_given) {
 		janus_config_add_item(config, "certificates", "cert_pem", args_info.cert_pem_arg);
@@ -3550,7 +3557,19 @@ gint main(int argc, char *argv[])
 	}
 	/* Also check if the token based authentication mechanism needs to be enabled */
 	item = janus_config_get_item_drilldown(config, "general", "token_auth");
-	janus_auth_init(item && item->value && janus_is_true(item->value));
+        if (item && item->value) {
+                if (!strcasecmp(item->value, "external")) {
+                        janus_auth_init('E');
+                        item = janus_config_get_item_drilldown(config, "general", "token_auth_private");
+                        if (item && item->value) {
+                                janus_auth_set_external_private_data((void *) item->value);
+                        }
+                } else {
+                        janus_auth_init(janus_is_true(item->value) ? 'I' : '-');
+                }
+        } else {
+                janus_auth_init('-');
+        }
 
 	/* Initialize the recorder code */
 	item = janus_config_get_item_drilldown(config, "general", "recordings_tmp_ext");

--- a/janus.ggo
+++ b/janus.ggo
@@ -27,5 +27,5 @@ option "debug-level" d "Debug/logging level (0=disable debugging, 7=maximum debu
 option "debug-timestamps" D "Enable debug/logging timestamps" flag off
 option "disable-colors" o "Disable color in the logging" flag off
 option "apisecret" a "API secret all requests need to pass in order to be accepted by Janus (useful when wrapping Janus API requests in a server, none by default)" string typestr="randomstring" optional
-option "token-auth" A "Enable token-based authentication for all requests" flag off
+option "token-auth" A "Enable token-based authentication for all requests. With the optional argument, specify private data for an external token authenticator." string optional argoptional default=""
 option "event-handlers" e "Enable event handlers" flag off


### PR DESCRIPTION
The traditional Janus token authentication provides limited ability to control
access. It allows blocking access to plugins entirely, but no finer-grained
control than that, e.g., it is not possible to have a token that allows access
to particular rooms from the videoroom and/or particular streams from the
streaming plugin.

With this patch, external authentication is allowed. In the default case,
authentication is accomplished via an HTTP server. An example server
implementation is provided in the new directory auth-external, which
demonstrates how to allow certain requests while denying others, even to the
same plugin.

Although the default external authenticator sends its requests to an HTTP
server, other authenticators could be written. Only a single function pointer
need be changed to switch to a different authenticator.

The HTTP authenticator uses libcurl to talk with the authenticator server. If
libcurl is not available and external authentication is requested, a default
authenticator that always disallows requests is used.

The general->token_auth configuration key in janus.cfg may be set to a boolean
value as before ("yes", "no", "true", "false"). It may now additionally be set
to "external" to enable the external token authenticator.

One new configuration key is added to janus.cfg: general->token_auth_private.
For the default external authenticator (sending HTTP requests), this private
data is set to the URL at which the authenticator is listening.