### PR TITLE
Memory allocation improvements

### DIFF
--- a/config.c
+++ b/config.c
@@ -188,10 +188,6 @@ error:
 
 janus_config *janus_config_create(const char *name) {
 	janus_config *jc = g_malloc0(sizeof(janus_config));
-	if(jc == NULL) {
-		JANUS_LOG(LOG_FATAL, "Memory error!\n");
-		return NULL;
-	}
 	if(name != NULL) {
 		jc->name = g_strdup(name);
 	}
@@ -258,10 +254,6 @@ janus_config_category *janus_config_add_category(janus_config *config, const cha
 		return c;
 	}
 	c = g_malloc0(sizeof(janus_config_category));
-	if(c == NULL) {
-		JANUS_LOG(LOG_FATAL, "Memory error!\n");
-		return NULL;
-	}
 	c->name = g_strdup(category);
 	config->categories = g_list_append(config->categories, c);
 	return c;
@@ -293,10 +285,6 @@ janus_config_item *janus_config_add_item(janus_config *config, const char *categ
 	if(item == NULL) {
 		/* Create it */
 		item = g_malloc0(sizeof(janus_config_item));
-		if(item == NULL) {
-			JANUS_LOG(LOG_FATAL, "Memory error!\n");
-			return NULL;
-		}
 		item->name = g_strdup(name);
 		item->value = g_strdup(value);
 		if(c != NULL) {

--- a/dtls.c
+++ b/dtls.c
@@ -433,10 +433,6 @@ janus_dtls_srtp *janus_dtls_srtp_create(void *ice_component, janus_dtls_role rol
 		return NULL;
 	}
 	janus_dtls_srtp *dtls = g_malloc0(sizeof(janus_dtls_srtp));
-	if(dtls == NULL) {
-		JANUS_LOG(LOG_FATAL, "Memory error!\n");
-		return NULL;
-	}
 	/* Create SSL context, at last */
 	dtls->srtp_valid = 0;
 	dtls->ssl = SSL_new(ssl_ctx);

--- a/ice.c
+++ b/ice.c
@@ -910,7 +910,7 @@ janus_ice_handle *janus_ice_handle_create(void *gateway_session, const char *opa
 		}
 	}
 	JANUS_LOG(LOG_INFO, "Creating new handle in session %"SCNu64": %"SCNu64"\n", session->session_id, handle_id);
-	janus_ice_handle *handle = (janus_ice_handle *)g_malloc0(sizeof(janus_ice_handle));
+	janus_ice_handle *handle = g_malloc0(sizeof(janus_ice_handle));
 	handle->session = gateway_session;
 	if(opaque_id)
 		handle->opaque_id = g_strdup(opaque_id);
@@ -2313,7 +2313,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 							p->last_retransmit = now;
 							retransmits_cnt++;
 							/* Enqueue it */
-							janus_ice_queued_packet *pkt = (janus_ice_queued_packet *)g_malloc(sizeof(janus_ice_queued_packet));
+							janus_ice_queued_packet *pkt = g_malloc(sizeof(janus_ice_queued_packet));
 							pkt->data = g_malloc(p->length);
 							memcpy(pkt->data, p->data, p->length);
 							pkt->length = p->length;
@@ -2885,7 +2885,7 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 	handle->stream_id = 0;
 	/* Now create an ICE stream for all the media we'll handle */
 	handle->stream_id = nice_agent_add_stream(handle->agent, 1);
-	janus_ice_stream *stream = (janus_ice_stream *)g_malloc0(sizeof(janus_ice_stream));
+	janus_ice_stream *stream = g_malloc0(sizeof(janus_ice_stream));
 	stream->stream_id = handle->stream_id;
 	stream->handle = handle;
 	stream->audio_payload_type = -1;
@@ -2933,7 +2933,7 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 #endif
 	}
 	handle->stream = stream;
-	janus_ice_component *component = (janus_ice_component *)g_malloc0(sizeof(janus_ice_component));
+	janus_ice_component *component = g_malloc0(sizeof(janus_ice_component));
 	component->stream = stream;
 	component->stream_id = stream->stream_id;
 	component->component_id = 1;
@@ -3650,8 +3650,8 @@ void *janus_ice_send_thread(void *data) {
 								pkt = NULL;
 								continue;
 							}
-							janus_rtp_packet *p = (janus_rtp_packet *)g_malloc(sizeof(janus_rtp_packet));
-							p->data = (char *)g_malloc(protected);
+							janus_rtp_packet *p = g_malloc(sizeof(janus_rtp_packet));
+							p->data = g_malloc(protected);
 							memcpy(p->data, sbuf, protected);
 							p->length = protected;
 							p->created = janus_get_monotonic_time();
@@ -3753,7 +3753,7 @@ void janus_ice_relay_rtp(janus_ice_handle *handle, int video, char *buf, int len
 			|| (video && !janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO)))
 		return;
 	/* Queue this packet */
-	janus_ice_queued_packet *pkt = (janus_ice_queued_packet *)g_malloc(sizeof(janus_ice_queued_packet));
+	janus_ice_queued_packet *pkt = g_malloc(sizeof(janus_ice_queued_packet));
 	pkt->data = g_malloc(len);
 	memcpy(pkt->data, buf, len);
 	pkt->length = len;
@@ -3791,7 +3791,7 @@ void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, int video, char *bu
 			video ? stream->video_ssrc_peer[0] : stream->audio_ssrc_peer);
 	}
 	/* Queue this packet */
-	janus_ice_queued_packet *pkt = (janus_ice_queued_packet *)g_malloc(sizeof(janus_ice_queued_packet));
+	janus_ice_queued_packet *pkt = g_malloc(sizeof(janus_ice_queued_packet));
 	pkt->data = g_malloc(len);
 	memcpy(pkt->data, rtcp_buf, rtcp_len);
 	pkt->length = rtcp_len;
