### PR TITLE
Simplify internals by always assuming single stream/component

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,11 +350,6 @@ or on the command line:
 	-T, --ice-tcp                 Whether to enable ICE-TCP or not (warning: only
                                   works with ICE Lite)
                                   (default=off)
-	-U, --bundle                  Whether to force BUNDLE or not (whether audio,
-                                  video and data will always be bundled)
-                                  (default=off)
-	-u, --rtcp-mux                Whether to force rtcp-mux or not (whether RTP
-                                  and RTCP will always be muxed)  (default=off)
 	-q, --max-nack-queue=number   Maximum size of the NACK queue (in ms) per user
                                   for retransmissions
 	-t, --no-media-timer=number   Time (in s) that should pass with no media

--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -70,18 +70,15 @@ cert_key = @certdir@/mycert.key
 ; to enable IPv6 support (still WIP, so handle with care), the maximum size
 ; of the NACK queue (in milliseconds, defaults to 500ms) for retransmissions, the
 ; range of ports to use for RTP and RTCP (by default, no range is envisaged), the
-; starting MTU for DTLS (1472 by default, it adapts automatically),
-; if BUNDLE should be forced (defaults to false) and if RTCP muxing should
-; be forced (defaults to false), and finally how much time, in seconds,
-; should pass with no media (audio or video) being received before Janus
-; notifies you about this (default=1s, 0 disables these events entirely).
+; starting MTU for DTLS (1472 by default, it adapts automatically), and
+; finally how much time, in seconds, should pass with no media (audio or
+; video) being received before Janus notifies you about this (default=1s,
+; 0 disables these events entirely).
 [media]
 ;ipv6 = true
 ;max_nack_queue = 500
 ;rtp_port_range = 20000-40000
 ;dtls_mtu = 1200
-;force-bundle = true
-;force-rtcp-mux = true
 ;no_media_timer = 1
 
 

--- a/dtls.c
+++ b/dtls.c
@@ -752,9 +752,7 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 				dtls->srtp_valid = 1;
 				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Created outbound SRTP session for component %d in stream %d\n", handle->handle_id, component->component_id, stream->stream_id);
 #ifdef HAVE_SCTP
-				if(component->stream_id == handle->data_id ||
-						(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE) &&
-						janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_DATA_CHANNELS))) {
+				if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_DATA_CHANNELS)) {
 					/* Create SCTP association as well */
 					janus_dtls_srtp_create_sctp(dtls);
 				}

