### PR TITLE
infra: add support for building on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
 sudo: false 
-language: node_js
+language: c
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+dist: trusty
+sudo: false 
+language: node_js
+
+env:
+  global:
+    - CPPFLAGS=-I${HOME}/srtp/include
+    - LDFLAGS=-L${HOME}/srtp/lib
+
+addons:
+  apt: 
+    packages:
+      - build-essential 
+      - libmicrohttpd-dev
+      - libjansson-dev
+      - libnice-dev
+      - libssl-dev
+      - libsrtp-dev
+      - libsofia-sip-ua-dev
+      - libglib2.0-dev
+      - libopus-dev
+      - libogg-dev
+      - libcurl4-openssl-dev
+      - pkg-config
+      - gengetopt
+      - libtool
+      - automake
+
+before_script:
+ - cd ..
+ - mkdir srtp
+ - wget https://github.com/cisco/libsrtp/archive/v2.0.0.tar.gz
+ - tar xfv v2.0.0.tar.gz
+ - cd libsrtp-2.0.0
+ - ./configure --prefix=${HOME}/srtp --enable-openssl
+ - make shared_library
+ - make install
+ - cd ../janus-gateway
+
+script:
+  - sh autogen.sh
+  - ./configure
+  - make


### PR DESCRIPTION
adds a .travis.yml which allows building on https://travis-ci.org/ on every pull request.

job output is here: https://travis-ci.org/fippo/janus-gateway/jobs/254195305
After logging in to https://travis-ci.org/ one can enable build on pushes or pull requests, see [their getting started guide](https://docs.travis-ci.com/user/getting-started/)

(yes, I really did not want to install dependencies locally... :-))