### PR TITLE
Avoid slow reverse-DNS requests caused by libwebsocket.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -369,6 +369,10 @@ AC_CHECK_LIB([websockets],
 								  AM_CONDITIONAL([ENABLE_WEBSOCKETS_NEWAPI], true)
 								  WS_MANUAL_LIBS="-lwebsockets"
 								  enable_websockets=yes
+								  AC_CHECK_LIB([websockets],
+							                   [lws_get_peer_simple],
+							                   [AC_DEFINE(HAVE_LIBWEBSOCKETS_PEER_SIMPLE)]
+							                  )
 							   ])
 							 ],
 							 [

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -1086,7 +1086,7 @@ static int janus_websockets_common_callback(
 			/* Is there any filtering we should apply? */
 			char name[256], ip[256];
 #ifdef HAVE_LIBWEBSOCKETS_NEWAPI
-			lws_get_peer_addresses(wsi, lws_get_socket_fd(wsi), name, 256, ip, 256);
+			lws_get_peer_simple(wsi, name, 256);
 #else
 			libwebsockets_get_peer_addresses(this, wsi, libwebsocket_get_socket_fd(wsi), name, 256, ip, 256);
 #endif

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -1088,7 +1088,11 @@ static int janus_websockets_common_callback(
 #ifdef HAVE_LIBWEBSOCKETS_PEER_SIMPLE
 			lws_get_peer_simple(wsi, name, 256);
 #else
+#ifdef HAVE_LIBWEBSOCKETS_NEWAPI
+			lws_get_peer_addresses(wsi, lws_get_socket_fd(wsi), name, 256, ip, 256);
+#else
 			libwebsockets_get_peer_addresses(this, wsi, libwebsocket_get_socket_fd(wsi), name, 256, ip, 256);
+#endif
 #endif
 			JANUS_LOG(LOG_VERB, "[%s-%p] WebSocket connection opened from %s by %s\n", log_prefix, wsi, ip, name);
 			if(!janus_websockets_is_allowed(ip, admin)) {

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -1085,7 +1085,7 @@ static int janus_websockets_common_callback(
 		case LWS_CALLBACK_ESTABLISHED: {
 			/* Is there any filtering we should apply? */
 			char name[256], ip[256];
-#ifdef HAVE_LIBWEBSOCKETS_NEWAPI
+#ifdef HAVE_LIBWEBSOCKETS_PEER_SIMPLE
 			lws_get_peer_simple(wsi, name, 256);
 #else
 			libwebsockets_get_peer_addresses(this, wsi, libwebsocket_get_socket_fd(wsi), name, 256, ip, 256);


### PR DESCRIPTION
According to https://github.com/warmcat/libwebsockets/issues/537 and following my own experience, in some circumstances `lws_get_peer_addresses` can take several seconds to execute a reverse DNS request on a connected peer IP.  The effect is that sometimes a websocket connection with Janus takes several seconds before it is established.
This PR addresses the described issue by replacing `lws_get_peer_addresses` with `lws_get_peer_simple` that completely skips the RDNS request.
Some macros have been added too, in order to check the availability of the API at compile time (it should be available for lws > 2.0) and fallback to the previous implementation eventually.