--- a/html/janus.js
+++ b/html/janus.js
@@ -854,12 +854,6 @@ function Janus(gatewayCallbacks) {
 			request["token"] = token;
 		if(apisecret !== null && apisecret !== undefined)
 			request["apisecret"] = apisecret;
-		// If we know the browser supports BUNDLE and/or rtcp-mux, let's advertise those right away
-		if(Janus.webRTCAdapter.browserDetails.browser == "chrome" || Janus.webRTCAdapter.browserDetails.browser == "firefox" ||
-				Janus.webRTCAdapter.browserDetails.browser == "safari") {
-			request["force-bundle"] = true;
-			request["force-rtcp-mux"] = true;
-		}
 		if(websockets) {
 			transactions[transaction] = function(json) {
 				Janus.debug(json);

--- a/janus.c
+++ b/janus.c
@@ -85,8 +85,6 @@ static struct janus_json_parameter incoming_request_parameters[] = {
 static struct janus_json_parameter attach_parameters[] = {
 	{"plugin", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
 	{"opaque_id", JSON_STRING, 0},
-	{"force-bundle", JANUS_JSON_BOOL, 0},
-	{"force-rtcp-mux", JANUS_JSON_BOOL, 0}
 };
 static struct janus_json_parameter body_parameters[] = {
 	{"body", JSON_OBJECT, JANUS_JSON_PARAM_REQUIRED}
@@ -828,8 +826,6 @@ int janus_process_incoming_request(janus_request *request) {
 			goto jsondone;
 		}
 		json_t *plugin = json_object_get(root, "plugin");
-		gboolean force_bundle = json_is_true(json_object_get(root, "force-bundle"));
-		gboolean force_rtcp_mux = json_is_true(json_object_get(root, "force-rtcp-mux"));
 		const gchar *plugin_text = json_string_value(plugin);
 		janus_plugin *plugin_t = janus_plugin_find(plugin_text);
 		if(plugin_t == NULL) {
@@ -859,8 +855,6 @@ int janus_process_incoming_request(janus_request *request) {
 			goto jsondone;
 		}
 		handle_id = handle->handle_id;
-		handle->force_bundle = force_bundle;
-		handle->force_rtcp_mux = force_rtcp_mux;
 		/* Attach to the plugin */
 		int error = 0;
 		if((error = janus_ice_handle_attach_plugin(session, handle_id, plugin_t)) != 0) {
@@ -1030,9 +1024,8 @@ int janus_process_incoming_request(janus_request *request) {
 			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Remote SDP:\n%s", handle->handle_id, jsep_sdp);
 			/* Is this valid SDP? */
 			char error_str[512];
-			int audio = 0, video = 0, data = 0, bundle = 0, rtcpmux = 0, trickle = 0;
-			janus_sdp *parsed_sdp = janus_sdp_preparse(jsep_sdp, error_str, sizeof(error_str), &audio, &video, &data, &bundle, &rtcpmux, &trickle);
-			trickle = trickle && do_trickle;
+			int audio = 0, video = 0, data = 0;
+			janus_sdp *parsed_sdp = janus_sdp_preparse(jsep_sdp, error_str, sizeof(error_str), &audio, &video, &data);
 			if(parsed_sdp == NULL) {
 				/* Invalid SDP */
 				ret = janus_process_error_string(request, session_id, transaction_text, JANUS_ERROR_JSEP_INVALID_SDP, error_str);
@@ -1066,17 +1059,13 @@ int janus_process_incoming_request(janus_request *request) {
 				JANUS_LOG(LOG_WARN, "[%"SCNu64"]   -- DataChannels have been negotiated, but support for them has not been compiled...\n", handle->handle_id);
 			}
 #endif
-			JANUS_LOG(LOG_VERB, "[%"SCNu64"] The browser: %s BUNDLE, %s rtcp-mux, %s doing Trickle ICE\n", handle->handle_id,
-			                    bundle  ? "supports" : "does NOT support",
-			                    rtcpmux ? "supports" : "does NOT support",
-			                    trickle ? "is"       : "is NOT");
 			/* Check if it's a new session, or an update... */
 			if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_READY)
 					|| janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT)) {
 				/* New session */
 				if(offer) {
 					/* Setup ICE locally (we received an offer) */
-					if(janus_ice_setup_local(handle, offer, audio, video, data, bundle, rtcpmux, trickle) < 0) {
+					if(janus_ice_setup_local(handle, offer, audio, video, data, do_trickle) < 0) {
 						JANUS_LOG(LOG_ERR, "Error setting ICE locally\n");
 						janus_sdp_free(parsed_sdp);
 						g_free(jsep_type);
@@ -1108,160 +1097,7 @@ int janus_process_incoming_request(janus_request *request) {
 				}
 				if(!offer) {
 					/* Set remote candidates now (we received an answer) */
-					if(bundle) {
-						janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE);
-					} else {
-						janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE);
-					}
-					if(rtcpmux) {
-						janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX);
-					} else {
-						janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX);
-					}
-					if(trickle) {
-						janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_TRICKLE);
-					} else {
-						janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_TRICKLE);
-					}
-					if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-						JANUS_LOG(LOG_HUGE, "[%"SCNu64"]   -- bundle is supported by the browser, getting rid of one of the RTP/RTCP components, if any...\n", handle->handle_id);
-						janus_ice_stream *stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(handle->bundle_id));
-						if(handle->audio_stream && handle->audio_stream != stream) {
-							/* This stream is redundant, merge it with the bundled stream */
-							if(stream->rtp_component && handle->audio_stream->rtp_component)
-								stream->rtp_component->do_audio_nacks = handle->audio_stream->rtp_component->do_audio_nacks;
-							stream->audio_ssrc = handle->audio_stream->audio_ssrc;
-							stream->audio_ssrc_peer = handle->audio_stream->audio_ssrc_peer;
-							stream->audio_send = handle->audio_stream->audio_send;
-							stream->audio_recv = handle->audio_stream->audio_recv;
-							nice_agent_attach_recv(handle->agent, handle->audio_stream->stream_id, 1, g_main_loop_get_context (handle->iceloop), NULL, NULL);
-							if(!handle->force_rtcp_mux && !janus_ice_is_rtcpmux_forced())
-								nice_agent_attach_recv(handle->agent, handle->audio_stream->stream_id, 2, g_main_loop_get_context (handle->iceloop), NULL, NULL);
-							nice_agent_remove_stream(handle->agent, handle->audio_stream->stream_id);
-							handle->audio_stream = NULL;
-							handle->audio_id = 0;
-							janus_ice_stream_free(handle->streams, handle->audio_stream);
-						}
-						if(handle->video_stream && handle->video_stream != stream) {
-							/* This stream is redundant, merge it with the bundled stream */
-							if(stream->rtp_component && handle->video_stream->rtp_component)
-								stream->rtp_component->do_video_nacks = handle->video_stream->rtp_component->do_video_nacks;
-							stream->video_ssrc = handle->video_stream->video_ssrc;
-							stream->video_ssrc_peer[0] = handle->video_stream->video_ssrc_peer[0];
-							stream->video_ssrc_peer_rtx = handle->video_stream->video_ssrc_peer_rtx;
-							stream->video_ssrc_peer[1] = handle->video_stream->video_ssrc_peer[1];
-							stream->video_ssrc_peer[2] = handle->video_stream->video_ssrc_peer[2];
-							stream->video_send = handle->video_stream->video_send;
-							stream->video_recv = handle->video_stream->video_recv;
-							nice_agent_attach_recv(handle->agent, handle->video_stream->stream_id, 1, g_main_loop_get_context (handle->iceloop), NULL, NULL);
-							if(!handle->force_rtcp_mux && !janus_ice_is_rtcpmux_forced())
-								nice_agent_attach_recv(handle->agent, handle->video_stream->stream_id, 2, g_main_loop_get_context (handle->iceloop), NULL, NULL);
-							nice_agent_remove_stream(handle->agent, handle->video_stream->stream_id);
-							handle->video_stream = NULL;
-							handle->video_id = 0;
-							janus_ice_stream_free(handle->streams, handle->video_stream);
-						}
-						if(handle->data_stream && handle->data_stream != stream) {
-							/* This stream is redundant, merge it with the bundled stream */
-							nice_agent_attach_recv(handle->agent, handle->data_stream->stream_id, 1, g_main_loop_get_context (handle->iceloop), NULL, NULL);
-							nice_agent_remove_stream(handle->agent, handle->data_stream->stream_id);
-							handle->data_stream = NULL;
-							handle->data_id = 0;
-							janus_ice_stream_free(handle->streams, handle->data_stream);
-						}
-					}
-					if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX) && !handle->force_rtcp_mux && !janus_ice_is_rtcpmux_forced()) {
-						JANUS_LOG(LOG_HUGE, "[%"SCNu64"]   -- rtcp-mux is supported by the browser, getting rid of RTCP components, if any...\n", handle->handle_id);
-						if(handle->audio_stream && handle->audio_stream->components != NULL) {
-							nice_agent_attach_recv(handle->agent, handle->audio_id, 2, g_main_loop_get_context (handle->iceloop), NULL, NULL);
-							/* Free the component */
-							janus_ice_component_free(handle->audio_stream->components, handle->audio_stream->rtcp_component);
-							handle->audio_stream->rtcp_component = NULL;
-							/* Create a dummy candidate and enforce it as the one to use for this now unneeded component */
-							NiceCandidate *c = nice_candidate_new(NICE_CANDIDATE_TYPE_HOST);
-							c->component_id = 2;
-							c->stream_id = handle->audio_stream->stream_id;
-#ifndef HAVE_LIBNICE_TCP
-							c->transport = NICE_CANDIDATE_TRANSPORT_UDP;
-#endif
-							strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
-							c->priority = 1;
-							nice_address_set_from_string(&c->addr, "127.0.0.1");
-							nice_address_set_port(&c->addr, janus_ice_get_rtcpmux_blackhole_port());
-							c->username = g_strdup(handle->audio_stream->ruser);
-							c->password = g_strdup(handle->audio_stream->rpass);
-							if(!nice_agent_set_selected_remote_candidate(handle->agent, handle->audio_stream->stream_id, 2, c)) {
-								JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error forcing dummy candidate on RTCP component of stream %d\n", handle->handle_id, handle->audio_stream->stream_id);
-								nice_candidate_free(c);
-							}
-						}
-						if(handle->video_stream && handle->video_stream->components != NULL) {
-							nice_agent_attach_recv(handle->agent, handle->video_id, 2, g_main_loop_get_context (handle->iceloop), NULL, NULL);
-							/* Free the component */
-							janus_ice_component_free(handle->video_stream->components, handle->video_stream->rtcp_component);
-							handle->video_stream->rtcp_component = NULL;
-							/* Create a dummy candidate and enforce it as the one to use for this now unneeded component */
-							NiceCandidate *c = nice_candidate_new(NICE_CANDIDATE_TYPE_HOST);
-							c->component_id = 2;
-							c->stream_id = handle->video_stream->stream_id;
-#ifndef HAVE_LIBNICE_TCP
-							c->transport = NICE_CANDIDATE_TRANSPORT_UDP;
-#endif
-							strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
-							c->priority = 1;
-							nice_address_set_from_string(&c->addr, "127.0.0.1");
-							nice_address_set_port(&c->addr, janus_ice_get_rtcpmux_blackhole_port());
-							c->username = g_strdup(handle->video_stream->ruser);
-							c->password = g_strdup(handle->video_stream->rpass);
-							if(!nice_agent_set_selected_remote_candidate(handle->agent, handle->video_stream->stream_id, 2, c)) {
-								JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error forcing dummy candidate on RTCP component of stream %d\n", handle->handle_id, handle->video_stream->stream_id);
-								nice_candidate_free(c);
-							}
-						}
-					}
-					/* FIXME Any disabled m-line? */
-					if(strstr(jsep_sdp, "m=audio 0")) {
-						JANUS_LOG(LOG_VERB, "[%"SCNu64"] Audio disabled via SDP\n", handle->handle_id);
-						if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)
-								|| (!video && !data)) {
-							JANUS_LOG(LOG_HUGE, "  -- Marking audio stream as disabled\n");
-							janus_ice_stream *stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(handle->audio_id));
-							if(stream)
-								stream->disabled = TRUE;
-						}
-					}
-					if(strstr(jsep_sdp, "m=video 0")) {
-						JANUS_LOG(LOG_VERB, "[%"SCNu64"] Video disabled via SDP\n", handle->handle_id);
-						if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)
-								|| (!audio && !data)) {
-							JANUS_LOG(LOG_HUGE, "  -- Marking video stream as disabled\n");
-							janus_ice_stream *stream = NULL;
-							if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-								stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(handle->video_id));
-							} else {
-								gint id = handle->bundle_id;
-								stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(id));
-							}
-							if(stream)
-								stream->disabled = TRUE;
-						}
-					}
-					if(strstr(jsep_sdp, "m=application 0 DTLS/SCTP")) {
-						JANUS_LOG(LOG_VERB, "[%"SCNu64"] Data Channel disabled via SDP\n", handle->handle_id);
-						if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)
-								|| (!audio && !video)) {
-							JANUS_LOG(LOG_HUGE, "  -- Marking data channel stream as disabled\n");
-							janus_ice_stream *stream = NULL;
-							if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-								stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(handle->data_id));
-							} else {
-								gint id = handle->bundle_id;
-								stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(id));
-							}
-							if(stream)
-								stream->disabled = TRUE;
-						}
-					}
+					janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_TRICKLE);
 					/* We got our answer */
 					janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_PROCESSING_OFFER);
 					/* Any pending trickles? */
