### PR TITLE
Move SRTP specific definitions from rtp.h to a new header

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,7 @@ bin_PROGRAMS = janus
 
 headerdir = $(includedir)/janus
 header_HEADERS = apierror.h config.h log.h debug.h mutex.h record.h \
-	rtcp.h rtp.h sdp-utils.h ip-utils.h utils.h text2pcap.h
+	rtcp.h rtp.h rtpsrtp.h sdp-utils.h ip-utils.h utils.h text2pcap.h
 
 pluginsheaderdir = $(includedir)/janus/plugins
 pluginsheader_HEADERS = plugins/plugin.h
@@ -116,6 +116,7 @@ janus_SOURCES = \
 	rtcp.h \
 	rtp.c \
 	rtp.h \
+	rtpsrtp.h \
 	sctp.c \
 	sctp.h \
 	sdp.c \

--- a/dtls.c
+++ b/dtls.c
@@ -15,7 +15,6 @@
 #include "janus.h"
 #include "debug.h"
 #include "dtls.h"
-#include "rtp.h"
 #include "rtcp.h"
 #include "events.h"
 

--- a/dtls.h
+++ b/dtls.h
@@ -19,6 +19,7 @@
 #include <glib.h>
 
 #include "rtp.h"
+#include "rtpsrtp.h"
 #include "sctp.h"
 #include "dtls-bio.h"
 

--- a/ice.c
+++ b/ice.c
@@ -29,7 +29,7 @@
 #include "turnrest.h"
 #include "dtls.h"
 #include "sdp.h"
-#include "rtp.h"
+#include "rtpsrtp.h"
 #include "rtcp.h"
 #include "apierror.h"
 #include "ip-utils.h"
@@ -266,12 +266,12 @@ static gboolean janus_is_dtls(gchar *buf) {
 }
 
 static gboolean janus_is_rtp(gchar *buf) {
-	rtp_header *header = (rtp_header *)buf;
+	janus_rtp_header *header = (janus_rtp_header *)buf;
 	return ((header->type < 64) || (header->type >= 96));
 }
 
 static gboolean janus_is_rtcp(gchar *buf) {
-	rtp_header *header = (rtp_header *)buf;
+	janus_rtp_header *header = (janus_rtp_header *)buf;
 	return ((header->type >= 64) && (header->type < 96));
 }
 