@@ -3815,7 +3815,7 @@ void janus_ice_relay_data(janus_ice_handle *handle, char *buf, int len) {
 	if(!handle || buf == NULL || len < 1)
 		return;
 	/* Queue this packet */
-	janus_ice_queued_packet *pkt = (janus_ice_queued_packet *)g_malloc(sizeof(janus_ice_queued_packet));
+	janus_ice_queued_packet *pkt = g_malloc(sizeof(janus_ice_queued_packet));
 	pkt->data = g_malloc(len);
 	memcpy(pkt->data, buf, len);
 	pkt->length = len;

--- a/ice.c
+++ b/ice.c
@@ -506,7 +506,7 @@ void janus_ice_notify_hangup(janus_ice_handle *handle, const char *reason) {
 janus_ice_trickle *janus_ice_trickle_new(janus_ice_handle *handle, const char *transaction, json_t *candidate) {
 	if(transaction == NULL || candidate == NULL)
 		return NULL;
-	janus_ice_trickle *trickle = g_malloc0(sizeof(janus_ice_trickle));
+	janus_ice_trickle *trickle = g_malloc(sizeof(janus_ice_trickle));
 	trickle->handle = handle;
 	trickle->received = janus_get_monotonic_time();
 	trickle->transaction = g_strdup(transaction);
@@ -957,7 +957,7 @@ gint janus_ice_handle_attach_plugin(void *gateway_session, guint64 handle_id, ja
 		return JANUS_ERROR_PLUGIN_ATTACH;
 	}
 	int error = 0;
-	janus_plugin_session *session_handle = g_malloc0(sizeof(janus_plugin_session));
+	janus_plugin_session *session_handle = g_malloc(sizeof(janus_plugin_session));
 	if(session_handle == NULL) {
 		JANUS_LOG(LOG_FATAL, "Memory error!\n");
 		return JANUS_ERROR_UNKNOWN;	/* FIXME Do we need something like "Internal Server Error"? */
@@ -2321,8 +2321,8 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 							p->last_retransmit = now;
 							retransmits_cnt++;
 							/* Enqueue it */
-							janus_ice_queued_packet *pkt = (janus_ice_queued_packet *)g_malloc0(sizeof(janus_ice_queued_packet));
-							pkt->data = g_malloc0(p->length);
+							janus_ice_queued_packet *pkt = (janus_ice_queued_packet *)g_malloc(sizeof(janus_ice_queued_packet));
+							pkt->data = g_malloc(p->length);
 							memcpy(pkt->data, p->data, p->length);
 							pkt->length = p->length;
 							pkt->type = video ? JANUS_ICE_PACKET_VIDEO : JANUS_ICE_PACKET_AUDIO;
@@ -3243,7 +3243,7 @@ void *janus_ice_send_thread(void *data) {
 						guint32 i = 0;
 						for (i = handle->stream->transport_wide_cc_last_feedback_seq_num+1; i<transport_seq_num; ++i) {
 							/* Create new stat */
-							janus_rtcp_transport_wide_cc_stats *missing = g_malloc0(sizeof(janus_rtcp_transport_wide_cc_stats));
+							janus_rtcp_transport_wide_cc_stats *missing = g_malloc(sizeof(janus_rtcp_transport_wide_cc_stats));
 							/* Add missing packet */
 							missing->transport_seq_num = i;
 							missing->timestamp = 0;
@@ -3417,7 +3417,6 @@ void *janus_ice_send_thread(void *data) {
 					/* There's a REMB, prepend a RR as it won't work otherwise */
 					int rrlen = 32;
 					char *rtcpbuf = g_malloc0(rrlen+pkt->length);
-					memset(rtcpbuf, 0, rrlen+pkt->length);
 					rtcp_rr *rr = (rtcp_rr *)rtcpbuf;
 					rr->header.version = 2;
 					rr->header.type = RTCP_RR;
@@ -3659,8 +3658,8 @@ void *janus_ice_send_thread(void *data) {
 								pkt = NULL;
 								continue;
 							}
-							janus_rtp_packet *p = (janus_rtp_packet *)g_malloc0(sizeof(janus_rtp_packet));
-							p->data = (char *)g_malloc0(protected);
+							janus_rtp_packet *p = (janus_rtp_packet *)g_malloc(sizeof(janus_rtp_packet));
+							p->data = (char *)g_malloc(protected);
 							memcpy(p->data, sbuf, protected);
 							p->length = protected;
 							p->created = janus_get_monotonic_time();
@@ -3762,8 +3761,8 @@ void janus_ice_relay_rtp(janus_ice_handle *handle, int video, char *buf, int len
 			|| (video && !janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO)))
 		return;
 	/* Queue this packet */
-	janus_ice_queued_packet *pkt = (janus_ice_queued_packet *)g_malloc0(sizeof(janus_ice_queued_packet));
-	pkt->data = g_malloc0(len);
+	janus_ice_queued_packet *pkt = (janus_ice_queued_packet *)g_malloc(sizeof(janus_ice_queued_packet));
+	pkt->data = g_malloc(len);
 	memcpy(pkt->data, buf, len);
 	pkt->length = len;
 	pkt->type = video ? JANUS_ICE_PACKET_VIDEO : JANUS_ICE_PACKET_AUDIO;
@@ -3800,8 +3799,8 @@ void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, int video, char *bu
 			video ? stream->video_ssrc_peer[0] : stream->audio_ssrc_peer);
 	}
 	/* Queue this packet */
-	janus_ice_queued_packet *pkt = (janus_ice_queued_packet *)g_malloc0(sizeof(janus_ice_queued_packet));
-	pkt->data = g_malloc0(len);
+	janus_ice_queued_packet *pkt = (janus_ice_queued_packet *)g_malloc(sizeof(janus_ice_queued_packet));
+	pkt->data = g_malloc(len);
 	memcpy(pkt->data, rtcp_buf, rtcp_len);
 	pkt->length = rtcp_len;
 	pkt->type = video ? JANUS_ICE_PACKET_VIDEO : JANUS_ICE_PACKET_AUDIO;
@@ -3824,8 +3823,8 @@ void janus_ice_relay_data(janus_ice_handle *handle, char *buf, int len) {
 	if(!handle || buf == NULL || len < 1)
 		return;
 	/* Queue this packet */
-	janus_ice_queued_packet *pkt = (janus_ice_queued_packet *)g_malloc0(sizeof(janus_ice_queued_packet));
-	pkt->data = g_malloc0(len);
+	janus_ice_queued_packet *pkt = (janus_ice_queued_packet *)g_malloc(sizeof(janus_ice_queued_packet));
+	pkt->data = g_malloc(len);
 	memcpy(pkt->data, buf, len);
 	pkt->length = len;
 	pkt->type = JANUS_ICE_PACKET_DATA;

--- a/ice.c
+++ b/ice.c
@@ -911,10 +911,6 @@ janus_ice_handle *janus_ice_handle_create(void *gateway_session, const char *opa
 	}
 	JANUS_LOG(LOG_INFO, "Creating new handle in session %"SCNu64": %"SCNu64"\n", session->session_id, handle_id);
 	janus_ice_handle *handle = (janus_ice_handle *)g_malloc0(sizeof(janus_ice_handle));
-	if(handle == NULL) {
-		JANUS_LOG(LOG_FATAL, "Memory error!\n");
-		return NULL;
-	}
 	handle->session = gateway_session;
 	if(opaque_id)
 		handle->opaque_id = g_strdup(opaque_id);
@@ -958,10 +954,6 @@ gint janus_ice_handle_attach_plugin(void *gateway_session, guint64 handle_id, ja
 	}
 	int error = 0;
 	janus_plugin_session *session_handle = g_malloc(sizeof(janus_plugin_session));
-	if(session_handle == NULL) {
-		JANUS_LOG(LOG_FATAL, "Memory error!\n");
-		return JANUS_ERROR_UNKNOWN;	/* FIXME Do we need something like "Internal Server Error"? */
-	}
 	session_handle->gateway_handle = handle;
 	session_handle->plugin_handle = NULL;
 	session_handle->stopped = 0;

--- a/janus.c
+++ b/janus.c
@@ -520,7 +520,7 @@ janus_session *janus_session_create(guint64 session_id) {
 		}
 	}
 	JANUS_LOG(LOG_INFO, "Creating new session: %"SCNu64"\n", session_id);
-	janus_session *session = (janus_session *)g_malloc(sizeof(janus_session));
+	janus_session *session = g_malloc(sizeof(janus_session));
 	session->session_id = session_id;
 	session->source = NULL;
 	g_atomic_int_set(&session->destroy, 0);
@@ -596,7 +596,7 @@ void janus_session_free(janus_session *session) {
 
 /* Requests management */
 janus_request *janus_request_new(janus_transport *transport, void *instance, void *request_id, gboolean admin, json_t *message) {
-	janus_request *request = (janus_request *)g_malloc(sizeof(janus_request));
+	janus_request *request = g_malloc(sizeof(janus_request));
 	request->transport = transport;
 	request->instance = instance;
 	request->request_id = request_id;

--- a/janus.c
+++ b/janus.c
@@ -520,7 +520,7 @@ janus_session *janus_session_create(guint64 session_id) {
 		}
 	}
 	JANUS_LOG(LOG_INFO, "Creating new session: %"SCNu64"\n", session_id);
-	janus_session *session = (janus_session *)g_malloc0(sizeof(janus_session));
+	janus_session *session = (janus_session *)g_malloc(sizeof(janus_session));
 	if(session == NULL) {
 		JANUS_LOG(LOG_FATAL, "Memory error!\n");
 		return NULL;
@@ -530,6 +530,7 @@ janus_session *janus_session_create(guint64 session_id) {
 	g_atomic_int_set(&session->destroy, 0);
 	g_atomic_int_set(&session->timeout, 0);
 	session->last_activity = janus_get_monotonic_time();
+	session->ice_handles = NULL;
 	janus_mutex_init(&session->mutex);
 	janus_mutex_lock(&sessions_mutex);
 	g_hash_table_insert(sessions, janus_uint64_dup(session->session_id), session);
@@ -599,7 +600,7 @@ void janus_session_free(janus_session *session) {
 
 /* Requests management */
 janus_request *janus_request_new(janus_transport *transport, void *instance, void *request_id, gboolean admin, json_t *message) {
-	janus_request *request = (janus_request *)g_malloc0(sizeof(janus_request));
+	janus_request *request = (janus_request *)g_malloc(sizeof(janus_request));
 	request->transport = transport;
 	request->instance = instance;
 	request->request_id = request_id;

--- a/janus.c
+++ b/janus.c
@@ -521,10 +521,6 @@ janus_session *janus_session_create(guint64 session_id) {
 	}
 	JANUS_LOG(LOG_INFO, "Creating new session: %"SCNu64"\n", session_id);
 	janus_session *session = (janus_session *)g_malloc(sizeof(janus_session));
-	if(session == NULL) {
-		JANUS_LOG(LOG_FATAL, "Memory error!\n");
-		return NULL;
-	}
 	session->session_id = session_id;
 	session->source = NULL;
 	g_atomic_int_set(&session->destroy, 0);

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -1502,7 +1502,7 @@ void janus_audiobridge_create_session(janus_plugin_session *handle, int *error) 
 		*error = -1;
 		return;
 	}	
-	janus_audiobridge_session *session = (janus_audiobridge_session *)g_malloc0(sizeof(janus_audiobridge_session));
+	janus_audiobridge_session *session = g_malloc0(sizeof(janus_audiobridge_session));
 	session->handle = handle;
 	session->started = FALSE;
 	session->stopping = FALSE;
@@ -4217,7 +4217,7 @@ static void *janus_audiobridge_participant_thread(void *data) {
 
 	/* Output buffer */
 	janus_audiobridge_rtp_relay_packet *outpkt = g_malloc(sizeof(janus_audiobridge_rtp_relay_packet));
-	outpkt->data = (janus_rtp_header *)g_malloc0(1500);
+	outpkt->data = g_malloc0(1500);
 	outpkt->ssrc = 0;
 	outpkt->timestamp = 0;
 	outpkt->seq_number = 0;

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -2575,7 +2575,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			|| !strcasecmp(request_text, "changeroom") || !strcasecmp(request_text, "leave")) {
 		/* These messages are handled asynchronously */
 		janus_mutex_unlock(&sessions_mutex);
-		janus_audiobridge_message *msg = g_malloc0(sizeof(janus_audiobridge_message));
+		janus_audiobridge_message *msg = g_malloc(sizeof(janus_audiobridge_message));
 		msg->handle = handle;
 		msg->transaction = transaction;
 		msg->message = root;
@@ -2671,13 +2671,14 @@ void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, int video, cha
 		}
 		/* Decode frame (Opus -> slinear) */
 		janus_rtp_header *rtp = (janus_rtp_header *)buf;
-		janus_audiobridge_rtp_relay_packet *pkt = g_malloc0(sizeof(janus_audiobridge_rtp_relay_packet));
+		janus_audiobridge_rtp_relay_packet *pkt = g_malloc(sizeof(janus_audiobridge_rtp_relay_packet));
 		pkt->data = g_malloc0(BUFFER_SAMPLES*sizeof(opus_int16));
 		pkt->ssrc = 0;
 		pkt->timestamp = ntohl(rtp->timestamp);
 		pkt->seq_number = ntohs(rtp->seq_number);
 		/* We might check the audio level extension to see if this is silence */
 		pkt->silence = FALSE;
+		pkt->length = 0;
 
 		if(participant->extmap_id > 0) {
 			/* Check the audio levels, in case we need to notify participants about who's talking */
@@ -4105,14 +4106,15 @@ static void *janus_audiobridge_mixer_thread(void *data) {
 				/* FIXME Smoothen/Normalize instead of truncating? */
 				outBuffer[i] = sumBuffer[i];
 			/* Enqueue this mixed frame for encoding in the participant thread */
-			janus_audiobridge_rtp_relay_packet *mixedpkt = g_malloc0(sizeof(janus_audiobridge_rtp_relay_packet));
+			janus_audiobridge_rtp_relay_packet *mixedpkt = g_malloc(sizeof(janus_audiobridge_rtp_relay_packet));
 			if(mixedpkt != NULL) {
-				mixedpkt->data = g_malloc0(samples*2);
+				mixedpkt->data = g_malloc(samples*2);
 				memcpy(mixedpkt->data, outBuffer, samples*2);
 				mixedpkt->length = samples;	/* We set the number of samples here, not the data length */
 				mixedpkt->timestamp = ts;
 				mixedpkt->seq_number = seq;
 				mixedpkt->ssrc = audiobridge->room_id;
+				mixedpkt->silence = FALSE;
 				g_async_queue_push(p->outbuf, mixedpkt);
 			}
 			if(pkt) {
@@ -4216,13 +4218,14 @@ static void *janus_audiobridge_participant_thread(void *data) {
 	janus_audiobridge_session *session = participant->session;
 
 	/* Output buffer */
-	janus_audiobridge_rtp_relay_packet *outpkt = g_malloc0(sizeof(janus_audiobridge_rtp_relay_packet));
+	janus_audiobridge_rtp_relay_packet *outpkt = g_malloc(sizeof(janus_audiobridge_rtp_relay_packet));
 	outpkt->data = (janus_rtp_header *)g_malloc0(1500);
 	outpkt->ssrc = 0;
 	outpkt->timestamp = 0;
 	outpkt->seq_number = 0;
+	outpkt->length = 0;
+	outpkt->silence = FALSE;
 	unsigned char *payload = (unsigned char *)outpkt->data;
-	memset(payload, 0, 1500);
 
 	janus_audiobridge_rtp_relay_packet *mixedpkt = NULL;
 

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -4107,16 +4107,14 @@ static void *janus_audiobridge_mixer_thread(void *data) {
 				outBuffer[i] = sumBuffer[i];
 			/* Enqueue this mixed frame for encoding in the participant thread */
 			janus_audiobridge_rtp_relay_packet *mixedpkt = g_malloc(sizeof(janus_audiobridge_rtp_relay_packet));
-			if(mixedpkt != NULL) {
-				mixedpkt->data = g_malloc(samples*2);
-				memcpy(mixedpkt->data, outBuffer, samples*2);
-				mixedpkt->length = samples;	/* We set the number of samples here, not the data length */
-				mixedpkt->timestamp = ts;
-				mixedpkt->seq_number = seq;
-				mixedpkt->ssrc = audiobridge->room_id;
-				mixedpkt->silence = FALSE;
-				g_async_queue_push(p->outbuf, mixedpkt);
-			}
+			mixedpkt->data = g_malloc(samples*2);
+			memcpy(mixedpkt->data, outBuffer, samples*2);
+			mixedpkt->length = samples;	/* We set the number of samples here, not the data length */
+			mixedpkt->timestamp = ts;
+			mixedpkt->seq_number = seq;
+			mixedpkt->ssrc = audiobridge->room_id;
+			mixedpkt->silence = FALSE;
+			g_async_queue_push(p->outbuf, mixedpkt);
 			if(pkt) {
 				if(pkt->data)
 					g_free(pkt->data);

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -502,7 +502,7 @@ struct janus_plugin_result *janus_echotest_handle_message(janus_plugin_session *
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
 
-	janus_echotest_message *msg = g_malloc0(sizeof(janus_echotest_message));
+	janus_echotest_message *msg = g_malloc(sizeof(janus_echotest_message));
 	msg->handle = handle;
 	msg->transaction = transaction;
 	msg->message = message;
@@ -727,7 +727,7 @@ void janus_echotest_incoming_data(janus_plugin_session *handle, char *buf, int l
 			return;
 		if(buf == NULL || len <= 0)
 			return;
-		char *text = g_malloc0(len+1);
+		char *text = g_malloc(len+1);
 		memcpy(text, buf, len);
 		*(text+len) = '\0';
 		JANUS_LOG(LOG_VERB, "Got a DataChannel message (%zu bytes) to bounce back: %s\n", strlen(text), text);
@@ -735,7 +735,7 @@ void janus_echotest_incoming_data(janus_plugin_session *handle, char *buf, int l
 		janus_recorder_save_frame(session->drc, text, strlen(text));
 		/* We send back the same text with a custom prefix */
 		const char *prefix = "Janus EchoTest here! You wrote: ";
-		char *reply = g_malloc0(strlen(prefix)+len+1);
+		char *reply = g_malloc(strlen(prefix)+len+1);
 		g_snprintf(reply, strlen(prefix)+len+1, "%s%s", prefix, text);
 		g_free(text);
 		gateway->relay_data(handle, reply, strlen(reply));
@@ -873,7 +873,7 @@ static void *janus_echotest_handler(void *data) {
 	JANUS_LOG(LOG_VERB, "Joining EchoTest handler thread\n");
 	janus_echotest_message *msg = NULL;
 	int error_code = 0;
-	char *error_cause = g_malloc0(512);
+	char *error_cause = g_malloc(512);
 	json_t *root = NULL;
 	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
 		msg = g_async_queue_pop(messages);

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -399,7 +399,7 @@ void janus_echotest_create_session(janus_plugin_session *handle, int *error) {
 		*error = -1;
 		return;
 	}	
-	janus_echotest_session *session = (janus_echotest_session *)g_malloc0(sizeof(janus_echotest_session));
+	janus_echotest_session *session = g_malloc0(sizeof(janus_echotest_session));
 	session->handle = handle;
 	session->has_audio = FALSE;
 	session->has_video = FALSE;

--- a/plugins/janus_nosip.c
+++ b/plugins/janus_nosip.c
@@ -722,7 +722,7 @@ json_t *janus_nosip_query_session(janus_plugin_session *handle) {
 struct janus_plugin_result *janus_nosip_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
-	janus_nosip_message *msg = g_malloc0(sizeof(janus_nosip_message));
+	janus_nosip_message *msg = g_malloc(sizeof(janus_nosip_message));
 	msg->handle = handle;
 	msg->transaction = transaction;
 	msg->message = message;

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -994,7 +994,7 @@ struct janus_plugin_result *janus_recordplay_handle_message(janus_plugin_session
 			|| !strcasecmp(request_text, "start") || !strcasecmp(request_text, "stop")) {
 		/* These messages are handled asynchronously */
 		janus_mutex_unlock(&sessions_mutex);
-		janus_recordplay_message *msg = g_malloc0(sizeof(janus_recordplay_message));
+		janus_recordplay_message *msg = g_malloc(sizeof(janus_recordplay_message));
 		msg->handle = handle;
 		msg->transaction = transaction;
 		msg->message = root;
@@ -2048,7 +2048,7 @@ janus_recordplay_frame_packet *janus_recordplay_get_frames(const char *dir, cons
 		JANUS_LOG(LOG_HUGE, "  -- RTP packet (ssrc=%"SCNu32", pt=%"SCNu16", ext=%"SCNu16", seq=%"SCNu16", ts=%"SCNu32")\n",
 				ntohl(rtp->ssrc), rtp->type, rtp->extension, ntohs(rtp->seq_number), ntohl(rtp->timestamp));
 		/* Generate frame packet and insert in the ordered list */
-		janus_recordplay_frame_packet *p = g_malloc0(sizeof(janus_recordplay_frame_packet));
+		janus_recordplay_frame_packet *p = g_malloc(sizeof(janus_recordplay_frame_packet));
 		p->seq = ntohs(rtp->seq_number);
 		if(reset == 0) {
 			/* Simple enough... */
@@ -2214,7 +2214,6 @@ static void *janus_recordplay_playout_thread(void *data) {
 
 	janus_recordplay_frame_packet *audio = session->aframes, *video = session->vframes;
 	char *buffer = (char *)g_malloc0(1500);
-	memset(buffer, 0, 1500);
 	int bytes = 0;
 	int64_t ts_diff = 0, passed = 0;
 

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -809,7 +809,7 @@ void janus_recordplay_create_session(janus_plugin_session *handle, int *error) {
 		*error = -1;
 		return;
 	}	
-	janus_recordplay_session *session = (janus_recordplay_session *)g_malloc0(sizeof(janus_recordplay_session));
+	janus_recordplay_session *session = g_malloc0(sizeof(janus_recordplay_session));
 	session->handle = handle;
 	session->active = FALSE;
 	session->recorder = FALSE;
@@ -1384,7 +1384,7 @@ static void *janus_recordplay_handler(void *data) {
 				}
 			}
 			JANUS_LOG(LOG_VERB, "Starting new recording with ID %"SCNu64"\n", id);
-			rec = (janus_recordplay_recording *)g_malloc0(sizeof(janus_recordplay_recording));
+			rec = g_malloc0(sizeof(janus_recordplay_recording));
 			rec->id = id;
 			rec->name = g_strdup(name_text);
 			rec->viewers = NULL;
@@ -1766,7 +1766,7 @@ void janus_recordplay_update_recordings_list(void) {
 			janus_config_destroy(nfo);
 			continue;
 		}
-		rec = (janus_recordplay_recording *)g_malloc0(sizeof(janus_recordplay_recording));
+		rec = g_malloc0(sizeof(janus_recordplay_recording));
 		rec->id = id;
 		rec->name = g_strdup(name->value);
 		rec->date = g_strdup(date->value);
@@ -2213,7 +2213,7 @@ static void *janus_recordplay_playout_thread(void *data) {
 	gettimeofday(&vbefore, NULL);
 
 	janus_recordplay_frame_packet *audio = session->aframes, *video = session->vframes;
-	char *buffer = (char *)g_malloc0(1500);
+	char *buffer = g_malloc0(1500);
 	int bytes = 0;
 	int64_t ts_diff = 0, passed = 0;
 

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1155,7 +1155,7 @@ json_t *janus_sip_query_session(janus_plugin_session *handle) {
 struct janus_plugin_result *janus_sip_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
-	janus_sip_message *msg = g_malloc0(sizeof(janus_sip_message));
+	janus_sip_message *msg = g_malloc(sizeof(janus_sip_message));
 	msg->handle = handle;
 	msg->transaction = transaction;
 	msg->message = message;
@@ -1432,7 +1432,7 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 	session->vrc_peer = NULL;
 	janus_mutex_unlock(&session->rec_mutex);
 	/* FIXME Simulate a "hangup" coming from the browser */
-	janus_sip_message *msg = g_malloc0(sizeof(janus_sip_message));
+	janus_sip_message *msg = g_malloc(sizeof(janus_sip_message));
 	msg->handle = handle;
 	msg->message = json_pack("{ss}", "request", "hangup");
 	msg->transaction = NULL;
@@ -3970,7 +3970,7 @@ static void *janus_sip_relay_thread(void *data) {
 				JANUS_LOG(LOG_ERR, "[SIP-%s]   -- %d (%s)\n", session->account.username, error, strerror(error));
 				goon = FALSE;	/* Can we assume it's pretty much over, after a POLLERR? */
 				/* FIXME Simulate a "hangup" coming from the browser */
-				janus_sip_message *msg = g_malloc0(sizeof(janus_sip_message));
+				janus_sip_message *msg = g_malloc(sizeof(janus_sip_message));
 				msg->handle = session->handle;
 				msg->message = json_pack("{ss}", "request", "hangup");
 				msg->transaction = NULL;

--- a/plugins/janus_sipre.c
+++ b/plugins/janus_sipre.c
@@ -297,7 +297,7 @@ typedef struct janus_sipre_mqueue_payload {
 	void *data;					/* Payload specific data */
 } janus_sipre_mqueue_payload;
 static janus_sipre_mqueue_payload *janus_sipre_mqueue_payload_create(void *session, const struct sip_msg *msg, int rcode, void *data) {
-	janus_sipre_mqueue_payload *payload = g_malloc0(sizeof(janus_sipre_mqueue_payload));
+	janus_sipre_mqueue_payload *payload = g_malloc(sizeof(janus_sipre_mqueue_payload));
 	payload->session = session;
 	payload->msg = msg;
 	payload->rcode = rcode;
@@ -1201,7 +1201,7 @@ json_t *janus_sipre_query_session(janus_plugin_session *handle) {
 struct janus_plugin_result *janus_sipre_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
-	janus_sipre_message *msg = g_malloc0(sizeof(janus_sipre_message));
+	janus_sipre_message *msg = g_malloc(sizeof(janus_sipre_message));
 	msg->handle = handle;
 	msg->transaction = transaction;
 	msg->message = message;
@@ -3137,7 +3137,7 @@ static void *janus_sipre_relay_thread(void *data) {
 				/* Can we assume it's pretty much over, after a POLLERR? */
 				goon = FALSE;
 				/* FIXME Simulate a "hangup" coming from the browser */
-				janus_sipre_message *msg = g_malloc0(sizeof(janus_sipre_message));
+				janus_sipre_message *msg = g_malloc(sizeof(janus_sipre_message));
 				msg->handle = session->handle;
 				msg->message = json_pack("{ss}", "request", "hangup");
 				msg->transaction = NULL;

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -1247,7 +1247,7 @@ void janus_streaming_create_session(janus_plugin_session *handle, int *error) {
 		*error = -1;
 		return;
 	}
-	janus_streaming_session *session = (janus_streaming_session *)g_malloc0(sizeof(janus_streaming_session));
+	janus_streaming_session *session = g_malloc0(sizeof(janus_streaming_session));
 	session->handle = handle;
 	session->mountpoint = NULL;	/* This will happen later */
 	session->started = FALSE;	/* This will happen later */

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2460,7 +2460,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			|| !strcasecmp(request_text, "configure") || !strcasecmp(request_text, "switch")) {
 		/* These messages are handled asynchronously */
 		janus_mutex_unlock(&sessions_mutex);
-		janus_streaming_message *msg = g_malloc0(sizeof(janus_streaming_message));
+		janus_streaming_message *msg = g_malloc(sizeof(janus_streaming_message));
 		msg->handle = handle;
 		msg->transaction = transaction;
 		msg->message = root;
@@ -3801,7 +3801,7 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 		curl_easy_setopt(curl, CURLOPT_PASSWORD, source->rtsp_password);
 	}
 	/* Send an RTSP DESCRIBE */
-	janus_streaming_buffer *curldata = g_malloc0(sizeof(janus_streaming_buffer));
+	janus_streaming_buffer *curldata = g_malloc(sizeof(janus_streaming_buffer));
 	curldata->buffer = g_malloc0(1);
 	curldata->size = 0;
 	curl_easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, source->rtsp_url);
@@ -4671,7 +4671,7 @@ static void *janus_streaming_relay_thread(void *data) {
 							janus_mutex_lock(&source->keyframe.mutex);
 							JANUS_LOG(LOG_HUGE, "[%s] ... other part of keyframe received! ts=%"SCNu32"\n", name, source->keyframe.temp_ts);
 							janus_streaming_rtp_relay_packet *pkt = g_malloc0(sizeof(janus_streaming_rtp_relay_packet));
-							pkt->data = g_malloc0(bytes);
+							pkt->data = g_malloc(bytes);
 							memcpy(pkt->data, buffer, bytes);
 							pkt->data->ssrc = htons(1);
 							pkt->data->type = mountpoint->codecs.video_pt;
@@ -4713,7 +4713,7 @@ static void *janus_streaming_relay_thread(void *data) {
 									JANUS_LOG(LOG_HUGE, "[%s] New keyframe received! ts=%"SCNu32"\n", name, source->keyframe.temp_ts);
 									janus_mutex_lock(&source->keyframe.mutex);
 									janus_streaming_rtp_relay_packet *pkt = g_malloc0(sizeof(janus_streaming_rtp_relay_packet));
-									pkt->data = g_malloc0(bytes);
+									pkt->data = g_malloc(bytes);
 									memcpy(pkt->data, buffer, bytes);
 									pkt->data->ssrc = htons(1);
 									pkt->data->type = mountpoint->codecs.video_pt;
@@ -4780,7 +4780,7 @@ static void *janus_streaming_relay_thread(void *data) {
 						continue;
 					}
 					/* Get a string out of the data */
-					char *text = g_malloc0(bytes+1);
+					char *text = g_malloc(bytes+1);
 					memcpy(text, buffer, bytes);
 					*(text+bytes) = '\0';
 					/* Relay on all sessions */
@@ -4793,7 +4793,7 @@ static void *janus_streaming_relay_thread(void *data) {
 					if(source->buffermsg) {
 						janus_mutex_lock(&source->buffermsg_mutex);
 						janus_streaming_rtp_relay_packet *pkt = g_malloc0(sizeof(janus_streaming_rtp_relay_packet));
-						pkt->data = g_malloc0(bytes+1);
+						pkt->data = g_malloc(bytes+1);
 						memcpy(pkt->data, text, bytes+1);
 						packet.is_rtp = FALSE;
 						pkt->length = bytes+1;

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -624,7 +624,7 @@ void janus_textroom_create_session(janus_plugin_session *handle, int *error) {
 		*error = -1;
 		return;
 	}
-	janus_textroom_session *session = (janus_textroom_session *)g_malloc0(sizeof(janus_textroom_session));
+	janus_textroom_session *session = g_malloc0(sizeof(janus_textroom_session));
 	session->handle = handle;
 	session->rooms = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free, NULL);
 	session->destroyed = 0;

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -757,7 +757,7 @@ struct janus_plugin_result *janus_textroom_handle_message(janus_plugin_session *
 	} else if(!strcasecmp(request_text, "setup") || !strcasecmp(request_text, "ack") || !strcasecmp(request_text, "restart")) {
 		/* These messages are handled asynchronously */
 		janus_mutex_unlock(&sessions_mutex);
-		janus_textroom_message *msg = g_malloc0(sizeof(janus_textroom_message));
+		janus_textroom_message *msg = g_malloc(sizeof(janus_textroom_message));
 		msg->handle = handle;
 		msg->transaction = transaction;
 		msg->message = root;
@@ -833,7 +833,7 @@ void janus_textroom_incoming_data(janus_plugin_session *handle, char *buf, int l
 		return;
 	if(buf == NULL || len <= 0)
 		return;
-	char *text = g_malloc0(len+1);
+	char *text = g_malloc(len+1);
 	memcpy(text, buf, len);
 	*(text+len) = '\0';
 	JANUS_LOG(LOG_VERB, "Got a DataChannel message (%zu bytes): %s\n", strlen(text), text);
@@ -1059,7 +1059,7 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 		json_t *display = json_object_get(root, "display");
 		const char *display_text = json_string_value(display);
 		/* Create a participant instance */
-		participant = g_malloc0(sizeof(janus_textroom_participant));
+		participant = g_malloc(sizeof(janus_textroom_participant));
 		participant->session = session;
 		participant->room = textroom;
 		participant->username = g_strdup(username_text);

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -668,7 +668,7 @@ json_t *janus_videocall_query_session(janus_plugin_session *handle) {
 struct janus_plugin_result *janus_videocall_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
-	janus_videocall_message *msg = g_malloc0(sizeof(janus_videocall_message));
+	janus_videocall_message *msg = g_malloc(sizeof(janus_videocall_message));
 	msg->handle = handle;
 	msg->transaction = transaction;
 	msg->message = message;
@@ -894,7 +894,7 @@ void janus_videocall_incoming_data(janus_plugin_session *handle, char *buf, int 
 			return;
 		if(buf == NULL || len <= 0)
 			return;
-		char *text = g_malloc0(len+1);
+		char *text = g_malloc(len+1);
 		memcpy(text, buf, len);
 		*(text+len) = '\0';
 		JANUS_LOG(LOG_VERB, "Got a DataChannel message (%zu bytes) to forward: %s\n", strlen(text), text);

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -561,7 +561,7 @@ void janus_videocall_create_session(janus_plugin_session *handle, int *error) {
 		*error = -1;
 		return;
 	}	
-	janus_videocall_session *session = (janus_videocall_session *)g_malloc0(sizeof(janus_videocall_session));
+	janus_videocall_session *session = g_malloc0(sizeof(janus_videocall_session));
 	session->handle = handle;
 	session->has_audio = FALSE;
 	session->has_video = FALSE;

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -2906,7 +2906,7 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		/* These messages are handled asynchronously */
 		janus_mutex_unlock(&sessions_mutex);
 
-		janus_videoroom_message *msg = g_malloc0(sizeof(janus_videoroom_message));
+		janus_videoroom_message *msg = g_malloc(sizeof(janus_videoroom_message));
 		msg->handle = handle;
 		msg->transaction = transaction;
 		msg->message = root;
@@ -3355,7 +3355,7 @@ void janus_videoroom_incoming_data(janus_plugin_session *handle, char *buf, int 
 	}
 	janus_mutex_unlock(&participant->rtp_forwarders_mutex);
 	/* Get a string out of the data */
-	char *text = g_malloc0(len+1);
+	char *text = g_malloc(len+1);
 	memcpy(text, buf, len);
 	*(text+len) = '\0';
 	JANUS_LOG(LOG_VERB, "Got a DataChannel message (%zu bytes) to forward: %s\n", strlen(text), text);
@@ -4996,7 +4996,7 @@ static void *janus_videoroom_handler(void *data) {
 						janus_videoroom_listener *listener = (janus_videoroom_listener *)s->data;
 						if(listener && listener->session && listener->session->handle) {
 							/* Enqueue the fake request: this will trigger a renegotiation */
-							janus_videoroom_message *msg = g_malloc0(sizeof(janus_videoroom_message));
+							janus_videoroom_message *msg = g_malloc(sizeof(janus_videoroom_message));
 							msg->handle = listener->session->handle;
 							msg->message = update;
 							json_incref(update);

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1336,7 +1336,7 @@ void janus_videoroom_create_session(janus_plugin_session *handle, int *error) {
 		*error = -1;
 		return;
 	}	
-	janus_videoroom_session *session = (janus_videoroom_session *)g_malloc0(sizeof(janus_videoroom_session));
+	janus_videoroom_session *session = g_malloc0(sizeof(janus_videoroom_session));
 	session->handle = handle;
 	session->participant_type = janus_videoroom_p_type_none;
 	session->participant = NULL;

--- a/plugins/janus_voicemail.c
+++ b/plugins/janus_voicemail.c
@@ -456,7 +456,7 @@ void janus_voicemail_create_session(janus_plugin_session *handle, int *error) {
 		*error = -1;
 		return;
 	}	
-	janus_voicemail_session *session = (janus_voicemail_session *)g_malloc0(sizeof(janus_voicemail_session));
+	janus_voicemail_session *session = g_malloc0(sizeof(janus_voicemail_session));
 	session->handle = handle;
 	session->recording_id = janus_random_uint64();
 	session->start_time = 0;

--- a/plugins/janus_voicemail.c
+++ b/plugins/janus_voicemail.c
@@ -531,7 +531,7 @@ json_t *janus_voicemail_query_session(janus_plugin_session *handle) {
 struct janus_plugin_result *janus_voicemail_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
-	janus_voicemail_message *msg = g_malloc0(sizeof(janus_voicemail_message));
+	janus_voicemail_message *msg = g_malloc(sizeof(janus_voicemail_message));
 	msg->handle = handle;
 	msg->transaction = transaction;
 	msg->message = message;
@@ -582,7 +582,7 @@ void janus_voicemail_incoming_rtp(janus_plugin_session *handle, int video, char 
 	if((now-session->start_time) >= 10*G_USEC_PER_SEC) {
 		/* FIXME Simulate a "stop" coming from the browser */
 		session->started = FALSE;
-		janus_voicemail_message *msg = g_malloc0(sizeof(janus_voicemail_message));
+		janus_voicemail_message *msg = g_malloc(sizeof(janus_voicemail_message));
 		msg->handle = handle;
 		msg->message = json_pack("{ss}", "request", "stop");
 		msg->transaction = NULL;
@@ -888,8 +888,8 @@ void le16(unsigned char *p, int v) {
 /* ;anufacture a generic OpusHead packet */
 ogg_packet *op_opushead(void) {
 	int size = 19;
-	unsigned char *data = g_malloc0(size);
-	ogg_packet *op = g_malloc0(sizeof(*op));
+	unsigned char *data = g_malloc(size);
+	ogg_packet *op = g_malloc(sizeof(*op));
 
 	if(!data) {
 		JANUS_LOG(LOG_ERR, "Couldn't allocate data buffer...\n");
@@ -923,8 +923,8 @@ ogg_packet *op_opustags(void) {
 	const char *identifier = "OpusTags";
 	const char *vendor = "Janus VoiceMail plugin";
 	int size = strlen(identifier) + 4 + strlen(vendor) + 4;
-	unsigned char *data = g_malloc0(size);
-	ogg_packet *op = g_malloc0(sizeof(*op));
+	unsigned char *data = g_malloc(size);
+	ogg_packet *op = g_malloc(sizeof(*op));
 
 	if(!data) {
 		JANUS_LOG(LOG_ERR, "Couldn't allocate data buffer...\n");
@@ -952,7 +952,7 @@ ogg_packet *op_opustags(void) {
 
 /* Allocate an ogg_packet */
 ogg_packet *op_from_pkt(const unsigned char *pkt, int len) {
-	ogg_packet *op = g_malloc0(sizeof(*op));
+	ogg_packet *op = g_malloc(sizeof(*op));
 	if(!op) {
 		JANUS_LOG(LOG_ERR, "Couldn't allocate Ogg packet.\n");
 		return NULL;
@@ -962,6 +962,8 @@ ogg_packet *op_from_pkt(const unsigned char *pkt, int len) {
 	op->bytes = len;
 	op->b_o_s = 0;
 	op->e_o_s = 0;
+	op->granulepos = 0;
+	op->packetno = 0;
 
 	return op;
 }

--- a/plugins/janus_voicemail.c
+++ b/plugins/janus_voicemail.c
@@ -709,12 +709,6 @@ static void *janus_voicemail_handler(void *data) {
 				goto error;
 			}
 			session->stream = g_malloc0(sizeof(ogg_stream_state));
-			if(session->stream == NULL) {
-				JANUS_LOG(LOG_ERR, "Couldn't allocate stream struct\n");
-				error_code = JANUS_VOICEMAIL_ERROR_UNKNOWN_ERROR;
-				g_snprintf(error_cause, 512, "Couldn't allocate stream struct");
-				goto error;
-			}
 			if(ogg_stream_init(session->stream, rand()) < 0) {
 				JANUS_LOG(LOG_ERR, "Couldn't initialize Ogg stream state\n");
 				error_code = JANUS_VOICEMAIL_ERROR_LIBOGG_ERROR;
@@ -891,15 +885,6 @@ ogg_packet *op_opushead(void) {
 	unsigned char *data = g_malloc(size);
 	ogg_packet *op = g_malloc(sizeof(*op));
 
-	if(!data) {
-		JANUS_LOG(LOG_ERR, "Couldn't allocate data buffer...\n");
-		return NULL;
-	}
-	if(!op) {
-		JANUS_LOG(LOG_ERR, "Couldn't allocate Ogg packet...\n");
-		return NULL;
-	}
-
 	memcpy(data, "OpusHead", 8);  /* identifier */
 	data[8] = 1;                  /* version */
 	data[9] = 2;                  /* channels */
@@ -926,15 +911,6 @@ ogg_packet *op_opustags(void) {
 	unsigned char *data = g_malloc(size);
 	ogg_packet *op = g_malloc(sizeof(*op));
 
-	if(!data) {
-		JANUS_LOG(LOG_ERR, "Couldn't allocate data buffer...\n");
-		return NULL;
-	}
-	if(!op) {
-		JANUS_LOG(LOG_ERR, "Couldn't allocate Ogg packet...\n");
-		return NULL;
-	}
-
 	memcpy(data, identifier, 8);
 	le32(data + 8, strlen(vendor));
 	memcpy(data + 12, vendor, strlen(vendor));
@@ -953,10 +929,6 @@ ogg_packet *op_opustags(void) {
 /* Allocate an ogg_packet */
 ogg_packet *op_from_pkt(const unsigned char *pkt, int len) {
 	ogg_packet *op = g_malloc(sizeof(*op));
-	if(!op) {
-		JANUS_LOG(LOG_ERR, "Couldn't allocate Ogg packet.\n");
-		return NULL;
-	}
 
 	op->packet = (unsigned char *)pkt;
 	op->bytes = len;

--- a/plugins/plugin.c
+++ b/plugins/plugin.c
@@ -19,8 +19,6 @@
 janus_plugin_result *janus_plugin_result_new(janus_plugin_result_type type, const char *text, json_t *content) {
 	JANUS_LOG(LOG_HUGE, "Creating plugin result...\n");
 	janus_plugin_result *result = (janus_plugin_result *)g_malloc(sizeof(janus_plugin_result));
-	if(result == NULL)
-		return NULL;
 	result->type = type;
 	result->text = text;
 	result->content = content;

--- a/plugins/plugin.c
+++ b/plugins/plugin.c
@@ -28,7 +28,7 @@ janus_plugin_result *janus_plugin_result_new(janus_plugin_result_type type, cons
 /*! \brief Helper to quickly destroy a janus_plugin_result instance
  * @param[in] result The janus_plugin_result instance to destroy
  * @note Will decrease the reference counter of the JSON content, if available
- * @returns A valid janus_plugin_result instance, if successful, or NULL otherwise */
+ */
 void janus_plugin_result_destroy(janus_plugin_result *result) {
 	JANUS_LOG(LOG_HUGE, "Destroying plugin result...\n");
 	result->text = NULL;

--- a/plugins/plugin.c
+++ b/plugins/plugin.c
@@ -18,7 +18,7 @@
 
 janus_plugin_result *janus_plugin_result_new(janus_plugin_result_type type, const char *text, json_t *content) {
 	JANUS_LOG(LOG_HUGE, "Creating plugin result...\n");
-	janus_plugin_result *result = (janus_plugin_result *)g_malloc(sizeof(janus_plugin_result));
+	janus_plugin_result *result = g_malloc(sizeof(janus_plugin_result));
 	result->type = type;
 	result->text = text;
 	result->content = content;

--- a/plugins/plugin.c
+++ b/plugins/plugin.c
@@ -18,7 +18,7 @@
 
 janus_plugin_result *janus_plugin_result_new(janus_plugin_result_type type, const char *text, json_t *content) {
 	JANUS_LOG(LOG_HUGE, "Creating plugin result...\n");
-	janus_plugin_result *result = (janus_plugin_result *)g_malloc0(sizeof(janus_plugin_result));
+	janus_plugin_result *result = (janus_plugin_result *)g_malloc(sizeof(janus_plugin_result));
 	if(result == NULL)
 		return NULL;
 	result->type = type;

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -421,10 +421,6 @@ int main(int argc, char *argv[])
 			len -= sizeof(gint64);
 			/* Generate frame packet and insert in the ordered list */
 			janus_pp_frame_packet *p = g_malloc(sizeof(janus_pp_frame_packet));
-			if(p == NULL) {
-				JANUS_LOG(LOG_ERR, "Memory error!\n");
-				return -1;
-			}
 			p->seq = 0;
 			/* We "abuse" the timestamp field for the timing info */
 			p->ts = when-c_time;
@@ -474,10 +470,6 @@ int main(int argc, char *argv[])
 		}
 		/* Generate frame packet and insert in the ordered list */
 		janus_pp_frame_packet *p = g_malloc0(sizeof(janus_pp_frame_packet));
-		if(p == NULL) {
-			JANUS_LOG(LOG_ERR, "Memory error!\n");
-			return -1;
-		}
 		p->seq = ntohs(rtp->seq_number);
 		p->pt = rtp->type;
 		/* Due to resets, we need to mess a bit with the original timestamps */

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -420,14 +420,16 @@ int main(int argc, char *argv[])
 			offset += sizeof(gint64);
 			len -= sizeof(gint64);
 			/* Generate frame packet and insert in the ordered list */
-			janus_pp_frame_packet *p = g_malloc0(sizeof(janus_pp_frame_packet));
+			janus_pp_frame_packet *p = g_malloc(sizeof(janus_pp_frame_packet));
 			if(p == NULL) {
 				JANUS_LOG(LOG_ERR, "Memory error!\n");
 				return -1;
 			}
+			p->seq = 0;
 			/* We "abuse" the timestamp field for the timing info */
 			p->ts = when-c_time;
 			p->len = len;
+			p->pt = 0;
 			p->drop = 0;
 			p->offset = offset;
 			p->skip = 0;

--- a/postprocessing/pp-opus.c
+++ b/postprocessing/pp-opus.c
@@ -42,10 +42,6 @@ int ogg_flush(void);
 
 int janus_pp_opus_create(char *destination) {
 	stream = g_malloc0(sizeof(ogg_stream_state));
-	if(stream == NULL) {
-		JANUS_LOG(LOG_ERR, "Couldn't allocate stream struct\n");
-		return -1;
-	}
 	if(ogg_stream_init(stream, rand()) < 0) {
 		JANUS_LOG(LOG_ERR, "Couldn't initialize Ogg stream state\n");
 		return -1;
@@ -164,15 +160,6 @@ ogg_packet *op_opushead(void) {
 	unsigned char *data = g_malloc(size);
 	ogg_packet *op = g_malloc(sizeof(*op));
 
-	if(!data) {
-		JANUS_LOG(LOG_ERR, "Couldn't allocate data buffer...\n");
-		return NULL;
-	}
-	if(!op) {
-		JANUS_LOG(LOG_ERR, "Couldn't allocate Ogg packet...\n");
-		return NULL;
-	}
-
 	memcpy(data, "OpusHead", 8);  /* identifier */
 	data[8] = 1;                  /* version */
 	data[9] = 2;                  /* channels */
@@ -199,15 +186,6 @@ ogg_packet *op_opustags(void) {
 	unsigned char *data = g_malloc(size);
 	ogg_packet *op = g_malloc(sizeof(*op));
 
-	if(!data) {
-		JANUS_LOG(LOG_ERR, "Couldn't allocate data buffer...\n");
-		return NULL;
-	}
-	if(!op) {
-		JANUS_LOG(LOG_ERR, "Couldn't allocate Ogg packet...\n");
-		return NULL;
-	}
-
 	memcpy(data, identifier, 8);
 	le32(data + 8, strlen(vendor));
 	memcpy(data + 12, vendor, strlen(vendor));
@@ -226,10 +204,6 @@ ogg_packet *op_opustags(void) {
 /* Allocate an ogg_packet */
 ogg_packet *op_from_pkt(const unsigned char *pkt, int len) {
 	ogg_packet *op = g_malloc(sizeof(*op));
-	if(!op) {
-		JANUS_LOG(LOG_ERR, "Couldn't allocate Ogg packet.\n");
-		return NULL;
-	}
 
 	op->packet = (unsigned char *)pkt;
 	op->bytes = len;

--- a/postprocessing/pp-opus.c
+++ b/postprocessing/pp-opus.c
@@ -161,8 +161,8 @@ void le16(unsigned char *p, int v) {
 /* Manufacture a generic OpusHead packet */
 ogg_packet *op_opushead(void) {
 	int size = 19;
-	unsigned char *data = g_malloc0(size);
-	ogg_packet *op = g_malloc0(sizeof(*op));
+	unsigned char *data = g_malloc(size);
+	ogg_packet *op = g_malloc(sizeof(*op));
 
 	if(!data) {
 		JANUS_LOG(LOG_ERR, "Couldn't allocate data buffer...\n");
@@ -196,8 +196,8 @@ ogg_packet *op_opustags(void) {
 	const char *identifier = "OpusTags";
 	const char *vendor = "Janus post-processing";
 	int size = strlen(identifier) + 4 + strlen(vendor) + 4;
-	unsigned char *data = g_malloc0(size);
-	ogg_packet *op = g_malloc0(sizeof(*op));
+	unsigned char *data = g_malloc(size);
+	ogg_packet *op = g_malloc(sizeof(*op));
 
 	if(!data) {
 		JANUS_LOG(LOG_ERR, "Couldn't allocate data buffer...\n");
@@ -225,7 +225,7 @@ ogg_packet *op_opustags(void) {
 
 /* Allocate an ogg_packet */
 ogg_packet *op_from_pkt(const unsigned char *pkt, int len) {
-	ogg_packet *op = g_malloc0(sizeof(*op));
+	ogg_packet *op = g_malloc(sizeof(*op));
 	if(!op) {
 		JANUS_LOG(LOG_ERR, "Couldn't allocate Ogg packet.\n");
 		return NULL;
@@ -235,6 +235,8 @@ ogg_packet *op_from_pkt(const unsigned char *pkt, int len) {
 	op->bytes = len;
 	op->b_o_s = 0;
 	op->e_o_s = 0;
+	op->granulepos = 0;
+	op->packetno = 0;
 
 	return op;
 }

--- a/record.c
+++ b/record.c
@@ -84,10 +84,6 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	}
 	/* Create the recorder */
 	janus_recorder *rc = g_malloc0(sizeof(janus_recorder));
-	if(rc == NULL) {
-		JANUS_LOG(LOG_FATAL, "Memory error!\n");
-		return NULL;
-	}
 	rc->dir = NULL;
 	rc->filename = NULL;
 	rc->file = NULL;

--- a/sctp.c
+++ b/sctp.c
@@ -120,7 +120,7 @@ janus_sctp_association *janus_sctp_association_create(void *dtls, uint64_t handl
 	 * be encapsulated in DTLS and actually sent/received by libnice, and not by
 	 * usrsctp itself... as such, we make use of the AF_CONN approach */
 
-	janus_sctp_association *sctp = (janus_sctp_association *)g_malloc0(sizeof(janus_sctp_association));
+	janus_sctp_association *sctp = g_malloc0(sizeof(janus_sctp_association));
 	sctp->dtls = dtls;
 	sctp->handle_id = handle_id;
 	sctp->local_port = 5000;	/* FIXME We always use this one */
@@ -707,7 +707,7 @@ void janus_sctp_send_outgoing_stream_reset(janus_sctp_association *sctp) {
 		return;
 	}
 	len = sizeof(sctp_assoc_t) + (2 + sctp->stream_buffer_counter) * sizeof(uint16_t);
-	srs = (struct sctp_reset_streams *)g_malloc0(len);
+	srs = g_malloc0(len);
 	srs->srs_flags = SCTP_STREAM_RESET_OUTGOING;
 	srs->srs_number_streams = sctp->stream_buffer_counter;
 	for(i = 0; i < sctp->stream_buffer_counter; i++) {

--- a/sctp.c
+++ b/sctp.c
@@ -121,10 +121,6 @@ janus_sctp_association *janus_sctp_association_create(void *dtls, uint64_t handl
 	 * usrsctp itself... as such, we make use of the AF_CONN approach */
 
 	janus_sctp_association *sctp = (janus_sctp_association *)g_malloc0(sizeof(janus_sctp_association));
-	if(sctp == NULL) {
-		JANUS_LOG(LOG_FATAL, "Memory error!\n");
-		return NULL;
-	}
 	sctp->dtls = dtls;
 	sctp->handle_id = handle_id;
 	sctp->local_port = 5000;	/* FIXME We always use this one */
@@ -712,9 +708,6 @@ void janus_sctp_send_outgoing_stream_reset(janus_sctp_association *sctp) {
 	}
 	len = sizeof(sctp_assoc_t) + (2 + sctp->stream_buffer_counter) * sizeof(uint16_t);
 	srs = (struct sctp_reset_streams *)g_malloc0(len);
-	if(srs == NULL) {
-		return;
-	}
 	srs->srs_flags = SCTP_STREAM_RESET_OUTGOING;
 	srs->srs_number_streams = sctp->stream_buffer_counter;
 	for(i = 0; i < sctp->stream_buffer_counter; i++) {
@@ -1346,14 +1339,7 @@ janus_sctp_message *janus_sctp_message_create(gboolean incoming, char *buffer, s
 	if(buffer == NULL || length == 0)
 		return NULL;
 	janus_sctp_message *message = g_malloc(sizeof(janus_sctp_message));
-	if(message == NULL)
-		return NULL;
 	message->buffer = g_malloc(length);
-	if(message->buffer == NULL) {
-		g_free(message);
-		message = NULL;
-		return NULL;
-	}
 	memcpy(message->buffer, buffer, length);
 	message->length = length;
 	message->incoming = incoming;

--- a/sctp.c
+++ b/sctp.c
@@ -473,7 +473,6 @@ int janus_sctp_send_open_request_message(struct socket *sock, uint16_t stream, u
 	JANUS_LOG(LOG_VERB, "Using label '%s' (%zu, %u with padding)\n", label, strlen(label), label_size);
 
 	req = g_malloc0(sizeof(janus_datachannel_open_request) + label_size);
-	memset(req, 0, sizeof(janus_datachannel_open_request) + label_size);
 	req->msg_type = DATA_CHANNEL_OPEN_REQUEST;
 	switch (pr_policy) {
 		case SCTP_PR_SCTP_NONE:
@@ -716,7 +715,6 @@ void janus_sctp_send_outgoing_stream_reset(janus_sctp_association *sctp) {
 	if(srs == NULL) {
 		return;
 	}
-	memset(srs, 0, len);
 	srs->srs_flags = SCTP_STREAM_RESET_OUTGOING;
 	srs->srs_number_streams = sctp->stream_buffer_counter;
 	for(i = 0; i < sctp->stream_buffer_counter; i++) {
@@ -829,7 +827,7 @@ void janus_sctp_handle_open_request_message(janus_sctp_association *sctp, janus_
 	char *label = NULL;
 	guint len = ntohs(req->label_length);
 	if(len > 0 && len < length) {
-		label = g_malloc0(len+1);
+		label = g_malloc(len+1);
 		memcpy(label, req->label, len);
 		label[len] = '\0'; 
 	}
@@ -1347,10 +1345,10 @@ void *janus_sctp_thread(void *data) {
 janus_sctp_message *janus_sctp_message_create(gboolean incoming, char *buffer, size_t length) {
 	if(buffer == NULL || length == 0)
 		return NULL;
-	janus_sctp_message *message = g_malloc0(sizeof(janus_sctp_message));
+	janus_sctp_message *message = g_malloc(sizeof(janus_sctp_message));
 	if(message == NULL)
 		return NULL;
-	message->buffer = g_malloc0(length);
+	message->buffer = g_malloc(length);
 	if(message->buffer == NULL) {
 		g_free(message);
 		message = NULL;

--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -126,9 +126,10 @@ int janus_sdp_mline_remove(janus_sdp *sdp, janus_sdp_mtype type) {
 janus_sdp_attribute *janus_sdp_attribute_create(const char *name, const char *value, ...) {
 	if(!name)
 		return NULL;
-	janus_sdp_attribute *a = g_malloc0(sizeof(janus_sdp_attribute));
+	janus_sdp_attribute *a = g_malloc(sizeof(janus_sdp_attribute));
 	a->name = g_strdup(name);
 	a->direction = JANUS_SDP_DEFAULT;
+	a->value = NULL;
 	if(value) {
 		char buffer[512];
 		va_list ap;
@@ -687,7 +688,7 @@ const char *janus_sdp_get_codec_rtpmap(const char *codec) {
 char *janus_sdp_write(janus_sdp *imported) {
 	if(!imported)
 		return NULL;
-	char *sdp = g_malloc0(JANUS_BUFSIZE), buffer[512];
+	char *sdp = g_malloc(JANUS_BUFSIZE), buffer[512];
 	*sdp = '\0';
 	/* v= */
 	g_snprintf(buffer, sizeof(buffer), "v=%d\r\n", imported->version);
@@ -888,7 +889,7 @@ const char *janus_sdp_match_preferred_codec(janus_sdp_mtype type, char *codec) {
 }
 
 janus_sdp *janus_sdp_new(const char *name, const char *address) {
-	janus_sdp *sdp = g_malloc0(sizeof(janus_sdp));
+	janus_sdp *sdp = g_malloc(sizeof(janus_sdp));
 	/* Fill in some predefined stuff */
 	sdp->version = 0;
 	sdp->o_name = g_strdup("-");
@@ -901,6 +902,8 @@ janus_sdp *janus_sdp_new(const char *name, const char *address) {
 	sdp->t_stop = 0;
 	sdp->c_ipv4 = TRUE;
 	sdp->c_addr = g_strdup(address ? address : "127.0.0.1");
+	sdp->attributes = NULL;
+	sdp->m_lines = NULL;
 	/* Done */
 	return sdp;
 }
@@ -1071,7 +1074,7 @@ janus_sdp *janus_sdp_generate_answer(janus_sdp *offer, ...) {
 	do_data = FALSE;
 #endif
 
-	janus_sdp *answer = g_malloc0(sizeof(janus_sdp));
+	janus_sdp *answer = g_malloc(sizeof(janus_sdp));
 	/* Start by copying some of the headers */
 	answer->version = offer->version;
 	answer->o_name = g_strdup(offer->o_name ? offer->o_name : "-");
@@ -1084,6 +1087,8 @@ janus_sdp *janus_sdp_generate_answer(janus_sdp *offer, ...) {
 	answer->t_stop = 0;
 	answer->c_ipv4 = offer->c_ipv4;
 	answer->c_addr = g_strdup(offer->c_addr ? offer->c_addr : "127.0.0.1");
+	answer->attributes = NULL;
+	answer->m_lines = NULL;
 
 	/* Now iterate on all media, and let's see what we should do */
 	int audio = 0, video = 0, data = 0;

--- a/text2pcap.c
+++ b/text2pcap.c
@@ -70,7 +70,6 @@ janus_text2pcap *janus_text2pcap_create(const char *dir, const char *filename, i
 		}
 	}
 	char newname[1024];
-	memset(newname, 0, 1024);
 	if(filename == NULL) {
 		/* Choose a random username */
 		g_snprintf(newname, 1024, "janus-text2pcap-%"SCNu32".txt", janus_random_uint32());
@@ -87,7 +86,6 @@ janus_text2pcap *janus_text2pcap_create(const char *dir, const char *filename, i
 			tp->filename = g_strdup(newname);
 	} else {
 		char path[1024];
-		memset(path, 0, 1024);
 		g_snprintf(path, 1024, "%s/%s", dir, newname);
 		tp->file = fopen(path, "ab");
 		if(tp->file == NULL)

--- a/text2pcap.c
+++ b/text2pcap.c
@@ -54,10 +54,6 @@ janus_text2pcap *janus_text2pcap_create(const char *dir, const char *filename, i
 		return NULL;
 	/* Create the text2pcap instance */
 	janus_text2pcap *tp = g_malloc0(sizeof(janus_text2pcap));
-	if(tp == NULL) {
-		JANUS_LOG(LOG_FATAL, "Memory error!\n");
-		return NULL;
-	}
 	tp->filename = NULL;
 	tp->file = NULL;
 	tp->truncate = truncate;

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -1122,12 +1122,6 @@ int janus_http_handler(void *cls, struct MHD_Connection *connection, const char 
 		JANUS_LOG(LOG_DBG, "Got a HTTP %s request on %s...\n", method, url);
 		JANUS_LOG(LOG_DBG, " ... Just parsing headers for now...\n");
 		msg = g_malloc0(sizeof(janus_http_msg));
-		if(msg == NULL) {
-			JANUS_LOG(LOG_FATAL, "Memory error!\n");
-			ret = MHD_queue_response(connection, MHD_HTTP_INTERNAL_SERVER_ERROR, response);
-			MHD_destroy_response(response);
-			goto done;
-		}
 		msg->connection = connection;
 		janus_mutex_init(&msg->wait_mutex);
 		janus_condition_init(&msg->wait_cond);
@@ -1245,12 +1239,6 @@ int janus_http_handler(void *cls, struct MHD_Connection *connection, const char 
 				msg->payload = g_malloc0(*upload_data_size+1);
 			else
 				msg->payload = g_realloc(msg->payload, msg->len+*upload_data_size+1);
-			if(msg->payload == NULL) {
-				JANUS_LOG(LOG_FATAL, "Memory error!\n");
-				ret = MHD_queue_response(connection, MHD_HTTP_INTERNAL_SERVER_ERROR, response);
-				MHD_destroy_response(response);
-				goto done;
-			}
 			memcpy(msg->payload+msg->len, upload_data, *upload_data_size);
 			msg->len += *upload_data_size;
 			memset(msg->payload + msg->len, '\0', 1);
@@ -1485,12 +1473,6 @@ int janus_http_admin_handler(void *cls, struct MHD_Connection *connection, const
 		JANUS_LOG(LOG_VERB, "Got an admin/monitor HTTP %s request on %s...\n", method, url);
 		JANUS_LOG(LOG_DBG, " ... Just parsing headers for now...\n");
 		msg = g_malloc0(sizeof(janus_http_msg));
-		if(msg == NULL) {
-			JANUS_LOG(LOG_FATAL, "Memory error!\n");
-			ret = MHD_queue_response(connection, MHD_HTTP_INTERNAL_SERVER_ERROR, response);
-			MHD_destroy_response(response);
-			goto done;
-		}
 		msg->connection = connection;
 		janus_mutex_init(&msg->wait_mutex);
 		janus_condition_init(&msg->wait_cond);
@@ -1610,12 +1592,6 @@ int janus_http_admin_handler(void *cls, struct MHD_Connection *connection, const
 				msg->payload = g_malloc0(*upload_data_size+1);
 			else
 				msg->payload = g_realloc(msg->payload, msg->len+*upload_data_size+1);
-			if(msg->payload == NULL) {
-				JANUS_LOG(LOG_FATAL, "Memory error!\n");
-				ret = MHD_queue_response(connection, MHD_HTTP_INTERNAL_SERVER_ERROR, response);
-				MHD_destroy_response(response);
-				goto done;
-			}
 			memcpy(msg->payload+msg->len, upload_data, *upload_data_size);
 			msg->len += *upload_data_size;
 			memset(msg->payload + msg->len, '\0', 1);

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -1331,7 +1331,7 @@ int janus_http_handler(void *cls, struct MHD_Connection *connection, const char 
 		gateway->incoming_request(&janus_http_transport, msg, (void *)keepalive_id, FALSE, root, NULL);
 		/* Ok, go on */
 		if(handle_path) {
-			char *location = (char *)g_malloc(strlen(ws_path) + strlen(session_path) + 2);
+			char *location = g_malloc(strlen(ws_path) + strlen(session_path) + 2);
 			g_sprintf(location, "%s/%s", ws_path, session_path);
 			JANUS_LOG(LOG_ERR, "Invalid GET to %s, redirecting to %s\n", url, location);
 			response = MHD_create_response_from_buffer(0, NULL, MHD_RESPMEM_PERSISTENT);

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -1235,10 +1235,7 @@ int janus_http_handler(void *cls, struct MHD_Connection *connection, const char 
 	if(!strcasecmp(method, "POST")) {
 		JANUS_LOG(LOG_HUGE, "Processing POST data (%s) (%zu bytes)...\n", msg->contenttype, *upload_data_size);
 		if(*upload_data_size != 0) {
-			if(msg->payload == NULL)
-				msg->payload = g_malloc0(*upload_data_size+1);
-			else
-				msg->payload = g_realloc(msg->payload, msg->len+*upload_data_size+1);
+			msg->payload = g_realloc(msg->payload, msg->len+*upload_data_size+1);
 			memcpy(msg->payload+msg->len, upload_data, *upload_data_size);
 			msg->len += *upload_data_size;
 			memset(msg->payload + msg->len, '\0', 1);
@@ -1588,10 +1585,7 @@ int janus_http_admin_handler(void *cls, struct MHD_Connection *connection, const
 	if(!strcasecmp(method, "POST")) {
 		JANUS_LOG(LOG_HUGE, "Processing POST data (%s) (%zu bytes)...\n", msg->contenttype, *upload_data_size);
 		if(*upload_data_size != 0) {
-			if(msg->payload == NULL)
-				msg->payload = g_malloc0(*upload_data_size+1);
-			else
-				msg->payload = g_realloc(msg->payload, msg->len+*upload_data_size+1);
+			msg->payload = g_realloc(msg->payload, msg->len+*upload_data_size+1);
 			memcpy(msg->payload+msg->len, upload_data, *upload_data_size);
 			msg->len += *upload_data_size;
 			memset(msg->payload + msg->len, '\0', 1);

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -1036,7 +1036,7 @@ void janus_http_session_created(void *transport, guint64 session_id) {
 		janus_mutex_unlock(&sessions_mutex);
 		return;
 	}
-	janus_http_session *session = g_malloc0(sizeof(janus_http_session));
+	janus_http_session *session = g_malloc(sizeof(janus_http_session));
 	session->events = g_async_queue_new();
 	session->destroyed = 0;
 	g_hash_table_insert(sessions, janus_uint64_dup(session_id), session);
@@ -1129,13 +1129,6 @@ int janus_http_handler(void *cls, struct MHD_Connection *connection, const char 
 			goto done;
 		}
 		msg->connection = connection;
-		msg->acrh = NULL;
-		msg->acrm = NULL;
-		msg->payload = NULL;
-		msg->len = 0;
-		msg->session_id = 0;
-		msg->got_response = FALSE;
-		msg->response = NULL;
 		janus_mutex_init(&msg->wait_mutex);
 		janus_condition_init(&msg->wait_cond);
 		janus_mutex_lock(&messages_mutex);
@@ -1353,7 +1346,7 @@ int janus_http_handler(void *cls, struct MHD_Connection *connection, const char 
 		gateway->incoming_request(&janus_http_transport, msg, (void *)keepalive_id, FALSE, root, NULL);
 		/* Ok, go on */
 		if(handle_path) {
-			char *location = (char *)g_malloc0(strlen(ws_path) + strlen(session_path) + 2);
+			char *location = (char *)g_malloc(strlen(ws_path) + strlen(session_path) + 2);
 			g_sprintf(location, "%s/%s", ws_path, session_path);
 			JANUS_LOG(LOG_ERR, "Invalid GET to %s, redirecting to %s\n", url, location);
 			response = MHD_create_response_from_buffer(0, NULL, MHD_RESPMEM_PERSISTENT);
@@ -1499,13 +1492,6 @@ int janus_http_admin_handler(void *cls, struct MHD_Connection *connection, const
 			goto done;
 		}
 		msg->connection = connection;
-		msg->acrh = NULL;
-		msg->acrm = NULL;
-		msg->payload = NULL;
-		msg->len = 0;
-		msg->session_id = 0;
-		msg->got_response = FALSE;
-		msg->response = NULL;
 		janus_mutex_init(&msg->wait_mutex);
 		janus_condition_init(&msg->wait_cond);
 		janus_mutex_lock(&messages_mutex);

--- a/transports/janus_pfunix.c
+++ b/transports/janus_pfunix.c
@@ -608,8 +608,9 @@ void *janus_pfunix_thread(void *data) {
 							JANUS_LOG(LOG_INFO, "Got new Unix Sockets %s API client: %d\n",
 								poll_fds[i].fd == pfd ? "Janus" : "Admin", cfd);
 							/* Allocate new client */
-							janus_pfunix_client *client = g_malloc0(sizeof(janus_pfunix_client));
+							janus_pfunix_client *client = g_malloc(sizeof(janus_pfunix_client));
 							client->fd = cfd;
+							memset(&client->addr, 0, sizeof(client->addr));
 							client->admin = (poll_fds[i].fd == admin_pfd);	/* API client type */
 							client->messages = g_async_queue_new();
 							client->session_timeout = FALSE;
@@ -652,7 +653,7 @@ void *janus_pfunix_thread(void *data) {
 							JANUS_LOG(LOG_INFO, "Got new Unix Sockets %s API client: %s\n",
 								poll_fds[i].fd == pfd ? "Janus" : "Admin", uaddr->sun_path);
 							/* Allocate new client */
-							client = g_malloc0(sizeof(janus_pfunix_client));
+							client = g_malloc(sizeof(janus_pfunix_client));
 							client->fd = -1;
 							memcpy(&client->addr, uaddr, sizeof(struct sockaddr_un));
 							client->admin = (poll_fds[i].fd == admin_pfd);	/* API client type */
@@ -750,7 +751,7 @@ void *janus_pfunix_thread(void *data) {
 	}
 
 	socklen_t addrlen = sizeof(struct sockaddr_un);
-	void *addr = g_malloc0(addrlen+1);
+	void *addr = g_malloc(addrlen+1);
 	if(pfd > -1) {
 		/* Unlink the path name first */
 		if(getsockname(pfd, (struct sockaddr *)addr, &addrlen) != -1) {

--- a/transports/janus_rabbitmq.c
+++ b/transports/janus_rabbitmq.c
@@ -600,7 +600,7 @@ int janus_rabbitmq_send_message(void *transport, void *request_id, gboolean admi
 	}
 	JANUS_LOG(LOG_HUGE, "Sending %s API %s via RabbitMQ\n", admin ? "admin" : "Janus", request_id ? "response" : "event");
 	/* FIXME Add to the queue of outgoing messages */
-	janus_rabbitmq_response *response = (janus_rabbitmq_response *)g_malloc0(sizeof(janus_rabbitmq_response));
+	janus_rabbitmq_response *response = (janus_rabbitmq_response *)g_malloc(sizeof(janus_rabbitmq_response));
 	response->admin = admin;
 	response->payload = message;
 	response->correlation_id = (char *)request_id;

--- a/transports/janus_rabbitmq.c
+++ b/transports/janus_rabbitmq.c
@@ -317,10 +317,6 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 	} else {
 		/* FIXME We currently support a single application, create a new janus_rabbitmq_client instance */
 		rmq_client = g_malloc0(sizeof(janus_rabbitmq_client));
-		if(rmq_client == NULL) {
-			JANUS_LOG(LOG_FATAL, "Memory error!\n");
-			goto error;
-		}
 		/* Connect */
 		rmq_client->rmq_conn = amqp_new_connection();
 		amqp_socket_t *socket = NULL;

--- a/transports/janus_rabbitmq.c
+++ b/transports/janus_rabbitmq.c
@@ -596,7 +596,7 @@ int janus_rabbitmq_send_message(void *transport, void *request_id, gboolean admi
 	}
 	JANUS_LOG(LOG_HUGE, "Sending %s API %s via RabbitMQ\n", admin ? "admin" : "Janus", request_id ? "response" : "event");
 	/* FIXME Add to the queue of outgoing messages */
-	janus_rabbitmq_response *response = (janus_rabbitmq_response *)g_malloc(sizeof(janus_rabbitmq_response));
+	janus_rabbitmq_response *response = g_malloc(sizeof(janus_rabbitmq_response));
 	response->admin = admin;
 	response->payload = message;
 	response->correlation_id = (char *)request_id;
@@ -673,7 +673,7 @@ void *janus_rmq_in_thread(void *data) {
 		}
 		char *correlation = NULL;
 		if(p->_flags & AMQP_BASIC_CORRELATION_ID_FLAG) {
-			correlation = (char *)g_malloc0(p->correlation_id.len+1);
+			correlation = g_malloc0(p->correlation_id.len+1);
 			sprintf(correlation, "%.*s", (int) p->correlation_id.len, (char *) p->correlation_id.bytes);
 			JANUS_LOG(LOG_VERB, "  -- Correlation-id: %s\n", correlation);
 		}
@@ -682,7 +682,7 @@ void *janus_rmq_in_thread(void *data) {
 		}
 		/* And the body */
 		uint64_t total = frame.payload.properties.body_size, received = 0;
-		char *payload = (char *)g_malloc0(total+1), *index = payload;
+		char *payload = g_malloc0(total+1), *index = payload;
 		while(received < total) {
 			amqp_simple_wait_frame(rmq_client->rmq_conn, &frame);
 			JANUS_LOG(LOG_VERB, "Frame type %d, channel %d\n", frame.frame_type, frame.channel);

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -964,7 +964,7 @@ static int janus_websockets_common_callback(
 			const size_t remaining = lws_remaining_packet_payload(wsi);
 			if(ws_client->incoming == NULL) {
 				JANUS_LOG(LOG_HUGE, "[%s-%p] First fragment: %zu bytes, %zu remaining\n", log_prefix, wsi, len, remaining);
-				ws_client->incoming = g_malloc0(len+1);
+				ws_client->incoming = g_malloc(len+1);
 				memcpy(ws_client->incoming, in, len);
 				ws_client->incoming[len] = '\0';
 				JANUS_LOG(LOG_HUGE, "%s\n", ws_client->incoming);

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -1024,12 +1024,7 @@ static int janus_websockets_common_callback(
 				if(response && !ws_client->destroy && !g_atomic_int_get(&stopping)) {
 					/* Gotcha! */
 					int buflen = LWS_SEND_BUFFER_PRE_PADDING + strlen(response) + LWS_SEND_BUFFER_POST_PADDING;
-					if(ws_client->buffer == NULL) {
-						/* Let's allocate a shared buffer */
-						JANUS_LOG(LOG_HUGE, "[%s-%p] Allocating %d bytes (response is %zu bytes)\n", log_prefix, wsi, buflen, strlen(response));
-						ws_client->buflen = buflen;
-						ws_client->buffer = g_malloc0(buflen);
-					} else if(buflen > ws_client->buflen) {
+					if (buflen > ws_client->buflen) {
 						/* We need a larger shared buffer */
 						JANUS_LOG(LOG_HUGE, "[%s-%p] Re-allocating to %d bytes (was %d, response is %zu bytes)\n", log_prefix, wsi, buflen, ws_client->buflen, strlen(response));
 						ws_client->buflen = buflen;

--- a/turnrest.c
+++ b/turnrest.c
@@ -218,7 +218,7 @@ janus_turnrest_response *janus_turnrest_request(void) {
 		return NULL;
 	}
 	/* Turn the response into a janus_turnrest_response object we can use */
-	janus_turnrest_response *response = g_malloc0(sizeof(janus_turnrest_response));
+	janus_turnrest_response *response = g_malloc(sizeof(janus_turnrest_response));
 	response->username = g_strdup(json_string_value(username));
 	response->password = g_strdup(json_string_value(password));
 	response->ttl = ttl ? json_integer_value(ttl) : 0;
@@ -235,7 +235,7 @@ janus_turnrest_response *janus_turnrest_request(void) {
 			JANUS_LOG(LOG_WARN, "Skipping invalid TURN URI '%s' (not a TURN URI)...\n", turn_uri);
 			continue;
 		}
-		janus_turnrest_instance *instance = g_malloc0(sizeof(janus_turnrest_instance));
+		janus_turnrest_instance *instance = g_malloc(sizeof(janus_turnrest_instance));
 		instance->transport = NICE_RELAY_TYPE_TURN_UDP;
 		if(strstr(turn_uri, "turns:") == turn_uri)
 			instance->transport = NICE_RELAY_TYPE_TURN_TLS;

--- a/turnrest.c
+++ b/turnrest.c
@@ -45,11 +45,6 @@ static size_t janus_turnrest_callback(void *payload, size_t size, size_t nmemb, 
 	janus_turnrest_buffer *buf = (struct janus_turnrest_buffer *)data;
 	/* (Re)allocate if needed */
 	buf->buffer = g_realloc(buf->buffer, buf->size+realsize+1);
-	if(buf->buffer == NULL) {
-		/* Memory error! */ 
-		JANUS_LOG(LOG_FATAL, "Memory error!\n");
-		return 0;
-	}
 	/* Update the buffer */
 	memcpy(&(buf->buffer[buf->size]), payload, realsize);
 	buf->size += realsize;

--- a/utils.c
+++ b/utils.c
@@ -161,10 +161,6 @@ char *janus_string_replace(char *message, const char *old_string, const char *ne
 		uint16_t old_stringlen = strlen(outgoing)+1, new_stringlen = old_stringlen + diff*counter;
 		if(diff > 0) {	/* Resize now */
 			tmp = g_realloc(outgoing, new_stringlen);
-			if(!tmp) {
-				g_free(outgoing);
-				return NULL;
-			}
 			outgoing = tmp;
 		}
 		/* Replace string */
@@ -187,10 +183,6 @@ char *janus_string_replace(char *message, const char *old_string, const char *ne
 		}
 		if(diff < 0) {	/* We skipped the resize previously (shrinking memory) */
 			tmp = g_realloc(outgoing, new_stringlen);
-			if(!tmp) {
-				g_free(outgoing);
-				return NULL;
-			}
 			outgoing = tmp;
 		}
 		outgoing[strlen(outgoing)] = '\0';

--- a/utils.c
+++ b/utils.c
@@ -52,10 +52,8 @@ gboolean janus_strcmp_const_time(const void *str1, const void *str2) {
 	if(strlen((char *)string2) > maxlen)
 		maxlen = strlen((char *)string2);
 	unsigned char *buf1 = g_malloc0(maxlen+1);
-	memset(buf1, 0, maxlen);
 	memcpy(buf1, string1, strlen(str1));
 	unsigned char *buf2 = g_malloc0(maxlen+1);
-	memset(buf2, 0, maxlen);
 	memcpy(buf2, string2, strlen(str2));
 	unsigned char result = 0;
 	size_t i = 0;
@@ -90,8 +88,8 @@ guint64 janus_random_uint64(void) {
 }
 
 guint64 *janus_uint64_dup(guint64 num) {
-	guint64 *numdup = g_malloc0(sizeof(guint64));
-	memcpy(numdup, &num, sizeof(num));
+	guint64 *numdup = g_malloc(sizeof(guint64));
+	*numdup = num;
 	return numdup;
 }
 


### PR DESCRIPTION
Hi! I've made some general fixes and improvements to Janus code. The changes were the following:

- wrong usage of getsockname();
- unneeded or redundant use of g_malloc0() and memset() functions, either because they were used together, or the allocated memory is for a struct that has all members set after the allocation, or a memcpy() is done after the allocation;
- unneeded memory allocations checking, as GLib's g_malloc() and others abort the program on failure;
- some unneeded run-time checking of pointers to decide which of g_malloc() and g_realloc() functions should be used - g_realloc(NULL, size) is equivalent to g_malloc(size);
- allocation bug on transports/janus_http.c where calloc() were substituted incorrectly with a g_malloc0();
- a possible memory leak at janus_text2pcap_create();
- an incorrect comment header for janus_plugin_result_destroy(); and
- removed castings from memory allocations.

Please refer to the commits' comments for more details. Thanks!