@@ -1317,18 +1153,8 @@ int janus_process_incoming_request(janus_request *request) {
 						janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_START);
 					} else {
 						JANUS_LOG(LOG_VERB, "[%"SCNu64"] Done! Sending connectivity checks...\n", handle->handle_id);
-						if(handle->audio_id > 0) {
-							janus_ice_setup_remote_candidates(handle, handle->audio_id, 1);
-							if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX))	/* http://tools.ietf.org/html/rfc5761#section-5.1.3 */
-								janus_ice_setup_remote_candidates(handle, handle->audio_id, 2);
-						}
-						if(handle->video_id > 0) {
-							janus_ice_setup_remote_candidates(handle, handle->video_id, 1);
-							if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX))	/* http://tools.ietf.org/html/rfc5761#section-5.1.3 */
-								janus_ice_setup_remote_candidates(handle, handle->video_id, 2);
-						}
-						if(handle->data_id > 0) {
-							janus_ice_setup_remote_candidates(handle, handle->data_id, 1);
+						if(handle->stream_id > 0) {
+							janus_ice_setup_remote_candidates(handle, handle->stream_id, 1);
 						}
 					}
 				}
@@ -1349,17 +1175,9 @@ int janus_process_incoming_request(janus_request *request) {
 				if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART)) {
 					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Restarting ICE...\n", handle->handle_id);
 					/* Update remote credentials for ICE */
-					if(handle->audio_stream) {
-						nice_agent_set_remote_credentials(handle->agent, handle->audio_stream->stream_id,
-							handle->audio_stream->ruser, handle->audio_stream->rpass);
-					}
-					if(handle->video_stream) {
-						nice_agent_set_remote_credentials(handle->agent, handle->video_stream->stream_id,
-							handle->video_stream->ruser, handle->video_stream->rpass);
-					}
-					if(handle->data_stream) {
-						nice_agent_set_remote_credentials(handle->agent, handle->data_stream->stream_id,
-							handle->data_stream->ruser, handle->data_stream->rpass);
+					if(handle->stream) {
+						nice_agent_set_remote_credentials(handle->agent, handle->stream->stream_id,
+							handle->stream->ruser, handle->stream->rpass);
 					}
 					/* FIXME We only need to do that for offers: if it's an answer, we did that already */
 					if(offer) {
@@ -1372,15 +1190,12 @@ int janus_process_incoming_request(janus_request *request) {
 				if(!offer) {
 					/* Were datachannels just added? */
 					if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_DATA_CHANNELS)) {
-						janus_ice_stream *stream = handle->data_stream;
-						if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-							stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(handle->bundle_id));
-						}
-						if(stream != NULL && stream->rtp_component != NULL
-								&& stream->rtp_component->dtls != NULL && stream->rtp_component->dtls->sctp == NULL) {
+						janus_ice_stream *stream = handle->stream;
+						if(stream != NULL && stream->component != NULL
+								&& stream->component->dtls != NULL && stream->component->dtls->sctp == NULL) {
 							/* Create SCTP association as well */
 							JANUS_LOG(LOG_WARN, "[%"SCNu64"] Creating datachannels...\n", handle->handle_id);
-							janus_dtls_srtp_create_sctp(stream->rtp_component->dtls);
+							janus_dtls_srtp_create_sctp(stream->component->dtls);
 						}
 					}
 				}
@@ -1421,19 +1236,12 @@ int janus_process_incoming_request(janus_request *request) {
 			body_jsep = json_pack("{ssss}", "type", jsep_type, "sdp", jsep_sdp_stripped);
 			/* Check if VP8 simulcasting is enabled */
 			if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO)) {
-				if(handle->video_stream && handle->video_stream->video_ssrc_peer[1]) {
+				if(handle->stream && handle->stream->video_ssrc_peer[1]) {
 					json_t *simulcast = json_object();
-					json_object_set(simulcast, "ssrc-0", json_integer(handle->video_stream->video_ssrc_peer[0]));
-					json_object_set(simulcast, "ssrc-1", json_integer(handle->video_stream->video_ssrc_peer[1]));
-					if(handle->video_stream->video_ssrc_peer[2])
-						json_object_set(simulcast, "ssrc-2", json_integer(handle->video_stream->video_ssrc_peer[2]));
-					json_object_set(body_jsep, "simulcast", simulcast);
-				} else if(handle->audio_stream && handle->audio_stream->video_ssrc_peer[1]) {
-					json_t *simulcast = json_object();
-					json_object_set(simulcast, "ssrc-0", json_integer(handle->audio_stream->video_ssrc_peer[0]));
-					json_object_set(simulcast, "ssrc-1", json_integer(handle->audio_stream->video_ssrc_peer[1]));
-					if(handle->audio_stream->video_ssrc_peer[2])
-						json_object_set(simulcast, "ssrc-2", json_integer(handle->audio_stream->video_ssrc_peer[2]));
+					json_object_set(simulcast, "ssrc-0", json_integer(handle->stream->video_ssrc_peer[0]));
+					json_object_set(simulcast, "ssrc-1", json_integer(handle->stream->video_ssrc_peer[1]));
+					if(handle->stream->video_ssrc_peer[2])
+						json_object_set(simulcast, "ssrc-2", json_integer(handle->stream->video_ssrc_peer[2]));
 					json_object_set(body_jsep, "simulcast", simulcast);
 				}
 			}
@@ -1525,7 +1333,7 @@ int janus_process_incoming_request(janus_request *request) {
 			janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_TRICKLE);
 		}
 		/* Is there any stream ready? this trickle may get here before the SDP it relates to */
-		if(handle->audio_stream == NULL && handle->video_stream == NULL && handle->data_stream == NULL) {
+		if(handle->stream == NULL) {
 			JANUS_LOG(LOG_WARN, "[%"SCNu64"] No stream, queueing this trickle as it got here before the SDP...\n", handle->handle_id);
 			/* Enqueue this trickle candidate(s), we'll process this later */
 			janus_ice_trickle *early_trickle = janus_ice_trickle_new(handle, transaction_text, candidate ? candidate : candidates);
@@ -2361,8 +2169,6 @@ int janus_process_incoming_admin_request(janus_request *request) {
 		json_object_set_new(flags, "ready", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_READY) ? json_true() : json_false());
 		json_object_set_new(flags, "stopped", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_STOP) ? json_true() : json_false());
 		json_object_set_new(flags, "alert", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT) ? json_true() : json_false());
