### PR TITLE
Make RTCPeerConnection a configurable dependency

### DIFF
--- a/mainpage.dox
+++ b/mainpage.dox
@@ -592,6 +592,7 @@ janus.attach(
  * should return a new WebSocket (or something that acts like it)
  * -# \c webRTCAdapter: an \c adapter object such as provided by the
  * <a href="https://github.com/webrtc/adapter">webrtc-adapter</a> library
+ * -# \c newRTCPeerConnection: a function that returns a new RTCPeerConnection instance.
  * -# \c isArray: a function which tests if a given argument is a JavaScript array
  * -# \c checkJanusExtension: a function which tests if the Janus Screensharing extension
  * for Chrome is installed/available. This can be done by testing whether or not an element


### PR DESCRIPTION
This change will be transparent to anyone who does not care
to customize the use of the RTCPeerConnection constructor.
However, it provides extra control to the options and constraints
being passed to the RTCPeerConnection constructor so that you
can do stuff like this:
```javascript
Janus.init({
  debug,
  callback,
  dependencies: Janus.useDefaultDependencies({
    newRTCPeerConnection(config, constraints) {
      // Add additional constraints
      constraints.optional.push({
        googCpuOveruseDetection: false,
      })

      return new RTCPeerConnection(config, constraints)
    }
  }),
})
```