### PR TITLE
Fix a regression in websocket ACL.

### DIFF
--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -898,13 +898,15 @@ static int janus_websockets_common_callback(
 	switch(reason) {
 		case LWS_CALLBACK_ESTABLISHED: {
 			/* Is there any filtering we should apply? */
-			char name[256], ip[256];
+			char ip[256];
 #ifdef HAVE_LIBWEBSOCKETS_PEER_SIMPLE
-			lws_get_peer_simple(wsi, name, 256);
+			lws_get_peer_simple(wsi, ip, 256);
+			JANUS_LOG(LOG_VERB, "[%s-%p] WebSocket connection opened from %s\n", log_prefix, wsi, ip);
 #else
+			char name[256];
 			lws_get_peer_addresses(wsi, lws_get_socket_fd(wsi), name, 256, ip, 256);
-#endif
 			JANUS_LOG(LOG_VERB, "[%s-%p] WebSocket connection opened from %s by %s\n", log_prefix, wsi, ip, name);
+#endif
 			if(!janus_websockets_is_allowed(ip, admin)) {
 				JANUS_LOG(LOG_ERR, "[%s-%p] IP %s is unauthorized to connect to the WebSockets %s API interface\n", log_prefix, wsi, ip, admin ? "Admin" : "Janus");
 				/* Close the connection */


### PR DESCRIPTION
This PR resolves #1019, fixing a regression introduced in PR #957.