### PR TITLE
Added support for offerless INVITEs to the SIP plugin

### DIFF
--- a/html/siptest.js
+++ b/html/siptest.js
@@ -206,12 +206,18 @@ $(document).ready(function() {
 										} else if(event === 'incomingcall') {
 											Janus.log("Incoming call from " + result["username"] + "!");
 											var doAudio = true, doVideo = true;
+											var offerlessInvite = false;
 											if(jsep !== null && jsep !== undefined) {
 												// What has been negotiated?
 												doAudio = (jsep.sdp.indexOf("m=audio ") > -1);
 												doVideo = (jsep.sdp.indexOf("m=video ") > -1);
 												Janus.debug("Audio " + (doAudio ? "has" : "has NOT") + " been negotiated");
 												Janus.debug("Video " + (doVideo ? "has" : "has NOT") + " been negotiated");
+											} else {
+												Janus.log("This call doesn't contain an offer... we'll need to provide one ourselves");
+												offerlessInvite = true;
+												// In case you want to offer video when reacting to an offerless call, set this to true
+												doVideo = false;
 											}
 											// Any security offered? A missing "srtp" attribute means plain RTP
 											var rtpType = "";
@@ -222,8 +228,11 @@ $(document).ready(function() {
 												rtpType = " (SDES-SRTP mandatory)";
 											// Notify user
 											bootbox.hideAll();
+											var extra = "";
+											if(offerlessInvite)
+												extra = " (no SDP offer provided)"
 											incoming = bootbox.dialog({
-												message: "Incoming call from " + result["username"] + "!" + rtpType,
+												message: "Incoming call from " + result["username"] + "!" + rtpType + extra,
 												title: "Incoming call",
 												closeButton: false,
 												buttons: {
@@ -233,12 +242,15 @@ $(document).ready(function() {
 														callback: function() {
 															incoming = null;
 															$('#peer').val(result["username"]).attr('disabled', true);
-															sipcall.createAnswer(
+															// Notice that we can only answer if we got an offer: if this was
+															// an offerless call, we'll need to create an offer ourselves
+															var sipcallAction = (offerlessInvite ? sipcall.createOffer : sipcall.createAnswer);
+															sipcallAction(
 																{
 																	jsep: jsep,
 																	media: { audio: doAudio, video: doVideo },
 																	success: function(jsep) {
-																		Janus.debug("Got SDP! audio=" + doAudio + ", video=" + doVideo);
+																		Janus.debug("Got SDP " + jsep.type + "! audio=" + doAudio + ", video=" + doVideo);
 																		Janus.debug(jsep);
 																		var body = { request: "accept" };
 																		// Note: as with "call", you can add a "srtp" attribute to
@@ -278,7 +290,8 @@ $(document).ready(function() {
 											});											
 										} else if(event === 'accepted') {
 											Janus.log(result["username"] + " accepted the call!");
-											// TODO Video call can start
+											Janus.log(jsep);
+											// Call can start, now: handle the remote answer
 											if(jsep !== null && jsep !== undefined) {
 												sipcall.handleRemoteJsep({jsep: jsep, error: doHangup });
 											}

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1135,7 +1135,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 				session->media.video_ssrc = ntohl(header->ssrc);
 				JANUS_LOG(LOG_VERB, "Got SIP video SSRC: %"SCNu32"\n", session->media.video_ssrc);
 			}
-			if(session->media.has_video && session->media.video_rtp_fd) {
+			if(session->media.has_video && session->media.video_rtp_fd != -1) {
 				/* Save the frame if we're recording */
 				janus_recorder_save_frame(session->vrc, buf, len);
 				/* Is SRTP involved? */
@@ -1169,7 +1169,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 				session->media.audio_ssrc = ntohl(header->ssrc);
 				JANUS_LOG(LOG_VERB, "Got SIP audio SSRC: %"SCNu32"\n", session->media.audio_ssrc);
 			}
-			if(session->media.has_audio && session->media.audio_rtp_fd) {
+			if(session->media.has_audio && session->media.audio_rtp_fd != -1) {
 				/* Save the frame if we're recording */
 				janus_recorder_save_frame(session->arc, buf, len);
 				/* Is SRTP involved? */
@@ -1210,7 +1210,7 @@ void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf,
 			return;
 		/* Forward to our SIP peer */
 		if(video) {
-			if(session->media.has_video && session->media.video_rtcp_fd) {
+			if(session->media.has_video && session->media.video_rtcp_fd != -1) {
 				/* Fix SSRCs as the gateway does */
 				JANUS_LOG(LOG_HUGE, "[SIP] Fixing SSRCs (local %u, peer %u)\n",
 					session->media.video_ssrc, session->media.video_ssrc_peer);
@@ -1234,7 +1234,7 @@ void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf,
 				}
 			}
 		} else {
-			if(session->media.has_audio && session->media.audio_rtcp_fd) {
+			if(session->media.has_audio && session->media.audio_rtcp_fd != -1) {
 				/* Fix SSRCs as the gateway does */
 				JANUS_LOG(LOG_HUGE, "[SIP] Fixing SSRCs (local %u, peer %u)\n",
 					session->media.audio_ssrc, session->media.audio_ssrc_peer);
@@ -1956,6 +1956,10 @@ static void *janus_sip_handler(void *data) {
 			}
 			/* Accept a call from another peer */
 			JANUS_LOG(LOG_VERB, "We're accepting the call from %s\n", session->callee);
+			gboolean answer = !strcasecmp(msg_sdp_type, "answer");
+			if(!answer) {
+				JANUS_LOG(LOG_VERB, "This is a response to an offerless INVITE\n");
+			}
 			JANUS_LOG(LOG_VERB, "This is involving a negotiation (%s) as well:\n%s\n", msg_sdp_type, msg_sdp);
 			session->media.has_srtp_local = answer_srtp;
 			if(answer_srtp) {
@@ -2029,14 +2033,16 @@ static void *janus_sip_handler(void *data) {
 			/* Send an ack back */
 			result = json_object();
 			json_object_set_new(result, "event", json_string("accepted"));
-			/* Start the media */
-			session->media.ready = TRUE;	/* FIXME Maybe we need a better way to signal this */
-			GError *error = NULL;
-			char tname[16];
-			g_snprintf(tname, sizeof(tname), "siprtp %s", session->account.username);
-			g_thread_try_new(tname, janus_sip_relay_thread, session, &error);
-			if(error != NULL) {
-				JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the RTP/RTCP thread...\n", error->code, error->message ? error->message : "??");
+			if(answer) {
+				/* Start the media */
+				session->media.ready = TRUE;	/* FIXME Maybe we need a better way to signal this */
+				GError *error = NULL;
+				char tname[16];
+				g_snprintf(tname, sizeof(tname), "siprtp %s", session->account.username);
+				g_thread_try_new(tname, janus_sip_relay_thread, session, &error);
+				if(error != NULL) {
+					JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the RTP/RTCP thread...\n", error->code, error->message ? error->message : "??");
+				}
 			}
 		} else if(!strcasecmp(request_text, "decline")) {
 			/* Reject an incoming call */
@@ -2577,9 +2583,15 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			JANUS_LOG(LOG_VERB, "[%s][%s]: %d %s\n", session->account.username, nua_event_name(event), status, phrase ? phrase : "??");
 			break;
 	/* SIP requests */
-		case nua_i_ack:
+		case nua_i_ack: {
 			JANUS_LOG(LOG_VERB, "[%s][%s]: %d %s\n", session->account.username, nua_event_name(event), status, phrase ? phrase : "??");
+			/* We're only interested in this when there's been an offerless INVITE, as here's where we'd get our answer */
+			if(sip->sip_payload && sip->sip_payload->pl_data) {
+				JANUS_LOG(LOG_VERB, "This ACK contains a payload, probably as a result of an offerless INVITE: simulating 200 OK...\n");
+				janus_sip_sofia_callback(nua_r_invite, 700, "ACK", nua, magic, nh, hmagic, sip, tags);
+			}
 			break;
+		}
 		case nua_i_outbound:
 			JANUS_LOG(LOG_VERB, "[%s][%s]: %d %s\n", session->account.username, nua_event_name(event), status, phrase ? phrase : "??");
 			break;
@@ -2596,18 +2608,6 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			if(ssip == NULL) {
 				JANUS_LOG(LOG_ERR, "\tInvalid SIP stack\n");
 				nua_respond(nh, 500, sip_status_phrase(500), TAG_END());
-				break;
-			}
-			if(!sip->sip_payload) {
-				JANUS_LOG(LOG_WARN,"\tReceived re-invite without SDP - responding 200 OK\n");
-				nua_respond(nh, 200, sip_status_phrase(200), TAG_END());
-				break;
-			}
-			char sdperror[100];
-			janus_sdp *sdp = janus_sdp_parse(sip->sip_payload->pl_data, sdperror, sizeof(sdperror));
-			if(!sdp) {
-				JANUS_LOG(LOG_ERR, "\tError parsing SDP! %s\n", sdperror);
-				nua_respond(nh, 488, sip_status_phrase(488), TAG_END());
 				break;
 			}
 			gboolean reinvite = FALSE;
@@ -2645,6 +2645,19 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 					break;
 				}
 			}
+			/* Check if there's an SDP to process */
+			janus_sdp *sdp = NULL;
+			if(!sip->sip_payload) {
+				JANUS_LOG(LOG_VERB,"Received offerless %s\n", reinvite ? "re-INVITE" : "INVITE");
+			} else {
+				char sdperror[100];
+				sdp = janus_sdp_parse(sip->sip_payload->pl_data, sdperror, sizeof(sdperror));
+				if(!sdp) {
+					JANUS_LOG(LOG_ERR, "\tError parsing SDP! %s\n", sdperror);
+					nua_respond(nh, 488, sip_status_phrase(488), TAG_END());
+					break;
+				}
+			}
 			if(!reinvite) {
 				/* New incoming call */
 				session->callee = g_strdup(url_as_string(session->stack->s_home, sip->sip_from->a_url));
@@ -2660,18 +2673,20 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				reinvite ? "updating" : "inviting us in",
 				sip->sip_payload->pl_data);
 			gboolean changed = FALSE;
-			janus_sip_sdp_process(session, sdp, FALSE, reinvite, &changed);
-			/* Check if offer has neither audio nor video, fail with 488 */
-			if (!session->media.has_audio && !session->media.has_video) {
-				nua_respond(nh, 488, sip_status_phrase(488), TAG_END());
-				janus_sdp_free(sdp);
-				break;
-			}
-			/* Also fail with 488 if there's no remote IP address that can be used for RTP */
-			if (!session->media.remote_ip) {
-				nua_respond(nh, 488, sip_status_phrase(488), TAG_END());
-				janus_sdp_free(sdp);
-				break;
+			if(sdp) {
+				janus_sip_sdp_process(session, sdp, FALSE, reinvite, &changed);
+				/* Check if offer has neither audio nor video, fail with 488 */
+				if(!session->media.has_audio && !session->media.has_video) {
+					nua_respond(nh, 488, sip_status_phrase(488), TAG_END());
+					janus_sdp_free(sdp);
+					break;
+				}
+				/* Also fail with 488 if there's no remote IP address that can be used for RTP */
+				if(!session->media.remote_ip) {
+					nua_respond(nh, 488, sip_status_phrase(488), TAG_END());
+					janus_sdp_free(sdp);
+					break;
+				}
 			}
 			if(reinvite) {
 				/* No need to involve the browser: we reply ourselves */
@@ -2679,9 +2694,10 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				janus_sdp_free(sdp);
 				break;
 			}
-			/* Send SDP to the browser */
-			char *fixed_sdp = g_strdup(sip->sip_payload->pl_data);
-			json_t *jsep = json_pack("{ssss}", "type", "offer", "sdp", fixed_sdp);
+			/* Notify the browser about the call */
+			json_t *jsep = NULL;
+			if(sdp)
+				jsep = json_pack("{ssss}", "type", "offer", "sdp", sip->sip_payload->pl_data);
 			json_t *call = json_object();
 			json_object_set_new(call, "sip", json_string("event"));
 			json_t *calling = json_object();
@@ -2690,7 +2706,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			if(sip->sip_from && sip->sip_from->a_display) {
 				json_object_set_new(calling, "displayname", json_string(sip->sip_from->a_display));
 			}
-			if(session->media.has_srtp_remote) {
+			if(sdp && session->media.has_srtp_remote) {
 				/* FIXME Maybe a true/false instead? */
 				json_object_set_new(calling, "srtp", json_string(session->media.require_srtp ? "sdes_mandatory" : "sdes_optional"));
 			}
@@ -2698,8 +2714,8 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, call, jsep);
 			JANUS_LOG(LOG_VERB, "  >> Pushing event to peer: %d (%s)\n", ret, janus_get_api_error(ret));
 			json_decref(call);
-			json_decref(jsep);
-			g_free(fixed_sdp);
+			if(jsep)
+				json_decref(jsep);
 			janus_sdp_free(sdp);
 			/* Also notify event handlers */
 			if(notify_events && gateway->events_is_enabled()) {
@@ -2791,7 +2807,9 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 					NUTAG_AUTH(auth),
 					TAG_END());
 				break;
-			} else if(status >= 400) {
+			} else if(status == 700) {
+				JANUS_LOG(LOG_VERB, "Handling SDP answer in ACK\n");
+			} else if(status >= 400 && status != 700) {
 				break;
 			}
 			if(ssip == NULL) {
@@ -3437,16 +3455,35 @@ static void *janus_sip_relay_thread(void *data) {
 		int i = 0;
 		for(i=0; i<num; i++) {
 			if(fds[i].revents & (POLLERR | POLLHUP)) {
-				/* Socket error? */
-				JANUS_LOG(LOG_ERR, "[SIP-%s] Error polling: %s...\n", session->account.username,
-					fds[i].revents & POLLERR ? "POLLERR" : "POLLHUP");
-				JANUS_LOG(LOG_ERR, "[SIP-%s]   -- %d (%s)\n", session->account.username, errno, strerror(errno));
-				if(errno == 0) {
-					/* Maybe not a breaking error? */
-					continue;
-				}
+				/* If we just updated the session, let's wait until things have calmed down */
 				if(session->media.updated)
 					break;
+				/* Check the socket error */
+				int error = 0;
+				socklen_t errlen = sizeof(error);
+				getsockopt(fds[i].fd, SOL_SOCKET, SO_ERROR, (void *)&error, &errlen);
+				if(error == 0) {
+					/* Maybe not a breaking error after all? */
+					continue;
+				} else if(error == 111) {
+					/* ICMP error? If it's related to RTCP, let's just close the RTCP socket and move on */
+					if(fds[i].fd == session->media.audio_rtcp_fd) {
+						JANUS_LOG(LOG_WARN, "[SIP-%s] Got a '%s' on the audio RTCP socket, closing it\n",
+							session->account.username, strerror(error));
+						close(session->media.audio_rtcp_fd);
+						session->media.audio_rtcp_fd = -1;
+					} else if(fds[i].fd == session->media.video_rtcp_fd) {
+						JANUS_LOG(LOG_WARN, "[SIP-%s] Got a '%s' on the video RTCP socket, closing it\n",
+							session->account.username, strerror(error));
+						close(session->media.video_rtcp_fd);
+						session->media.video_rtcp_fd = -1;
+					}
+					/* FIXME Should we do the same with the RTP sockets as well? We may risk overreacting, there... */
+					continue;
+				}
+				JANUS_LOG(LOG_ERR, "[SIP-%s] Error polling %d (socket #%d): %s...\n", session->account.username,
+					fds[i].fd, i, fds[i].revents & POLLERR ? "POLLERR" : "POLLHUP");
+				JANUS_LOG(LOG_ERR, "[SIP-%s]   -- %d (%s)\n", session->account.username, error, strerror(error));
 				goon = FALSE;	/* Can we assume it's pretty much over, after a POLLERR? */
 				/* FIXME Simulate a "hangup" coming from the browser */
 				janus_sip_message *msg = g_malloc0(sizeof(janus_sip_message));

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -2019,6 +2019,11 @@ static void *janus_sip_handler(void *data) {
 				gateway->notify_event(&janus_sip_plugin, session->handle, info);
 			}
 			/* Send 200 OK */
+			if(!answer) {
+				if(session->transaction)
+					g_free(session->transaction);
+				session->transaction = msg->transaction ? g_strdup(msg->transaction) : NULL;
+			}
 			g_atomic_int_set(&session->hangingup, 0);
 			session->status = janus_sip_call_status_incall;
 			if(session->stack->s_nh_i == NULL) {


### PR DESCRIPTION
As the title suggests, this adds support for offerless INVITEs. The support is only for *incoming* INVITEs, that is those the plugin *receives*. You're still required to provide an offer when calling yourself using the plugin.

The patch also fixes some other problems here and there, mostly related to some spurious POLLERR notifications that could occur from time to time, apparently caused by ICMP errors (mostly when the peer doesn't listen on the RTCP port).

Feedback welcome, as usual, especially if you use the SIP plugin a lot and this was something you were waiting for. I tested this briefly by generating offerless INVITE calls with SIPp (media included) and it seems to be working fine for me. More comprehensive testing would help confirm this works as expected, though.

As usual, I won't wait forever, and plan to merge soon, so the sooner you shout if something's wrong, the better!