### PR TITLE
Fix SSL library detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -225,10 +225,9 @@ AS_IF([test "x$enable_dtls_settimeout" = "xyes"],
       ])
 AM_CONDITIONAL([ENABLE_DTLS_SETTIMEOUT], [test "x$enable_dtls_settimeout" = "xyes"])
 
-AC_CHECK_LIB([crypto],
-             [RAND_egd],
-             [AM_CONDITIONAL([LIBRESSL_DETECTED], false)],
-             [AM_CONDITIONAL([LIBRESSL_DETECTED], true)]
+AC_SEARCH_LIBS([tls_config_set_ca_mem],[tls],
+             [AM_CONDITIONAL([LIBRESSL_DETECTED], true)],
+             [AM_CONDITIONAL([LIBRESSL_DETECTED], false)]
              )
 
 AC_CHECK_LIB([nice],

--- a/dtls-bio.c
+++ b/dtls-bio.c
@@ -36,7 +36,7 @@ int janus_dtls_bio_filter_new(BIO *h);
 int janus_dtls_bio_filter_free(BIO *data);
 
 /* Filter initialization */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if JANUS_USE_OPENSSL_PRE_1_1_API
 static BIO_METHOD janus_dtls_bio_filter_methods = {
 	BIO_TYPE_FILTER,
 	"janus filter",
@@ -53,7 +53,7 @@ static BIO_METHOD janus_dtls_bio_filter_methods = {
 static BIO_METHOD *janus_dtls_bio_filter_methods = NULL;
 #endif
 int janus_dtls_bio_filter_init(void) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if JANUS_USE_OPENSSL_PRE_1_1_API
 	/* No initialization needed for OpenSSL pre-1.1.0 */
 #else
 	janus_dtls_bio_filter_methods = BIO_meth_new(BIO_TYPE_FILTER | BIO_get_new_index(), "janus filter");
@@ -67,7 +67,7 @@ int janus_dtls_bio_filter_init(void) {
 	return 0;
 }
 BIO_METHOD *BIO_janus_dtls_filter(void) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if JANUS_USE_OPENSSL_PRE_1_1_API
 	return(&janus_dtls_bio_filter_methods);
 #else
 	return janus_dtls_bio_filter_methods;
@@ -88,7 +88,7 @@ int janus_dtls_bio_filter_new(BIO *bio) {
 	janus_mutex_init(&filter->mutex);
 	
 	/* Set the BIO as initialized */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if JANUS_USE_OPENSSL_PRE_1_1_API
 	bio->init = 1;
 	bio->ptr = filter;
 	bio->flags = 0;
@@ -105,7 +105,7 @@ int janus_dtls_bio_filter_free(BIO *bio) {
 		return 0;
 		
 	/* Get rid of the filter state */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if JANUS_USE_OPENSSL_PRE_1_1_API
 	janus_dtls_bio_filter *filter = (janus_dtls_bio_filter *)bio->ptr;
 #else
 	janus_dtls_bio_filter *filter = (janus_dtls_bio_filter *)BIO_get_data(bio);
@@ -115,7 +115,7 @@ int janus_dtls_bio_filter_free(BIO *bio) {
 		filter->packets = NULL;
 		g_free(filter);
 	}
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if JANUS_USE_OPENSSL_PRE_1_1_API
 	bio->ptr = NULL;
 	bio->init = 0;
 	bio->flags = 0;
@@ -129,7 +129,7 @@ int janus_dtls_bio_filter_free(BIO *bio) {
 int janus_dtls_bio_filter_write(BIO *bio, const char *in, int inl) {
 	JANUS_LOG(LOG_HUGE, "janus_dtls_bio_filter_write: %p, %d\n", in, inl);
 	/* Forward data to the write BIO */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if JANUS_USE_OPENSSL_PRE_1_1_API
 	long ret = BIO_write(bio->next_bio, in, inl);
 #else
 	long ret = BIO_write(BIO_next(bio), in, inl);
@@ -137,7 +137,7 @@ int janus_dtls_bio_filter_write(BIO *bio, const char *in, int inl) {
 	JANUS_LOG(LOG_HUGE, "  -- %ld\n", ret);
 	
 	/* Keep track of the packet, as we'll advertize them one by one after a pending check */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if JANUS_USE_OPENSSL_PRE_1_1_API
 	janus_dtls_bio_filter *filter = (janus_dtls_bio_filter *)bio->ptr;
 #else
 	janus_dtls_bio_filter *filter = (janus_dtls_bio_filter *)BIO_get_data(bio);
@@ -164,7 +164,7 @@ long janus_dtls_bio_filter_ctrl(BIO *bio, int cmd, long num, void *ptr) {
 			return 0L;
 		case BIO_CTRL_PENDING: {
 			/* We only advertize one packet at a time, as they may be fragmented */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if JANUS_USE_OPENSSL_PRE_1_1_API
 			janus_dtls_bio_filter *filter = (janus_dtls_bio_filter *)bio->ptr;
 #else
 			janus_dtls_bio_filter *filter = (janus_dtls_bio_filter *)BIO_get_data(bio);

--- a/dtls-bio.h
+++ b/dtls-bio.h
@@ -14,6 +14,7 @@
 #ifndef _JANUS_DTLS_BIO_H
 #define _JANUS_DTLS_BIO_H
 
+#include <openssl/opensslv.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 
@@ -32,5 +33,11 @@ BIO_METHOD *BIO_janus_dtls_filter(void);
  * @param start_mtu The MTU to start from (1472 by default)
  */
 void janus_dtls_bio_filter_set_mtu(int start_mtu);
+
+#if defined(LIBRESSL_VERSION_NUMBER)
+#define JANUS_USE_OPENSSL_PRE_1_1_API (1)
+#else
+#define JANUS_USE_OPENSSL_PRE_1_1_API (OPENSSL_VERSION_NUMBER < 0x10100000L)
+#endif
 
 #endif

--- a/dtls.c
+++ b/dtls.c
@@ -105,7 +105,7 @@ void *janus_dtls_sctp_setup_thread(void *data);
 #endif
 
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if JANUS_USE_OPENSSL_PRE_1_1_API
 /*
  * DTLS locking stuff to make OpenSSL thread safe (not needed for 1.1.0)
  *
@@ -308,7 +308,7 @@ error:
 /* DTLS-SRTP initialization */
 gint janus_dtls_srtp_init(const char* server_pem, const char* server_key) {
 	const char *crypto_lib = NULL;
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if JANUS_USE_OPENSSL_PRE_1_1_API
 #if defined(LIBRESSL_VERSION_NUMBER)
 	crypto_lib = "LibreSSL";
 #else
@@ -331,7 +331,7 @@ gint janus_dtls_srtp_init(const char* server_pem, const char* server_key) {
 	JANUS_LOG(LOG_INFO, "Crypto: %s\n", crypto_lib);
 
 	/* Go on and create the DTLS context */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if JANUS_USE_OPENSSL_PRE_1_1_API
 	ssl_ctx = SSL_CTX_new(DTLSv1_method());
 #else
 	ssl_ctx = SSL_CTX_new(DTLS_method());


### PR DESCRIPTION
Currently, searching for RAND_egd doesn't seem to work properly against
OpenSSL 1.1, as it always returns false.

Instead, searching for the function tls_config_set_ca_mem in libtls seems to
be the preferred way to determine if LibreSSL is being compiled against, as
this function does not exist in OpenSSL.

Openntpd uses this callout in their configure.ac. Because Openntpd is
maintained by the OpenBSD foundation, and they also maintain LibreSSL, it would
be a good idea to follow their example.