### PR TITLE
Allow UglifyJS to compile janus.js to ES5

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1366,7 +1366,9 @@ function Janus(gatewayCallbacks) {
 		};
 		if(stream !== null && stream !== undefined) {
 			Janus.log('Adding local stream');
-			stream.getTracks().forEach(track => config.pc.addTrack(track, stream));
+			stream.getTracks().forEach(function(track) {
+				config.pc.addTrack(track, stream)
+			});
 			pluginHandle.onlocalstream(stream);
 		}
 		config.pc.ontrack = function(event) {


### PR DESCRIPTION
When using UglifyJS to compile to ES5 (the default), it throws this error for janus.js:

```
ERROR in mycode.js from UglifyJs
Unexpected token: operator (>) [./node_modules/imports-loader/libraries/adapter.js!./node_modules/exports-loader?Janus!./src/mycode/js/libraries/janus.js:1365,0][mycode.js:72901,37]
```

Changing the arrow function to a regular function fixes this problem.