-		json_object_set_new(flags, "bundle", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE) ? json_true() : json_false());
-		json_object_set_new(flags, "rtcp-mux", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX) ? json_true() : json_false());
 		json_object_set_new(flags, "trickle", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_TRICKLE) ? json_true() : json_false());
 		json_object_set_new(flags, "all-trickles", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALL_TRICKLES) ? json_true() : json_false());
 		json_object_set_new(flags, "trickle-synced", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_TRICKLE_SYNCED) ? json_true() : json_false());
@@ -2376,10 +2182,6 @@ int janus_process_incoming_admin_request(janus_request *request) {
 			json_object_set_new(info, "ice-mode", json_string(janus_ice_is_ice_lite_enabled() ? "lite" : "full"));
 			json_object_set_new(info, "ice-role", json_string(handle->controlling ? "controlling" : "controlled"));
 		}
-		if(handle->force_bundle)
-			json_object_set_new(info, "force-bundle", json_true());
-		if(handle->force_rtcp_mux)
-			json_object_set_new(info, "force-rtcp-mux", json_true());
 		json_t *sdps = json_object();
 		if(handle->rtp_profile)
 			json_object_set_new(sdps, "profile", json_string(handle->rtp_profile));
@@ -2398,18 +2200,8 @@ int janus_process_incoming_admin_request(janus_request *request) {
 			json_object_set_new(info, "text2pcap-file", json_string(handle->text2pcap->filename));
 		}
 		json_t *streams = json_array();
