### PR TITLE
Support for RFC4588 retransmissions (rtx/90000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ or on the command line:
 	-T, --ice-tcp                 Whether to enable ICE-TCP or not (warning: only
                                   works with ICE Lite)
                                   (default=off)
-	-R, --no-rfc-4588             Whether to disable RFC4588 retransmissions
+	-R, --rfc-4588                Whether to enable RFC4588 retransmissions
                                   support or not  (default=off)
 	-q, --max-nack-queue=number   Maximum size of the NACK queue (in ms) per user
                                   for retransmissions

--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ or on the command line:
 	-T, --ice-tcp                 Whether to enable ICE-TCP or not (warning: only
                                   works with ICE Lite)
                                   (default=off)
+	-R, --no-rfc-4588             Whether to disable RFC4588 retransmissions
+                                  support or not  (default=off)
 	-q, --max-nack-queue=number   Maximum size of the NACK queue (in ms) per user
                                   for retransmissions
 	-t, --no-media-timer=number   Time (in s) that should pass with no media

--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -67,7 +67,8 @@ cert_key = @certdir@/mycert.key
 
 
 ; Media-related stuff: you can configure whether if you want
-; to enable IPv6 support (still WIP, so handle with care), the maximum size
+; to enable IPv6 support (still WIP, so handle with care), if RFC4588
+; support should be negotiated or not (they are by default), the maximum size
 ; of the NACK queue (in milliseconds, defaults to 500ms) for retransmissions, the
 ; range of ports to use for RTP and RTCP (by default, no range is envisaged), the
 ; starting MTU for DTLS (1472 by default, it adapts automatically), and
@@ -77,6 +78,7 @@ cert_key = @certdir@/mycert.key
 [media]
 ;ipv6 = true
 ;max_nack_queue = 500
+;rfc_4588 = no
 ;rtp_port_range = 20000-40000
 ;dtls_mtu = 1200
 ;no_media_timer = 1

--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -68,7 +68,7 @@ cert_key = @certdir@/mycert.key
 
 ; Media-related stuff: you can configure whether if you want
 ; to enable IPv6 support (still WIP, so handle with care), if RFC4588
-; support should be negotiated or not (they are by default), the maximum size
+; support should be negotiated or not (off by default), the maximum size
 ; of the NACK queue (in milliseconds, defaults to 500ms) for retransmissions, the
 ; range of ports to use for RTP and RTCP (by default, no range is envisaged), the
 ; starting MTU for DTLS (1472 by default, it adapts automatically), and
@@ -78,7 +78,7 @@ cert_key = @certdir@/mycert.key
 [media]
 ;ipv6 = true
 ;max_nack_queue = 500
-;rfc_4588 = no
+;rfc_4588 = yes
 ;rtp_port_range = 20000-40000
 ;dtls_mtu = 1200
 ;no_media_timer = 1

--- a/ice.c
+++ b/ice.c
@@ -1969,7 +1969,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 						vindex = 1;
 						JANUS_LOG(LOG_HUGE, "[%"SCNu64"] RFC4588 rtx packet on video #%d (SSRC %"SCNu32")...\n",
 							handle->handle_id, vindex, packet_ssrc);
-					} else if(stream->video_ssrc_peer_rtx[1] == packet_ssrc) {
+					} else if(stream->video_ssrc_peer_rtx[2] == packet_ssrc) {
 						rtx = 1;
 						vindex = 2;
 						JANUS_LOG(LOG_HUGE, "[%"SCNu64"] RFC4588 rtx packet on video #%d (SSRC %"SCNu32")...\n",

--- a/ice.c
+++ b/ice.c
@@ -2012,7 +2012,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 					/* Finally, remove the original sequence number from the payload: rather than moving
 					 * the whole payload back two bytes, we shift the header forward (less bytes to move) */
 					buflen -= 2;
-					size_t hsize = payload-buf-2;
+					size_t hsize = payload-buf;
 					memmove(buf+2, buf, hsize);
 					buf += 2;
 					header = (janus_rtp_header *)buf;
@@ -2138,9 +2138,11 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 					}
 				}
 
-				/* Update the RTCP context as well */
-				rtcp_context *rtcp_ctx = video ? stream->video_rtcp_ctx[vindex] : stream->audio_rtcp_ctx;
-				janus_rtcp_process_incoming_rtp(rtcp_ctx, buf, buflen);
+				/* Update the RTCP context as well (but not if it's a retransmission) */
+				if(!rtx) {
+					rtcp_context *rtcp_ctx = video ? stream->video_rtcp_ctx[vindex] : stream->audio_rtcp_ctx;
+					janus_rtcp_process_incoming_rtp(rtcp_ctx, buf, buflen);
+				}
 
 				/* Keep track of RTP sequence numbers, in case we need to NACK them */
 				/* 	Note: unsigned int overflow/underflow wraps (defined behavior) */

