### PR TITLE
Integrate support for building JavaScript modules within the build system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,9 @@ recordings_DATA = $(NULL)
 demosdir = $(datadir)/janus/demos
 demos_DATA = $(NULL)
 
+jsmodulesdir = $(datadir)/janus/javascript
+jsmodules_DATA = html/janus.js
+
 %.sample: %.sample.in
 	$(MKDIR_P) $(@D)
 	$(AM_V_GEN) sed -e "\
@@ -437,6 +440,40 @@ endif
 
 if ENABLE_DOCS
 SUBDIRS += docs
+endif
+
+##
+# JavaScript module flavours for janus.js
+##
+
+if ENABLE_JAVASCRIPT_ES_MODULE
+jsmodules_DATA += npm/bundles/janus.es.js
+CLEANFILES += npm/bundles/janus.es.js
+endif
+
+if ENABLE_JAVASCRIPT_UMD_MODULE
+jsmodules_DATA += npm/bundles/janus.umd.js
+CLEANFILES += npm/bundles/janus.umd.js
+endif
+
+if ENABLE_JAVASCRIPT_IIFE_MODULE
+jsmodules_DATA += npm/bundles/janus.iife.js
+CLEANFILES += npm/bundles/janus.iife.js
+endif
+
+if ENABLE_JAVASCRIPT_COMMON_JS_MODULE
+jsmodules_DATA += npm/bundles/janus.cjs.js
+CLEANFILES += npm/bundles/janus.cjs.js
+endif
+
+if ENABLE_JAVASCRIPT_MODULES
+
+npm/node_modules/rollup/bin/rollup: npm/package.json
+	cd npm && $(NPM) install && touch node_modules/rollup/bin/rollup
+
+npm/bundles/janus.%.js: html/janus.js npm/node_modules/rollup/bin/rollup npm/rollup.config.js npm/module.js
+	cd npm && $(NPM) run rollup -- --o $(patsubst npm/%,%,$@) --f $*
+
 endif
 
 ##

--- a/configure.ac
+++ b/configure.ac
@@ -169,6 +169,54 @@ AC_ARG_ENABLE([sample-event-handler],
                      [enable_sample_event_handler=no])],
               [enable_sample_event_handler=maybe])
 