-		if(handle->audio_stream) {
-			json_t *s = janus_admin_stream_summary(handle->audio_stream);
-			if(s)
-				json_array_append_new(streams, s);
-		}
-		if(handle->video_stream) {
-			json_t *s = janus_admin_stream_summary(handle->video_stream);
-			if(s)
-				json_array_append_new(streams, s);
-		}
-		if(handle->data_stream) {
-			json_t *s = janus_admin_stream_summary(handle->data_stream);
+		if(handle->stream) {
+			json_t *s = janus_admin_stream_summary(handle->stream);
 			if(s)
 				json_array_append_new(streams, s);
 		}
@@ -2489,7 +2281,6 @@ json_t *janus_admin_stream_summary(janus_ice_stream *stream) {
 	json_t *s = json_object();
 	json_object_set_new(s, "id", json_integer(stream->stream_id));
 	json_object_set_new(s, "ready", json_integer(stream->cdone));
-	json_object_set_new(s, "disabled", stream->disabled ? json_true() : json_false());
 	json_t *ss = json_object();
 	if(stream->audio_ssrc)
 		json_object_set_new(ss, "audio", json_integer(stream->audio_ssrc));
@@ -2534,13 +2325,8 @@ json_t *janus_admin_stream_summary(janus_ice_stream *stream) {
 		json_object_set_new(s, "codecs", sc);
 	}
 	json_t *components = json_array();
-	if(stream->rtp_component) {
-		json_t *c = janus_admin_component_summary(stream->rtp_component);
-		if(c)
-			json_array_append_new(components, c);
-	}
-	if(stream->rtcp_component) {
-		json_t *c = janus_admin_component_summary(stream->rtcp_component);
+	if(stream->component) {
+		json_t *c = janus_admin_component_summary(stream->component);
 		if(c)
 			json_array_append_new(components, c);
 	}
@@ -2928,8 +2714,8 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 	}
 	/* Is this valid SDP? */
 	char error_str[512];
-	int audio = 0, video = 0, data = 0, bundle = 0, rtcpmux = 0, trickle = 0;
-	janus_sdp *parsed_sdp = janus_sdp_preparse(sdp, error_str, sizeof(error_str), &audio, &video, &data, &bundle, &rtcpmux, &trickle);
+	int audio = 0, video = 0, data = 0;
+	janus_sdp *parsed_sdp = janus_sdp_preparse(sdp, error_str, sizeof(error_str), &audio, &video, &data);
 	if(parsed_sdp == NULL) {
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] Couldn't parse SDP... %s\n", ice_handle->handle_id, error_str);
 		return NULL;
@@ -2972,7 +2758,7 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 		}
 		if(ice_handle->agent == NULL) {
 			/* Process SDP in order to setup ICE locally (this is going to result in an answer from the browser) */
-			if(janus_ice_setup_local(ice_handle, 0, audio, video, data, bundle, rtcpmux, trickle) < 0) {
+			if(janus_ice_setup_local(ice_handle, 0, audio, video, data, 1) < 0) {
 				JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error setting ICE locally\n", ice_handle->handle_id);
 				janus_sdp_free(parsed_sdp);
 				return NULL;
@@ -2984,7 +2770,7 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 	}
 	if(!updating) {
 		/* Wait for candidates-done callback */
-		while(ice_handle->cdone < ice_handle->streams_num) {
+		while(ice_handle->cdone < 1) {
 			if(ice_handle == NULL || janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_STOP)
 					|| janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT)) {
 				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Handle detached or PC closed, giving up...!\n", ice_handle ? ice_handle->handle_id : 0);
@@ -3019,49 +2805,6 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 		return NULL;
 	}
 	janus_sdp_free(parsed_sdp);
-	/* FIXME Any disabled m-line? */
-	if(strstr(sdp_merged, "m=audio 0")) {
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Audio disabled via SDP\n", ice_handle->handle_id);
-		if(!janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)
-				|| (!video && !data)) {
-			JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Marking audio stream as disabled\n", ice_handle->handle_id);
-			janus_ice_stream *stream = g_hash_table_lookup(ice_handle->streams, GUINT_TO_POINTER(ice_handle->audio_id));
-			if(stream)
-				stream->disabled = TRUE;
-		}
-	}
-	if(strstr(sdp_merged, "m=video 0")) {
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Video disabled via SDP\n", ice_handle->handle_id);
-		if(!janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)
-				|| (!audio && !data)) {
-			JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Marking video stream as disabled\n", ice_handle->handle_id);
-			janus_ice_stream *stream = NULL;
-			if(!janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-				stream = g_hash_table_lookup(ice_handle->streams, GUINT_TO_POINTER(ice_handle->video_id));
-			} else {
-				gint id = ice_handle->bundle_id;
-				stream = g_hash_table_lookup(ice_handle->streams, GUINT_TO_POINTER(id));
-			}
-			if(stream)
-				stream->disabled = TRUE;
-		}
-	}
-	if(strstr(sdp_merged, "m=application 0 DTLS/SCTP")) {
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Data Channel disabled via SDP\n", ice_handle->handle_id);
-		if(!janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)
-				|| (!audio && !video)) {
-			JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Marking data channel stream as disabled\n", ice_handle->handle_id);
-			janus_ice_stream *stream = NULL;
-			if(!janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-				stream = g_hash_table_lookup(ice_handle->streams, GUINT_TO_POINTER(ice_handle->data_id));
-			} else {
-				gint id = ice_handle->bundle_id;
-				stream = g_hash_table_lookup(ice_handle->streams, GUINT_TO_POINTER(id));
-			}
-			if(stream)
-				stream->disabled = TRUE;
-		}
-	}
 
 	if(!updating) {
 		if(offer) {
@@ -3069,101 +2812,6 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 			janus_flags_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_PROCESSING_OFFER);
 		} else {
 			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Done! Ready to setup remote candidates and send connectivity checks...\n", ice_handle->handle_id);
-			if(janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-				JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- bundle is supported by the browser, getting rid of one of the RTP/RTCP components, if any...\n", ice_handle->handle_id);
-				janus_ice_stream *stream = g_hash_table_lookup(ice_handle->streams, GUINT_TO_POINTER(ice_handle->bundle_id));
-				if(ice_handle->audio_stream && ice_handle->audio_stream != stream) {
-					/* This stream is redundant, merge it with the bundled stream */
-					if(stream->rtp_component && ice_handle->audio_stream->rtp_component)
-						stream->rtp_component->do_audio_nacks = ice_handle->audio_stream->rtp_component->do_audio_nacks;
-					stream->audio_ssrc = ice_handle->audio_stream->audio_ssrc;
-					stream->audio_ssrc_peer = ice_handle->audio_stream->audio_ssrc_peer;
-					stream->audio_send = ice_handle->audio_stream->audio_send;
-					stream->audio_recv = ice_handle->audio_stream->audio_recv;
-					nice_agent_attach_recv(ice_handle->agent, ice_handle->audio_stream->stream_id, 1, g_main_loop_get_context (ice_handle->iceloop), NULL, NULL);
-					if(!ice_handle->force_rtcp_mux && !janus_ice_is_rtcpmux_forced())
-						nice_agent_attach_recv(ice_handle->agent, ice_handle->audio_stream->stream_id, 2, g_main_loop_get_context (ice_handle->iceloop), NULL, NULL);
-					nice_agent_remove_stream(ice_handle->agent, ice_handle->audio_stream->stream_id);
-					ice_handle->audio_stream = NULL;
-					ice_handle->audio_id = 0;
-					janus_ice_stream_free(ice_handle->streams, ice_handle->audio_stream);
-				}
-				if(ice_handle->video_stream && ice_handle->video_stream != stream) {
-					/* This stream is redundant, merge it with the bundled stream */
-					if(stream->rtp_component && ice_handle->video_stream->rtp_component)
-						stream->rtp_component->do_video_nacks = ice_handle->video_stream->rtp_component->do_video_nacks;
-					stream->video_ssrc_peer[0] = ice_handle->video_stream->video_ssrc_peer[0];
-					stream->video_ssrc_peer_rtx = ice_handle->video_stream->video_ssrc_peer_rtx;
-					stream->video_ssrc_peer[1] = ice_handle->video_stream->video_ssrc_peer[1];
-					stream->video_ssrc_peer[2] = ice_handle->video_stream->video_ssrc_peer[2];
-					stream->video_send = ice_handle->video_stream->video_send;
-					stream->video_recv = ice_handle->video_stream->video_recv;
-					nice_agent_attach_recv(ice_handle->agent, ice_handle->video_stream->stream_id, 1, g_main_loop_get_context (ice_handle->iceloop), NULL, NULL);
-					if(!ice_handle->force_rtcp_mux && !janus_ice_is_rtcpmux_forced())
-						nice_agent_attach_recv(ice_handle->agent, ice_handle->video_stream->stream_id, 2, g_main_loop_get_context (ice_handle->iceloop), NULL, NULL);
-					nice_agent_remove_stream(ice_handle->agent, ice_handle->video_stream->stream_id);
-					ice_handle->video_stream = NULL;
-					ice_handle->video_id = 0;
-					janus_ice_stream_free(ice_handle->streams, ice_handle->video_stream);
-				}
-				if(ice_handle->data_stream && ice_handle->data_stream != stream) {
-					/* This stream is redundant, merge it with the bundled stream */
-					nice_agent_attach_recv(ice_handle->agent, ice_handle->data_stream->stream_id, 1, g_main_loop_get_context (ice_handle->iceloop), NULL, NULL);
-					nice_agent_remove_stream(ice_handle->agent, ice_handle->data_stream->stream_id);
-					ice_handle->data_stream = NULL;
-					ice_handle->data_id = 0;
-					janus_ice_stream_free(ice_handle->streams, ice_handle->data_stream);
-				}
-			}
-			if(janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX) && !ice_handle->force_rtcp_mux && !janus_ice_is_rtcpmux_forced()) {
-				JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- rtcp-mux is supported by the browser, getting rid of RTCP components, if any...\n", ice_handle->handle_id);
-				if(ice_handle->audio_stream && ice_handle->audio_stream->rtcp_component && ice_handle->audio_stream->components != NULL) {
-					nice_agent_attach_recv(ice_handle->agent, ice_handle->audio_id, 2, g_main_loop_get_context (ice_handle->iceloop), NULL, NULL);
-					/* Free the component */
-					janus_ice_component_free(ice_handle->audio_stream->components, ice_handle->audio_stream->rtcp_component);
-					ice_handle->audio_stream->rtcp_component = NULL;
-					/* Create a dummy candidate and enforce it as the one to use for this now unneeded component */
-					NiceCandidate *c = nice_candidate_new(NICE_CANDIDATE_TYPE_HOST);
-					c->component_id = 2;
-					c->stream_id = ice_handle->audio_stream->stream_id;
-#ifndef HAVE_LIBNICE_TCP
-					c->transport = NICE_CANDIDATE_TRANSPORT_UDP;
-#endif
-					strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
-					c->priority = 1;
-					nice_address_set_from_string(&c->addr, "127.0.0.1");
-					nice_address_set_port(&c->addr, janus_ice_get_rtcpmux_blackhole_port());
-					c->username = g_strdup(ice_handle->audio_stream->ruser);
-					c->password = g_strdup(ice_handle->audio_stream->rpass);
-					if(!nice_agent_set_selected_remote_candidate(ice_handle->agent, ice_handle->audio_stream->stream_id, 2, c)) {
-						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error forcing dummy candidate on RTCP component of stream %d\n", ice_handle->handle_id, ice_handle->audio_stream->stream_id);
-						nice_candidate_free(c);
-					}
-				}
-				if(ice_handle->video_stream && ice_handle->video_stream->rtcp_component && ice_handle->video_stream->components != NULL) {
-					nice_agent_attach_recv(ice_handle->agent, ice_handle->video_id, 2, g_main_loop_get_context (ice_handle->iceloop), NULL, NULL);
-					/* Free the component */
-					janus_ice_component_free(ice_handle->video_stream->components, ice_handle->video_stream->rtcp_component);
-					ice_handle->video_stream->rtcp_component = NULL;
-					/* Create a dummy candidate and enforce it as the one to use for this now unneeded component */
-					NiceCandidate *c = nice_candidate_new(NICE_CANDIDATE_TYPE_HOST);
-					c->component_id = 2;
-					c->stream_id = ice_handle->video_stream->stream_id;
-#ifndef HAVE_LIBNICE_TCP
-					c->transport = NICE_CANDIDATE_TRANSPORT_UDP;
-#endif
-					strncpy(c->foundation, "1", NICE_CANDIDATE_MAX_FOUNDATION);
-					c->priority = 1;
-					nice_address_set_from_string(&c->addr, "127.0.0.1");
-					nice_address_set_port(&c->addr, janus_ice_get_rtcpmux_blackhole_port());
-					c->username = g_strdup(ice_handle->video_stream->ruser);
-					c->password = g_strdup(ice_handle->video_stream->rpass);
-					if(!nice_agent_set_selected_remote_candidate(ice_handle->agent, ice_handle->video_stream->stream_id, 2, c)) {
-						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error forcing dummy candidate on RTCP component of stream %d\n", ice_handle->handle_id, ice_handle->video_stream->stream_id);
-						nice_candidate_free(c);
-					}
-				}
-			}
 			janus_mutex_lock(&ice_handle->mutex);
 			/* We got our answer */
 			janus_flags_clear(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_PROCESSING_OFFER);
@@ -3220,18 +2868,8 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 				janus_flags_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_START);
 			} else {
 				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Done! Sending connectivity checks...\n", ice_handle->handle_id);
-				if(ice_handle->audio_id > 0) {
-					janus_ice_setup_remote_candidates(ice_handle, ice_handle->audio_id, 1);
-					if(!janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX))	/* http://tools.ietf.org/html/rfc5761#section-5.1.3 */
-						janus_ice_setup_remote_candidates(ice_handle, ice_handle->audio_id, 2);
-				}
-				if(ice_handle->video_id > 0) {
-					janus_ice_setup_remote_candidates(ice_handle, ice_handle->video_id, 1);
-					if(!janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX))	/* http://tools.ietf.org/html/rfc5761#section-5.1.3 */
-						janus_ice_setup_remote_candidates(ice_handle, ice_handle->video_id, 2);
-				}
-				if(ice_handle->data_id > 0) {
-					janus_ice_setup_remote_candidates(ice_handle, ice_handle->data_id, 1);
+				if(ice_handle->stream_id > 0) {
+					janus_ice_setup_remote_candidates(ice_handle, ice_handle->stream_id, 1);
 				}
 			}
 			janus_mutex_unlock(&ice_handle->mutex);
