### PR TITLE
Npm es6 post processing

### DIFF
--- a/npm/rollup.config.js
+++ b/npm/rollup.config.js
@@ -5,7 +5,9 @@ export default {
     name: 'Janus',
     input: 'module.js',
     output: {
-        strict: false
+        strict: false,
+        format: 'es',
+        file: '../html/janus.es.js',
     },
     plugins: [
         replace({

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "html/janus.js",
   "files": [
     "html/janus.js",
-    "html/janus.es.js"
+    "html/janus.es.js",
+    "npm/rollup.config.js",
+    "npm/module.js"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "html/janus.js",
   "files": [
     "html/janus.js",
-    "html/janus.nojquery.js",
-    "html/adapter.js"
+    "html/janus.es.js"
   ],
   "repository": {
     "type": "git",
@@ -16,6 +15,13 @@
   "license": "GPL-3.0",
   "bugs": {
     "url": "https://github.com/meetecho/janus-gateway/issues"
+  },
+  "scripts": {
+    "postinstall": "cd npm && rollup -c rollup.config.js -f es -o ../html/janus.es.js"
+  },
+  "devDependencies": {
+    "rollup": "^0.50.0",
+    "rollup-plugin-replace": "^2.0.0"
   },
   "homepage": "https://github.com/meetecho/janus-gateway#readme"
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "postinstall": "cd npm && rollup -c rollup.config.js -f es -o ../html/janus.es.js"
   },
-  "devDependencies": {
+  "dependencies": {
     "rollup": "^0.50.0",
     "rollup-plugin-replace": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "files": [
     "html/janus.js",
     "html/janus.es.js",
-    "npm/rollup.config.js",
-    "npm/module.js"
+    "npm/*.js"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/meetecho/janus-gateway/issues"
   },
   "scripts": {
-    "postinstall": "cd npm && rollup -c rollup.config.js -f es -o ../html/janus.es.js"
+    "postinstall": "cd npm && rollup -c rollup.config.js"
   },
   "dependencies": {
     "rollup": "^0.50.0",


### PR DESCRIPTION
Hi Lorenzo,

This is a proposal to automatic build an es2015 compliant version of Janus automatically when using npm to manage dependencies.

I started using webpack and npm with es6 for managing/bundling the front-end code.

Ideally, we would like to have janus as an npm dependency, and then just import it like this:
```js
import adapter from 'webrtc-adapter';
import Janus from 'janus-gateway/html/janus';
```

Nothing that original, and I've seen many discussions on different pull requests.
So far, correct me if I'm wrong:

- we can generate as es6 compliant version of janus.js during compilation; but that's a bit too complicated when you're *only* interested into that one janus.es.js file
- there is a [janus-gateway](https://www.npmjs.com/package/janus-gateway) npm package available, but it is outdated (0.2.3) and does not provide all the different flavors of janus, including es6
- there is an npm directory in this repo, which uses rollup to generate an es6 compliant version of janus, but at the moment, 1) it is broken as rollup latest version require more configuration, and 2) it does not add anything when using npm, in fact it is not even called during install process.

This PR open the discussion about automatically generating the different flavors of Janus from `janus.js` during the npm installation. I'm not sure if this is the best way to go, but at least it solves the problem I explained earlier.

Right now, if I just:
```bash
npm install --save RouquinBlanc/janus-gateway#npm_es6
```

The resulting package installed contains both `janus.js` and `janus.es.js`, allowing me to import janus properly in our code.

This is mainly for discussion purpose; I'm not really an npm expert, but this seems much more acceptable than what we currently do, which is generating the es6 version of janus (manually, as we use an old version of janus), then copying the resulting file at the right location...

Note that this generation phase could happen in a separate git repo:

- Use janus-gateway untouched as a dependency
- Then generate the different flavors on the fly

This approach could allow to support several backward versions of janus, but that's the only advantage compared to integrating this directly here, in the main repo, so on the long term it's much less interesting...

Thanks & Best regards
  