### PR TITLE
Honor trickle configuration when using ext. stream

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1374,6 +1374,7 @@ function Janus(gatewayCallbacks) {
 			}
 			return;
 		}
+		config.trickle = isTrickleEnabled(callbacks.trickle);
 		// Was a MediaStream object passed, or do we need to take care of that?
 		if(callbacks.stream !== null && callbacks.stream !== undefined) {
 			var stream = callbacks.stream;
@@ -1384,7 +1385,6 @@ function Janus(gatewayCallbacks) {
 			streamsDone(handleId, jsep, media, callbacks, stream);
 			return;
 		}
-		config.trickle = isTrickleEnabled(callbacks.trickle);
 		if(isAudioSendEnabled(media) || isVideoSendEnabled(media)) {
 			var constraints = { mandatory: {}, optional: []};
 			pluginHandle.consentDialog(true);

--- a/html/janus.nojquery.js
+++ b/html/janus.nojquery.js
@@ -1425,6 +1425,7 @@ function Janus(gatewayCallbacks) {
 			}
 			return;
 		}
+		config.trickle = isTrickleEnabled(callbacks.trickle);
 		// Was a MediaStream object passed, or do we need to take care of that?
 		if(callbacks.stream !== null && callbacks.stream !== undefined) {
 			var stream = callbacks.stream;
@@ -1435,7 +1436,6 @@ function Janus(gatewayCallbacks) {
 			streamsDone(handleId, jsep, media, callbacks, stream);
 			return;
 		}
-		config.trickle = isTrickleEnabled(callbacks.trickle);
 		if(isAudioSendEnabled(media) || isVideoSendEnabled(media)) {
 			var constraints = { mandatory: {}, optional: []};
 			pluginHandle.consentDialog(true);


### PR DESCRIPTION
The check for config.trickle was not done when an external stream is passed. This moves the check/set for config.trickle before the check for external provided stream, making it possible to disable ICE trickle when the external application provides the stream.