### PR TITLE
Refcount improvements

### DIFF
--- a/apierror.h
+++ b/apierror.h
@@ -63,6 +63,8 @@
 #define JANUS_ERROR_UNEXPECTED_ANSWER			469
 /*! \brief The auth token the request refers to doesn't exist */
 #define JANUS_ERROR_TOKEN_NOT_FOUND				470
+/*! \brief The current request cannot be handled because of not compatible WebRTC state */
+#define JANUS_ERROR_WEBRTC_STATE				471
 
 
 /*! \brief Helper method to get a string representation of an API error code

--- a/dtls.c
+++ b/dtls.c
@@ -993,6 +993,7 @@ void *janus_dtls_sctp_setup_thread(void *data) {
 	janus_dtls_srtp *dtls = (janus_dtls_srtp *)data;
 	if(dtls->sctp == NULL) {
 		JANUS_LOG(LOG_ERR, "No SCTP stack??\n");
+		janus_refcount_decrease(&dtls->ref);
 		g_thread_unref(g_thread_self());
 		return NULL;
 	}

--- a/ice.c
+++ b/ice.c
@@ -1097,7 +1097,7 @@ void janus_ice_webrtc_hangup(janus_ice_handle *handle, const char *reason) {
 	if(plugin != NULL) {
 		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Telling the plugin about the hangup because of a %s (%s)\n",
 			handle->handle_id, reason, plugin->get_name());
-		if(plugin && plugin->hangup_media)
+		if(plugin && plugin->hangup_media  && janus_plugin_session_is_alive(handle->app_handle))
 			plugin->hangup_media(handle->app_handle);
 		janus_ice_notify_hangup(handle, reason);
 	}
@@ -1456,7 +1456,7 @@ static gboolean janus_ice_check_failed(gpointer data) {
 		janus_plugin *plugin = (janus_plugin *)handle->app;
 		if(plugin != NULL) {
 			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Telling the plugin about it (%s)\n", handle->handle_id, plugin->get_name());
-			if(plugin && plugin->hangup_media)
+			if(plugin && plugin->hangup_media  && janus_plugin_session_is_alive(handle->app_handle))
 				plugin->hangup_media(handle->app_handle);
 		}
 		janus_ice_notify_hangup(handle, "ICE failed");

--- a/ice.c
+++ b/ice.c
@@ -2355,11 +2355,15 @@ void *janus_ice_thread(void *data) {
 	g_usleep (100000);
 	JANUS_LOG(LOG_DBG, "[%"SCNu64"] Looping (ICE)...\n", handle->handle_id);
 	g_main_loop_run (loop);
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"] ICE thread quit ICE loop %p\n", handle->handle_id, handle);
 	janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_CLEANING);
 	if(handle->cdone == 0)
 		handle->cdone = -1;
-	JANUS_LOG(LOG_VERB, "[%"SCNu64"] ICE thread ended! %p\n", handle->handle_id, handle);
+	if (handle->send_thread != NULL && janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_STOP)) {
+		g_thread_join(handle->send_thread);
+	}
 	janus_ice_webrtc_free(handle);
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"] ICE thread ended! %p\n", handle->handle_id, handle);
 	/* This ICE session is over, unref it */
 	janus_refcount_decrease(&handle->ref);
 	g_thread_unref(g_thread_self());

--- a/ice.c
+++ b/ice.c
@@ -1107,7 +1107,7 @@ void janus_ice_webrtc_hangup(janus_ice_handle *handle, const char *reason) {
 		janus_ice_notify_hangup(handle, reason);
 	}
 	if(handle->queued_packets != NULL)
-		g_async_queue_push(handle->queued_packets, &janus_ice_dtls_alert);
+		g_async_queue_push_front(handle->queued_packets, &janus_ice_dtls_alert);
 	if(handle->send_thread == NULL) {
 		/* Get rid of the loop */
 		if(handle->iceloop != NULL) {

--- a/ice.c
+++ b/ice.c
@@ -993,7 +993,7 @@ gint janus_ice_handle_destroy(void *core_session, janus_ice_handle *handle) {
 		janus_refcount_decrease(&handle->ref);
 		janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT);
 		janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_STOP);
-		if(handle->iceloop != NULL && g_main_loop_is_running(handle->iceloop)) {
+		if(handle->iceloop != NULL) {
 			if(handle->audio_id > 0) {
 				nice_agent_attach_recv(handle->agent, handle->audio_id, 1, g_main_loop_get_context (handle->iceloop), NULL, NULL);
 				if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX))
@@ -1007,7 +1007,8 @@ gint janus_ice_handle_destroy(void *core_session, janus_ice_handle *handle) {
 			if(handle->data_id > 0) {
 				nice_agent_attach_recv(handle->agent, handle->data_id, 1, g_main_loop_get_context (handle->iceloop), NULL, NULL);
 			}
-			g_main_loop_quit(handle->iceloop);
+			if (g_main_loop_is_running(handle->iceloop))
+				g_main_loop_quit(handle->iceloop);
 		}
 		return 0;
 	}
@@ -1027,7 +1028,7 @@ gint janus_ice_handle_destroy(void *core_session, janus_ice_handle *handle) {
 	}
 	janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT);
 	janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_STOP);
