### PR TITLE
Add a "configure" request to SIP plugins to alter sending audio/video RTP to remote peer

### DIFF
--- a/plugins/janus_nosip.c
+++ b/plugins/janus_nosip.c
@@ -152,6 +152,10 @@ static struct janus_json_parameter recording_parameters[] = {
 	{"peer_video", JANUS_JSON_BOOL, 0},
 	{"filename", JSON_STRING, 0}
 };
+static struct janus_json_parameter configure_parameters[] = {
+        {"audio", JANUS_JSON_BOOL, 0},
+        {"video", JANUS_JSON_BOOL, 0}
+};
 
 /* Useful stuff */
 static volatile gint initialized = 0, stopping = 0;
@@ -1150,6 +1154,16 @@ static void *janus_nosip_handler(void *data) {
 			gateway->close_pc(session->handle);
 			result = json_object();
 			json_object_set_new(result, "event", json_string("hangingup"));
+		} else if(!strcasecmp(request_text, "configure")) {
+			JANUS_VALIDATE_JSON_OBJECT(root, configure_parameters,
+				error_code, error_cause, TRUE,
+				JANUS_NOSIP_ERROR_MISSING_ELEMENT, JANUS_NOSIP_ERROR_INVALID_ELEMENT);
+			json_t *audio = json_object_get(root, "audio");
+			if(audio)
+				session->media.audio_send = json_is_true(audio);
+			json_t *video = json_object_get(root, "video");
+			if(video)
+				session->media.video_send = json_is_true(video);
 		} else if(!strcasecmp(request_text, "recording")) {
 			/* Start or stop recording */
 			JANUS_VALIDATE_JSON_OBJECT(root, recording_parameters,

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -192,8 +192,7 @@ static struct janus_json_parameter sipmessage_parameters[] = {
 };
 static struct janus_json_parameter configure_parameters[] = {
         {"audio", JANUS_JSON_BOOL, 0},
-        {"video", JANUS_JSON_BOOL, 0},
-        {"data", JANUS_JSON_BOOL, 0}
+        {"video", JANUS_JSON_BOOL, 0}
 };
 
 /* Useful stuff */

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -31,7 +31,7 @@
  *
  * The supported requests are \c register , \c unregister , \c call ,
  * \c accept, \c info , \c message , \c dtmf_info , \c recording ,
- * \c hold , \c unhold and \c hangup . \c register can be used,
+ * \c hold , \c unhold , \c configure and \c hangup . \c register can be used,
  * as the name suggests, to register a username at a SIP registrar to
  * call and be called, while \c unregister unregisters it; \c call is used
  * to send an INVITE to a different SIP URI through the plugin, while
@@ -189,6 +189,11 @@ static struct janus_json_parameter info_parameters[] = {
 };
 static struct janus_json_parameter sipmessage_parameters[] = {
 	{"content", JSON_STRING, JANUS_JSON_PARAM_REQUIRED}
+};
+static struct janus_json_parameter configure_parameters[] = {
+        {"audio", JANUS_JSON_BOOL, 0},
+        {"video", JANUS_JSON_BOOL, 0},
+        {"data", JANUS_JSON_BOOL, 0}
 };
 
 /* Useful stuff */
@@ -2321,6 +2326,16 @@ static void *janus_sip_handler(void *data) {
 			/* Send an ack back */
 			result = json_object();
 			json_object_set_new(result, "event", json_string(hold ? "holding" : "resuming"));
+                } else if(!strcasecmp(request_text, "configure")) {
+                        JANUS_VALIDATE_JSON_OBJECT(root, configure_parameters,
+                                error_code, error_cause, TRUE,
+                                JANUS_SIP_ERROR_MISSING_ELEMENT, JANUS_SIP_ERROR_INVALID_ELEMENT);
+                        json_t *audio = json_object_get(root, "audio");
+                        if(audio)
+                                session->media.audio_send = json_is_true(audio);
+                        json_t *video = json_object_get(root, "video");
+                        if(video)
+                                session->media.video_send = json_is_true(video);
 		} else if(!strcasecmp(request_text, "hangup")) {
 			/* Hangup an ongoing call */
 			if(!(session->status == janus_sip_call_status_inviting || session->status == janus_sip_call_status_incall)) {


### PR DESCRIPTION
Add a "configure" request to SIP plugins so as to allow temporarily disable/enable sending of audio/video rtp to remote peer without the latency associated with hold/unhold signalling