### PR TITLE
options.error is supposed to return two strings

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -96,7 +96,7 @@ Janus.useDefaultDependencies = function (deps) {
 				}
 			}).catch(function(error) {
 				if(typeof(options.error) === typeof(Janus.noop)) {
-					options.error(error.message || '<< internal error >>', error);
+					options.error(error.message || '<< internal error >>', error && error.error ? error.error.message : error);
 				}
 			});
 


### PR DESCRIPTION
all the calls to httpAPICall functions contain an error handler that returns two strings, I fixed options.error in once instance where it was returning a string and an object so that the error handler doesn't see [object object] in the final error string