-	if(handle->iceloop != NULL && g_main_loop_is_running(handle->iceloop)) {
+	if(handle->iceloop != NULL) {
 		if(handle->audio_id > 0) {
 			nice_agent_attach_recv(handle->agent, handle->audio_id, 1, g_main_loop_get_context (handle->iceloop), NULL, NULL);
 			if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX))
@@ -1041,7 +1042,8 @@ gint janus_ice_handle_destroy(void *core_session, janus_ice_handle *handle) {
 		if(handle->data_id > 0) {
 			nice_agent_attach_recv(handle->agent, handle->data_id, 1, g_main_loop_get_context (handle->iceloop), NULL, NULL);
 		}
-		g_main_loop_quit(handle->iceloop);
+		if (g_main_loop_is_running(handle->iceloop))
+			g_main_loop_quit(handle->iceloop);
 	}
 
 	/* Prepare JSON event to notify user/application */
@@ -1108,7 +1110,7 @@ void janus_ice_webrtc_hangup(janus_ice_handle *handle, const char *reason) {
 		g_async_queue_push(handle->queued_packets, &janus_ice_dtls_alert);
 	if(handle->send_thread == NULL) {
 		/* Get rid of the loop */
-		if(handle->iceloop != NULL && g_main_loop_is_running(handle->iceloop)) {
+		if(handle->iceloop != NULL) {
 			if(handle->audio_id > 0) {
 				nice_agent_attach_recv(handle->agent, handle->audio_id, 1, g_main_loop_get_context (handle->iceloop), NULL, NULL);
 				if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX))
@@ -1132,8 +1134,8 @@ void janus_ice_webrtc_hangup(janus_ice_handle *handle, const char *reason) {
 					break;
 				}
 			}
-			if(handle->iceloop != NULL && g_main_loop_is_running(handle->iceloop)) {
-				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Forcing ICE loop to quit (%s)\n", handle->handle_id, g_main_loop_is_running(handle->iceloop) ? "running" : "NOT running");
+			if(g_main_loop_is_running(handle->iceloop)) {
+				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Forcing ICE loop to quit\n", handle->handle_id);
 				g_main_loop_quit(handle->iceloop);
 				if (handle->icectx != NULL) {
 					g_main_context_wakeup(handle->icectx);

--- a/ice.c
+++ b/ice.c
@@ -474,7 +474,7 @@ void janus_ice_notify_hangup(janus_ice_handle *handle, const char *reason) {
 
 
 /* Trickle helpers */
-janus_ice_trickle *janus_ice_trickle_new(janus_ice_handle *handle, const char *transaction, json_t *candidate) {
+janus_ice_trickle *janus_ice_trickle_new(const char *transaction, json_t *candidate) {
 	if(transaction == NULL || candidate == NULL)
 		return NULL;
 	janus_ice_trickle *trickle = g_malloc0(sizeof(janus_ice_trickle));
@@ -482,8 +482,6 @@ janus_ice_trickle *janus_ice_trickle_new(janus_ice_handle *handle, const char *t
 		JANUS_LOG(LOG_FATAL, "Memory error!\n");
 		return NULL;
 	}
-	trickle->handle = handle;
-	janus_refcount_increase(&handle->ref);
 	trickle->received = janus_get_monotonic_time();
 	trickle->transaction = g_strdup(transaction);
 	trickle->candidate = json_deep_copy(candidate);
@@ -584,8 +582,6 @@ gint janus_ice_trickle_parse(janus_ice_handle *handle, json_t *candidate, const 
 void janus_ice_trickle_destroy(janus_ice_trickle *trickle) {
 	if(trickle == NULL)
 		return;
-	janus_refcount_decrease(&trickle->handle->ref);
-	trickle->handle = NULL;
 	g_free(trickle->transaction);
 	trickle->transaction = NULL;
 	if(trickle->candidate)
@@ -1186,7 +1182,6 @@ void janus_ice_webrtc_free(janus_ice_handle *handle) {
 	handle->video_mid = NULL;
 	g_free(handle->data_mid);
 	handle->data_mid = NULL;
-	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_READY);
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_CLEANING);
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AGENT);
 	janus_mutex_unlock(&handle->mutex);

--- a/ice.h
+++ b/ice.h
@@ -488,8 +488,6 @@ struct janus_ice_component {
 
 /*! \brief Helper to handle pending trickle candidates (e.g., when we're still waiting for an offer) */
 struct janus_ice_trickle {
-	/*! \brief Janus ICE handle this trickle candidate belongs to */
-	janus_ice_handle *handle;
 	/*! \brief Monotonic time of when this trickle candidate has been received */
 	gint64 received;
 	/*! \brief Janus API transaction ID of the original trickle request */
@@ -506,7 +504,7 @@ struct janus_ice_trickle {
  * @param[in] transaction The Janus API ID of the original trickle request
  * @param[in] candidate The trickle candidate, as a Jansson object
  * @returns a pointer to the new instance, if successful, NULL otherwise */
-janus_ice_trickle *janus_ice_trickle_new(janus_ice_handle *handle, const char *transaction, json_t *candidate);
+janus_ice_trickle *janus_ice_trickle_new(const char *transaction, json_t *candidate);
 /*! \brief Helper method to parse trickle candidates
  * @param[in] handle The Janus ICE handle this candidate belongs to
  * @param[in] candidate The trickle candidate to parse, as a Jansson object

--- a/janus.c
+++ b/janus.c
@@ -1472,7 +1472,7 @@ int janus_process_incoming_request(janus_request *request) {
 		if(handle->audio_stream == NULL && handle->video_stream == NULL && handle->data_stream == NULL) {
 			JANUS_LOG(LOG_WARN, "[%"SCNu64"] No stream, queueing this trickle as it got here before the SDP...\n", handle->handle_id);
 			/* Enqueue this trickle candidate(s), we'll process this later */
-			janus_ice_trickle *early_trickle = janus_ice_trickle_new(handle, transaction_text, candidate ? candidate : candidates);
+			janus_ice_trickle *early_trickle = janus_ice_trickle_new(transaction_text, candidate ? candidate : candidates);
 			handle->pending_trickles = g_list_append(handle->pending_trickles, early_trickle);
 			/* Send the ack right away, an event will tell the application if the candidate(s) failed */
 			goto trickledone;
@@ -1491,7 +1491,7 @@ int janus_process_incoming_request(janus_request *request) {
 			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Still %s, queueing this trickle to wait until we're done there...\n",
 				handle->handle_id, cause);
 			/* Enqueue this trickle candidate(s), we'll process this later */
-			janus_ice_trickle *early_trickle = janus_ice_trickle_new(handle, transaction_text, candidate ? candidate : candidates);
+			janus_ice_trickle *early_trickle = janus_ice_trickle_new(transaction_text, candidate ? candidate : candidates);
 			handle->pending_trickles = g_list_append(handle->pending_trickles, early_trickle);
 			/* Send the ack right away, an event will tell the application if the candidate(s) failed */
 			goto trickledone;

--- a/janus.c
+++ b/janus.c
@@ -1213,7 +1213,8 @@ int janus_process_incoming_request(janus_request *request) {
 					waited += 100000;
 					if(waited >= 3*G_USEC_PER_SEC) {
 						JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Waited 3 seconds, that's enough!\n", handle->handle_id);
-						break;
+						ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_WEBRTC_STATE, "Still cleaning a previous session");
+						goto jsondone;
 					}
 				}
 			}
@@ -1454,6 +1455,11 @@ int janus_process_incoming_request(janus_request *request) {
 		}
 		if(candidate != NULL && candidates != NULL) {
 			ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_INVALID_JSON, "Can't have both candidate and candidates");
+			goto jsondone;
+		}
+		if(janus_flags_is_set(&handle->webrtc_flags,JANUS_ICE_HANDLE_WEBRTC_CLEANING)) {
+			JANUS_LOG(LOG_ERR, "[%"SCNu64"] Received a trickle, but still cleaning a previous session\n", handle->handle_id);
+			ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_WEBRTC_STATE, "Still cleaning a previous session");
 			goto jsondone;
 		}
 		janus_mutex_lock(&handle->mutex);
@@ -2749,7 +2755,8 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 				waited += 100000;
 				if(waited >= 3*G_USEC_PER_SEC) {
 					JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Waited 3 seconds, that's enough!\n", ice_handle->handle_id);
-					break;
+					janus_sdp_destroy(parsed_sdp);
+					return NULL;
 				}
 			}
 		}


### PR DESCRIPTION
This PR tries to improve the `refcount` branch in many ways.
Some of the changes are ported from #1035 .

Changelog ins random order:
- reject sdps and trickles directed to handles in CLEANING state. This should avoid strange behaviors when quickly destroying/creating a peer connection on the same handle.
- use the active plugin sessions map in place of the old plugin sessions map. This is a pretty straightforward change, Janus should check the validity of a given plugin session using a live map of active plugin sessions and not storing the deleted ones.
- Check `g_main_loop_is_running` only before doing `g_main_loop_quit`. The rationale here is not using the glib loop status to control the flow in Janus logic, but only to manage the glib loop.
-  Add some missing `janus_plugin_session_is_alive` checks. This should avoid some potential crashes.
-  Front-push the DTLS alert packet onto the packet queue. This should help getting a faster and cleaner peer connection teardown.
- `janus_ice_thread` joins `send_thread` in case the latter has been created and a `detach` has been requested. This should avoid a crash happening when the `send_thread` uses contexts and resources being freed by `janus_ice_thread`.
- `janus_ice_thread` creation is moved to the bottom of `janus_ice_setup_local`, in order to create the iceloop thread when all the resources and the contexts that the thread needs are correctly initialized. As a consequence the `sleep` call has been removed from `janus_ice_thread`, because the loop can start without any other waiting.
- Remove the wait for `g_main_loop_is_running` in `janus_ice_webrtc_hangup`. I think this is not the correct approach to handle a hangup request received too early (e.g. when the glib loop still have to pass in running state). This issue will be discussed and addressed later.