@@ -3241,15 +2879,12 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 	if(!offer) {
 		/* Check if datachannels were just added on an existing PeerConnection */
 		if(janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_DATA_CHANNELS)) {
-			janus_ice_stream *stream = ice_handle->data_stream;
-			if(janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-				stream = g_hash_table_lookup(ice_handle->streams, GUINT_TO_POINTER(ice_handle->bundle_id));
-			}
-			if(stream != NULL && stream->rtp_component != NULL &&
-					stream->rtp_component->dtls != NULL && stream->rtp_component->dtls->sctp == NULL) {
+			janus_ice_stream *stream = ice_handle->stream;
+			if(stream != NULL && stream->component != NULL &&
+					stream->component->dtls != NULL && stream->component->dtls->sctp == NULL) {
 				/* Create SCTP association as well */
 				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Creating datachannels...\n", ice_handle->handle_id);
-				janus_dtls_srtp_create_sctp(stream->rtp_component->dtls);
+				janus_dtls_srtp_create_sctp(stream->component->dtls);
 			}
 		}
 	}
@@ -3673,12 +3308,6 @@ gint main(int argc, char *argv[])
 	if(args_info.ipv6_candidates_given) {
 		janus_config_add_item(config, "media", "ipv6", "true");
 	}
-	if(args_info.force_bundle_given) {
-		janus_config_add_item(config, "media", "force-bundle", "true");
-	}
-	if(args_info.force_rtcp_mux_given) {
-		janus_config_add_item(config, "media", "force-rtcp-mux", "true");
-	}
 	if(args_info.max_nack_queue_given) {
 		char mnq[20];
 		g_snprintf(mnq, 20, "%d", args_info.max_nack_queue_arg);
@@ -3961,14 +3590,6 @@ gint main(int argc, char *argv[])
 			                    " Expect trouble if this is supposed to work over the internet and not just in a LAN...\n", test_ip);
 		}
 	}
-	/* Are we going to force BUNDLE and/or rtcp-mux? */
-	gboolean force_bundle = FALSE, force_rtcpmux = FALSE;
-	item = janus_config_get_item_drilldown(config, "media", "force-bundle");
-	force_bundle = (item && item->value) ? janus_is_true(item->value) : FALSE;
-	janus_ice_force_bundle(force_bundle);
-	item = janus_config_get_item_drilldown(config, "media", "force-rtcp-mux");
-	force_rtcpmux = (item && item->value) ? janus_is_true(item->value) : FALSE;
-	janus_ice_force_rtcpmux(force_rtcpmux);
 	/* NACK related stuff */
 	item = janus_config_get_item_drilldown(config, "media", "max_nack_queue");
 	if(item && item->value) {

--- a/janus.ggo
+++ b/janus.ggo
@@ -17,8 +17,6 @@ option "ipv6-candidates" 6 "Whether to enable IPv6 candidates or not (experiment
 option "libnice-debug" l "Whether to enable libnice debugging or not" flag off
 option "ice-lite" I "Whether to enable the ICE Lite mode or not" flag off
 option "ice-tcp" T "Whether to enable ICE-TCP or not (warning: only works with ICE Lite)" flag off
-option "force-bundle" U "Whether to force BUNDLE or not (whether audio, video and data will always be bundled)" flag off
-option "force-rtcp-mux" u "Whether to force rtcp-mux or not (whether RTP and RTCP will always be muxed)" flag off
 option "max-nack-queue" q "Maximum size of the NACK queue (in ms) per user for retransmissions" int typestr="number" optional
 option "no-media-timer" t "Time (in s) that should pass with no media (audio or video) being received before Janus notifies you about this" int typestr="number" optional
 option "rtp-port-range" r "Port range to use for RTP/RTCP" string typestr="min-max" optional

--- a/sdp.c
+++ b/sdp.c
@@ -27,8 +27,8 @@
 
 /* Pre-parse SDP: is this SDP valid? how many audio/video lines? any features to take into account? */
 janus_sdp *janus_sdp_preparse(const char *jsep_sdp, char *error_str, size_t errlen,
-		int *audio, int *video, int *data, int *bundle, int *rtcpmux, int *trickle) {
-	if(!jsep_sdp || !audio || !video || !data || !bundle || !rtcpmux || !trickle) {
+		int *audio, int *video, int *data) {
+	if(!jsep_sdp || !audio || !video || !data) {
 		JANUS_LOG(LOG_ERR, "  Can't preparse, invalid arguments\n");
 		return NULL;
 	}
@@ -54,11 +54,6 @@ janus_sdp *janus_sdp_preparse(const char *jsep_sdp, char *error_str, size_t errl
 #else
 	*data = 0;
 #endif
-	*bundle = strstr(jsep_sdp, "a=group:BUNDLE") ? 1 : 0;	/* FIXME This is a really hacky way of checking... */
-	*rtcpmux = strstr(jsep_sdp, "a=rtcp-mux") ? 1 : 0;	/* FIXME Should we make this check per-medium? */
-	//~ *trickle = (strstr(jsep_sdp, "trickle") || strstr(jsep_sdp, "google-ice") || strstr(jsep_sdp, "Mozilla")) ? 1 : 0;	/* FIXME This is a really hacky way of checking... */
-	/* FIXME We're assuming trickle is always supported, see https://github.com/meetecho/janus-gateway/issues/83 */
-	*trickle = 1;
 
 	return parsed_sdp;
 }
@@ -68,7 +63,9 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 	if(!ice_handle || !remote_sdp)
 		return -1;
 	janus_ice_handle *handle = (janus_ice_handle *)ice_handle;
-	janus_ice_stream *stream = NULL;
+	janus_ice_stream *stream = handle->stream;
+	if(!stream)
+		return -1;
 	gchar *ruser = NULL, *rpass = NULL, *rhashing = NULL, *rfingerprint = NULL;
 	int audio = 0, video = 0;
 #ifdef HAVE_SCTP
@@ -103,11 +100,11 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 		temp = temp->next;
 	}
 	/* Now go on with m-line and their attributes */
+	int mlines = 0;
 	temp = remote_sdp->m_lines;
-	gboolean bundled = FALSE;
 	while(temp) {
+		mlines++;
 		janus_sdp_mline *m = (janus_sdp_mline *)temp->data;
-		bundled = FALSE;
 		if(m->type == JANUS_SDP_AUDIO) {
 			if(handle->rtp_profile == NULL && m->proto != NULL)
 				handle->rtp_profile = g_strdup(m->proto);
@@ -116,13 +113,6 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 				if(audio > 1) {
 					temp = temp->next;
 					continue;
-				}
-				if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-					stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(handle->audio_id));
-				} else {
-					guint id = handle->bundle_id;
-					stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(id));
-					bundled = handle->audio_id != handle->bundle_id;
 				}
 				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Parsing audio candidates (stream=%d)...\n", handle->handle_id, stream->stream_id);
 				if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AUDIO)) {
@@ -169,13 +159,6 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 				if(video > 1) {
 					temp = temp->next;
 					continue;
-				}
-				if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-					stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(handle->video_id));
-				} else {
-					guint id = handle->bundle_id;
-					stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(id));
-					bundled = handle->video_id != handle->bundle_id;
 				}
 				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Parsing video candidates (stream=%d)...\n", handle->handle_id, stream->stream_id);
 				if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO)) {
@@ -225,13 +208,6 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 					if(data > 1) {
 						temp = temp->next;
 						continue;
-					}
-					if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-						stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(handle->data_id));
-					} else {
-						guint id = handle->bundle_id;
-						stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(id));
-						bundled = handle->data_id != handle->bundle_id;
 					}
 					JANUS_LOG(LOG_VERB, "[%"SCNu64"] Parsing SCTP candidates (stream=%d)...\n", handle->handle_id, stream->stream_id);
 					if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_DATA_CHANNELS)) {
@@ -314,24 +290,23 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 			}
 			tempA = tempA->next;
 		}
