### PR TITLE
Static RTP forwarder for audiobridge

### DIFF
--- a/conf/janus.plugin.audiobridge.cfg.sample
+++ b/conf/janus.plugin.audiobridge.cfg.sample
@@ -11,6 +11,7 @@
 ; audio_level_average = 25 (average value of audio level, 127=muted, 0='too loud', default=25)
 ; record = true|false (whether this room should be recorded, default=false)
 ; record_file = /path/to/recording.wav (where to save the recording)
+; rtp_forward_id = numeric RTP forwarder ID for referencing it via API (optional: random ID used if missing)
 ; rtp_forward_host = host address to forward RTP packets of mixed audio to
 ; rtp_forward_port = port to forward RTP packets of mixed audio to
 ; rtp_forward_ssrc = SSRC to use to use when streaming (optional: stream_id used if missing)

--- a/conf/janus.plugin.audiobridge.cfg.sample
+++ b/conf/janus.plugin.audiobridge.cfg.sample
@@ -11,6 +11,11 @@
 ; audio_level_average = 25 (average value of audio level, 127=muted, 0='too loud', default=25)
 ; record = true|false (whether this room should be recorded, default=false)
 ; record_file = /path/to/recording.wav (where to save the recording)
+; rtp_forward_host = host address to forward RTP packets of mixed audio to
+; rtp_forward_port = port to forward RTP packets of mixed audio to
+; rtp_forward_ssrc = SSRC to use to use when streaming (optional: stream_id used if missing)
+; rtp_forward_ptype = payload type to use when streaming (optional: 100 used if missing)
+; rtp_forward_always_on = true|false, whether silence should be forwarded when the room is empty (optional: false used if missing)
 
 [general]
 ;admin_key = supersecret		; If set, rooms can be created via API only

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -75,7 +75,9 @@ rtp_forward_always_on = true|false, whether silence should be forwarded when the
  * process the mixer audio stream. You can add new RTP forwarders with
  * the \c rtp_forward request; a \c stop_rtp_forward request removes an
  * existing RTP forwarder; \c listforwarders lists all the current RTP
- * forwarders on a specific AudioBridge room instance.
+ * forwarders on a specific AudioBridge room instance. As an alternative,
+ * you can configure a single static RTP forwarder in the plugin
+ * configuration file.
  *
  * \c create can be used to create a new audio room, and has to be
  * formatted as follows:

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -30,6 +30,11 @@ audiolevel_ext = yes|no (whether the ssrc-audio-level RTP extension must be
 	negotiated/used or not for new joins, default=yes)
 record = true|false (whether this room should be recorded, default=false)
 record_file =	/path/to/recording.wav (where to save the recording)
+rtp_forward_host = host address to forward RTP packets of mixed audio to
+rtp_forward_port = port to forward RTP packets of mixed audio to
+rtp_forward_ssrc = SSRC to use to use when streaming (optional: stream_id used if missing)
+rtp_forward_ptype = payload type to use when streaming (optional: 100 used if missing)
+rtp_forward_always_on = true|false, whether silence should be forwarded when the room is empty (optional: false used if missing)
 \endverbatim
  *
  * \section bridgeapi Audio Bridge API