+AC_ARG_ENABLE([javascript-es-module],
+              [AS_HELP_STRING([--enable-javascript-es-module],
+                              [Enable generating an ECMAScript style module from janus.js])],
+              [AS_IF([test "x$enable_javascript_es_module" = "xyes"],
+                     [enable_javascript_es_module=yes])],
+              [enable_javascript_es_module=no])
+AM_CONDITIONAL([ENABLE_JAVASCRIPT_ES_MODULE], [test "x$enable_javascript_es_module" = "xyes" ])
+
+AC_ARG_ENABLE([javascript-umd-module],
+              [AS_HELP_STRING([--enable-javascript-umd-module],
+                              [Enable generating an UMD style module from janus.js])],
+              [AS_IF([test "x$enable_javascript_umd_module" = "xyes"],
+                     [enable_javascript_umd_module=yes])],
+              [enable_javascript_umd_module=no])
+AM_CONDITIONAL([ENABLE_JAVASCRIPT_UMD_MODULE], [test "x$enable_javascript_umd_module" = "xyes" ])
+
+AC_ARG_ENABLE([javascript-iife-module],
+              [AS_HELP_STRING([--enable-javascript-iife-module],
+                              [Enable generating an IIFE style wrapper around janus.js])],
+              [AS_IF([test "x$enable_javascript_iife_module" = "xyes"],
+                     [enable_javascript_iife_module=yes])],
+              [enable_javascript_iife_module=no])
+AM_CONDITIONAL([ENABLE_JAVASCRIPT_IIFE_MODULE], [test "x$enable_javascript_iife_module" = "xyes" ])
+
+AC_ARG_ENABLE([javascript-common-js-module],
+              [AS_HELP_STRING([--enable-javascript-common-js-module],
+                              [Enable generating an CommonJS style module from janus.js])],
+              [AS_IF([test "x$enable_javascript_common_js_module" = "xyes"],
+                     [enable_javascript_common_js_module=yes])],
+              [enable_javascript_common_js_module=no])
+AM_CONDITIONAL([ENABLE_JAVASCRIPT_COMMON_JS_MODULE], [test "x$enable_javascript_common_js_module" = "xyes" ])
+
+case "-${enable_javascript_common_js_module}-${enable_javascript_iife_module}-${enable_javascript_umd_module}-${enable_javascript_es_module}-" in
+    *-yes*)
+        AM_CONDITIONAL([ENABLE_JAVASCRIPT_MODULES], true)
+    ;;
+    *)
+        AM_CONDITIONAL([ENABLE_JAVASCRIPT_MODULES], false)
+    ;;
+esac
+
+AC_ARG_VAR(NPM,"npm executable to use")
+AC_PATH_PROG(NPM,npm,,)
+AM_CONDITIONAL([NPM_FOUND], [test "x$NPM" != "x" ])
+AM_COND_IF([ENABLE_JAVASCRIPT_MODULES],[
+    AM_COND_IF([NPM_FOUND],,[AC_MSG_ERROR([npm not found])])
+])
+
 PKG_CHECK_MODULES([JANUS],
                   [
                     glib-2.0 >= $glib_version
@@ -674,6 +722,23 @@ echo "Event handlers:"
 AM_COND_IF([ENABLE_SAMPLEEVH],
 	[echo "    Sample event handler:  yes"],
 	[echo "    Sample event handler:  no"])
+AM_COND_IF([ENABLE_JAVASCRIPT_MODULES], [
+	echo "JavaScript modules:        yes"
+	echo "    Using npm:             $NPM"
+	AM_COND_IF([ENABLE_JAVASCRIPT_ES_MODULE],
+		[echo "    ES syntax:             yes"],
+		[echo "    ES syntax:             no"])
+	AM_COND_IF([ENABLE_JAVASCRIPT_IIFE_MODULE],
+		[echo "    IIFE syntax:           yes"],
+		[echo "    IIFE syntax:           no"])
+	AM_COND_IF([ENABLE_JAVASCRIPT_UMD_MODULE],
+		[echo "    UMD syntax:            yes"],
+		[echo "    UMD syntax:            no"])
+	AM_COND_IF([ENABLE_JAVASCRIPT_COMMON_JS_MODULE],
+		[echo "    CommonJS syntax:       yes"],
+		[echo "    CommonJS syntax:       no"])
+	],
+	[echo "JavaScript modules:        no"])
 
 echo
 echo "If this configuration is ok for you, do a 'make' to start building Janus. A 'make install' will install Janus and its plugins to the specified prefix. Finally, a 'make configs' will install some sample configuration files too (something you'll only want to do the first time, though)."

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -96,6 +96,7 @@
  * - \b libogg: http://xiph.org/ogg/ (\c optional, only needed for the voicemail plugin)
  * - \b libcurl: https://curl.haxx.se/libcurl/ (\c optional, only needed for the TURN REST API,
  * RTSP support in the Streaming plugin and the sample Event Handler plugin)
+ * - \b npm: https://docs.npmjs.com/ (\c optional, used during build for generating JavaScript modules)
  *
  */
 
@@ -157,7 +158,10 @@
  *
  * <hr>
  *
- * As a first step, you should include the \c janus.js library in your project:
+ * As a first step, you should include the Janus library in your project.
+ * Depending on your needs you can either use \c janus.js or one of the generated
+ * JavaScript module variants of it. For available module syntaxes and how to build the
+ * corresponding variants, see: \ref js-modules
  *
 \verbatim
 <script type="text/javascript" src="janus.js" ></script>
@@ -185,6 +189,23 @@ Janus.init({
    callback: function() {
 	   // Done!
    });
+ \endverbatim
+ *
+ * \note When using one of the JavaScript module variants of \c janus.js, you
+ * will need to import the \c Janus symbol from the module first. See also: \ref js-modules
+ * For example, using the ECMAScript module variant, the above example should be altered to:
+ *
+ *
+ \verbatim
+import * as Janus from './janus.es.js'
+
+Janus.init({
+   debug: true,
+   dependencies: Janus.useDefaultDependencies(), // or: Janus.useOldDependencies() to get the behaviour of previous Janus versions
+   callback: function() {
+	   // Done!
+   });
+});
  \endverbatim
  *
  * Once the library has been initialized, you can start creating sessions.
@@ -580,6 +601,65 @@ janus.attach(
  *
  * This is it! For more information about the API, have a look at the
  * demo pages that are available in the \b html folder in this package.
+ *
+ */
+
+/*!\page js-modules Using janus.js as JavaScript module
+ *
+ * To facilitate integration of \c janus.js within modular JavaScript code bases,
+ * you can instruct the build system(s) to generate a modular variants of \c janus.js.
+ * Generated modules may then be copied to your own JavaScript projects and seamlessly integrated with your own project's build system.
+ *
+ * Building the modules can be done in two ways:
+ *
+ * -# As part of a regular build of the Janus Gateway, using \c make, by enabling the integrated support via \c configure
+ * -# By running NPM commands manually. This may be useful if you are looking to build just the JavaScript modules without
+ *    incurring the overhead of a full build of the Janus Gateway.
+ *
+ * \section auto-build-js-modules Building modules using make
+ * Each supported variant may be enabled by passing a corresponding \c --enable-javascript-*-module=yes flag
+ * to \c configure before invoking \c make to build the Janus Gateway.
+ * Please note: if you do not pass any such flag, by default no modules will be built.
+ *
+ * The following table provides a summary of available module formats and their corresponding \c configure options:
+ *
+ * <table>
+ * <caption id="js-module-support">Available JavaScript module formats</caption>
+ * <tr><th>Module format (syntax)</th><th>File name</th><th>\c configure flag to pass</th></tr>
+ * <tr><td>ECMAScript</td><td>janus.es.js</td><td>\c --enable-javascript-es-module=yes </td></tr>
+ * <tr><td>Universal Module Definition (UMD)</td><td>janus.umd.js</td><td>\c --enable-javascript-umd-module=yes </td></tr>
+ * <tr><td>CommonJS</td><td>janus.cjs.js</td><td>\c --enable-javascript-common-js-module=yes </td></tr>
+ * <tr><td>Immediately Invoked Function Expression (IIFE)</td><td>janus.iife.js</td><td>\c --enable-javascript-iffe-module=yes </td></tr>
+ * </table>
+ *
+ * When built and installed, these module variants may be found in the \c $PREFIX/share/janus/javascript
+ * folder, alongside the \c janus.js file itself (assuming \c $PREFIX the installation directory passed to \c configure).
+ *
+ * \note Building the JavaScript modules still requires NPM and may involve an \c install which means \c npm must be able
+ * to download dependencies. By default \c configure will attempt to auto-detect available \c npm on your PATH, but
+ * if you have installed NPM outside the PATH you can override this by passing the (full) path to your \c npm executable, e.g.:
+ *
+ \verbatim
+ ./configure NPM=/path/to/my/custom/npm --enable-javascript-es-module=yes
+ \endverbatim
+ *
+ * \section manual-build-modules Building modules manually with NPM
+ * You can also opt to build modules by invoking \c npm manually. The \c npm subdirectory contains the necessary
+ * configuration files to get you started:
+ *
+ \verbatim
+ cd ./npm
+ npm install
+ npm run rollup -- --o /path/to/desired/output/file-name.js --f cjs # or es, iffe, umd, amd, ...
+ \endverbatim
+ *
+ * Using \c npm directly is useful if you want to build the JavaScript modules only, without building the Janus Gateway itself
+ * or if you are looking for advanced customisation options or alternative formats which are not integrated in \c configure yet.
+ * As you may have surmised from the example command, the actual build consists mostly of invoking \c rollup with the
+ * correct parameters. For more information on available parameters, please refer to the \c rollup documentation:
+ *
+ * -# https://rollupjs.org/#command-line-flags
+ * -# https://rollupjs.org/#configuration-files
  *
  */
 

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,3 @@
+bundles/
+node_modules/
+npm-debug.log

--- a/npm/module.js
+++ b/npm/module.js
@@ -1,0 +1,8 @@
+/*
+ * Module shim for rollup.js to work with.
+ * Simply re-export Janus from janus.js, the real 'magic' is in the rollup config
+ */
+
+@JANUS_CODE@
+
+export default Janus;

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "janus",
+  "description": "The Janus WebRTC Server",
+  "author": "Meetecho",
+  "license": "GPL-3.0",
+  "repository": "github:meetecho/janus-gateway",
+  "scripts": {
+    "rollup": "rollup -c rollup.config.js"
+  },
+  "devDependencies": {
+    "rollup": "^0.50.0",
+    "rollup-plugin-replace": "^2.0.0"
+  }
+}

--- a/npm/rollup.config.js
+++ b/npm/rollup.config.js
@@ -1,0 +1,17 @@
+import replace from 'rollup-plugin-replace';
+import * as fs from 'fs';
+
+export default {
+    name: 'Janus',
+    input: 'module.js',
+    output: {
+        strict: false
+    },
+    plugins: [
+        replace({
+            JANUS_CODE: fs.readFileSync('../html/janus.js', 'utf-8'),
+            delimiters: ['@','@'],
+            includes: 'module.js'
+        })
+    ]
+};


### PR DESCRIPTION
Integrate support for building JavaScript modules within the build system

Building JavaScript modules is opt-in, i.e. disabled by default.
Various 'flavours' of JavaScript module syntax are supported:

 - ECMAScript (es)
 - CommonJS (cjs)
 - Immediately Invoked Function Expression (iife)
 - Universal Module Definition (umd)

To enable a particular flavour one of the `--enable-javascript-*-module` flags may be passed with an argument of `yes` during `./configure`:

 - `--enable-javascript-es-module`
 - `--enable-javascript-common-js-module`
 - `--enable-javascript-iife-module`
 - `--enable-javascript-umd-module`

Additionally, `configure.ac` is further extended to look for an available version of `npm` if any of the supported module flavours are enabled. If no `npm` can be found and a module flavour is enabled, `./configure` will now fail with an error message accordingly. *Nota bene*: this check for `npm` applies if and only if modules are actually enabled, therefore by default Janus will still build without `npm`.

When modules are enabled, generated modules will be built in `./npm/bundles` (during `make`) and installed to `$PREFIX/share/janus/javascript` (during `make install`). Additionally `janus.js` itself is now always installed to `$PREFIX/share/janus/javascript` as well (even if no modules are enabled). The idea is that `$PREFIX/share/janus/javascript` acts as the installation location for the generically re-usable JavaScript libraries which are part of Janus.