--- a/ice.c
+++ b/ice.c
@@ -1244,7 +1244,7 @@ void janus_ice_stream_free(janus_ice_stream *stream) {
 	stream->video_payload_types = NULL;
 	if(stream->rtx_payload_types != NULL)
 		g_hash_table_destroy(stream->rtx_payload_types);
-	old_handles = NULL;
+	stream->rtx_payload_types = NULL;
 	g_free(stream->audio_codec);
 	stream->audio_codec = NULL;
 	g_free(stream->video_codec);

--- a/ice.c
+++ b/ice.c
@@ -245,7 +245,7 @@ uint janus_get_no_media_timer(void) {
 
 
 /* RFC4588 support */
-static gboolean rfc4588_enabled = TRUE;
+static gboolean rfc4588_enabled = FALSE;
 void janus_set_rfc4588_enabled(gboolean enabled) {
 	rfc4588_enabled = enabled;
 	JANUS_LOG(LOG_VERB, "RFC4588 support is %s\n", rfc4588_enabled ? "enabled" : "disabled");

--- a/ice.c
+++ b/ice.c
@@ -244,6 +244,17 @@ uint janus_get_no_media_timer(void) {
 }
 
 
+/* RFC4588 support */
+static gboolean rfc4588_enabled = TRUE;
+void janus_set_rfc4588_enabled(gboolean enabled) {
+	rfc4588_enabled = enabled;
+	JANUS_LOG(LOG_VERB, "RFC4588 support is %s\n", rfc4588_enabled ? "enabled" : "disabled");
+}
+gboolean janus_is_rfc4588_enabled(void) {
+	return rfc4588_enabled;
+}
+
+
 /* Maximum value, in milliseconds, for the NACK queue/retransmissions (default=500ms) */
 #define DEFAULT_MAX_NACK_QUEUE	500
 /* Maximum ignore count after retransmission (200ms) */

--- a/ice.c
+++ b/ice.c
@@ -3871,6 +3871,7 @@ void janus_ice_relay_rtp(janus_ice_handle *handle, int video, char *buf, int len
 	pkt->type = video ? JANUS_ICE_PACKET_VIDEO : JANUS_ICE_PACKET_AUDIO;
 	pkt->control = FALSE;
 	pkt->encrypted = FALSE;
+	pkt->retransmission = FALSE;
 	if(handle->queued_packets != NULL)
 		g_async_queue_push(handle->queued_packets, pkt);
 }
@@ -3909,6 +3910,7 @@ void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, int video, char *bu
 	pkt->type = video ? JANUS_ICE_PACKET_VIDEO : JANUS_ICE_PACKET_AUDIO;
 	pkt->control = TRUE;
 	pkt->encrypted = FALSE;
+	pkt->retransmission = FALSE;
 	if(handle->queued_packets != NULL)
 		g_async_queue_push(handle->queued_packets, pkt);
 	if(rtcp_buf != buf) {
@@ -3933,6 +3935,7 @@ void janus_ice_relay_data(janus_ice_handle *handle, char *buf, int len) {
 	pkt->type = JANUS_ICE_PACKET_DATA;
 	pkt->control = FALSE;
 	pkt->encrypted = FALSE;
+	pkt->retransmission = FALSE;
 	if(handle->queued_packets != NULL)
 		g_async_queue_push(handle->queued_packets, pkt);
 }

--- a/ice.h
+++ b/ice.h
@@ -120,6 +120,12 @@ void janus_set_no_media_timer(uint timer);
 /*! \brief Method to get the current no-media event timer (see above)
  * @returns The current no-media event timer */
 uint janus_get_no_media_timer(void);
+/*! \brief Method to enable or disable the RFC4588 support negotiation
+ * @param[in] enabled The new timer value, in seconds */
+void janus_set_rfc4588_enabled(gboolean enabled);
+/*! \brief Method to check whether the RFC4588 support is enabled
+ * @returns TRUE if it's enabled, FALSE otherwise */
+gboolean janus_is_rfc4588_enabled(void);
 /*! \brief Method to modify the event handler statistics period (i.e., the number of seconds that should pass before Janus notifies event handlers about media statistics for a PeerConnection)
  * @param[in] timer The new timer value, in seconds */
 void janus_ice_set_event_stats_period(int period);

--- a/ice.h
+++ b/ice.h
@@ -355,6 +355,8 @@ struct janus_ice_stream {
 	janus_rtcp_context *audio_rtcp_ctx;
 	/*! \brief RTCP context(s) for the video stream (may be simulcasting) */
 	janus_rtcp_context *video_rtcp_ctx[3];
+	/*! \brief Map(s) of the NACKed packets (to track retransmissions and avoid duplicates) */
+	GHashTable *rtx_nacked[3];
 	/*! \brief First received audio NTP timestamp */
 	gint64 audio_first_ntp_ts;
 	/*! \brief First received audio RTP timestamp */

--- a/janus.c
+++ b/janus.c
@@ -3375,8 +3375,8 @@ gint main(int argc, char *argv[])
 		g_snprintf(nmt, 20, "%d", args_info.no_media_timer_arg);
 		janus_config_add_item(config, "media", "no_media_timer", nmt);
 	}
-	if(args_info.no_rfc_4588_given) {
-		janus_config_add_item(config, "media", "rfc_4588", "no");
+	if(args_info.rfc_4588_given) {
+		janus_config_add_item(config, "media", "rfc_4588", "yes");
 	}
 	if(args_info.rtp_port_range_given) {
 		janus_config_add_item(config, "media", "rtp_port_range", args_info.rtp_port_range_arg);

--- a/janus.c
+++ b/janus.c
@@ -2178,6 +2178,7 @@ int janus_process_incoming_admin_request(janus_request *request) {
 		json_object_set_new(flags, "data-channels", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_DATA_CHANNELS) ? json_true() : json_false());
 		json_object_set_new(flags, "has-audio", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AUDIO) ? json_true() : json_false());
 		json_object_set_new(flags, "has-video", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO) ? json_true() : json_false());
+		json_object_set_new(flags, "rfc4588-rtx", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX) ? json_true() : json_false());
 		json_object_set_new(flags, "cleaning", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_CLEANING) ? json_true() : json_false());
 		json_object_set_new(info, "flags", flags);
 		if(handle->agent) {
@@ -2289,16 +2290,22 @@ json_t *janus_admin_stream_summary(janus_ice_stream *stream) {
 		json_object_set_new(ss, "audio", json_integer(stream->audio_ssrc));
 	if(stream->video_ssrc)
 		json_object_set_new(ss, "video", json_integer(stream->video_ssrc));
+	if(stream->video_ssrc_rtx)
+		json_object_set_new(ss, "video-rtx", json_integer(stream->video_ssrc_rtx));
 	if(stream->audio_ssrc_peer)
 		json_object_set_new(ss, "audio-peer", json_integer(stream->audio_ssrc_peer));
 	if(stream->video_ssrc_peer[0])
 		json_object_set_new(ss, "video-peer", json_integer(stream->video_ssrc_peer[0]));
-	if(stream->video_ssrc_peer_rtx)
-		json_object_set_new(ss, "video-peer-rtx", json_integer(stream->video_ssrc_peer_rtx));
 	if(stream->video_ssrc_peer[1])
 		json_object_set_new(ss, "video-peer-sim-1", json_integer(stream->video_ssrc_peer[1]));
 	if(stream->video_ssrc_peer[2])
 		json_object_set_new(ss, "video-peer-sim-2", json_integer(stream->video_ssrc_peer[2]));
+	if(stream->video_ssrc_peer_rtx[0])
+		json_object_set_new(ss, "video-peer-rtx", json_integer(stream->video_ssrc_peer_rtx[0]));
+	if(stream->video_ssrc_peer_rtx[1])
+		json_object_set_new(ss, "video-peer-sim-1-rtx", json_integer(stream->video_ssrc_peer_rtx[1]));
+	if(stream->video_ssrc_peer_rtx[2])
+		json_object_set_new(ss, "video-peer-sim-2-rtx", json_integer(stream->video_ssrc_peer_rtx[2]));
 	if(stream->rid[0]) {
 		json_t *rid = json_array();
 		json_array_append_new(rid, json_string(stream->rid[0]));
@@ -2323,6 +2330,8 @@ json_t *janus_admin_stream_summary(janus_ice_stream *stream) {
 			json_object_set_new(sc, "audio-codec", json_string(stream->audio_codec));
 		if(stream->video_payload_type > -1)
 			json_object_set_new(sc, "video-pt", json_integer(stream->video_payload_type));
+		if(stream->video_rtx_payload_type > -1)
+			json_object_set_new(sc, "video-rtx-pt", json_integer(stream->video_rtx_payload_type));
 		if(stream->video_codec != NULL)
 			json_object_set_new(sc, "video-codec", json_string(stream->video_codec));
 		json_object_set_new(s, "codecs", sc);
@@ -2764,6 +2773,8 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 			}
 		}
 		if(ice_handle->agent == NULL) {
+			/* We still need to configure the WebRTC stuff: negotiate RFC4588 by default */
+			janus_flags_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX);
 			/* Process SDP in order to setup ICE locally (this is going to result in an answer from the browser) */
 			if(janus_ice_setup_local(ice_handle, 0, audio, video, data, 1) < 0) {
 				JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error setting ICE locally\n", ice_handle->handle_id);
@@ -2809,6 +2820,40 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 	if(offer && restart)
 		janus_ice_restart(ice_handle);
 	/* Add our details */
+	janus_ice_stream *stream = ice_handle->stream;
+	if(janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX) &&
+			stream && stream->rtx_payload_types == NULL) {
+		/* Make sure we have a list of rtx payload types to generate, if needed */
+		janus_sdp_mline *m = janus_sdp_mline_find(parsed_sdp, JANUS_SDP_VIDEO);
+		if(m && m->ptypes) {
+			stream->rtx_payload_types = g_hash_table_new(NULL, NULL);
+			GList *ptypes = g_list_copy(m->ptypes), *tempP = ptypes;
+			GList *rtx_ptypes = g_hash_table_get_values(stream->rtx_payload_types);
+			while(tempP) {
+				int ptype = GPOINTER_TO_INT(tempP->data);
+				int rtx_ptype = ptype+1;
+				while(g_list_find(m->ptypes, GINT_TO_POINTER(rtx_ptype))
+						|| g_list_find(rtx_ptypes, GINT_TO_POINTER(rtx_ptype))) {
+					rtx_ptype++;
+					if(rtx_ptype > 127)
+						rtx_ptype = 96;
+					if(rtx_ptype == ptype) {
+						/* We did a whole round? should never happen... */
+						rtx_ptype = -1;
+						break;
+					}
+				}
+				if(rtx_ptype > 0)
+					g_hash_table_insert(stream->rtx_payload_types, GINT_TO_POINTER(ptype), GINT_TO_POINTER(rtx_ptype));
+				g_list_free(rtx_ptypes);
+				rtx_ptypes = g_hash_table_get_values(stream->rtx_payload_types);
+				tempP = tempP->next;
+			}
+			g_list_free(ptypes);
+			g_list_free(rtx_ptypes);
+		}
+	}
+	/* Enrich the SDP the plugin gave us with all the WebRTC related stuff */
 	char *sdp_merged = janus_sdp_merge(ice_handle, parsed_sdp, offer ? TRUE : FALSE);
 	if(sdp_merged == NULL) {
 		/* Couldn't merge SDP */

--- a/janus.ggo
+++ b/janus.ggo
@@ -17,7 +17,7 @@ option "ipv6-candidates" 6 "Whether to enable IPv6 candidates or not (experiment
 option "libnice-debug" l "Whether to enable libnice debugging or not" flag off
 option "ice-lite" I "Whether to enable the ICE Lite mode or not" flag off
 option "ice-tcp" T "Whether to enable ICE-TCP or not (warning: only works with ICE Lite)" flag off
-option "no-rfc-4588" R "Whether to disable RFC4588 retransmissions support or not" flag off
+option "rfc-4588" R "Whether to enable RFC4588 retransmissions support or not" flag off
 option "max-nack-queue" q "Maximum size of the NACK queue (in ms) per user for retransmissions" int typestr="number" optional
 option "no-media-timer" t "Time (in s) that should pass with no media (audio or video) being received before Janus notifies you about this" int typestr="number" optional
 option "rtp-port-range" r "Port range to use for RTP/RTCP" string typestr="min-max" optional

--- a/janus.ggo
+++ b/janus.ggo
@@ -17,6 +17,7 @@ option "ipv6-candidates" 6 "Whether to enable IPv6 candidates or not (experiment
 option "libnice-debug" l "Whether to enable libnice debugging or not" flag off
 option "ice-lite" I "Whether to enable the ICE Lite mode or not" flag off
 option "ice-tcp" T "Whether to enable ICE-TCP or not (warning: only works with ICE Lite)" flag off
+option "no-rfc-4588" R "Whether to disable RFC4588 retransmissions support or not" flag off
 option "max-nack-queue" q "Maximum size of the NACK queue (in ms) per user for retransmissions" int typestr="number" optional
 option "no-media-timer" t "Time (in s) that should pass with no media (audio or video) being received before Janus notifies you about this" int typestr="number" optional
 option "rtp-port-range" r "Port range to use for RTP/RTCP" string typestr="min-max" optional

--- a/sdp.c
+++ b/sdp.c
@@ -454,11 +454,13 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 						if(sscanf(a->value, "%d apt=%d", &rtx_ptype, &ptype) != 2) {
 							JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to parse fmtp/apt attribute...\n", handle->handle_id);
 						} else {
-							rtx = TRUE;
-							janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX);
-							if(stream->rtx_payload_types == NULL)
-								stream->rtx_payload_types = g_hash_table_new(NULL, NULL);
-							g_hash_table_insert(stream->rtx_payload_types, GINT_TO_POINTER(ptype), GINT_TO_POINTER(rtx_ptype));
+							if(janus_is_rfc4588_enabled()) {
+								rtx = TRUE;
+								janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX);
+								if(stream->rtx_payload_types == NULL)
+									stream->rtx_payload_types = g_hash_table_new(NULL, NULL);
+								g_hash_table_insert(stream->rtx_payload_types, GINT_TO_POINTER(ptype), GINT_TO_POINTER(rtx_ptype));
+							}
 						}
 					}
 				}

--- a/sdp.c
+++ b/sdp.c
@@ -71,6 +71,7 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 #ifdef HAVE_SCTP
 	int data = 0;
 #endif
+	gboolean rtx = FALSE;
 	/* Ok, let's start with global attributes */
 	GList *temp = remote_sdp->attributes;
 	while(temp) {
@@ -146,6 +147,10 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 						stream->audio_recv = TRUE;
 						break;
 				}
+				if(m->ptypes != NULL) {
+					g_list_free(stream->audio_payload_types);
+					stream->audio_payload_types = g_list_copy(m->ptypes);
+				}
 			} else {
 				/* Audio rejected? */
 				janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AUDIO);
