### PR TITLE
fix for proper timestamps

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -28,13 +28,13 @@
 gint64 janus_get_monotonic_time(void) {
 	struct timespec ts;
 	clock_gettime (CLOCK_MONOTONIC, &ts);
-	return (ts.tv_sec*G_GINT64_CONSTANT(1000000)) + (ts.tv_nsec/G_GINT64_CONSTANT(1000));
+	return (ts.tv_sec*G_GINT64_CONSTANT(1000)) + (ts.tv_nsec/G_GINT64_CONSTANT(1000));
 }
 
 gint64 janus_get_real_time(void) {
 	struct timespec ts;
 	clock_gettime (CLOCK_REALTIME, &ts);
-	return (ts.tv_sec*G_GINT64_CONSTANT(1000000)) + (ts.tv_nsec/G_GINT64_CONSTANT(1000));
+	return (ts.tv_sec*G_GINT64_CONSTANT(1000)) + (ts.tv_nsec/G_GINT64_CONSTANT(1000));
 }
 
 gboolean janus_is_true(const char *value) {


### PR DESCRIPTION
This is fix for internal timestamp handling.

Still what janus-admin gives back is wrong. Timestamps are not in a way they usable as a unix (or javascript) timestamp