### PR TITLE
Fixed inconsistent event naming for plugins event notifications

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -2486,7 +2486,7 @@ void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, int video, cha
 							/* Also notify event handlers */
 							if(notify_events && gateway->events_is_enabled()) {
 								json_t *info = json_object();
-								json_object_set_new(info, "audiobridge", json_string(participant->talking ? "talking" : "stopped-talking"));
+								json_object_set_new(info, "event", json_string(participant->talking ? "talking" : "stopped-talking"));
 								json_object_set_new(info, "room", json_integer(participant->room->room_id));
 								json_object_set_new(info, "id", json_integer(participant->user_id));
 								gateway->notify_event(&janus_audiobridge_plugin, session->handle, info);

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2646,7 +2646,7 @@ static void *janus_streaming_handler(void *data) {
 			/* Also notify event handlers */
 			if(notify_events && gateway->events_is_enabled()) {
 				json_t *info = json_object();
-				json_object_set_new(info, "status", json_string("starting"));
+				json_object_set_new(info, "event", json_string("starting"));
 				if(session->mountpoint != NULL)
 					json_object_set_new(info, "id", json_integer(session->mountpoint->id));
 				gateway->notify_event(&janus_streaming_plugin, session->handle, info);
@@ -2665,7 +2665,7 @@ static void *janus_streaming_handler(void *data) {
 			/* Also notify event handlers */
 			if(notify_events && gateway->events_is_enabled()) {
 				json_t *info = json_object();
-				json_object_set_new(info, "status", json_string("pausing"));
+				json_object_set_new(info, "event", json_string("pausing"));
 				if(session->mountpoint != NULL)
 					json_object_set_new(info, "id", json_integer(session->mountpoint->id));
 				gateway->notify_event(&janus_streaming_plugin, session->handle, info);
@@ -2788,7 +2788,7 @@ static void *janus_streaming_handler(void *data) {
 			/* Also notify event handlers */
 			if(notify_events && gateway->events_is_enabled()) {
 				json_t *info = json_object();
-				json_object_set_new(info, "status", json_string("switching"));
+				json_object_set_new(info, "event", json_string("switching"));
 				json_object_set_new(info, "id", json_integer(id_value));
 				gateway->notify_event(&janus_streaming_plugin, session->handle, info);
 			}
@@ -2823,7 +2823,7 @@ static void *janus_streaming_handler(void *data) {
 			/* Also notify event handlers */
 			if(notify_events && gateway->events_is_enabled()) {
 				json_t *info = json_object();
-				json_object_set_new(info, "status", json_string("stopping"));
+				json_object_set_new(info, "event", json_string("stopping"));
 				if(mp)
 					json_object_set_new(info, "id", json_integer(mp->id));
 				gateway->notify_event(&janus_streaming_plugin, session->handle, info);

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -1352,7 +1352,7 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 		/* Also notify event handlers */
 		if(notify_events && gateway->events_is_enabled()) {
 			json_t *info = json_object();
-			json_object_set_new(info, "textroom", json_string("kicked"));
+			json_object_set_new(info, "event", json_string("kicked"));
 			json_object_set_new(info, "room", json_integer(textroom->room_id));
 			json_object_set_new(info, "username", json_string(participant->username));
 			gateway->notify_event(&janus_textroom_plugin, session->handle, info);

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -2603,7 +2603,7 @@ void janus_videoroom_incoming_rtp(janus_plugin_session *handle, int video, char 
 					/* Also notify event handlers */
 					if(notify_events && gateway->events_is_enabled()) {
 						json_t *info = json_object();
-						json_object_set_new(info, "videoroom", json_string(participant->talking ? "talking" : "stopped-talking"));
+						json_object_set_new(info, "event", json_string(participant->talking ? "talking" : "stopped-talking"));
 						json_object_set_new(info, "room", json_integer(participant->room->room_id));
 						json_object_set_new(info, "id", json_integer(participant->user_id));
 						gateway->notify_event(&janus_videoroom_plugin, session->handle, info);


### PR DESCRIPTION
Most of plugins' event names in event notifications are named as `event`, but a few of them (probably because of copy and paste from the preceding code) have different names, like `status` or `videoroom`.