@@ -192,6 +197,10 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 						stream->video_send = TRUE;
 						stream->video_recv = TRUE;
 						break;
+				}
+				if(m->ptypes != NULL) {
+					g_list_free(stream->video_payload_types);
+					stream->video_payload_types = g_list_copy(m->ptypes);
 				}
 			} else {
 				/* Video rejected? */
@@ -358,12 +367,57 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 			}
 			tempA = tempA->next;
 		}
-		/* Now look for candidates and other info */
+		/* Let's start figuring out the SSRCs, and any grouping that may be there */
 		stream->audio_ssrc_peer_new = 0;
 		stream->video_ssrc_peer_new[0] = 0;
-		stream->video_ssrc_peer_rtx_new = 0;
 		stream->video_ssrc_peer_new[1] = 0;
 		stream->video_ssrc_peer_new[2] = 0;
+		stream->video_ssrc_peer_rtx_new[0] = 0;
+		stream->video_ssrc_peer_rtx_new[1] = 0;
+		stream->video_ssrc_peer_rtx_new[2] = 0;
+		/* Any SSRC SIM group? */
+		tempA = m->attributes;
+		while(tempA) {
+			janus_sdp_attribute *a = (janus_sdp_attribute *)tempA->data;
+			if(a->name && a->value) {
+				if(!strcasecmp(a->name, "ssrc-group") && strstr(a->value, "SIM")) {
+					int res = janus_sdp_parse_ssrc_group(stream, (const char *)a->value, m->type == JANUS_SDP_VIDEO);
+					if(res != 0) {
+						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to parse SSRC SIM group attribute... (%d)\n", handle->handle_id, res);
+					}
+				}
+			}
+			tempA = tempA->next;
+		}
+		/* Any SSRC FID group? */
+		tempA = m->attributes;
+		while(tempA) {
+			janus_sdp_attribute *a = (janus_sdp_attribute *)tempA->data;
+			if(a->name && a->value) {
+				if(!strcasecmp(a->name, "ssrc-group") && strstr(a->value, "FID")) {
+					int res = janus_sdp_parse_ssrc_group(stream, (const char *)a->value, m->type == JANUS_SDP_VIDEO);
+					if(res != 0) {
+						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to parse SSRC FID group attribute... (%d)\n", handle->handle_id, res);
+					}
+				}
+			}
+			tempA = tempA->next;
+		}
+		/* Any SSRC in general? */
+		tempA = m->attributes;
+		while(tempA) {
+			janus_sdp_attribute *a = (janus_sdp_attribute *)tempA->data;
+			if(a->name && a->value) {
+				if(!strcasecmp(a->name, "ssrc")) {
+					int res = janus_sdp_parse_ssrc(stream, (const char *)a->value, m->type == JANUS_SDP_VIDEO);
+					if(res != 0) {
+						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to parse SSRC attribute... (%d)\n", handle->handle_id, res);
+					}
+				}
+			}
+			tempA = tempA->next;
+		}
+		/* Now look for candidates and other info */
 		tempA = m->attributes;
 		while(tempA) {
 			janus_sdp_attribute *a = (janus_sdp_attribute *)tempA->data;
@@ -383,17 +437,6 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 							JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to parse candidate... (%d)\n", handle->handle_id, res);
 						}
 					}
