### PR TITLE
fix libressl call in dtls.c

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -308,9 +308,9 @@ error:
 /* DTLS-SRTP initialization */
 gint janus_dtls_srtp_init(const char* server_pem, const char* server_key) {
 	const char *crypto_lib = NULL;
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 #if defined(LIBRESSL_VERSION_NUMBER)
-	crypt_lib = "LibreSSL"
+	crypto_lib = "LibreSSL";
 #else
 	crypto_lib = "OpenSSL pre-1.1.0";
 #endif


### PR DESCRIPTION
OpenSSL is reported even if compiled against libressl.
Fix this with a check to see if libressl is defined.

Also, add a ";" after LibreSSL.