### PR TITLE
Bugfix missing variable timePassed

### DIFF
--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -2059,6 +2059,7 @@ function Janus(gatewayCallbacks) {
 										config.bitrate.tsbefore = config.bitrate.tsnow;
 									} else {
 										// Calculate bitrate
+										var timePassed = config.bitrate.tsnow - config.bitrate.tsbefore;
 										if(adapter.browserDetails.browser == "safari")
 											timePassed = timePassed/1000;	// Apparently the timestamp is in microseconds, in Safari
 										var bitRate = Math.round((config.bitrate.bsnow - config.bitrate.bsbefore) * 8 / timePassed);


### PR DESCRIPTION
Definition of timePassed missing in janus.nojquery.js