-				} else if(!strcasecmp(a->name, "ssrc-group")) {
-					/* FIXME This can be either FID or SIM */
-					int res = janus_sdp_parse_ssrc_group(stream, (const char *)a->value, m->type == JANUS_SDP_VIDEO);
-					if(res != 0) {
-						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to parse SSRC group attribute... (%d)\n", handle->handle_id, res);
-					}
-				} else if(!strcasecmp(a->name, "ssrc")) {
-					int res = janus_sdp_parse_ssrc(stream, (const char *)a->value, m->type == JANUS_SDP_VIDEO);
-					if(res != 0) {
-						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to parse SSRC attribute... (%d)\n", handle->handle_id, res);
-					}
 				} else if(!strcasecmp(a->name, "rtcp-fb")) {
 					if(a->value && strstr(a->value, "nack") && stream->component) {
 						if(m->type == JANUS_SDP_AUDIO) {
@@ -402,6 +445,20 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 						} else if(m->type == JANUS_SDP_VIDEO) {
 							/* Enable NACKs for video */
 							stream->component->do_video_nacks = TRUE;
+						}
+					}
+				} else if(!strcasecmp(a->name, "fmtp")) {
+					if(a->value && strstr(a->value, "apt=")) {
+						/* RFC4588 rtx payload type mapping */
+						int ptype = -1, rtx_ptype = -1;
+						if(sscanf(a->value, "%d apt=%d", &rtx_ptype, &ptype) != 2) {
+							JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to parse fmtp/apt attribute...\n", handle->handle_id);
+						} else {
+							rtx = TRUE;
+							janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX);
+							if(stream->rtx_payload_types == NULL)
+								stream->rtx_payload_types = g_hash_table_new(NULL, NULL);
+							g_hash_table_insert(stream->rtx_payload_types, GINT_TO_POINTER(ptype), GINT_TO_POINTER(rtx_ptype));
 						}
 					}
 				}
