### PR TITLE
Bower: update webrtc-adapter to 5.0.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "janus-gateway",
-  "version": "0.2.3",
+  "version": "0.2.6",
   "homepage": "https://github.com/meetecho/janus-gateway",
   "authors": [
     "Lorenzo Miniero <lorenzo@meetecho.com>",
@@ -34,6 +34,6 @@
   ],
   "dependencies": {
     "jquery": "*",
-    "webrtc-adapter": "3.4.3"
+    "webrtc-adapter": "5.0.1"
   }
 }


### PR DESCRIPTION
As usual when I have time to work in a new release of Jangouts. Here is the corresponding update for the bower.json file. :-)