### PR TITLE
Refcount improvements 2

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -757,6 +757,7 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 					dtls->sctp = janus_sctp_association_create(dtls, handle->handle_id, 5000);
 					if(dtls->sctp != NULL) {
 						/* FIXME We need to start it in a thread, though, since it has blocking accept/connect stuff */
+						janus_refcount_increase(&dtls->ref);
 						janus_refcount_increase(&dtls->sctp->ref);
 						GError *error = NULL;
 						char tname[16];
@@ -764,6 +765,8 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 						g_thread_try_new(tname, janus_dtls_sctp_setup_thread, dtls, &error);
 						if(error != NULL) {
 							/* Something went wrong... */
+							janus_refcount_decrease(&dtls->ref);
+							janus_refcount_decrease(&dtls->sctp->ref);
 							JANUS_LOG(LOG_ERR, "[%"SCNu64"] Got error %d (%s) trying to launch the DTLS-SCTP thread...\n", handle->handle_id, error->code, error->message ? error->message : "??");
 						}
 						dtls->srtp_valid = 1;
@@ -990,6 +993,7 @@ void *janus_dtls_sctp_setup_thread(void *data) {
 	janus_dtls_srtp *dtls = (janus_dtls_srtp *)data;
 	if(dtls->sctp == NULL) {
 		JANUS_LOG(LOG_ERR, "No SCTP stack??\n");
+		janus_refcount_decrease(&dtls->ref);
 		g_thread_unref(g_thread_self());
 		return NULL;
 	}
@@ -997,6 +1001,7 @@ void *janus_dtls_sctp_setup_thread(void *data) {
 	/* Do the accept/connect stuff now */
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Started thread: setup of the SCTP association\n", sctp->handle_id);
 	janus_sctp_association_setup(sctp);
+	janus_refcount_decrease(&dtls->ref);
 	g_thread_unref(g_thread_self());
 	return NULL;
 }

--- a/ice.h
+++ b/ice.h
@@ -508,7 +508,7 @@ struct janus_ice_trickle {
  * @param[in] transaction The Janus API ID of the original trickle request
  * @param[in] candidate The trickle candidate, as a Jansson object
  * @returns a pointer to the new instance, if successful, NULL otherwise */
-janus_ice_trickle *janus_ice_trickle_new(janus_ice_handle *handle, const char *transaction, json_t *candidate);
+janus_ice_trickle *janus_ice_trickle_new(const char *transaction, json_t *candidate);
 /*! \brief Helper method to parse trickle candidates
  * @param[in] handle The Janus ICE handle this candidate belongs to
  * @param[in] candidate The trickle candidate to parse, as a Jansson object

--- a/janus.c
+++ b/janus.c
@@ -1472,7 +1472,7 @@ int janus_process_incoming_request(janus_request *request) {
 		if(handle->audio_stream == NULL && handle->video_stream == NULL && handle->data_stream == NULL) {
 			JANUS_LOG(LOG_WARN, "[%"SCNu64"] No stream, queueing this trickle as it got here before the SDP...\n", handle->handle_id);
 			/* Enqueue this trickle candidate(s), we'll process this later */
-			janus_ice_trickle *early_trickle = janus_ice_trickle_new(handle, transaction_text, candidate ? candidate : candidates);
+			janus_ice_trickle *early_trickle = janus_ice_trickle_new(transaction_text, candidate ? candidate : candidates);
 			handle->pending_trickles = g_list_append(handle->pending_trickles, early_trickle);
 			/* Send the ack right away, an event will tell the application if the candidate(s) failed */
 			goto trickledone;
@@ -1491,7 +1491,7 @@ int janus_process_incoming_request(janus_request *request) {
 			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Still %s, queueing this trickle to wait until we're done there...\n",
 				handle->handle_id, cause);
 			/* Enqueue this trickle candidate(s), we'll process this later */
-			janus_ice_trickle *early_trickle = janus_ice_trickle_new(handle, transaction_text, candidate ? candidate : candidates);
+			janus_ice_trickle *early_trickle = janus_ice_trickle_new(transaction_text, candidate ? candidate : candidates);
 			handle->pending_trickles = g_list_append(handle->pending_trickles, early_trickle);
 			/* Send the ack right away, an event will tell the application if the candidate(s) failed */
 			goto trickledone;


### PR DESCRIPTION
This is a subset and a refinement of #1089, after #1035 has been merged into `master`.
Respect to the original #1089 the joining mechanism for `janus_ice_thread` with `send_thread` has been changed from a `g_thread_join` to a way less elegant `while(!condition)` and `sleep` loop. This is because `g_thread_join` consumes a reference to the passed-in thread, and I think it is better to handle the reference from inside the `send_thread`, mainly because `janus_ice_thread` and `send_thread` do have a separate and different life cycle:
- `janus_ice_thread` can be short termed and can be destroyed and recreated when needed.
- `janus_ice_send_thread` is created once, just after the first `janus_ice_thread`.
Using a check on `handle->send_thread` we are sure that in case of `detach` the `send_thread` terminates before `janus_ice_webrtc_free` is called.