### PR TITLE
janus_streaming: g_async_queue_pop() will never return NULL

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2435,8 +2435,6 @@ static void *janus_streaming_handler(void *data) {
 	json_t *root = NULL;
 	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
 		msg = g_async_queue_pop(messages);
-		if(msg == NULL)
-			continue;
 		if(msg == &exit_message)
 			break;
 		if(msg->handle == NULL) {


### PR DESCRIPTION
It blocks until the queue has data. The non-blocking version is
g_async_queue_try_pop().