### PR TITLE
bower: external webrtc-adapter instead of bundled one

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "janus-gateway",
-  "version": "0.1.0",
+  "version": "0.2.3",
   "homepage": "https://github.com/meetecho/janus-gateway",
   "authors": [
     "Lorenzo Miniero <lorenzo@meetecho.com>",
@@ -21,7 +21,7 @@
     "Scott <scottmortonashton@gmail.com>"
   ],
   "description": "A javascript library for interacting with the C based Janus WebRTC Gateway",
-  "main": "./html/{adapter,janus}.js",
+  "main": "./html/janus.js",
   "license": "GPLv3",
   "ignore": [
     "**/.*",
@@ -33,6 +33,7 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "*"    
+    "jquery": "*",
+    "webrtc-adapter": "3.4.3"
   }
 }


### PR DESCRIPTION
@lminiero, on [d5a5868331d2](https://github.com/meetecho/janus-gateway/commit/d5a5868331d2e24be2e54b1f93ce74e2ac135397) you removed the bundled adapter.js and started to use the externalized one. This adapt your bower.json to that new reality (with the very same version of adapter you are using now in the demos). I tested this with Jangouts (maybe the only project relying on Bower nowadays to use Janus) and it works. It will of course break nothing for projects not using Bower.

So thanks for merging 😉 