### PR TITLE
brew installation of libcurl is now called just `curl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ MacOS as well, there are a few aspects to highlight when doing that.
 First of all, you can use `brew` to install most of the dependencies:
 
 	brew tap homebrew/boneyard
-	brew install jansson libnice openssl libusrsctp libmicrohttpd libwebsockets cmake rabbitmq-c sofia-sip opus libogg libcurl glib pkg-config gengetopt autoconf automake libtool
+	brew install jansson libnice openssl libusrsctp libmicrohttpd libwebsockets cmake rabbitmq-c sofia-sip opus libogg curl glib pkg-config gengetopt autoconf automake libtool
 
 For what concerns `libsrtp`, which needs to be installed manually, just
 pass `/usr/local` as a prefix when configuring, and proceed as normal:


### PR DESCRIPTION
Helping the mac user to deploy using brew. Note that with [the websocket issue](https://groups.google.com/forum/#!topic/meetecho-janus/HsFaEXBz4Cg), you would need libwebsockets from master to use the libwebsockets transport on mac osx. Waiting for feedbacks on that before updating the doc on that.