### PR TITLE
Early media support in the SIP plugin via 183+SDP

### DIFF
--- a/html/siptest.html
+++ b/html/siptest.html
@@ -12,6 +12,7 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/4.1.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/blueimp-md5/2.6.0/js/md5.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.3/toastr.min.js"></script>
 <script type="text/javascript" src="janus.js" ></script>
 <script type="text/javascript" src="siptest.js"></script>
 <script>
@@ -26,6 +27,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.2/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.3/toastr.css"/>
 </head>
 <body>
 

--- a/html/siptest.js
+++ b/html/siptest.js
@@ -288,6 +288,16 @@ $(document).ready(function() {
 													}
 												}
 											});											
+										} else if(event === 'accepting') {
+											// Response to an offerless INVITE, let's wait for an 'accepted'
+										} else if(event === 'progress') {
+											Janus.log("There's early media from " + result["username"] + ", wairing for the call!");
+											Janus.log(jsep);
+											// Call can start already: handle the remote answer
+											if(jsep !== null && jsep !== undefined) {
+												sipcall.handleRemoteJsep({jsep: jsep, error: doHangup });
+											}
+											toastr.info("Early media...");
 										} else if(event === 'accepted') {
 											Janus.log(result["username"] + " accepted the call!");
 											Janus.log(jsep);
@@ -295,6 +305,7 @@ $(document).ready(function() {
 											if(jsep !== null && jsep !== undefined) {
 												sipcall.handleRemoteJsep({jsep: jsep, error: doHangup });
 											}
+											toastr.success("Call accepted!");
 										} else if(event === 'hangup') {
 											if(incoming != null) {
 												incoming.modal('hide');


### PR DESCRIPTION
As the title suggests, this patch is supposed to implement early media support when an SDP is found in a `183 Session Progress` response to an INVITE. I took advantage of this to also add some new events to the SIP plugin, namely:

- you're now notified with a `ringing` event when a `180` arrives;
- I changed the answer to offerless INVITES to `accepting`, to avoid ambiguities with the actual `accepted` later on (before you'd get two `accepted`, one without SDP and one with); 
- if a `183` arrives and it contains an SDP, you get a `progress` event with an SDP attached (the demo handles it as a regular answer, but shows a toastr message clarifying it's early media);
- if a `200 OK` arrives after a `183`, you get an `accepted` event *without* SDP (you already received it before), meaning this is only there to confirm the call has been accepted.

Notice that, with early media, we only send the browser the SDP from the 183, *not* the 200, as we don't do renegotiations on the WebRTC side yet. This means that if the 183 SDP used sendonly media to play a message, and then the 200 OK turns it into sendrecv, this won't work, as we didn't get the microphone in the browser.

Tested this briefly and this seems to work, but please test and provide feedback to make sure this doesn't introduce any regression.