### PR TITLE
Provide support for CI, using Docker & Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+
+sudo: required
+
+node_js:
+    - node
+
+notifications:
+    email:
+        on_success: change
+        on_failure: change
+
+script: ./docker/travis-ci.sh
+
+env:
+ - image=cmacq2/janus-build-env:js-modules
+ - image=cmacq2/janus-build-env:http-w-openssl
+

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,4 @@
+*.docker
+travis-ci.sh
+build-docker-images.sh
+.dockerignore

--- a/docker/base.docker
+++ b/docker/base.docker
@@ -1,0 +1,30 @@
+FROM debian:sid-slim
+
+ENV LANG=C.UTF-8 \
+    LANGUAGE=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+RUN apt-get update -qq \
+    && apt-get install -qq -y --no-install-recommends \
+        locales \
+        autoconf \
+        automake \
+        make \
+        libtool \
+        pkg-config \
+        gengetopt \
+        git \
+        libglib2.0-dev \
+        libjansson-dev \
+        libnice-dev \
+        libsrtp2-dev \
+        libssl-dev \
+        libcurl4-gnutls-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && /usr/sbin/locale-gen C.UTF-8 \
+    && /usr/sbin/update-locale LANG=C.UTF-8 \
+    && mkdir -p /janus/src \
+    && mkdir -p /janus/dist
+
+COPY entrypoint.sh /build-janus.sh
+ENTRYPOINT ["/build-janus.sh"]

--- a/docker/build-docker-images.sh
+++ b/docker/build-docker-images.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -e
+
+SCRIPT_FILE=$(readlink -m "$0")
+SCRIPT_DIR=$(dirname "$SCRIPT_FILE")
+IMAGE_FLAVOURS="base js-modules http-w-openssl"
+
+build_docker_images_usage ()
+{
+    cat << USAGE
+$(basename "$0") <docker-repository/namespace>
+
+Builds images from *.docker files in this directory: $SCRIPT_DIR
+You must pass it the name of the repository/namespace which the generated images should reside in.
+Image flavours to be generated:
+ - $IMAGE_FLAVOURS
+USAGE
+}
+
+build_docker_image ()
+{
+    if [ ! -f "$SCRIPT_DIR/$2.docker" ]
+    then
+        echo "No such file: '$SCRIPT_DIR/$2.docker', please check/fix the flavour named '$2'"
+        exit 254
+    fi
+    if [ "$2" = "base" ]
+    then
+        docker build -t "$1:$2" -f "$SCRIPT_DIR/$2.docker" "$SCRIPT_DIR"
+    else
+        docker build -t "$1:$2" - < "$SCRIPT_DIR/$2.docker"
+    fi
+}
+
+if [ -n "$1" ]
+then
+  for flavour in $IMAGE_FLAVOURS
+  do
+    build_docker_image "$1" "$flavour"
+  done
+else
+    build_docker_images_usage
+    exit 255
+fi
+

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+echo_eval ()
+{
+    echo $@
+    eval $@
+}
+
+echo "Number of cores available for the build: $(nproc)"
+echo_eval cd /janus/src
+echo_eval ./autogen.sh
+echo_eval ./configure --prefix=/janus/dist $@
+echo_eval make clean # useful for local development
+echo_eval make # note: we do not yet take advantage of available parallelism: -j $(nproc)
+echo_eval make install

--- a/docker/http-w-openssl.docker
+++ b/docker/http-w-openssl.docker
@@ -1,0 +1,11 @@
+FROM cmacq2/janus-build-env:base
+RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
+        libmicrohttpd-dev
+
+CMD ["--disable-dependency-tracking", \
+     "--disable-unix-sockets", \
+     "--disable-mqtt", \
+     "--disable-websockets", \
+     "--disable-rabbitmq", \
+     "--disable-data-channels" \
+    ]

--- a/docker/js-modules.docker
+++ b/docker/js-modules.docker
@@ -1,0 +1,30 @@
+FROM cmacq2/janus-build-env:base
+
+#
+# Apart from the generic base build environment/configuration a 'sane' npm + node are required.
+# To obtain a useful npm, turn to the NodeSource repositories.
+# Unfortunately, the canonical way to "install" NodeSource's node & npm versions is a byzantine installation script.
+# See: https://deb.nodesource.com/setup_8.x
+#
+# The command below tries to replicate the useful bits assuming a fixed Node version, 8, which is the current LTS release at the time of writing.
+#
+RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends wget gnupg ca-certificates \
+    && echo 'deb https://deb.nodesource.com/node_8.x sid main' >> /etc/apt/sources.list.d/nodesource.list \
+    && wget -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | tee | apt-key add - \
+    && apt-get remove --purge  -qq -y wget gnupg \
+    && apt-get update -qq && apt-get install -qq -y --no-install-recommends \
+        nodejs
+
+CMD ["--enable-all-js-modules", \
+     "--disable-dependency-tracking", \
+     "--disable-all-plugins", \
+     "--disable-all-transports", \
+     "--disable-all-handlers", \
+     "--disable-turn-rest-api", \
+     "--disable-unix-sockets", \
+     "--disable-rest", \
+     "--disable-mqtt", \
+     "--disable-websockets", \
+     "--disable-rabbitmq", \
+     "--disable-data-channels" \
+    ]

--- a/docker/travis-ci.sh
+++ b/docker/travis-ci.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+echo_eval ()
+{
+    echo $@
+    eval $@
+}
+
+echo "SANITY CHECK: image is: '$image'"
+if [ -n "$image" ]
+then
+    echo "Number of cores available on the build host: $(nproc)"
+    if echo -n "$image" | grep -q js-modules
+    then
+        # pre-empt invocation of npm install during subsequent build
+        # as that will probably not work because the docker container will probably not have access to a NPM package repository/registry
+        echo_eval cd npm && rm -rf node_modules
+        echo_eval npm install
+        echo_eval cd ..
+    fi
+    echo_eval mkdir -p dist
+    echo_eval docker pull \"$image\"
+    echo_eval docker run -t -v \"$(pwd):/janus/src\" -v \"$(pwd)/dist:/janus/dist\" \"$image\"
+else
+    echo "Image required!"
+    exit 1
+fi


### PR DESCRIPTION
The purpose of this PR is to make it a *lot* easier to run CI on the Janus project. Incidentally it also makes it a lot easier to build/test various different build environments/configurations for Janus.

With this PR:
 - A developer can use predefined Docker images to build Janus and do basic sanity checking.
 - A Travis CI configuration is added, if you opt in to letting Travis run on your (fork of this) repository you get automatic CI (consisting of running the Docker images) for free.
 - In theory you no longer need to have all the development dependencies installed to work on Janus, instead you could just use docker.

The PR consists of two commits, the first of which adds a couple of predefined docker files to build the Docker images from, and the second adds the Travis CI integration.

A couple of points worth noting:

 1. Currently the docker files refer to 'my' Docker Hub repository, ideally there would be a Meetecho one to refer to instead. I'd suggest that if this PR is merged, a follow up commit changes this once the images have been synced to a new Meetecho repository.
 2. I'd like to propose that Meetecho also enable Travis CI on the Janus repository once the PR is merged.
 3. The docker images are by no means intended as the 'definitive' judgement on what build configurations the project should support, instead they are meant to get the ball rolling and provide a starting point for discussion.
 4. Yes, these images are pretty large. Although it is not too bad for an occasional download and nothing which CI shouldn't be able to handle, if you are actively developing & pushing the images you probably do want to be on a cheap + fast broadband link.