### PR TITLE
Fixed some getStats related stuff for Firefox and Safari

### DIFF
--- a/html/devicetest.js
+++ b/html/devicetest.js
@@ -364,7 +364,8 @@ $(document).ready(function() {
 										echotest.send({"message": { "bitrate": bitrate }});
 										return false;
 									});
-									if(adapter.browserDetails.browser === "chrome" || adapter.browserDetails.browser === "firefox") {
+									if(adapter.browserDetails.browser === "chrome" || adapter.browserDetails.browser === "firefox" ||
+											adapter.browserDetails.browser === "safari") {
 										$('#curbitrate').removeClass('hide').show();
 										bitrateTimer = setInterval(function() {
 											// Display updated bitrate, if supported

--- a/html/echotest.js
+++ b/html/echotest.js
@@ -285,7 +285,8 @@ $(document).ready(function() {
 										echotest.send({"message": { "bitrate": bitrate }});
 										return false;
 									});
-									if(adapter.browserDetails.browser === "chrome" || adapter.browserDetails.browser === "firefox") {
+									if(adapter.browserDetails.browser === "chrome" || adapter.browserDetails.browser === "firefox" ||
+											adapter.browserDetails.browser === "safari") {
 										$('#curbitrate').removeClass('hide').show();
 										bitrateTimer = setInterval(function() {
 											// Display updated bitrate, if supported

--- a/html/janus.js
+++ b/html/janus.js
@@ -767,7 +767,8 @@ function Janus(gatewayCallbacks) {
 		if(apisecret !== null && apisecret !== undefined)
 			request["apisecret"] = apisecret;
 		// If we know the browser supports BUNDLE and/or rtcp-mux, let's advertise those right away
-		if(adapter.browserDetails.browser == "chrome" || adapter.browserDetails.browser == "firefox") {
+		if(adapter.browserDetails.browser == "chrome" || adapter.browserDetails.browser == "firefox" ||
+				adapter.browserDetails.browser == "safari") {
 			request["force-bundle"] = true;
 			request["force-rtcp-mux"] = true;
 		}
@@ -1989,83 +1990,35 @@ function Janus(gatewayCallbacks) {
 		if(config.pc === null || config.pc === undefined)
 			return "Invalid PeerConnection";
 		// Start getting the bitrate, if getStats is supported
-		if(config.pc.getStats && adapter.browserDetails.browser == "chrome") {
-			// Do it the Chrome way
-			if(config.remoteStream === null || config.remoteStream === undefined) {
-				Janus.warn("Remote stream unavailable");
-				return "Remote stream unavailable";
-			}
-			// http://webrtc.googlecode.com/svn/trunk/samples/js/demos/html/constraints-and-stats.html
+		if(config.pc.getStats) {
 			if(config.bitrate.timer === null || config.bitrate.timer === undefined) {
-				Janus.log("Starting bitrate timer (Chrome)");
+				Janus.log("Starting bitrate timer (via getStats)");
 				config.bitrate.timer = setInterval(function() {
-					config.pc.getStats(function(stats) {
-						var results = stats.result();
-						for(var i=0; i<results.length; i++) {
-							var res = results[i];
-							if(res.type == 'ssrc' && res.stat('googFrameHeightReceived')) {
-								config.bitrate.bsnow = res.stat('bytesReceived');
-								config.bitrate.tsnow = res.timestamp;
-								if(config.bitrate.bsbefore === null || config.bitrate.tsbefore === null) {
-									// Skip this round
-									config.bitrate.bsbefore = config.bitrate.bsnow;
-									config.bitrate.tsbefore = config.bitrate.tsnow;
-								} else {
-									// Calculate bitrate
-									var bitRate = Math.round((config.bitrate.bsnow - config.bitrate.bsbefore) * 8 / (config.bitrate.tsnow - config.bitrate.tsbefore));
-									config.bitrate.value = bitRate + ' kbits/sec';
-									//~ Janus.log("Estimated bitrate is " + config.bitrate.value);
-									config.bitrate.bsbefore = config.bitrate.bsnow;
-									config.bitrate.tsbefore = config.bitrate.tsnow;
+					config.pc.getStats()
+						.then(function(stats) {
+							stats.forEach(res => {
+								if(res && (res.mediaType === "video" || res.id.toLowerCase().indexOf("video") > -1) &&
+										res.type === "inbound-rtp" && res.id.indexOf("rtcp") < 0) {
+									config.bitrate.bsnow = res.bytesReceived;
+									config.bitrate.tsnow = res.timestamp;
+									if(config.bitrate.bsbefore === null || config.bitrate.tsbefore === null) {
+										// Skip this round
+										config.bitrate.bsbefore = config.bitrate.bsnow;
+										config.bitrate.tsbefore = config.bitrate.tsnow;
+									} else {
+										// Calculate bitrate
+										var timePassed = config.bitrate.tsnow - config.bitrate.tsbefore;
+										if(adapter.browserDetails.browser == "safari")
+											timePassed = timePassed/1000;	// Apparently the timestamp is in microseconds, in Safari
+										var bitRate = Math.round((config.bitrate.bsnow - config.bitrate.bsbefore) * 8 / timePassed);
+										config.bitrate.value = bitRate + ' kbits/sec';
+										//~ Janus.log("Estimated bitrate is " + config.bitrate.value);
+										config.bitrate.bsbefore = config.bitrate.bsnow;
+										config.bitrate.tsbefore = config.bitrate.tsnow;
+									}
 								}
-							}
-						}
-					});
-				}, 1000);
-				return "0 kbits/sec";	// We don't have a bitrate value yet
-			}
-			return config.bitrate.value;
-		} else if(config.pc.getStats && adapter.browserDetails.browser == "firefox") {
-			// Do it the Firefox way
-			if(config.remoteStream === null || config.remoteStream === undefined
-					|| config.remoteStream.streams[0] === null || config.remoteStream.streams[0] === undefined) {
-				Janus.warn("Remote stream unavailable");
-				return "Remote stream unavailable";
-			}
-			var videoTracks = config.remoteStream.streams[0].getVideoTracks();
-			if(videoTracks === null || videoTracks === undefined || videoTracks.length < 1) {
-				Janus.warn("No video track");
-				return "No video track";
-			}
-			// https://github.com/muaz-khan/getStats/blob/master/getStats.js
-			if(config.bitrate.timer === null || config.bitrate.timer === undefined) {
-				Janus.log("Starting bitrate timer (Firefox)");
-				config.bitrate.timer = setInterval(function() {
-					// We need a helper callback
-					var cb = function(res) {
-						if(res === null || res === undefined ||
-								res.inbound_rtp_video_1 == null || res.inbound_rtp_video_1 == null) {
-							config.bitrate.value = "Missing inbound_rtp_video_1";
-							return;
-						}
-						config.bitrate.bsnow = res.inbound_rtp_video_1.bytesReceived;
-						config.bitrate.tsnow = res.inbound_rtp_video_1.timestamp;
-						if(config.bitrate.bsbefore === null || config.bitrate.tsbefore === null) {
-							// Skip this round
-							config.bitrate.bsbefore = config.bitrate.bsnow;
-							config.bitrate.tsbefore = config.bitrate.tsnow;
-						} else {
-							// Calculate bitrate
-							var bitRate = Math.round((config.bitrate.bsnow - config.bitrate.bsbefore) * 8 / (config.bitrate.tsnow - config.bitrate.tsbefore));
-							config.bitrate.value = bitRate + ' kbits/sec';
-							config.bitrate.bsbefore = config.bitrate.bsnow;
-							config.bitrate.tsbefore = config.bitrate.tsnow;
-						}
-					};
-					// Actually get the stats
-					config.pc.getStats(videoTracks[0], function(stats) {
-						cb(stats);
-					}, cb);
+							});
+						});
 				}, 1000);
 				return "0 kbits/sec";	// We don't have a bitrate value yet
 			}

--- a/html/videocalltest.js
+++ b/html/videocalltest.js
@@ -371,7 +371,8 @@ $(document).ready(function() {
 										videocall.send({"message": { "request": "set", "bitrate": bitrate }});
 										return false;
 									});
-									if(adapter.browserDetails.browser === "chrome" || adapter.browserDetails.browser === "firefox") {
+									if(adapter.browserDetails.browser === "chrome" || adapter.browserDetails.browser === "firefox" ||
+											adapter.browserDetails.browser === "safari") {
 										$('#curbitrate').removeClass('hide').show();
 										bitrateTimer = setInterval(function() {
 											// Display updated bitrate, if supported

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -507,7 +507,8 @@ function newRemoteFeed(id, display) {
 							'<span class="no-video-text" style="font-size: 16px;">No remote video available</span>' +
 						'</div>');
 				}
-				if(adapter.browserDetails.browser === "chrome" || adapter.browserDetails.browser === "firefox") {
+				if(adapter.browserDetails.browser === "chrome" || adapter.browserDetails.browser === "firefox" ||
+						adapter.browserDetails.browser === "safari") {
 					$('#curbitrate'+remoteFeed.rfindex).removeClass('hide').show();
 					bitrateTimer[remoteFeed.rfindex] = setInterval(function() {
 						// Display updated bitrate, if supported


### PR DESCRIPTION
It was about time we aligned to a more up-to-date usage of `getStats`, especially considering that getting the remote bitrate in some demos (e.g., EchoTest) wasn't working with Firefox anymore. This PR takes care of that, and has a shared management of that for Chrome, Firefox and Safari. I don't have an Edge to test against, so not even sure if they support 'getStats` at all: as such, for now `getBitrate` is disabled for Edge.

I'm planning to merge soon, so please test and let us know if this breaks your janus.js-based applications.