### PR TITLE
Close websocket connection when destroying session

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -769,7 +769,7 @@ function Janus(gatewayCallbacks) {
 				if(wsKeepaliveTimeoutId) {
 					clearTimeout(wsKeepaliveTimeoutId);
 				}
-				ws.close()
+				ws.close();
 			};
 
 			var onUnbindMessage = function(event){

--- a/html/janus.js
+++ b/html/janus.js
@@ -769,6 +769,7 @@ function Janus(gatewayCallbacks) {
 				if(wsKeepaliveTimeoutId) {
 					clearTimeout(wsKeepaliveTimeoutId);
 				}
+				ws.close()
 			};
 
 			var onUnbindMessage = function(event){


### PR DESCRIPTION
`createSession` creates new websocket connection but `destroySession` does not close it.
This leaves websocket opened and connections accumulate over time.

This pull request fixes described issue
