### PR TITLE
Recursive mkdir when a full path has been passed as recording filename.

### DIFF
--- a/record.c
+++ b/record.c
@@ -108,18 +108,17 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 		const char *filename_parent = dirname(copy_for_parent);
 		/* Get filename base file */
 		const char *filename_base = basename(copy_for_base);
-		/* If "filename" is a actual file name and not a path, then dirname returns "." and basename "filename" */
-		if (dir && !strcasecmp(filename_parent, ".") && !strcasecmp(filename_base, filename)) {
-			/* In this case we have to create dir and filename*/
-			rec_dir = dir;
-			rec_file = filename;
-		/* If dir is NULL we have to create filename_parent and filename_base */
-		} else if (!dir) {
+		if (!dir) {
+			/* If dir is NULL we have to create filename_parent and filename_base */
 			rec_dir = filename_parent;
 			rec_file = filename_base;
 		} else {
-			JANUS_LOG(LOG_ERR, "Invalid combination of dir and filename %s %s\n", dir, filename);
-			return NULL;
+			/* If dir is valid we have to create dir and filename*/
+			rec_dir = dir;
+			rec_file = filename;
+			if (strcasecmp(filename_parent, ".") || strcasecmp(filename_base, filename)) {
+				JANUS_LOG(LOG_WARN, "Unsupported combination of dir and filename %s %s\n", dir, filename);
+			}
 		}
 	}
 	if(rec_dir != NULL) {
@@ -192,10 +191,8 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	/* We still need to also write the info header first */
 	g_atomic_int_set(&rc->header, 0);
 	janus_mutex_init(&rc->mutex);
-	if (copy_for_parent)
-		g_free(copy_for_parent);
-	if (copy_for_base)
-		g_free(copy_for_base);
+	g_free(copy_for_parent);
+	g_free(copy_for_base);
 	return rc;
 }
 

--- a/record.c
+++ b/record.c
@@ -19,6 +19,7 @@
 #include <arpa/inet.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <libgen.h>
 
 #include <glib.h>
 #include <jansson.h>
@@ -94,14 +95,41 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	rc->file = NULL;
 	rc->codec = g_strdup(codec);
 	rc->created = janus_get_real_time();