-		if(!ruser || !rpass || !rfingerprint || !rhashing) {
-			/* Missing mandatory information, failure... */
-			if(ruser)
-				g_free(ruser);
-			ruser = NULL;
-			if(rpass)
-				g_free(rpass);
-			rpass = NULL;
-			if(rhashing)
-				g_free(rhashing);
-			rhashing = NULL;
-			if(rfingerprint)
-				g_free(rfingerprint);
-			rfingerprint = NULL;
-			return -2;
-		}
-		/* Make sure we don't overwrite previously parsed fingerprints and ICE credentials if we're bundling */
-		if(!bundled) {
+		if(mlines == 1) {
+			if(!ruser || !rpass || !rfingerprint || !rhashing) {
+				/* Missing mandatory information, failure... */
+				if(ruser)
+					g_free(ruser);
+				ruser = NULL;
+				if(rpass)
+					g_free(rpass);
+				rpass = NULL;
+				if(rhashing)
+					g_free(rhashing);
+				rhashing = NULL;
+				if(rfingerprint)
+					g_free(rfingerprint);
+				rfingerprint = NULL;
+				return -2;
+			}
 			/* If this is a renegotiation, check if this is an ICE restart */
 			if((ruser && stream->ruser && strcmp(ruser, stream->ruser)) ||
 					(rpass && stream->rpass && strcmp(rpass, stream->rpass))) {
@@ -389,12 +364,12 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 			janus_sdp_attribute *a = (janus_sdp_attribute *)tempA->data;
 			if(a->name) {
 				if(!strcasecmp(a->name, "candidate")) {
-					if(m->type == JANUS_SDP_AUDIO && handle->audio_id != handle->bundle_id && janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
+					if(m->type == JANUS_SDP_AUDIO && mlines > 1) {
 						JANUS_LOG(LOG_VERB, "[%"SCNu64"] This is an audio candidate but we're bundling on another stream, ignoring...\n", handle->handle_id);
-					} else if(m->type == JANUS_SDP_VIDEO && handle->video_id != handle->bundle_id && janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
+					} else if(m->type == JANUS_SDP_VIDEO && mlines > 1) {
 						JANUS_LOG(LOG_VERB, "[%"SCNu64"] This is a video candidate but we're bundling on another stream, ignoring...\n", handle->handle_id);
 #ifdef HAVE_SCTP
-					} else if(m->type == JANUS_SDP_APPLICATION && handle->data_id != handle->bundle_id && janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
+					} else if(m->type == JANUS_SDP_APPLICATION && mlines > 1) {
 						JANUS_LOG(LOG_VERB, "[%"SCNu64"] This is a SCTP candidate but we're bundling on another stream, ignoring...\n", handle->handle_id);
 #endif
 					} else {
@@ -415,13 +390,13 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to parse SSRC attribute... (%d)\n", handle->handle_id, res);
 					}
 				} else if(!strcasecmp(a->name, "rtcp-fb")) {
-					if(a->value && strstr(a->value, "nack") && stream->rtp_component) {
+					if(a->value && strstr(a->value, "nack") && stream->component) {
 						if(m->type == JANUS_SDP_AUDIO) {
 							/* Enable NACKs for audio */
-							stream->rtp_component->do_audio_nacks = TRUE;
+							stream->component->do_audio_nacks = TRUE;
 						} else if(m->type == JANUS_SDP_VIDEO) {
 							/* Enable NACKs for video */
-							stream->rtp_component->do_video_nacks = TRUE;
+							stream->component->do_video_nacks = TRUE;
 						}
 					}
 				}
@@ -440,7 +415,7 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Audio SSRC changed: %"SCNu32" --> %"SCNu32"\n",
 					handle->handle_id, stream->audio_ssrc_peer, stream->audio_ssrc_peer_new);
 				/* FIXME Reset the RTCP context */
-				janus_ice_component *component = stream->rtp_component;
+				janus_ice_component *component = stream->component;
 				janus_mutex_lock(&component->mutex);
 				if(stream->audio_rtcp_ctx) {
 					memset(stream->audio_rtcp_ctx, 0, sizeof(*stream->audio_rtcp_ctx));
@@ -460,7 +435,7 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Video SSRC (#%d) changed: %"SCNu32" --> %"SCNu32"\n",
 						handle->handle_id, vindex, stream->video_ssrc_peer[vindex], stream->video_ssrc_peer_new[vindex]);
 					/* FIXME Reset the RTCP context */
-					janus_ice_component *component = stream->rtp_component;
+					janus_ice_component *component = stream->component;
 					janus_mutex_lock(&component->mutex);
 					if(stream->video_rtcp_ctx[vindex]) {
 						memset(stream->video_rtcp_ctx[vindex], 0, sizeof(*stream->video_rtcp_ctx[vindex]));
@@ -538,18 +513,10 @@ int janus_sdp_parse_candidate(void *ice_stream, const char *candidate, int trick
 	}
 	if(res >= 7) {
 		/* Add remote candidate */
-		component = g_hash_table_lookup(stream->components, GUINT_TO_POINTER(rcomponent));
-		if(component == NULL) {
-			if(rcomponent == 2 && janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX)) {
-				JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Skipping component %d in stream %d (rtcp-muxing)\n", handle->handle_id, rcomponent, stream->stream_id);
-			} else {
-				JANUS_LOG(LOG_ERR, "[%"SCNu64"]   -- No such component %d in stream %d?\n", handle->handle_id, rcomponent, stream->stream_id);
-			}
+		component = stream->component;
+		if(component == NULL || rcomponent > 1) {
+			JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Skipping component %d in stream %d (rtcp-muxing)\n", handle->handle_id, rcomponent, stream->stream_id);
 		} else {
-			if(rcomponent == 2 && janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX)) {
-				JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Skipping component %d in stream %d (rtcp-muxing)\n", handle->handle_id, rcomponent, stream->stream_id);
-				return 0;
-			}
 			//~ if(trickle) {
 				//~ if(component->dtls != NULL) {
 					//~ /* This component is already ready, ignore this further candidate */
@@ -941,7 +908,7 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 	if(ice_handle == NULL || anon == NULL)
 		return NULL;
 	janus_ice_handle *handle = (janus_ice_handle *)ice_handle;
-	janus_ice_stream *stream = NULL;
+	janus_ice_stream *stream = handle->stream;
 	char *rtp_profile = handle->rtp_profile ? handle->rtp_profile : (char *)"UDP/TLS/RTP/SAVPF";
 	gboolean ipv4 = !strstr(janus_get_public_ip(), ":");
 	/* Origin o= */
@@ -1035,26 +1002,11 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 		m->c_ipv4 = ipv4;
 		m->c_addr = g_strdup(janus_get_public_ip());
 		/* Check if we need to refuse the media or not */
-		stream = NULL;
 		if(m->type == JANUS_SDP_AUDIO) {
 			audio++;
-			guint id = handle->audio_id;
-			if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-				stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(handle->audio_id));
-			} else {
-				id = handle->bundle_id;
-				stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(id));
-			}
 			/* Audio */
-			if(stream == NULL) {
-				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping audio line (invalid stream %d)\n", handle->handle_id, id);
-				m->port = 0;
-				m->direction = JANUS_SDP_INACTIVE;
-				temp = temp->next;
-				continue;
-			}
-			if(audio > 1 || !id) {
-				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping audio line (we have %d audio lines, and the id is %d)\n", handle->handle_id, audio, id);
+			if(audio > 1) {
+				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping audio line (we have one already)\n", handle->handle_id);
 				m->port = 0;
 			}
 			if(m->port == 0)
@@ -1083,27 +1035,13 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 			}
 		} else if(m->type == JANUS_SDP_VIDEO) {
 			video++;
-			guint id = handle->video_id;
-			if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-				stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(handle->video_id));
-			} else {
-				id = handle->bundle_id;
-				stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(id));
-			}
-			if(stream == NULL) {
-				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping video line (invalid stream %d)\n", handle->handle_id, id);
-				m->port = 0;
-				m->direction = JANUS_SDP_INACTIVE;
-				temp = temp->next;
-				continue;
-			}
-			if(video > 1 || !id) {
-				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping video line (we have %d video lines, and the id is %d)\n", handle->handle_id, video, id);
+			/* Video */
+			if(video > 1) {
+				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping video line (we have one already)\n", handle->handle_id);
 				m->port = 0;
 			}
 			if(m->port == 0)
 				m->direction = JANUS_SDP_INACTIVE;
-			/* Video */
 			if(video == 1) {
 				switch(m->direction) {
 					case JANUS_SDP_INACTIVE:
@@ -1132,23 +1070,8 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 			if(!strcasecmp(m->proto, "DTLS/SCTP") && m->port > 0) {
 				/* Yep */
 				data++;
-				guint id = handle->data_id;
-				if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_BUNDLE)) {
-					stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(handle->data_id));
-				} else {
-					id = handle->bundle_id;
-					stream = g_hash_table_lookup(handle->streams, GUINT_TO_POINTER(id));
-				}
-				/* SCTP */
-				if(stream == NULL) {
-					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping SCTP line (invalid stream %d)\n", handle->handle_id, id);
-					m->port = 0;
-					m->direction = JANUS_SDP_INACTIVE;
-					temp = temp->next;
-					continue;
-				}
-				if(data > 1 || !id) {
-					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping SCTP line (we have %d SCTP lines, and the id is %d)\n", handle->handle_id, data, id);
+				if(data > 1) {
+					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping SCTP line (we have one already)\n", handle->handle_id);
 					m->port = 0;
 					m->direction = JANUS_SDP_INACTIVE;
 					temp = temp->next;
@@ -1249,9 +1172,6 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 		}
 		/* And now the candidates */
 		janus_ice_candidates_to_sdp(handle, m, stream->stream_id, 1);
-		if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RTCPMUX) &&
-				(m->type == JANUS_SDP_AUDIO || m->type == JANUS_SDP_VIDEO))
-			janus_ice_candidates_to_sdp(handle, m, stream->stream_id, 2);
 		/* Since we're half-trickling, we need to notify the peer that these are all the
 		 * candidates we have for this media stream, via an end-of-candidates attribute:
 		 * https://tools.ietf.org/html/draft-ietf-mmusic-trickle-ice-02#section-4.1 */

--- a/sdp.h
+++ b/sdp.h
@@ -41,11 +41,8 @@
  * @param[out] audio The number of audio m-lines
  * @param[out] video The number of video m-lines
  * @param[out] data The number of SCTP m-lines
- * @param[out] bundle Whether BUNDLE has been negotiated or not
- * @param[out] rtcpmux Whether rtcp-mux has been negotiated or not
- * @param[out] trickle Whether ICE trickling is being used (no candidates) or not
  * @returns The Janus SDP object in case of success, NULL in case the SDP is invalid */
-janus_sdp *janus_sdp_preparse(const char *jsep_sdp, char *error_str, size_t errlen, int *audio, int *video, int *data, int *bundle, int *rtcpmux, int *trickle);
+janus_sdp *janus_sdp_preparse(const char *jsep_sdp, char *error_str, size_t errlen, int *audio, int *video, int *data);
 
 /*! \brief Method to process a parsed session description
  * \details This method will process a session description coming from a peer, and set up the ICE candidates accordingly


### PR DESCRIPTION
I thought about this for a while, and then eventually went on with it.

Just to give you some context, so far Janus was flexibly in terms of ICE streams and components. In case the client didn't support bundle, we would create different streams (and so allocate different ports, DTLS contexts, etc.) per media; for the same reason, just in case the client didn't support rtcp-mux, we would create different components (again, different ports, DTLS contexts, etc.) for RTP and RTCP too. If it turned up the client did indeed support them, we would get rid of the extra streams and components, and fall back to the single one to use.

We already had a "force bundle and/or force rtcp-mux" option when launching Janus, and for Chrome and Firefox we would force it from janus.js anyway. Now that we know that Safari and Edge do support both too, it really makes no sense to keep this optional support around: it made the code too complex for no reason at all. Besides, the upcoming multistream support would have made this optional support impossible to handle (we can't possibly allocate 10 ports for every new PeerConnection). As such, I just went on and got rid of all the configurable bundle/rtcp-mux stuff: now we just assume they're supported by default, and greatly simplified the code as you can see from the diff.

Please test and let me know if something broke: I'm planning to merge soon, so if you can make additional tests with Edge and Safari too just to confirm they still work as expected, it would help too.