### PR TITLE
fixing media_hangup deadlock

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -2613,7 +2613,7 @@ void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, int video, cha
 			JANUS_LOG(LOG_ERR, "[Opus] Ops! got an error accessing the RTP payload\n");
 			g_free(pkt->data);
 			g_free(pkt);
-		  participant->working = FALSE;
+		  	participant->working = FALSE;
 			return;
 		}
 		pkt->length = opus_decode(participant->decoder, payload, plen, (opus_int16 *)pkt->data, BUFFER_SAMPLES, USE_FEC);

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -2613,6 +2613,7 @@ void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, int video, cha
 			JANUS_LOG(LOG_ERR, "[Opus] Ops! got an error accessing the RTP payload\n");
 			g_free(pkt->data);
 			g_free(pkt);
+		  participant->working = FALSE;
 			return;
 		}
 		pkt->length = opus_decode(participant->decoder, payload, plen, (opus_int16 *)pkt->data, BUFFER_SAMPLES, USE_FEC);


### PR DESCRIPTION
Not setting this flag and returning leads to eventual deadlock while sessions_mutex in janus.c is acquired but not released indefinitely by the "janus_audiobridge_hangup_media"

janus_audiobridge.c
while(participant->working)
2741     g_usleep(5000);

