### PR TITLE
Don't use es6 specific code

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1366,7 +1366,7 @@ function Janus(gatewayCallbacks) {
 		};
 		if(stream !== null && stream !== undefined) {
 			Janus.log('Adding local stream');
-			stream.getTracks().forEach(track => config.pc.addTrack(track, stream));
+			stream.getTracks().forEach(function(track) { config.pc.addTrack(track, stream); });
 			pluginHandle.onlocalstream(stream);
 		}
 		config.pc.ontrack = function(event) {


### PR DESCRIPTION
This change allows janus.js to remain compatible with Chrome < 45 and with Node.js < 4.8.6

@lminiero  I know you don't care much about supporting "ancient" browsers, but this is a really tiny change with a quite noticeable benefit in terms of compatibility.

Arrow functions are not supported in Chrome/Chromium prior to version 45 (so far, we support back to version 41 in Jangouts) and are not supported in old versions of Node.js (so far, we support back to version 0.12 as development environment for Jangouts).

If you disagree, feel free to close the pull request. I guess we (Jangouts) can raise our requirements for use and development. But coming from an "enterprisey" background, I believe that such a small change is worth the compatibility benefit.