@@ -1973,7 +1973,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 		if(!component->dtls || !component->dtls->srtp_valid || !component->dtls->srtp_in) {
 			JANUS_LOG(LOG_WARN, "[%"SCNu64"]     Missing valid SRTP session (packet arrived too early?), skipping...\n", handle->handle_id);
 		} else {
-			rtp_header *header = (rtp_header *)buf;
+			janus_rtp_header *header = (janus_rtp_header *)buf;
 			guint32 packet_ssrc = ntohl(header->ssrc);
 			/* Is this audio or video? */
 			int video = 0;
@@ -2046,7 +2046,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 			if(res != srtp_err_status_ok) {
 				if(res != srtp_err_status_replay_fail && res != srtp_err_status_replay_old) {
 					/* Only print the error if it's not a 'replay fail' or 'replay old' (which is probably just the result of us NACKing a packet) */
-					rtp_header *header = (rtp_header *)buf;
+					janus_rtp_header *header = (janus_rtp_header *)buf;
 					guint32 timestamp = ntohl(header->timestamp);
 					guint16 seq = ntohs(header->seq_number);
 					JANUS_LOG(LOG_ERR, "[%"SCNu64"]     SRTP unprotect error: %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")\n", handle->handle_id, janus_srtp_error_str(res), len, buflen, timestamp, seq);
@@ -2325,7 +2325,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 						while(rp) {
 							janus_rtp_packet *p = (janus_rtp_packet *)rp->data;
 							if(p) {
-								rtp_header *rh = (rtp_header *)p->data;
+								janus_rtp_header *rh = (janus_rtp_header *)p->data;
 								if(ntohs(rh->seq_number) == seqnr) {
 									/* Should we retransmit this packet? */
 									if((p->last_retransmit > 0) && (now-p->last_retransmit < MAX_NACK_IGNORE)) {
@@ -3841,7 +3841,7 @@ void *janus_ice_send_thread(void *data) {
 				component->noerrorlog = FALSE;
 				if(pkt->encrypted) {
 					/* Already RTP (probably a retransmission?) */
-					rtp_header *header = (rtp_header *)pkt->data;
+					janus_rtp_header *header = (janus_rtp_header *)pkt->data;
 					JANUS_LOG(LOG_HUGE, "[%"SCNu64"] ... Retransmitting seq.nr %"SCNu16"\n\n", handle->handle_id, ntohs(header->seq_number));
 					int sent = nice_agent_send(handle->agent, stream->stream_id, component->component_id, pkt->length, (const gchar *)pkt->data);
 					if(sent < pkt->length) {
@@ -3853,7 +3853,7 @@ void *janus_ice_send_thread(void *data) {
 					memcpy(sbuf, pkt->data, pkt->length);
 					if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_PLAN_B)) {
 						/* Overwrite SSRC */
-						rtp_header *header = (rtp_header *)sbuf;
+						janus_rtp_header *header = (janus_rtp_header *)sbuf;
 						header->ssrc = htonl(video ? stream->video_ssrc : stream->audio_ssrc);
 					}
 					/* Do we need to dump this packet for debugging? */
@@ -3868,7 +3868,7 @@ void *janus_ice_send_thread(void *data) {
 						handle->srtp_errors_count++;
 						handle->last_srtp_error = res;
 						/* If we're debugging, though, print every occurrence */
-						rtp_header *header = (rtp_header *)sbuf;
+						janus_rtp_header *header = (janus_rtp_header *)sbuf;
 						guint32 timestamp = ntohl(header->timestamp);
 						guint16 seq = ntohs(header->seq_number);
 						JANUS_LOG(LOG_DBG, "[%"SCNu64"] ... SRTP protect error... %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")...\n", handle->handle_id, janus_srtp_error_str(res), pkt->length, protected, timestamp, seq);
@@ -3881,7 +3881,7 @@ void *janus_ice_send_thread(void *data) {
 						/* Update stats */
 						if(sent > 0) {
 							/* Update the RTCP context as well */
-							rtp_header *header = (rtp_header *)sbuf;
+							janus_rtp_header *header = (janus_rtp_header *)sbuf;
 							guint32 timestamp = ntohl(header->timestamp);
 							if(pkt->type == JANUS_ICE_PACKET_AUDIO) {
 								component->out_stats.audio_packets++;

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -844,7 +844,7 @@ typedef struct janus_audiobridge_participant {
 
 /* Packets we get from gstreamer and relay */
 typedef struct janus_audiobridge_rtp_relay_packet {
-	rtp_header *data;
+	janus_rtp_header *data;
 	gint length;
 	uint32_t ssrc;
 	uint32_t timestamp;
@@ -2437,7 +2437,7 @@ void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, int video, cha
 			participant->reset = FALSE;
 		}
 		/* Decode frame (Opus -> slinear) */
-		rtp_header *rtp = (rtp_header *)buf;
+		janus_rtp_header *rtp = (janus_rtp_header *)buf;
 		janus_audiobridge_rtp_relay_packet *pkt = g_malloc0(sizeof(janus_audiobridge_rtp_relay_packet));
 		pkt->data = g_malloc0(BUFFER_SAMPLES*sizeof(opus_int16));
 		pkt->ssrc = 0;
@@ -3712,7 +3712,7 @@ static void *janus_audiobridge_mixer_thread(void *data) {
 
 	/* Base RTP packet, in case there are forwarders involved */
 	unsigned char *rtpbuffer = g_malloc0(1500);
-	rtp_header *rtph = (rtp_header *)rtpbuffer;
+	janus_rtp_header *rtph = (janus_rtp_header *)rtpbuffer;
 	rtph->version = 2;
 
 	/* Timer */
@@ -3960,7 +3960,7 @@ static void *janus_audiobridge_participant_thread(void *data) {
 
 	/* Output buffer */
 	janus_audiobridge_rtp_relay_packet *outpkt = g_malloc0(sizeof(janus_audiobridge_rtp_relay_packet));
-	outpkt->data = (rtp_header *)g_malloc0(1500);
+	outpkt->data = (janus_rtp_header *)g_malloc0(1500);
 	outpkt->ssrc = 0;
 	outpkt->timestamp = 0;
 	outpkt->seq_number = 0;

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -525,7 +525,7 @@ void janus_echotest_incoming_rtp(janus_plugin_session *handle, int video, char *
 			return;
 		if(video && session->video_active && session->rtpmapid_extmap_id != -1) {
 			/* FIXME Just a way to debug Firefox simulcasting */
-			rtp_header *header = (rtp_header *)buf;
+			janus_rtp_header *header = (janus_rtp_header *)buf;
 			uint32_t seq_number = ntohs(header->seq_number);
 			uint32_t timestamp = ntohl(header->timestamp);
 			uint32_t ssrc = ntohl(header->ssrc);
@@ -537,7 +537,7 @@ void janus_echotest_incoming_rtp(janus_plugin_session *handle, int video, char *
 		}
 		if(video && session->video_active && session->ssrc[0] != 0) {
 			/* Handle simulcast: don't relay if it's not the SSRC we wanted to handle */
-			rtp_header *header = (rtp_header *)buf;
+			janus_rtp_header *header = (janus_rtp_header *)buf;
 			uint32_t seq_number = ntohs(header->seq_number);
 			uint32_t timestamp = ntohl(header->timestamp);
 			uint32_t ssrc = ntohl(header->ssrc);

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -1106,7 +1106,7 @@ void janus_recordplay_incoming_rtp(janus_plugin_session *handle, int video, char
 			return;
 		if(video && session->simulcast_ssrc) {
 			/* The user is simulcasting: drop everything except the base layer */
-			rtp_header *header = (rtp_header *)buf;
+			janus_rtp_header *header = (janus_rtp_header *)buf;
 			uint32_t ssrc = ntohl(header->ssrc);
 			if(ssrc != session->simulcast_ssrc) {
 				JANUS_LOG(LOG_DBG, "Dropping packet (not base simulcast substream)\n");
@@ -1936,7 +1936,7 @@ janus_recordplay_frame_packet *janus_recordplay_get_frames(const char *dir, cons
 		}
 		/* Only read RTP header */
 		bytes = fread(prebuffer, sizeof(char), 16, file);
-		rtp_header *rtp = (rtp_header *)prebuffer;
+		janus_rtp_header *rtp = (janus_rtp_header *)prebuffer;
 		if(last_ts == 0) {
 			first_ts = ntohl(rtp->timestamp);
 			if(first_ts > 1000*1000)	/* Just used to check whether a packet is pre- or post-reset */
@@ -1983,7 +1983,7 @@ janus_recordplay_frame_packet *janus_recordplay_get_frames(const char *dir, cons
 			JANUS_LOG(LOG_WARN, "Error reading RTP header, stopping here...\n");
 			break;
 		}
-		rtp_header *rtp = (rtp_header *)prebuffer;
+		janus_rtp_header *rtp = (janus_rtp_header *)prebuffer;
 		JANUS_LOG(LOG_HUGE, "  -- RTP packet (ssrc=%"SCNu32", pt=%"SCNu16", ext=%"SCNu16", seq=%"SCNu16", ts=%"SCNu32")\n",
 				ntohl(rtp->ssrc), rtp->type, rtp->extension, ntohs(rtp->seq_number), ntohl(rtp->timestamp));
 		/* Generate frame packet and insert in the ordered list */
@@ -2180,7 +2180,7 @@ static void *janus_recordplay_playout_thread(void *data) {
 				if(bytes != audio->len)
 					JANUS_LOG(LOG_WARN, "Didn't manage to read all the bytes we needed (%d < %d)...\n", bytes, audio->len);
 				/* Update payload type */
-				rtp_header *rtp = (rtp_header *)buffer;
+				janus_rtp_header *rtp = (janus_rtp_header *)buffer;
 				rtp->type = audio_pt;
 				if(gateway != NULL)
 					gateway->relay_rtp(session->handle, 0, (char *)buffer, bytes);
@@ -2221,7 +2221,7 @@ static void *janus_recordplay_playout_thread(void *data) {
 					if(bytes != audio->len)
 						JANUS_LOG(LOG_WARN, "Didn't manage to read all the bytes we needed (%d < %d)...\n", bytes, audio->len);
 					/* Update payload type */
-					rtp_header *rtp = (rtp_header *)buffer;
+					janus_rtp_header *rtp = (janus_rtp_header *)buffer;
 					rtp->type = audio_pt;
 					if(gateway != NULL)
 						gateway->relay_rtp(session->handle, 0, (char *)buffer, bytes);
@@ -2240,7 +2240,7 @@ static void *janus_recordplay_playout_thread(void *data) {
 					if(bytes != video->len)
 						JANUS_LOG(LOG_WARN, "Didn't manage to read all the bytes we needed (%d < %d)...\n", bytes, video->len);
 					/* Update payload type */
-					rtp_header *rtp = (rtp_header *)buffer;
+					janus_rtp_header *rtp = (janus_rtp_header *)buffer;
 					rtp->type = video_pt;
 					if(gateway != NULL)
 						gateway->relay_rtp(session->handle, 1, (char *)buffer, bytes);
@@ -2285,7 +2285,7 @@ static void *janus_recordplay_playout_thread(void *data) {
 						if(bytes != video->len)
 							JANUS_LOG(LOG_WARN, "Didn't manage to read all the bytes we needed (%d < %d)...\n", bytes, video->len);
 						/* Update payload type */
-						rtp_header *rtp = (rtp_header *)buffer;
+						janus_rtp_header *rtp = (janus_rtp_header *)buffer;
 						rtp->type = video_pt;
 						if(gateway != NULL)
 							gateway->relay_rtp(session->handle, 1, (char *)buffer, bytes);

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -73,6 +73,7 @@
 #include "../mutex.h"
 #include "../record.h"
 #include "../rtp.h"
+#include "../rtpsrtp.h"
 #include "../rtcp.h"
 #include "../sdp-utils.h"
 #include "../utils.h"
@@ -1157,7 +1158,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 			}
 			if(session->media.simulcast_ssrc) {
 				/* The user is simulcasting: drop everything except the base layer */
-				rtp_header *header = (rtp_header *)buf;
+				janus_rtp_header *header = (janus_rtp_header *)buf;
 				uint32_t ssrc = ntohl(header->ssrc);
 				if(ssrc != session->media.simulcast_ssrc) {
 					JANUS_LOG(LOG_DBG, "Dropping packet (not base simulcast substream)\n");
@@ -1165,7 +1166,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 				}
 			}
 			if(session->media.video_ssrc == 0) {
-				rtp_header *header = (rtp_header *)buf;
+				janus_rtp_header *header = (janus_rtp_header *)buf;
 				session->media.video_ssrc = ntohl(header->ssrc);
 				JANUS_LOG(LOG_VERB, "Got SIP video SSRC: %"SCNu32"\n", session->media.video_ssrc);
 			}
@@ -1179,7 +1180,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 					int protected = len;
 					int res = srtp_protect(session->media.video_srtp_out, &sbuf, &protected);
 					if(res != srtp_err_status_ok) {
-						rtp_header *header = (rtp_header *)&sbuf;
+						janus_rtp_header *header = (janus_rtp_header *)&sbuf;
 						guint32 timestamp = ntohl(header->timestamp);
 						guint16 seq = ntohs(header->seq_number);
 						JANUS_LOG(LOG_ERR, "[SIP-%s] Video SRTP protect error... %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")...\n",
@@ -1187,7 +1188,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 					} else {
 						/* Forward the frame to the peer */
 						if(send(session->media.video_rtp_fd, sbuf, protected, 0) < 0) {
-							rtp_header *header = (rtp_header *)&sbuf;
+							janus_rtp_header *header = (janus_rtp_header *)&sbuf;
 							guint32 timestamp = ntohl(header->timestamp);
 							guint16 seq = ntohs(header->seq_number);
 							JANUS_LOG(LOG_HUGE, "[SIP-%s] Error sending SRTP video packet... %s (len=%d, ts=%"SCNu32", seq=%"SCNu16")...\n",
@@ -1197,7 +1198,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 				} else {
 					/* Forward the frame to the peer */
 					if(send(session->media.video_rtp_fd, buf, len, 0) < 0) {
-						rtp_header *header = (rtp_header *)&buf;
+						janus_rtp_header *header = (janus_rtp_header *)&buf;
 						guint32 timestamp = ntohl(header->timestamp);
 						guint16 seq = ntohs(header->seq_number);
 						JANUS_LOG(LOG_HUGE, "[SIP-%s] Error sending RTP video packet... %s (len=%d, ts=%"SCNu32", seq=%"SCNu16")...\n",
@@ -1211,7 +1212,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 				return;
 			}
 			if(session->media.audio_ssrc == 0) {
-				rtp_header *header = (rtp_header *)buf;
+				janus_rtp_header *header = (janus_rtp_header *)buf;
 				session->media.audio_ssrc = ntohl(header->ssrc);
 				JANUS_LOG(LOG_VERB, "Got SIP audio SSRC: %"SCNu32"\n", session->media.audio_ssrc);
 			}
@@ -1225,7 +1226,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 					int protected = len;
 					int res = srtp_protect(session->media.audio_srtp_out, &sbuf, &protected);
 					if(res != srtp_err_status_ok) {
-						rtp_header *header = (rtp_header *)&sbuf;
+						janus_rtp_header *header = (janus_rtp_header *)&sbuf;
 						guint32 timestamp = ntohl(header->timestamp);
 						guint16 seq = ntohs(header->seq_number);
 						JANUS_LOG(LOG_ERR, "[SIP-%s] Audio SRTP protect error... %s (len=%d-->%d, ts=%"SCNu32", seq=%"SCNu16")...\n",
@@ -1233,7 +1234,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 					} else {
 						/* Forward the frame to the peer */
 						if(send(session->media.audio_rtp_fd, sbuf, protected, 0) < 0) {
-							rtp_header *header = (rtp_header *)&sbuf;
+							janus_rtp_header *header = (janus_rtp_header *)&sbuf;
 							guint32 timestamp = ntohl(header->timestamp);
 							guint16 seq = ntohs(header->seq_number);
 							JANUS_LOG(LOG_HUGE, "[SIP-%s] Error sending SRTP audio packet... %s (len=%d, ts=%"SCNu32", seq=%"SCNu16")...\n",
@@ -1243,7 +1244,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 				} else {
 					/* Forward the frame to the peer */
 					if(send(session->media.audio_rtp_fd, buf, len, 0) < 0) {
-						rtp_header *header = (rtp_header *)&buf;
+						janus_rtp_header *header = (janus_rtp_header *)&buf;
 						guint32 timestamp = ntohl(header->timestamp);
 						guint16 seq = ntohs(header->seq_number);
 						JANUS_LOG(LOG_HUGE, "[SIP-%s] Error sending RTP audio packet... %s (len=%d, ts=%"SCNu32", seq=%"SCNu16")...\n",
@@ -3847,7 +3848,7 @@ static void *janus_sip_relay_thread(void *data) {
 						/* Failed to read? */
 						continue;
 					}
-					rtp_header *header = (rtp_header *)buffer;
+					janus_rtp_header *header = (janus_rtp_header *)buffer;
 					if(session->media.audio_ssrc_peer != ntohl(header->ssrc)) {
 						session->media.audio_ssrc_peer = ntohl(header->ssrc);
 						JANUS_LOG(LOG_VERB, "Got SIP peer audio SSRC: %"SCNu32"\n", session->media.audio_ssrc_peer);
@@ -3912,10 +3913,10 @@ static void *janus_sip_relay_thread(void *data) {
 						continue;
 					}
 					//~ JANUS_LOG(LOG_VERB, "************************\nGot %d bytes on the video RTP channel...\n", bytes);
-					//~ rtp_header_t *rtp = (rtp_header_t *)buffer;
+					//~ janus_rtp_header_t *rtp = (janus_rtp_header_t *)buffer;
 					//~ JANUS_LOG(LOG_VERB, " ... parsed RTP packet (ssrc=%u, pt=%u, seq=%u, ts=%u)...\n",
 						//~ ntohl(rtp->ssrc), rtp->type, ntohs(rtp->seq_number), ntohl(rtp->timestamp));
-					rtp_header *header = (rtp_header *)buffer;
+					janus_rtp_header *header = (janus_rtp_header *)buffer;
 					if(session->media.video_ssrc_peer != ntohl(header->ssrc)) {
 						session->media.video_ssrc_peer = ntohl(header->ssrc);
 						JANUS_LOG(LOG_VERB, "Got SIP peer video SSRC: %"SCNu32"\n", session->media.video_ssrc_peer);

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -537,7 +537,7 @@ static janus_mutex sessions_mutex = JANUS_MUTEX_INITIALIZER;
 
 /* Packets we get from outside and relay */
 typedef struct janus_streaming_rtp_relay_packet {
-	rtp_header *data;
+	janus_rtp_header *data;
 	gint length;
 	gboolean is_rtp;	/* This may be a data packet and not RTP */
 	gboolean is_video;
@@ -3849,7 +3849,7 @@ static void *janus_streaming_ondemand_thread(void *data) {
 	/* Set up RTP */
 	gint16 seq = 1;
 	gint32 ts = 0;
-	rtp_header *header = (rtp_header *)buf;
+	janus_rtp_header *header = (janus_rtp_header *)buf;
 	header->version = 2;
 	header->markerbit = 1;
 	header->type = mountpoint->codecs.audio_pt;
@@ -3968,7 +3968,7 @@ static void *janus_streaming_filesource_thread(void *data) {
 	/* Set up RTP */
 	gint16 seq = 1;
 	gint32 ts = 0;
-	rtp_header *header = (rtp_header *)buf;
+	janus_rtp_header *header = (janus_rtp_header *)buf;
 	header->version = 2;
 	header->markerbit = 1;
 	header->type = mountpoint->codecs.audio_pt;
@@ -4277,7 +4277,7 @@ static void *janus_streaming_relay_thread(void *data) {
 					/* If paused, ignore this packet */
 					if(!mountpoint->enabled)
 						continue;
-					rtp_header *rtp = (rtp_header *)buffer;
+					janus_rtp_header *rtp = (janus_rtp_header *)buffer;
 					//~ JANUS_LOG(LOG_VERB, " ... parsed RTP packet (ssrc=%u, pt=%u, seq=%u, ts=%u)...\n",
 						//~ ntohl(rtp->ssrc), rtp->type, ntohs(rtp->seq_number), ntohl(rtp->timestamp));
 					/* Relay on all sessions */
@@ -4336,7 +4336,7 @@ static void *janus_streaming_relay_thread(void *data) {
 						continue;
 					}
 					//~ JANUS_LOG(LOG_VERB, "************************\nGot %d bytes on the video channel...\n", bytes);
-					rtp_header *rtp = (rtp_header *)buffer;
+					janus_rtp_header *rtp = (janus_rtp_header *)buffer;
 					/* First of all, let's check if this is (part of) a keyframe that we may need to save it for future reference */
 					if(source->keyframe.enabled) {
 						if(source->keyframe.temp_ts > 0 && ntohl(rtp->timestamp) != source->keyframe.temp_ts) {
@@ -4377,7 +4377,7 @@ static void *janus_streaming_relay_thread(void *data) {
 						} else {
 							gboolean kf = FALSE;
 							/* Parse RTP header first */
-							rtp_header *header = (rtp_header *)buffer;
+							janus_rtp_header *header = (janus_rtp_header *)buffer;
 							guint32 timestamp = ntohl(header->timestamp);
 							guint16 seq = ntohs(header->seq_number);
 							JANUS_LOG(LOG_HUGE, "Checking if packet (size=%d, seq=%"SCNu16", ts=%"SCNu32") is a key frame...\n",
@@ -4480,7 +4480,7 @@ static void *janus_streaming_relay_thread(void *data) {
 					memcpy(text, buffer, bytes);
 					*(text+bytes) = '\0';
 					/* Relay on all sessions */
-					packet.data = (rtp_header *)text;
+					packet.data = (janus_rtp_header *)text;
 					packet.length = bytes+1;
 					packet.is_rtp = FALSE;
 					/* Is there a recorder? */

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -702,7 +702,7 @@ void janus_videocall_incoming_rtp(janus_plugin_session *handle, int video, char 
 			return;
 		if(video && session->video_active && session->rtpmapid_extmap_id != -1) {
 			/* FIXME Just a way to debug Firefox simulcasting */
-			rtp_header *header = (rtp_header *)buf;
+			janus_rtp_header *header = (janus_rtp_header *)buf;
 			uint32_t seq_number = ntohs(header->seq_number);
 			uint32_t timestamp = ntohl(header->timestamp);
 			uint32_t ssrc = ntohl(header->ssrc);
@@ -714,7 +714,7 @@ void janus_videocall_incoming_rtp(janus_plugin_session *handle, int video, char 
 		}
 		if(video && session->video_active && session->ssrc[0] != 0) {
 			/* Handle simulcast: don't relay if it's not the SSRC we wanted to handle */
-			rtp_header *header = (rtp_header *)buf;
+			janus_rtp_header *header = (janus_rtp_header *)buf;
 			uint32_t seq_number = ntohs(header->seq_number);
 			uint32_t timestamp = ntohl(header->timestamp);
 			uint32_t ssrc = ntohl(header->ssrc);

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -612,7 +612,7 @@ typedef struct janus_videoroom_listener {
 static void janus_videoroom_listener_free(janus_videoroom_listener *l);
 
 typedef struct janus_videoroom_rtp_relay_packet {
-	rtp_header *data;
+	janus_rtp_header *data;
 	gint length;
 	gboolean is_video;
 	uint32_t ssrc[3];
@@ -2622,7 +2622,7 @@ void janus_videoroom_incoming_rtp(janus_plugin_session *handle, int video, char 
 	}
 
 	if((!video && participant->audio_active) || (video && participant->video_active)) {
-		rtp_header *rtp = (rtp_header *)buf;
+		janus_rtp_header *rtp = (janus_rtp_header *)buf;
 		uint32_t ssrc = ntohl(rtp->ssrc);
 		int sc = -1;
 		/* Check if we're simulcasting, and if so, keep track of the "layer" */

--- a/plugins/janus_voicemail.c
+++ b/plugins/janus_voicemail.c
@@ -570,7 +570,7 @@ void janus_voicemail_incoming_rtp(janus_plugin_session *handle, int video, char 
 		return;
 	}
 	/* Save the frame */
-	rtp_header *rtp = (rtp_header *)buf;
+	janus_rtp_header *rtp = (janus_rtp_header *)buf;
 	uint16_t seq = ntohs(rtp->seq_number);
 	if(session->seq == 0)
 		session->seq = seq;

--- a/rtp.c
+++ b/rtp.c
@@ -12,13 +12,14 @@
  
 #include <string.h>
 #include "rtp.h"
+#include "rtpsrtp.h"
 #include "debug.h"
 
 char *janus_rtp_payload(char *buf, int len, int *plen) {
 	if(!buf || len < 12)
 		return NULL;
 
-	rtp_header *rtp = (rtp_header *)buf;
+	janus_rtp_header *rtp = (janus_rtp_header *)buf;
 	int hlen = 12;
 	if(rtp->csrccount)	/* Skip CSRC if needed */
 		hlen += rtp->csrccount*4;
@@ -109,7 +110,7 @@ static int janus_rtp_header_extension_find(char *buf, int len, int id,
 		uint8_t *byte, uint32_t *word, char **ref) {
 	if(!buf || len < 12)
 		return -1;
-	rtp_header *rtp = (rtp_header *)buf;
+	janus_rtp_header *rtp = (janus_rtp_header *)buf;
 	int hlen = 12;
 	if(rtp->csrccount)	/* Skip CSRC if needed */
 		hlen += rtp->csrccount*4;
@@ -229,7 +230,7 @@ void janus_rtp_switching_context_reset(janus_rtp_switching_context *context) {
 	memset(context, 0, sizeof(*context));
 }
 
-void janus_rtp_header_update(rtp_header *header, janus_rtp_switching_context *context, gboolean video, int step) {
+void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_context *context, gboolean video, int step) {
 	if(header == NULL || context == NULL || step < 1)
 		return;
 	uint32_t ssrc = ntohl(header->ssrc);

--- a/rtp.h
+++ b/rtp.h
@@ -26,31 +26,7 @@
 #include <string.h>
 #include <glib.h>
 
-#ifdef HAVE_SRTP_2
-#include <srtp2/srtp.h>
-#include <openssl/rand.h>
-#include <openssl/err.h>
-int srtp_crypto_get_random(uint8_t *key, int len);
-#else
-#include <srtp/srtp.h>
-#include <srtp/crypto_kernel.h>
-#define srtp_err_status_t err_status_t
-#define srtp_err_status_ok err_status_ok
-#define srtp_err_status_replay_fail err_status_replay_fail
-#define srtp_err_status_replay_old err_status_replay_old
-#define srtp_crypto_policy_set_rtp_default crypto_policy_set_rtp_default
-#define srtp_crypto_policy_set_rtcp_default crypto_policy_set_rtcp_default
-#define srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32 crypto_policy_set_aes_cm_128_hmac_sha1_32
-#define srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80 crypto_policy_set_aes_cm_128_hmac_sha1_80
-#define srtp_crypto_get_random crypto_get_random
-#endif
-
 #define RTP_HEADER_SIZE	12
-
-/* SRTP stuff (http://tools.ietf.org/html/rfc3711) */
-#define SRTP_MASTER_KEY_LENGTH	16
-#define SRTP_MASTER_SALT_LENGTH	14
-#define SRTP_MASTER_LENGTH (SRTP_MASTER_KEY_LENGTH + SRTP_MASTER_SALT_LENGTH)
 
 /*! \brief RTP Header (http://tools.ietf.org/html/rfc3550#section-5.1) */
 typedef struct rtp_header
@@ -75,6 +51,7 @@ typedef struct rtp_header
 	uint32_t ssrc;
 	uint32_t csrc[16];
 } rtp_header;
+typedef rtp_header janus_rtp_header;
 
 /*! \brief RTP packet */
 typedef struct janus_rtp_packet {
@@ -184,11 +161,6 @@ void janus_rtp_switching_context_reset(janus_rtp_switching_context *context);
  * @param[in] context The context to use as a reference
  * @param[in] video Whether this is an audio or a video packet
  * @param[in] step The expected timestamp step */
-void janus_rtp_header_update(rtp_header *header, janus_rtp_switching_context *context, gboolean video, int step);
-
-/*! \brief Helper method to get a string representation of a libsrtp error code
- * @param[in] error The libsrtp error code
- * @returns A string representation of the error code */
-const char *janus_srtp_error_str(int error);
+void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_context *context, gboolean video, int step);
 
 #endif

--- a/rtpsrtp.h
+++ b/rtpsrtp.h
@@ -1,0 +1,46 @@
+/*! \file    rtpsrtp.h
+ * \author   Lorenzo Miniero <lorenzo@meetecho.com>
+ * \copyright GNU General Public License v3
+ * \brief    SRTP definitions (headers)
+ * \details  Definitions of the SRTP usage. This header tries to abstract
+ * the differences there may be between libsrtp and libsrtp2, with respect
+ * to the structs and defines (e.g., errors), plus adding some helpers.
+ * 
+ * \ingroup protocols
+ * \ref protocols
+ */
+
+#ifndef _JANUS_RTPSRTP_H
+#define _JANUS_RTPSRTP_H
+
+#ifdef HAVE_SRTP_2
+#include <srtp2/srtp.h>
+#include <openssl/rand.h>
+#include <openssl/err.h>
+int srtp_crypto_get_random(uint8_t *key, int len);
+#else
+#include <srtp/srtp.h>
+#include <srtp/crypto_kernel.h>
+#define srtp_err_status_t err_status_t
+#define srtp_err_status_ok err_status_ok
+#define srtp_err_status_replay_fail err_status_replay_fail
+#define srtp_err_status_replay_old err_status_replay_old
+#define srtp_crypto_policy_set_rtp_default crypto_policy_set_rtp_default
+#define srtp_crypto_policy_set_rtcp_default crypto_policy_set_rtcp_default
+#define srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32 crypto_policy_set_aes_cm_128_hmac_sha1_32
+#define srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80 crypto_policy_set_aes_cm_128_hmac_sha1_80
+#define srtp_crypto_get_random crypto_get_random
+#endif
+
+/* SRTP stuff (http://tools.ietf.org/html/rfc3711) */
+#define SRTP_MASTER_KEY_LENGTH	16
+#define SRTP_MASTER_SALT_LENGTH	14
+#define SRTP_MASTER_LENGTH (SRTP_MASTER_KEY_LENGTH + SRTP_MASTER_SALT_LENGTH)
+
+
+/*! \brief Helper method to get a string representation of a libsrtp error code
+ * @param[in] error The libsrtp error code
+ * @returns A string representation of the error code */
+const char *janus_srtp_error_str(int error);
+
+#endif


### PR DESCRIPTION
As the title says, this PR moves all the SRTP related stuff we had in `rtp.h` to a new header, called `rtpsrtp.h`. The implementations are still in `rtp.c`.

The rationale for this comes from some issues we were told about, specifically with respect to plugins written as separate projects. Since SRTP definitions were in rtp.h, building plugins would require a dependendy on libsrtp as well, and one that had to be the same as the one Janus uses, due to the ifdefs we have in place. Since most plugins do not need SRTP at all, it made sense to split the SRTP stuff: the only stock plugin that uses SRTP is the SIP plugin, and we updated it to include the new header.

I took advantage of this change to also add a `typedef` to use `janus_rtp_header` instead of `rtp_header`, which is probably the only structure left that is still unprefixed. `rtp_header` is still there to ensure compatibility for a while longer, but I plan to get rid of it in the future, so if you're writing plugins stick to `janus_rtp_header` instead from now on.