### PR TITLE
Allow to override build date

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -164,8 +164,14 @@ dir_target = $(directory)-$(wildcard $(directory))
 dir_present = $(directory)-$(directory)
 dir_absent = $(directory)-
 
+if WITH_SOURCE_DATE_EPOCH
+build_date = $(shell LC_ALL=C date --utc --date="@$(SOURCE_DATE_EPOCH)")
+else
+build_date = $(shell date)
+endif
+
 version.c: FORCE | $(dir_target)
-	date | awk 'BEGIN {} {print "const char *janus_build_git_time = \""$$0"\";"} END {} ' >> version.c
+	echo $(build_date) | awk 'BEGIN {} {print "const char *janus_build_git_time = \""$$0"\";"} END {} ' >> version.c
 
 $(dir_present):
 	`which git` rev-parse HEAD | awk 'BEGIN {print "#include \"version.h\""} {print "const char *janus_build_git_sha = \"" $$0"\";"} END {}' > version.c

--- a/configure.ac
+++ b/configure.ac
@@ -588,6 +588,7 @@ AS_IF([test "x$enable_post_processing" = "xyes"],
                          ])
       ])
 
+AM_CONDITIONAL([WITH_SOURCE_DATE_EPOCH], [test "x$SOURCE_DATE_EPOCH" != "x"])
 AM_CONDITIONAL([ENABLE_POST_PROCESSING], [test "x$enable_post_processing" = "xyes"])
 
 AC_CONFIG_FILES([


### PR DESCRIPTION
in order to allow for reproducible builds.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Note: This variant will only work with GNU date. If BSD support is important, I can add this.