### PR TITLE
Explicit mode non-interleaved

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -3444,9 +3444,9 @@ static int janus_streaming_rtsp_parse_sdp(const char *buffer, const char *name, 
 	} while(port == -1);
 
 	if(IN_MULTICAST(ntohl(mcast))) {
-		g_snprintf(transport, 1024, "RTP/AVP;multicast;client_port=%d-%d", port, port+1);
+		g_snprintf(transport, 1024, "RTP/AVP/UDP;multicast;client_port=%d-%d", port, port+1);
 	} else {
-		g_snprintf(transport, 1024, "RTP/AVP;unicast;client_port=%d-%d", port, port+1);
+		g_snprintf(transport, 1024, "RTP/AVP/UDP;unicast;client_port=%d-%d", port, port+1);
 	}
 
 	return 0;


### PR DESCRIPTION
Some IP cameras, by default send RTP in TCP connection (interleaved mode), this fix to UDP (non-interleaved mode)

https://www.ietf.org/mail-archive/web/mmusic/current/msg02030.html