@@ -415,75 +472,80 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 			tempA = tempA->next;
 		}
 		/* Any change in SSRCs we should be aware of? */
-		if(stream->audio_ssrc_peer_new > 0) {
-			if(stream->audio_ssrc_peer > 0 && stream->audio_ssrc_peer != stream->audio_ssrc_peer_new) {
-				JANUS_LOG(LOG_INFO, "[%"SCNu64"] Audio SSRC changed: %"SCNu32" --> %"SCNu32"\n",
-					handle->handle_id, stream->audio_ssrc_peer, stream->audio_ssrc_peer_new);
-				/* FIXME Reset the RTCP context */
-				janus_ice_component *component = stream->component;
-				janus_mutex_lock(&component->mutex);
-				if(stream->audio_rtcp_ctx) {
-					memset(stream->audio_rtcp_ctx, 0, sizeof(*stream->audio_rtcp_ctx));
-					stream->audio_rtcp_ctx->tb = 48000;	/* May change later */
-				}
-				if(component->last_seqs_audio)
-					janus_seq_list_free(&component->last_seqs_audio);
-				janus_mutex_unlock(&component->mutex);
-			}
-			stream->audio_ssrc_peer = stream->audio_ssrc_peer_new;
-			stream->audio_ssrc_peer_new = 0;
-		}
-		int vindex = 0;
-		for(vindex=0; vindex<3; vindex++) {
-			if(stream->video_ssrc_peer_new[vindex] > 0) {
-				if(stream->video_ssrc_peer[vindex] > 0 && stream->video_ssrc_peer[vindex] != stream->video_ssrc_peer_new[vindex]) {
-					JANUS_LOG(LOG_INFO, "[%"SCNu64"] Video SSRC (#%d) changed: %"SCNu32" --> %"SCNu32"\n",
-						handle->handle_id, vindex, stream->video_ssrc_peer[vindex], stream->video_ssrc_peer_new[vindex]);
+		if(m->type == JANUS_SDP_AUDIO) {
+			if(stream->audio_ssrc_peer_new > 0) {
+				if(stream->audio_ssrc_peer > 0 && stream->audio_ssrc_peer != stream->audio_ssrc_peer_new) {
+					JANUS_LOG(LOG_INFO, "[%"SCNu64"] Audio SSRC changed: %"SCNu32" --> %"SCNu32"\n",
+						handle->handle_id, stream->audio_ssrc_peer, stream->audio_ssrc_peer_new);
 					/* FIXME Reset the RTCP context */
 					janus_ice_component *component = stream->component;
 					janus_mutex_lock(&component->mutex);
-					if(stream->video_rtcp_ctx[vindex]) {
-						memset(stream->video_rtcp_ctx[vindex], 0, sizeof(*stream->video_rtcp_ctx[vindex]));
-						stream->video_rtcp_ctx[vindex]->tb = 90000;
+					if(stream->audio_rtcp_ctx) {
+						memset(stream->audio_rtcp_ctx, 0, sizeof(*stream->audio_rtcp_ctx));
+						stream->audio_rtcp_ctx->tb = 48000;	/* May change later */
 					}
-					if(component->last_seqs_video[vindex])
-						janus_seq_list_free(&component->last_seqs_video[vindex]);
+					if(component->last_seqs_audio)
+						janus_seq_list_free(&component->last_seqs_audio);
 					janus_mutex_unlock(&component->mutex);
 				}
-				stream->video_ssrc_peer[vindex] = stream->video_ssrc_peer_new[vindex];
-				stream->video_ssrc_peer_new[vindex] = 0;
+				stream->audio_ssrc_peer = stream->audio_ssrc_peer_new;
+				stream->audio_ssrc_peer_new = 0;
 			}
-		}
-		if(stream->video_ssrc_peer[1] && stream->video_rtcp_ctx[1] == NULL) {
-			stream->video_rtcp_ctx[1] = g_malloc0(sizeof(rtcp_context));
-			stream->video_rtcp_ctx[1]->tb = 90000;
-		}
-		if(stream->video_ssrc_peer[2] && stream->video_rtcp_ctx[2] == NULL) {
-			stream->video_rtcp_ctx[2] = g_malloc0(sizeof(rtcp_context));
-			stream->video_rtcp_ctx[2]->tb = 90000;
-		}
-		if(stream->video_ssrc_peer_rtx_new > 0) {
-			if(stream->video_ssrc_peer_rtx > 0 && stream->video_ssrc_peer_rtx != stream->video_ssrc_peer_rtx_new) {
-				JANUS_LOG(LOG_INFO, "[%"SCNu64"] Video SSRC (rtx) changed: %"SCNu32" --> %"SCNu32"\n",
-					handle->handle_id, stream->video_ssrc_peer_rtx, stream->video_ssrc_peer_rtx_new);
+		} else if(m->type == JANUS_SDP_VIDEO) {
+			int vindex = 0;
+			for(vindex=0; vindex<3; vindex++) {
+				if(stream->video_ssrc_peer_new[vindex] > 0) {
+					if(stream->video_ssrc_peer[vindex] > 0 && stream->video_ssrc_peer[vindex] != stream->video_ssrc_peer_new[vindex]) {
+						JANUS_LOG(LOG_INFO, "[%"SCNu64"] Video SSRC (#%d) changed: %"SCNu32" --> %"SCNu32"\n",
+							handle->handle_id, vindex, stream->video_ssrc_peer[vindex], stream->video_ssrc_peer_new[vindex]);
+						/* FIXME Reset the RTCP context */
+						janus_ice_component *component = stream->component;
+						janus_mutex_lock(&component->mutex);
+						if(stream->video_rtcp_ctx[vindex]) {
+							memset(stream->video_rtcp_ctx[vindex], 0, sizeof(*stream->video_rtcp_ctx[vindex]));
+							stream->video_rtcp_ctx[vindex]->tb = 90000;
+						}
+						if(component->last_seqs_video[vindex])
+							janus_seq_list_free(&component->last_seqs_video[vindex]);
+						janus_mutex_unlock(&component->mutex);
+					}
+					stream->video_ssrc_peer[vindex] = stream->video_ssrc_peer_new[vindex];
+					stream->video_ssrc_peer_new[vindex] = 0;
+				}
+				/* Do the same with the related rtx SSRC, if any */
+				if(stream->video_ssrc_peer_rtx_new[vindex] > 0) {
+					if(stream->video_ssrc_peer_rtx[vindex] > 0 && stream->video_ssrc_peer_rtx[vindex] != stream->video_ssrc_peer_rtx_new[vindex]) {
+						JANUS_LOG(LOG_INFO, "[%"SCNu64"] Video SSRC (#%d rtx) changed: %"SCNu32" --> %"SCNu32"\n",
+							handle->handle_id, vindex, stream->video_ssrc_peer_rtx[vindex], stream->video_ssrc_peer_rtx_new[vindex]);
+					}
+					stream->video_ssrc_peer_rtx[vindex] = stream->video_ssrc_peer_rtx_new[vindex];
+					stream->video_ssrc_peer_rtx_new[vindex] = 0;
+					if(stream->video_ssrc_rtx == 0)
+						stream->video_ssrc_rtx = janus_random_uint32();	/* FIXME Should we look for conflicts? */
+				}
 			}
-			stream->video_ssrc_peer_rtx = stream->video_ssrc_peer_rtx_new;
-			stream->video_ssrc_peer_rtx_new = 0;
+			if(stream->video_ssrc_peer[1] && stream->video_rtcp_ctx[1] == NULL) {
+				stream->video_rtcp_ctx[1] = g_malloc0(sizeof(rtcp_context));
+				stream->video_rtcp_ctx[1]->tb = 90000;
+			}
+			if(stream->video_ssrc_peer[2] && stream->video_rtcp_ctx[2] == NULL) {
+				stream->video_rtcp_ctx[2] = g_malloc0(sizeof(rtcp_context));
+				stream->video_rtcp_ctx[2]->tb = 90000;
+			}
 		}
 		temp = temp->next;
 	}
-	if(ruser)
-		g_free(ruser);
-	ruser = NULL;
-	if(rpass)
-		g_free(rpass);
-	rpass = NULL;
-	if(rhashing)
-		g_free(rhashing);
-	rhashing = NULL;
-	if(rfingerprint)
-		g_free(rfingerprint);
-	rfingerprint = NULL;
+	/* Disable RFC4588 if the peer didn't negotiate it */
+	if(!rtx) {
+		janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX);
+		stream->video_ssrc_rtx = 0;
+	}
+	/* Cleanup */
+	g_free(ruser);
+	g_free(rpass);
+	g_free(rhashing);
+	g_free(rfingerprint);
+
 	return 0;	/* FIXME Handle errors better */
 }
 
@@ -707,6 +769,7 @@ int janus_sdp_parse_ssrc_group(void *ice_stream, const char *group_attr, int vid
 	gboolean fid = strstr(group_attr, "FID") != NULL;
 	gboolean sim = strstr(group_attr, "SIM") != NULL;
 	guint64 ssrc = 0;
+	guint32 first_ssrc = 0;
 	gchar **list = g_strsplit(group_attr, " ", -1);
 	gchar *index = list[0];
 	if(index != NULL) {
@@ -716,13 +779,45 @@ int janus_sdp_parse_ssrc_group(void *ice_stream, const char *group_attr, int vid
 				ssrc = g_ascii_strtoull(index, NULL, 0);
 				switch(i) {
 					case 1:
-						stream->video_ssrc_peer_new[0] = ssrc;
-						JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer video SSRC: %"SCNu32"\n", handle->handle_id, stream->video_ssrc_peer_new[0]);
+						first_ssrc = ssrc;
+						if(stream->video_ssrc_peer_new[0] == ssrc || stream->video_ssrc_peer_new[1] == ssrc
+								|| stream->video_ssrc_peer_new[2] == ssrc) {
+							JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Already parsed this SSRC: %"SCNu64" (%s group)\n",
+								handle->handle_id, ssrc, (fid ? "FID" : (sim ? "SIM" : "??")));
+						} else {
+							if(stream->video_ssrc_peer_new[0] == 0) {
+								stream->video_ssrc_peer_new[0] = ssrc;
+								JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer video SSRC: %"SCNu32"\n", handle->handle_id, stream->video_ssrc_peer_new[0]);
+							} else {
+								/* We already have a video SSRC: check if RID is involved, and we'll keep track of this for simulcasting */
+								if(stream->rid[0]) {
+									if(stream->video_ssrc_peer_new[1] == 0) {
+										stream->video_ssrc_peer_new[1] = ssrc;
+										JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer video SSRC (sim-1): %"SCNu32"\n", handle->handle_id, stream->video_ssrc_peer_new[1]);
+									} else if(stream->video_ssrc_peer_new[2] == 0) {
+										stream->video_ssrc_peer_new[2] = ssrc;
+										JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer video SSRC (sim-2): %"SCNu32"\n", handle->handle_id, stream->video_ssrc_peer_new[2]);
+									} else {
+										JANUS_LOG(LOG_WARN, "[%"SCNu64"] Don't know what to do with video SSRC: %"SCNu64"\n", handle->handle_id, ssrc);
+									}
+								}
+							}
+						}
 						break;
 					case 2:
 						if(fid) {
-							stream->video_ssrc_peer_rtx_new = ssrc;
-							JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer video SSRC (rtx): %"SCNu32"\n", handle->handle_id, stream->video_ssrc_peer_rtx_new);
+							if(stream->video_ssrc_peer_new[0] == first_ssrc && stream->video_ssrc_peer_rtx_new[0] == 0) {
+								stream->video_ssrc_peer_rtx_new[0] = ssrc;
+								JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer video SSRC (rtx): %"SCNu32"\n", handle->handle_id, stream->video_ssrc_peer_rtx_new[0]);
+							} else if(stream->video_ssrc_peer_new[1] == first_ssrc && stream->video_ssrc_peer_rtx_new[1] == 0) {
+								stream->video_ssrc_peer_rtx_new[1] = ssrc;
+								JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer video SSRC (sim-1 rtx): %"SCNu32"\n", handle->handle_id, stream->video_ssrc_peer_rtx_new[1]);
+							} else if(stream->video_ssrc_peer_new[2] == first_ssrc && stream->video_ssrc_peer_rtx_new[2] == 0) {
+								stream->video_ssrc_peer_rtx_new[2] = ssrc;
+								JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer video SSRC (sim-2 rtx): %"SCNu32"\n", handle->handle_id, stream->video_ssrc_peer_rtx_new[2]);
+							} else {
+								JANUS_LOG(LOG_WARN, "[%"SCNu64"] Don't know what to do with rtx SSRC: %"SCNu64"\n", handle->handle_id, ssrc);
+							}
 						} else if(sim) {
 							stream->video_ssrc_peer_new[1] = ssrc;
 							JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer video SSRC (sim-1): %"SCNu32"\n", handle->handle_id, stream->video_ssrc_peer_new[1]);
@@ -764,6 +859,11 @@ int janus_sdp_parse_ssrc(void *ice_stream, const char *ssrc_attr, int video) {
 	if(ssrc == 0 || ssrc > G_MAXUINT32)
 		return -3;
 	if(video) {
+		if(stream->video_ssrc_peer_new[0] == ssrc || stream->video_ssrc_peer_new[1] == ssrc
+				|| stream->video_ssrc_peer_new[2] == ssrc) {
+			JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Already parsed this SSRC: %"SCNu64"\n", handle->handle_id, ssrc);
+			return 0;
+		}
 		if(stream->video_ssrc_peer_new[0] == 0) {
 			stream->video_ssrc_peer_new[0] = ssrc;
 			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer video SSRC: %"SCNu32"\n", handle->handle_id, stream->video_ssrc_peer_new[0]);
@@ -1068,6 +1168,26 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 						stream->video_recv = TRUE;
 						break;
 				}
+				if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX)) {
+					/* Add RFC4588 stuff */
+					if(stream->rtx_payload_types && g_hash_table_size(stream->rtx_payload_types) > 0) {
+						janus_sdp_attribute *a = NULL;
+						GList *ptypes = g_list_copy(m->ptypes), *tempP = ptypes;
+						while(tempP) {
+							int ptype = GPOINTER_TO_INT(tempP->data);
+							int rtx_ptype = GPOINTER_TO_INT(g_hash_table_lookup(stream->rtx_payload_types, GINT_TO_POINTER(ptype)));
+							if(rtx_ptype > 0) {
+								m->ptypes = g_list_append(m->ptypes, GINT_TO_POINTER(rtx_ptype));
+								a = janus_sdp_attribute_create("rtpmap", "%d rtx/90000", rtx_ptype);
+								m->attributes = g_list_append(m->attributes, a);
+								a = janus_sdp_attribute_create("fmtp", "%d apt=%d", rtx_ptype, ptype);
+								m->attributes = g_list_append(m->attributes, a);
+							}
+							tempP = tempP->next;
+						}
+						g_list_free(ptypes);
+					}
+				}
 			}
 #ifdef HAVE_SCTP
 		} else if(m->type == JANUS_SDP_APPLICATION) {
@@ -1134,6 +1254,11 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 		a = janus_sdp_attribute_create("setup", "%s", janus_get_dtls_srtp_role(offer ? JANUS_DTLS_ROLE_ACTPASS : stream->dtls_role));
 		m->attributes = g_list_insert_before(m->attributes, first, a);
 		/* Add last attributes, rtcp and ssrc (msid) */
+		if(m->type == JANUS_SDP_VIDEO && janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX)) {
+			/* Add FID group to negotiate the RFC4588 stuff */
+			a = janus_sdp_attribute_create("ssrc-group", "FID %"SCNu32" %"SCNu32, stream->video_ssrc, stream->video_ssrc_rtx);
+			m->attributes = g_list_append(m->attributes, a);
+		}
 		if(m->type == JANUS_SDP_AUDIO &&
 				(m->direction == JANUS_SDP_DEFAULT || m->direction == JANUS_SDP_SENDRECV || m->direction == JANUS_SDP_SENDONLY)) {
 			a = janus_sdp_attribute_create("ssrc", "%"SCNu32" cname:janusaudio", stream->audio_ssrc);
@@ -1154,6 +1279,17 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 			m->attributes = g_list_append(m->attributes, a);
 			a = janus_sdp_attribute_create("ssrc", "%"SCNu32" label:janusv0", stream->video_ssrc);
 			m->attributes = g_list_append(m->attributes, a);
+			if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX)) {
+				/* Add rtx SSRC group to negotiate the RFC4588 stuff */
+				a = janus_sdp_attribute_create("ssrc", "%"SCNu32" cname:janusvideo", stream->video_ssrc_rtx);
+				m->attributes = g_list_append(m->attributes, a);
+				a = janus_sdp_attribute_create("ssrc", "%"SCNu32" msid:janus janusv0", stream->video_ssrc_rtx);
+				m->attributes = g_list_append(m->attributes, a);
+				a = janus_sdp_attribute_create("ssrc", "%"SCNu32" mslabel:janus", stream->video_ssrc_rtx);
+				m->attributes = g_list_append(m->attributes, a);
+				a = janus_sdp_attribute_create("ssrc", "%"SCNu32" label:janusv0", stream->video_ssrc_rtx);
+				m->attributes = g_list_append(m->attributes, a);
+			}
 		}
 		/* FIXME If the peer is Firefox and is negotiating simulcasting, add the rid attributes */
 		if(m->type == JANUS_SDP_VIDEO && stream->rid[0] != NULL) {


### PR DESCRIPTION
As the title says, this PR adds support for [RFC4588](https://tools.ietf.org/html/rfc4588) retransmissions, that is the RTP retransmission payload format that Chrome negotiates by default.

You may wander why this was done, considering we support NACKs and do retransmissions already. In theory, it wasn't strictly needed, as Firefox doesn't support them and, when refused, Chrome does plain retransmissions as well (blindly re-sending the previously encrypted SRTP packet). Anyway, just re-sending the SRTP packet as it was originally prepared isn't the proper way: there were reasons for standardizing such a format (you can read more in the RFC), and besides support for it is mandated in the [RTP usage draft](https://tools.ietf.org/html/draft-ietf-rtcweb-rtp-usage-26#section-6.1) for WebRTC, so I went on and did it. Eventually, although not trivial, it turned out to be less work than I expected, and it fits nicely in the way the core works.

Nothing changes in how you use Janus as a user or developer. This is negotiated automatically via SDP at the core level, so if the browser supports it, Janus will use it: Janus will also try and negotiate it by default, and fall back to the old way of doing retransmissions if the browser doesn't support it instead.

Tested briefly and seems to work. I encourage you to play with this PR to make sure you don't notice any regression in your application, as I plan to merge relatively soon.