@@ -953,6 +958,104 @@ typedef struct wav_header {
 #define JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_USER	492
 #define JANUS_AUDIOBRIDGE_ERROR_INVALID_SDP		493
 
+static int janus_audiobridge_create_udp_socket_if_needed(janus_audiobridge_room *audiobridge) {
+	if(audiobridge->rtp_udp_sock > 0) {
+		return 0;
+	}
+
+	audiobridge->rtp_udp_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if(audiobridge->rtp_udp_sock <= 0) {
+		JANUS_LOG(LOG_ERR, "Could not open UDP socket for RTP forwarder (room %"SCNu64")\n", audiobridge->room_id);
+		return -1;
+	}
+
+	return 0;
+}
+
+static int janus_audiobridge_create_opus_encoder_if_needed(janus_audiobridge_room *audiobridge) {
+	if(audiobridge->rtp_encoder != NULL) {
+		return 0;
+	}
+
+	int error = 0;
+	audiobridge->rtp_encoder = opus_encoder_create(audiobridge->sampling_rate, 1, OPUS_APPLICATION_VOIP, &error);
+	if(error != OPUS_OK) {
+		JANUS_LOG(LOG_ERR, "Error creating Opus encoder for RTP forwarder (room %"SCNu64")\n", audiobridge->room_id);
+		return -1;
+	}
+
+	if(audiobridge->sampling_rate == 8000) {
+		opus_encoder_ctl(audiobridge->rtp_encoder, OPUS_SET_MAX_BANDWIDTH(OPUS_BANDWIDTH_NARROWBAND));
+	} else if(audiobridge->sampling_rate == 12000) {
+		opus_encoder_ctl(audiobridge->rtp_encoder, OPUS_SET_MAX_BANDWIDTH(OPUS_BANDWIDTH_MEDIUMBAND));
+	} else if(audiobridge->sampling_rate == 16000) {
+		opus_encoder_ctl(audiobridge->rtp_encoder, OPUS_SET_MAX_BANDWIDTH(OPUS_BANDWIDTH_WIDEBAND));
+	} else if(audiobridge->sampling_rate == 24000) {
+		opus_encoder_ctl(audiobridge->rtp_encoder, OPUS_SET_MAX_BANDWIDTH(OPUS_BANDWIDTH_SUPERWIDEBAND));
+	} else if(audiobridge->sampling_rate == 48000) {
+		opus_encoder_ctl(audiobridge->rtp_encoder, OPUS_SET_MAX_BANDWIDTH(OPUS_BANDWIDTH_FULLBAND));
+	} else {
+		JANUS_LOG(LOG_WARN, "Unsupported sampling rate %d, setting 16kHz\n", audiobridge->sampling_rate);
+		opus_encoder_ctl(audiobridge->rtp_encoder, OPUS_SET_MAX_BANDWIDTH(OPUS_BANDWIDTH_WIDEBAND));
+	}
+
+	return 0;
+}
+
+static int janus_audiobridge_create_static_rtp_forwarder(janus_config_category *cat, janus_audiobridge_room *audiobridge) {
+	guint32 ssrc_value = 0;
+	janus_config_item *ssrc = janus_config_get_item(cat, "rtp_forward_ssrc");
+	if(ssrc != NULL && ssrc->value != NULL)
+		ssrc_value = atoi(ssrc->value);
+
+	int ptype = 100;
+	janus_config_item *pt = janus_config_get_item(cat, "rtp_forward_ptype");
+	if(pt != NULL && pt->value != NULL)
+		ptype = atoi(pt->value);
+
+	janus_config_item *port_item = janus_config_get_item(cat, "rtp_forward_port");
+	uint16_t port = 0;
+	if(port_item != NULL && port_item->value != NULL && strlen(port_item->value) > 0)
+		port = atoi(port_item->value);
+	if(port == 0) {
+		return 0;
+	}
+
+	janus_config_item *host_item = janus_config_get_item(cat, "rtp_forward_host");
+	if(host_item == NULL || host_item->value == NULL || strlen(host_item->value) == 0) {
+		return 0;
+	}
+	const gchar* host = g_strdup(host_item->value);
+
+	janus_config_item *always_on_item = janus_config_get_item(cat, "rtp_forward_always_on");
+	gboolean always_on = FALSE;
+	if(always_on_item != NULL && always_on_item->value != NULL && strlen(always_on_item->value) > 0) {
+		always_on = janus_is_true(always_on_item->value);
+	}
+
+	/* Update room */
+	janus_mutex_lock(&rooms_mutex);
+	janus_mutex_lock(&audiobridge->mutex);
+
+	if(janus_audiobridge_create_udp_socket_if_needed(audiobridge)) {
+		janus_mutex_unlock(&audiobridge->mutex);
+		janus_mutex_unlock(&rooms_mutex);
+		return -1;
+	}
+
+	if(janus_audiobridge_create_opus_encoder_if_needed(audiobridge)) {
+		janus_mutex_unlock(&audiobridge->mutex);
+		janus_mutex_unlock(&rooms_mutex);
+		return -1;
+	}
+
+	janus_audiobridge_rtp_forwarder_add_helper(audiobridge, host, port, ssrc_value, ptype, always_on);
+
+	janus_mutex_unlock(&audiobridge->mutex);
+	janus_mutex_unlock(&rooms_mutex);
+
+	return 0;
+}
 
 /* AudioBridge watchdog/garbage collector (sort of) */
 static void *janus_audiobridge_watchdog(void *data) {
@@ -1172,6 +1275,11 @@ int janus_audiobridge_init(janus_callbacks *callback, const char *config_path) {
 				audiobridge->is_private ? "private" : "public",
 				audiobridge->room_secret ? audiobridge->room_secret : "no secret",
 				audiobridge->room_pin ? audiobridge->room_pin : "no pin");
+
+			if(janus_audiobridge_create_static_rtp_forwarder(cat, audiobridge)) {
+				JANUS_LOG(LOG_ERR, "Error creating static RTP forwarder (room %"SCNu64")\n", audiobridge->room_id);
+			}
+
 			/* We need a thread for the mix */
 			GError *error = NULL;
 			char tname[16];
@@ -2196,48 +2304,27 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
 			goto plugin_response;
 		}
-		/* Create UDP socket, if needed */
-		if(audiobridge->rtp_udp_sock <= 0) {
-			audiobridge->rtp_udp_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-			if(audiobridge->rtp_udp_sock <= 0) {
-				janus_mutex_unlock(&audiobridge->mutex);
-				janus_mutex_unlock(&rooms_mutex);
-				JANUS_LOG(LOG_ERR, "Could not open UDP socket for RTP forwarder (room %"SCNu64")\n", room_id);
-				error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
-				g_snprintf(error_cause, 512, "Could not open UDP socket for RTP forwarder");
-				goto plugin_response;
-			}
+
+		if (janus_audiobridge_create_udp_socket_if_needed(audiobridge)) {
+			janus_mutex_unlock(&audiobridge->mutex);
+			janus_mutex_unlock(&rooms_mutex);
+			error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
+			g_snprintf(error_cause, 512, "Could not open UDP socket for RTP forwarder");
+			goto plugin_response;
 		}
-		/* Create Opus encoder, if needed */
-		if(audiobridge->rtp_encoder == NULL) {
-			int error = 0;
-			audiobridge->rtp_encoder = opus_encoder_create(audiobridge->sampling_rate, 1, OPUS_APPLICATION_VOIP, &error);
-			if(error != OPUS_OK) {
-				janus_mutex_unlock(&audiobridge->mutex);
-				janus_mutex_unlock(&rooms_mutex);
-				JANUS_LOG(LOG_ERR, "Error creating Opus encoder for RTP forwarder (room %"SCNu64")\n", room_id);
-				error_code = JANUS_AUDIOBRIDGE_ERROR_LIBOPUS_ERROR;
-				g_snprintf(error_cause, 512, "Error creating Opus decoder for RTP forwarder");
-				goto plugin_response;
-			}
-			if(audiobridge->sampling_rate == 8000) {
-				opus_encoder_ctl(audiobridge->rtp_encoder, OPUS_SET_MAX_BANDWIDTH(OPUS_BANDWIDTH_NARROWBAND));
-			} else if(audiobridge->sampling_rate == 12000) {
-				opus_encoder_ctl(audiobridge->rtp_encoder, OPUS_SET_MAX_BANDWIDTH(OPUS_BANDWIDTH_MEDIUMBAND));
-			} else if(audiobridge->sampling_rate == 16000) {
-				opus_encoder_ctl(audiobridge->rtp_encoder, OPUS_SET_MAX_BANDWIDTH(OPUS_BANDWIDTH_WIDEBAND));
-			} else if(audiobridge->sampling_rate == 24000) {
-				opus_encoder_ctl(audiobridge->rtp_encoder, OPUS_SET_MAX_BANDWIDTH(OPUS_BANDWIDTH_SUPERWIDEBAND));
-			} else if(audiobridge->sampling_rate == 48000) {
-				opus_encoder_ctl(audiobridge->rtp_encoder, OPUS_SET_MAX_BANDWIDTH(OPUS_BANDWIDTH_FULLBAND));
-			} else {
-				JANUS_LOG(LOG_WARN, "Unsupported sampling rate %d, setting 16kHz\n", audiobridge->sampling_rate);
-				opus_encoder_ctl(audiobridge->rtp_encoder, OPUS_SET_MAX_BANDWIDTH(OPUS_BANDWIDTH_WIDEBAND));
-			}
+
+		if (janus_audiobridge_create_opus_encoder_if_needed(audiobridge)) {
+			janus_mutex_unlock(&audiobridge->mutex);
+			janus_mutex_unlock(&rooms_mutex);
+			error_code = JANUS_AUDIOBRIDGE_ERROR_LIBOPUS_ERROR;
+			g_snprintf(error_cause, 512, "Error creating Opus decoder for RTP forwarder");
+			goto plugin_response;
 		}
+
 		guint32 stream_id = janus_audiobridge_rtp_forwarder_add_helper(audiobridge, host, port, ssrc_value, ptype, always_on);
 		janus_mutex_unlock(&audiobridge->mutex);
 		janus_mutex_unlock(&rooms_mutex);
+
 		/* Done, prepare response */
 		response = json_object();
 		json_object_set_new(response, "audiobridge", json_string("success"));


### PR DESCRIPTION
There are some use cases for audiobridge, where the mixed audio needs to be forwarded always to another application, e.g. for local playback at the server or custom post-processing. This change allows adding a single statically configured RTP forwarder in the audiobridge plugin configuration file.

Note: A similar feature could be implemented in the videoroom plugin, but I don't have any use for it.
