### PR TITLE
Implement websocket LWS_CALLBACK_GET_THREAD_ID callback

### DIFF
--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -872,6 +872,8 @@ static int janus_websockets_callback_http(
 				return -1;
 			}
 			break;
+		case LWS_CALLBACK_GET_THREAD_ID:
+			return (uint64_t)pthread_self();
 		default:
 			break;
 	}


### PR DESCRIPTION
Following [the discussion](https://groups.google.com/forum/#!topic/meetecho-janus/HsFaEXBz4Cg) on Meetecho's forum about problems using websocket transport on mac osx, implementing the LWS_CALLBACK_GET_THREAD_ID callback in protocols[0] will allow calls to `lws_callback_on_writable` to notice that the current thread is not the lws service thread, and force the ongoing `poll` (if any) to end right away instead of waiting until timeout (currently the service poll timeout is 50ms). This should speed up response time in some cases, and does not seem very harmful.

This is beneficial only when using libwebsockets@master where this new feature is implemented, but compatible with versions as far as `1.5-stable` (didn't look farther).