### PR TITLE
Allow handles to force BUNDLE/rtcp-mux via API without waiting for negotiation

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -768,6 +768,11 @@ function Janus(gatewayCallbacks) {
 			request["token"] = token;
 		if(apisecret !== null && apisecret !== undefined)
 			request["apisecret"] = apisecret;
+		// If we know the browser supports BUNDLE and/or rtcp-mux, let's advertise those right away
+		if(adapter.browserDetails.browser == "chrome" || adapter.browserDetails.browser == "firefox") {
+			request["force-bundle"] = true;
+			request["force-rtcp-mux"] = true;
+		}
 		if(websockets) {
 			transactions[transaction] = function(json) {
 				Janus.debug(json);

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -829,6 +829,11 @@ function Janus(gatewayCallbacks) {
 			request["token"] = token;
 		if(apisecret !== null && apisecret !== undefined)
 			request["apisecret"] = apisecret;
+		// If we know the browser supports BUNDLE and/or rtcp-mux, let's advertise those right away
+		if(adapter.browserDetails.browser == "chrome" || adapter.browserDetails.browser == "firefox") {
+			request["force-bundle"] = true;
+			request["force-rtcp-mux"] = true;
+		}
 		if(websockets) {
 			transactions[transaction] = function(json) {
 				Janus.debug(json);

--- a/ice.c
+++ b/ice.c
@@ -2637,14 +2637,14 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 	}
 	/* Note: in case this is not an OFFER, we don't know whether BUNDLE is supported on the other side or not yet,
 	 * unless Janus was configured to force BUNDLE in which case we enable it on our side anyway */
-	if((offer && bundle) || janus_force_bundle) {
+	if((offer && bundle) || janus_force_bundle || handle->force_bundle) {
 		janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE);
 	} else {
 		janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE);
 	}
 	/* Note: in case this is not an OFFER, we don't know whether rtcp-mux is supported on the other side or not yet,
 	 * unless Janus was configured to force rtcp-mux in which case we enable it on our side anyway */
-	if((offer && rtcpmux) || janus_force_rtcpmux) {
+	if((offer && rtcpmux) || janus_force_rtcpmux || handle->force_rtcp_mux) {
 		janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX);
 	} else {
 		janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX);

--- a/ice.h
+++ b/ice.h
@@ -271,6 +271,10 @@ struct janus_ice_handle {
 	janus_plugin_session *app_handle;
 	/*! \brief Mask of WebRTC-related flags for this handle */
 	janus_flags webrtc_flags;
+	/*! \brief Whether we have to force BUNDLE when negotiating (if true, overrides global configuration) */
+	gboolean force_bundle;
+	/*! \brief Whether we have to force rtcp-mux when negotiating (if true, overrides global configuration) */
+	gboolean force_rtcp_mux;
 	/*! \brief Number of gathered candidates */
 	gint cdone;
 	/*! \brief GLib context for libnice */


### PR DESCRIPTION
Very simple PR, that I plan to merge soon.

BUNDLE allows for putting audio/video/data on the same ports; rtcp-mux allows us to put RTP and RTCP on the same port. As you can imagine, using them allows us to greatly limit the number of ports needed for each PeerConnection. When both are used, we only use a single port per PeerConnection, which is the optimum. No news here: we've supported both since day one.

Anyway, as you might now, BUNDLE and rtcp-mux are typically only negotiated in the SDP. So if the browser offers an SDP, and advertizes support for both, we know we can only allocate one port and that's fine. If Janus is offering instead, we normally don't know if the endpoint will support it, so we have to allocate multiple ports, typically 2*number of streams; if the answer that comes back says they're supported, we can fall back to one and get rid of the others. Anyway, just allocating those is a waste of resources, although minimal.

We already had a configuration property to force BUNDLE and rtcp-mux. When enabled, Janus always allocates a single port and assumes the peers support them too. Anyway, while efficient, we can't give that for granted: AFAIK, for instance, Edge supports rtcp-mux but not BUNDLE, and other endpoints may do things differently. As such, this PR allows you to force those on a per-handle basis. When you create a handle, you can tell Janus if your endpoint supports BUNDLE and/or rtcp-mux: if it does, it only allocates one port when offering. If it doesn't, it behaves as normal.

Both `janus.js` and `janus.nojquery.js` handle this automatically. If you're on Chrome or Firefox, they set those properties, otherwise they don't. We can update the behaviour along the way for other endpoints. In case you're sending your own Janus API messages and want to take advantage of this new feature, the change is quite trivial, just add these when sending the attach:

```
{
   "janus": "attach",
   "janus": "janus.plugin.streaming",
   [...]
   "force-bundle": true,
   "force-rtcp-mux": true
}
```

Updated the Admin API "handle_info" response to return those properties too, if set.