-	if(dir != NULL) {
+	const char *rec_dir = NULL;
+	const char *rec_file = NULL;
+	char *copy_for_parent = NULL;
+	char *copy_for_base = NULL;
+	/* check dir and filename values */
+	if (filename != NULL) {
+		/* helper copies to avoid overwriting */
+		copy_for_parent = g_strdup(filename);
+		copy_for_base = g_strdup(filename);
+		/* get filename parent folder */
+		const char *filename_parent = dirname(copy_for_parent);
+		/* get filename base file */
+		const char *filename_base = basename(copy_for_base);
+		/* if "filename" is a actual file name and not a path, then dirname returns "." and basename "filename" */
+		if (dir && !strcasecmp(filename_parent, ".") && !strcasecmp(filename_base, filename)) {
+			/* in this case we have to create rec_dir and filename*/
+			rec_dir = dir;
+			rec_file = filename;
+		/* if dir is NULL we have to create filename_parent and filename_base */
+		} else if (!dir) {
+			rec_dir = filename_parent;
+			rec_file = filename_base;
+		} else {
+			JANUS_LOG(LOG_ERR, "Invalid combination of dir and filename %s %s\n", dir, filename);
+			return NULL;
+		}
+	}
+	if(rec_dir != NULL) {
 		/* Check if this directory exists, and create it if needed */
 		struct stat s;
-		int err = stat(dir, &s);
+		int err = stat(rec_dir, &s);
 		if(err == -1) {
 			if(ENOENT == errno) {
 				/* Directory does not exist, try creating it */
-				if(janus_mkdir(dir, 0755) < 0) {
+				if(janus_mkdir(rec_dir, 0755) < 0) {
 					JANUS_LOG(LOG_ERR, "mkdir error: %d\n", errno);
 					return NULL;
 				}
@@ -112,17 +140,17 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 		} else {
 			if(S_ISDIR(s.st_mode)) {
 				/* Directory exists */
-				JANUS_LOG(LOG_VERB, "Directory exists: %s\n", dir);
+				JANUS_LOG(LOG_VERB, "Directory exists: %s\n", rec_dir);
 			} else {
 				/* File exists but it's not a directory? */
-				JANUS_LOG(LOG_ERR, "Not a directory? %s\n", dir);
+				JANUS_LOG(LOG_ERR, "Not a directory? %s\n", rec_dir);
 				return NULL;
 			}
 		}
 	}
 	char newname[1024];
 	memset(newname, 0, 1024);
-	if(filename == NULL) {
+	if(rec_file == NULL) {
 		/* Choose a random username */
 		if(!rec_tempname) {
 			/* Use .mjr as an extension right away */
@@ -135,27 +163,27 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 		/* Just append the extension */
 		if(!rec_tempname) {
 			/* Use .mjr as an extension right away */
-			g_snprintf(newname, 1024, "%s.mjr", filename);
+			g_snprintf(newname, 1024, "%s.mjr", rec_file);
 		} else {
 			/* Append the temporary extension to .mjr, we'll rename when closing */
-			g_snprintf(newname, 1024, "%s.mjr.%s", filename, rec_tempext);
+			g_snprintf(newname, 1024, "%s.mjr.%s", rec_file, rec_tempext);
 		}
 	}
 	/* Try opening the file now */
-	if(dir == NULL) {
+	if(rec_dir == NULL) {
 		rc->file = fopen(newname, "wb");
 	} else {
 		char path[1024];
 		memset(path, 0, 1024);
-		g_snprintf(path, 1024, "%s/%s", dir, newname);
+		g_snprintf(path, 1024, "%s/%s", rec_dir, newname);
 		rc->file = fopen(path, "wb");
 	}
 	if(rc->file == NULL) {
 		JANUS_LOG(LOG_ERR, "fopen error: %d\n", errno);
 		return NULL;
 	}
-	if(dir)
-		rc->dir = g_strdup(dir);
+	if(rec_dir)
+		rc->dir = g_strdup(rec_dir);
 	rc->filename = g_strdup(newname);
 	rc->type = type;
 	/* Write the first part of the header */
@@ -164,6 +192,10 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	/* We still need to also write the info header first */
 	g_atomic_int_set(&rc->header, 0);
 	janus_mutex_init(&rc->mutex);
+	if (copy_for_parent)
+		g_free(copy_for_parent);
+	if (copy_for_base)
+		g_free(copy_for_base);
 	return rc;
 }
 

--- a/record.c
+++ b/record.c
@@ -99,21 +99,21 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	const char *rec_file = NULL;
 	char *copy_for_parent = NULL;
 	char *copy_for_base = NULL;
-	/* check dir and filename values */
+	/* Check dir and filename values */
 	if (filename != NULL) {
-		/* helper copies to avoid overwriting */
+		/* Helper copies to avoid overwriting */
 		copy_for_parent = g_strdup(filename);
 		copy_for_base = g_strdup(filename);
-		/* get filename parent folder */
+		/* Get filename parent folder */
 		const char *filename_parent = dirname(copy_for_parent);
-		/* get filename base file */
+		/* Get filename base file */
 		const char *filename_base = basename(copy_for_base);
-		/* if "filename" is a actual file name and not a path, then dirname returns "." and basename "filename" */
+		/* If "filename" is a actual file name and not a path, then dirname returns "." and basename "filename" */
 		if (dir && !strcasecmp(filename_parent, ".") && !strcasecmp(filename_base, filename)) {
-			/* in this case we have to create rec_dir and filename*/
+			/* In this case we have to create dir and filename*/
 			rec_dir = dir;
 			rec_file = filename;
-		/* if dir is NULL we have to create filename_parent and filename_base */
+		/* If dir is NULL we have to create filename_parent and filename_base */
 		} else if (!dir) {
 			rec_dir = filename_parent;
 			rec_file = filename_base;


### PR DESCRIPTION
This PR enables Janus to create the full path specified for a recording file.
As of now the API `janus_recorder_create` accepts a `dir` and a `filename`, then builds the path only if `dir` has been passed and opens the file `/dir/filename` or simply `filename`.
With the changes proposed here, the new logic is:
- **with** `dir` and **with** `filename` <del> check that `filename` is not a path too, and then preserve previous behavior</del> warn if `dir` and `filename` are paths  then preserve previous behavior
- **without** `dir` and **with** `filename` split `filename` in `parent` and `base`, then continue with previous behavior using `parent` as `dir` and `base` as `filename`
- any other case should be identical to previous implementation (e.g. wiithout `filename` a kind of random file name is generated)

The splitting of `filename` has been obtained with the methods `dirname` and `basename` of `libgen.h`. These methods should be available in all Unix-like systems.