### PR TITLE
Add full-trickle support to Janus local candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ or on the command line:
                                   (experimental)  (default=off)
 	-l, --libnice-debug           Whether to enable libnice debugging or not
                                   (default=off)
+	-f, --full-trickle            Do full-trickle instead of half-trickle
+                                  (default=off)
 	-I, --ice-lite                Whether to enable the ICE Lite mode or not
                                   (default=off)
 	-T, --ice-tcp                 Whether to enable ICE-TCP or not (warning: only

--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -90,7 +90,10 @@ cert_key = @certdir@/mycert.key
 ; browsers, but in the gathering of relay candidates by Janus itself,
 ; e.g., if you want to limit the ports used by a Janus instance on a
 ; private machine. Furthermore, you can choose whether Janus should be
-; configured to work in ICE-Lite mode (by default it doesn't). Finally,
+; configured to do full-trickle (Janus also trickles its candidates to
+; users) rather than the default half-trickle (Janus supports trickle
+; candidates from users, but sends its own within the SDP), and whether
+; it should work in ICE-Lite mode (by default it doesn't). Finally,
 ; you can also enable ICE-TCP support (beware that it currently *only*
 ; works if you enable ICE Lite as well), choose which interfaces should
 ; be used for gathering candidates, and enable or disable the
@@ -99,6 +102,7 @@ cert_key = @certdir@/mycert.key
 ;stun_server = stun.voip.eutelia.it
 ;stun_port = 3478
 nice_debug = false
+;full_trickle = true
 ;ice_lite = true
 ;ice_tcp = true
 

--- a/html/janus.js
+++ b/html/janus.js
@@ -464,6 +464,40 @@ function Janus(gatewayCallbacks) {
 				delete transactions[transaction];
 			}
 			return;
+		} else if(json["janus"] === "trickle") {
+			// We got a trickle candidate from Janus
+			var sender = json["sender"];
+			if(sender === undefined || sender === null) {
+				Janus.warn("Missing sender...");
+				return;
+			}
+			var pluginHandle = pluginHandles[sender];
+			if(pluginHandle === undefined || pluginHandle === null) {
+				Janus.debug("This handle is not attached to this session");
+				return;
+			}
+			var candidate = json["candidate"];
+			Janus.debug("Got a trickled candidate on session " + sessionId);
+			Janus.debug(candidate);
+			var config = pluginHandle.webrtcStuff;
+			if(config.pc && config.remoteSdp) {
+				// Add candidate right now
+				Janus.debug("Adding remote candidate:", candidate);
+				if(!candidate || candidate.completed === true) {
+					// end-of-candidates
+					config.pc.addIceCandidate();
+				} else {
+					// New candidate
+					config.pc.addIceCandidate(new RTCIceCandidate(candidate));
+				}
+			} else {
+				// We didn't do setRemoteDescription (trickle got here before the offer?)
+				Janus.debug("We didn't do setRemoteDescription (trickle got here before the offer?), caching candidate");
+				if(!config.candidates)
+					config.candidates = [];
+				config.candidates.push(candidate);
+				Janus.debug(config.candidates);
+			}
 		} else if(json["janus"] === "webrtcup") {
 			// The PeerConnection with the gateway is up! Notify this
 			Janus.debug("Got a webrtcup event on session " + sessionId);
@@ -1442,6 +1476,23 @@ function Janus(gatewayCallbacks) {
 					new RTCSessionDescription(jsep),
 					function() {
 						Janus.log("Remote description accepted!");
+						config.remoteSdp = jsep.sdp;
+						// Any trickle candidate we cached?
+						if(config.candidates && config.candidates.length > 0) {
+							for(var i in config.candidates) {
+								var candidate = config.candidates[i];
+								Janus.debug("Adding remote candidate:", candidate);
+								if(!candidate || candidate.completed === true) {
+									// end-of-candidates
+									config.pc.addIceCandidate();
+								} else {
+									// New candidate
+									config.pc.addIceCandidate(new RTCIceCandidate(candidate));
+								}
+							}
+							config.candidates = [];
+						}
+						// Create the answer now
 						createAnswer(handleId, media, callbacks);
 					}, callbacks.error);
 		}
@@ -1957,6 +2008,23 @@ function Janus(gatewayCallbacks) {
 					new RTCSessionDescription(jsep),
 					function() {
 						Janus.log("Remote description accepted!");
+						config.remoteSdp = jsep.sdp;
+						// Any trickle candidate we cached?
+						if(config.candidates && config.candidates.length > 0) {
+							for(var i in config.candidates) {
+								var candidate = config.candidates[i];
+								Janus.debug("Adding remote candidate:", candidate);
+								if(!candidate || candidate.completed === true) {
+									// end-of-candidates
+									config.pc.addIceCandidate();
+								} else {
+									// New candidate
+									config.pc.addIceCandidate(new RTCIceCandidate(candidate));
+								}
+							}
+							config.candidates = [];
+						}
+						// Done
 						callbacks.success();
 					}, callbacks.error);
 		} else {
@@ -2395,7 +2463,9 @@ function Janus(gatewayCallbacks) {
 				// Do nothing
 			}
 			config.pc = null;
+			config.candidates = null;
 			config.mySdp = null;
+			config.remoteSdp = null;
 			config.iceDone = false;
 			config.dataChannel = null;
 			config.dtmfSender = null;

--- a/ice.c
+++ b/ice.c
@@ -83,6 +83,12 @@ gboolean janus_ice_is_ice_tcp_enabled(void) {
 	return janus_ice_tcp_enabled;
 }
 
+/* Full-trickle support */
+static gboolean janus_full_trickle_enabled;
+gboolean janus_ice_is_full_trickle_enabled(void) {
+	return janus_full_trickle_enabled;
+}
+
 /* IPv6 support (still mostly WIP) */
 static gboolean janus_ipv6_enabled;
 gboolean janus_ice_is_ipv6_enabled(void) {
@@ -445,6 +451,35 @@ static gpointer janus_ice_handles_watchdog(gpointer user_data) {
 }
 
 
+static void janus_ice_notify_trickle(janus_ice_handle *handle, char *buffer) {
+	if(handle == NULL)
+		return;
+	char cbuffer[200];
+	if(buffer != NULL)
+		g_snprintf(cbuffer, sizeof(cbuffer), "candidate:%s", buffer);
+	/* Send a "trickle" event to the browser */
+	janus_session *session = (janus_session *)handle->session;
+	if(session == NULL)
+		return;
+	json_t *event = json_object();
+	json_object_set_new(event, "janus", json_string("trickle"));
+	json_object_set_new(event, "session_id", json_integer(session->session_id));
+	json_object_set_new(event, "sender", json_integer(handle->handle_id));
+	json_t *candidate = json_object();
+	if(buffer != NULL) {
+		json_object_set_new(candidate, "sdpMid", json_string(handle->stream_mid));
+		json_object_set_new(candidate, "sdpMLineIndex", json_integer(0));
+		json_object_set_new(candidate, "candidate", json_string(cbuffer));
+	} else {
+		json_object_set_new(candidate, "completed", json_true());
+	}
+	json_object_set_new(event, "candidate", candidate);
+	/* Send the event */
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Sending trickle event (%s) to transport...\n",
+		handle->handle_id, buffer ? "candidate" : "end-of-candidates");
+	janus_session_notify_event(session, event);
+}
+
 static void janus_ice_notify_media(janus_ice_handle *handle, gboolean video, gboolean up) {
 	if(handle == NULL)
 		return;
@@ -594,13 +629,15 @@ void janus_ice_trickle_destroy(janus_ice_trickle *trickle) {
 
 
 /* libnice initialization */
-void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean ipv6, uint16_t rtp_min_port, uint16_t rtp_max_port) {
+void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean full_trickle, gboolean ipv6, uint16_t rtp_min_port, uint16_t rtp_max_port) {
 	janus_ice_lite_enabled = ice_lite;
 	janus_ice_tcp_enabled = ice_tcp;
+	janus_full_trickle_enabled = full_trickle;
 	janus_ipv6_enabled = ipv6;
-	JANUS_LOG(LOG_INFO, "Initializing ICE stuff (%s mode, ICE-TCP candidates %s, IPv6 support %s)\n",
+	JANUS_LOG(LOG_INFO, "Initializing ICE stuff (%s mode, ICE-TCP candidates %s, %s-trickle, IPv6 support %s)\n",
 		janus_ice_lite_enabled ? "Lite" : "Full",
 		janus_ice_tcp_enabled ? "enabled" : "disabled",
+		janus_full_trickle_enabled ? "full" : "half",
 		janus_ipv6_enabled ? "enabled" : "disabled");
 	if(janus_ice_tcp_enabled) {
 #ifndef HAVE_LIBNICE_TCP
@@ -1177,6 +1214,7 @@ void janus_ice_webrtc_free(janus_ice_handle *handle) {
 	handle->local_sdp = NULL;
 	g_free(handle->remote_sdp);
 	handle->remote_sdp = NULL;
+	handle->stream_mid = NULL;
 	if(handle->audio_mid != NULL) {
 		g_free(handle->audio_mid);
 		handle->audio_mid = NULL;
@@ -1505,6 +1543,11 @@ static void janus_ice_cb_candidate_gathering_done(NiceAgent *agent, guint stream
 		return;
 	}
 	stream->cdone = 1;
+	/* If we're doing full-trickle, send an event to the user too */
+	if(janus_full_trickle_enabled) {
+		/* Send a "trickle" event with completed:true to the browser */
+		janus_ice_notify_trickle(handle, NULL);
+	}
 }
 
 static void janus_ice_cb_component_state_changed(NiceAgent *agent, guint stream_id, guint component_id, guint state, gpointer ice) {
@@ -1680,12 +1723,103 @@ static void janus_ice_cb_new_selected_pair (NiceAgent *agent, guint stream_id, g
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Creating retransmission timer with ID %u\n", handle->handle_id, id);
 }
 
+/* Candidates management */
+static int janus_ice_candidate_to_string(janus_ice_handle *handle, NiceCandidate *c, char *buffer, int buflen, gboolean log_candidate);
+#ifndef HAVE_LIBNICE_TCP
+static void janus_ice_cb_new_local_candidate (NiceAgent *agent, guint stream_id, guint component_id, gchar *foundation, gpointer ice) {
+#else
+static void janus_ice_cb_new_local_candidate (NiceAgent *agent, NiceCandidate *candidate, gpointer ice) {
+#endif
+	if(!janus_full_trickle_enabled) {
+		/* Ignore if we're not full-trickling: for half-trickle
+		 * janus_ice_candidates_to_sdp() is used instead */
+		return;
+	}
+	janus_ice_handle *handle = (janus_ice_handle *)ice;
+	if(!handle)
+		return;
+#ifndef HAVE_LIBNICE_TCP
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Discovered new local candidate for component %d in stream %d: foundation=%s\n", handle ? handle->handle_id : 0, component_id, stream_id, foundation);
+#else
+	const char *ctype = NULL;
+	switch(candidate->type) {
+		case NICE_CANDIDATE_TYPE_HOST:
+			ctype = "host";
+			break;
+		case NICE_CANDIDATE_TYPE_SERVER_REFLEXIVE:
+			ctype = "srflx";
+			break;
+		case NICE_CANDIDATE_TYPE_PEER_REFLEXIVE:
+			ctype = "prflx";
+			break;
+		case NICE_CANDIDATE_TYPE_RELAYED:
+			ctype = "relay";
+			break;
+		default:
+			break;
+	}
+	guint stream_id = candidate->stream_id;
+	guint component_id = candidate->component_id;
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Discovered new local candidate for component %d in stream %d: type=%s\n", handle ? handle->handle_id : 0, component_id, stream_id, ctype);
+#endif
+	if(component_id > 1) {
+		/* New remote candidate for a component we don't need anymore (rtcp-mux) */
+		return;
+	}
+	janus_ice_stream *stream = handle->stream;
+	if(!stream || stream->stream_id != stream_id) {
+		JANUS_LOG(LOG_ERR, "[%"SCNu64"]     No stream %d??\n", handle->handle_id, stream_id);
+		return;
+	}
+	janus_ice_component *component = stream->component;
+	if(!component || component->component_id != component_id) {
+		JANUS_LOG(LOG_ERR, "[%"SCNu64"]     No component %d in stream %d??\n", handle->handle_id, component_id, stream_id);
+		return;
+	}
+#ifndef HAVE_LIBNICE_TCP
+	/* Get local candidates and look for the related foundation */
+	NiceCandidate *candidate = NULL;
+	GSList *candidates = nice_agent_get_local_candidates(agent, component_id, stream_id), *tmp = candidates;
+	while(tmp) {
+		NiceCandidate *c = (NiceCandidate *)tmp->data;
+		/* Check if this is what we're looking for */
+		if(!strcasecmp(c->foundation, foundation)) {
+			/* It is! */
+			candidate = c;
+			break;
+		}
+		nice_candidate_free(c);
+		tmp = tmp->next;
+	}
+	g_slist_free(candidates);
+	if(candidate == NULL) {
+		JANUS_LOG(LOG_WARN, "Candidate with foundation %s not found?\n", foundation);
+		return;
+	}
+#endif
+	char buffer[200];
+	if(janus_ice_candidate_to_string(handle, candidate, buffer, sizeof(buffer), TRUE) == 0) {
+		/* Candidate encoded, send a "trickle" event to the browser (but only if it's not a 'prflx') */
+		if(candidate->type == NICE_CANDIDATE_TYPE_PEER_REFLEXIVE) {
+			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping prflx candidate...\n", handle->handle_id);
+		} else {
+			janus_ice_notify_trickle(handle, buffer);
+		}
+	}
+
+#ifndef HAVE_LIBNICE_TCP
+	nice_candidate_free(candidate);
+#endif
+}
+
 #ifndef HAVE_LIBNICE_TCP
 static void janus_ice_cb_new_remote_candidate (NiceAgent *agent, guint stream_id, guint component_id, gchar *foundation, gpointer ice) {
 #else
 static void janus_ice_cb_new_remote_candidate (NiceAgent *agent, NiceCandidate *candidate, gpointer ice) {
 #endif
 	janus_ice_handle *handle = (janus_ice_handle *)ice;
+	if(!handle)
+		return;
 #ifndef HAVE_LIBNICE_TCP
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Discovered new remote candidate for component %d in stream %d: foundation=%s\n", handle ? handle->handle_id : 0, component_id, stream_id, foundation);
 #else
@@ -1710,8 +1844,6 @@ static void janus_ice_cb_new_remote_candidate (NiceAgent *agent, NiceCandidate *
 	guint component_id = candidate->component_id;
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Discovered new remote candidate for component %d in stream %d: type=%s\n", handle ? handle->handle_id : 0, component_id, stream_id, ctype);
 #endif
-	if(!handle)
-		return;
 	if(component_id > 1) {
 		/* New remote candidate for a component we don't need anymore (rtcp-mux) */
 		return;
@@ -2416,9 +2548,165 @@ void *janus_ice_thread(void *data) {
 	return NULL;
 }
 
-/* Helper: candidates */
-void janus_ice_candidates_to_sdp(janus_ice_handle *handle, janus_sdp_mline *mline, guint stream_id, guint component_id)
-{
+/* Helper: encoding local candidates to string/SDP */
+static int janus_ice_candidate_to_string(janus_ice_handle *handle, NiceCandidate *c, char *buffer, int buflen, gboolean log_candidate) {
+	if(!handle || !handle->agent || !c || !buffer || buflen < 1)
+		return -1;
+	janus_ice_stream *stream = handle->stream;
+	if(!stream)
+		return -2;
+	janus_ice_component *component = stream->component;
+	if(!component)
+		return -3;
+	char *host_ip = NULL;
+	if(nat_1_1_enabled) {
+		/* A 1:1 NAT mapping was specified, overwrite all the host addresses with the public IP */
+		host_ip = janus_get_public_ip();
+		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Public IP specified and 1:1 NAT mapping enabled (%s), using that as host address in the candidates\n", handle->handle_id, host_ip);
+	}
+	/* Encode the candidate to a string */
+	gchar address[NICE_ADDRESS_STRING_LEN], base_address[NICE_ADDRESS_STRING_LEN];
+	gint port = 0, base_port = 0;
+	nice_address_to_string(&(c->addr), (gchar *)&address);
+	port = nice_address_get_port(&(c->addr));
+	nice_address_to_string(&(c->base_addr), (gchar *)&base_address);
+	base_port = nice_address_get_port(&(c->base_addr));
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"]   Address:    %s:%d\n", handle->handle_id, address, port);
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"]   Priority:   %d\n", handle->handle_id, c->priority);
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"]   Foundation: %s\n", handle->handle_id, c->foundation);
+	/* Start */
+	if(c->type == NICE_CANDIDATE_TYPE_HOST) {
+		/* 'host' candidate */
+		if(c->transport == NICE_CANDIDATE_TRANSPORT_UDP) {
+			g_snprintf(buffer, buflen,
+				"%s %d %s %d %s %d typ host",
+					c->foundation, c->component_id,
+					"udp", c->priority,
+					host_ip ? host_ip : address, port);
+		} else {
+			if(!janus_ice_tcp_enabled) {
+				/* ICE-TCP support disabled */
+				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping host TCP candidate, ICE-TCP support disabled...\n", handle->handle_id);
+				return -4;
+			}
+#ifndef HAVE_LIBNICE_TCP
+			/* TCP candidates are only supported since libnice 0.1.8 */
+			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping host TCP candidate, the libnice version doesn't support it...\n", handle->handle_id);
+			return -4;
+#else
+			const char *type = NULL;
+			switch(c->transport) {
+				case NICE_CANDIDATE_TRANSPORT_TCP_ACTIVE:
+					type = "active";
+					break;
+				case NICE_CANDIDATE_TRANSPORT_TCP_PASSIVE:
+					type = "passive";
+					break;
+				case NICE_CANDIDATE_TRANSPORT_TCP_SO:
+					type = "so";
+					break;
+				default:
+					break;
+			}
+			if(type == NULL) {
+				/* FIXME Unsupported transport */
+				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Unsupported transport, skipping non-UDP/TCP host candidate...\n", handle->handle_id);
+				return -5;
+			}
+			g_snprintf(buffer, buflen,
+				"%s %d %s %d %s %d typ host tcptype %s",
+					c->foundation, c->component_id,
+					"tcp", c->priority,
+					host_ip ? host_ip : address, port, type);
+#endif
+		}
+	} else if(c->type == NICE_CANDIDATE_TYPE_SERVER_REFLEXIVE ||
+			c->type == NICE_CANDIDATE_TYPE_PEER_REFLEXIVE ||
+			c->type == NICE_CANDIDATE_TYPE_RELAYED) {
+		/* 'srflx', 'prflx', or 'relay' candidate: what is this, exactly? */
+		const char *ltype = NULL;
+		switch(c->type) {
+			case NICE_CANDIDATE_TYPE_SERVER_REFLEXIVE:
+				ltype = "srflx";
+				break;
+			case NICE_CANDIDATE_TYPE_PEER_REFLEXIVE:
+				ltype = "prflx";
+				break;
+			case NICE_CANDIDATE_TYPE_RELAYED:
+				ltype = "relay";
+				break;
+			default:
+				break;
+		}
+		if(ltype == NULL)
+			return -5;
+		if(c->transport == NICE_CANDIDATE_TRANSPORT_UDP) {
+			nice_address_to_string(&(c->base_addr), (gchar *)&base_address);
+			gint base_port = nice_address_get_port(&(c->base_addr));
+			g_snprintf(buffer, buflen,
+				"%s %d %s %d %s %d typ %s raddr %s rport %d",
+					c->foundation, c->component_id,
+					"udp", c->priority,
+					address, port, ltype,
+					base_address, base_port);
+		} else {
+			if(!janus_ice_tcp_enabled) {
+				/* ICE-TCP support disabled */
+				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping srflx TCP candidate, ICE-TCP support disabled...\n", handle->handle_id);
+				return -4;
+			}
+#ifndef HAVE_LIBNICE_TCP
+			/* TCP candidates are only supported since libnice 0.1.8 */
+			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping srflx TCP candidate, the libnice version doesn't support it...\n", handle->handle_id);
+			return -4;
+#else
+			const char *type = NULL;
+			switch(c->transport) {
+				case NICE_CANDIDATE_TRANSPORT_TCP_ACTIVE:
+					type = "active";
+					break;
+				case NICE_CANDIDATE_TRANSPORT_TCP_PASSIVE:
+					type = "passive";
+					break;
+				case NICE_CANDIDATE_TRANSPORT_TCP_SO:
+					type = "so";
+					break;
+				default:
+					break;
+			}
+			if(type == NULL) {
+				/* FIXME Unsupported transport */
+				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Unsupported transport, skipping non-UDP/TCP srflx candidate...\n", handle->handle_id);
+				return -5;
+			} else {
+				g_snprintf(buffer, buflen,
+					"%s %d %s %d %s %d typ %s raddr %s rport %d tcptype %s",
+						c->foundation, c->component_id,
+						"tcp", c->priority,
+						address, port, ltype,
+						base_address, base_port, type);
+			}
+#endif
+		}
+	}
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"]     %s\n", handle->handle_id, buffer);
+	if(log_candidate) {
+		/* Save for the summary, in case we need it */
+		component->local_candidates = g_slist_append(component->local_candidates, g_strdup(buffer));
+		/* Notify event handlers */
+		if(janus_events_is_enabled()) {
+			janus_session *session = (janus_session *)handle->session;
+			json_t *info = json_object();
+			json_object_set_new(info, "local-candidate", json_string(buffer));
+			json_object_set_new(info, "stream_id", json_integer(stream->stream_id));
+			json_object_set_new(info, "component_id", json_integer(component->component_id));
+			janus_events_notify_handlers(JANUS_EVENT_TYPE_WEBRTC, session->session_id, handle->handle_id, info);
+		}
+	}
+	return 0;
+}
+
+void janus_ice_candidates_to_sdp(janus_ice_handle *handle, janus_sdp_mline *mline, guint stream_id, guint component_id) {
 	if(!handle || !handle->agent || !mline)
 		return;
 	janus_ice_stream *stream = handle->stream;
@@ -2431,230 +2719,22 @@ void janus_ice_candidates_to_sdp(janus_ice_handle *handle, janus_sdp_mline *mlin
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"]     No component %d in stream %d??\n", handle->handle_id, component_id, stream_id);
 		return;
 	}
-	NiceAgent* agent = handle->agent;
-	/* adding a stream should cause host candidates to be generated */
-	char *host_ip = NULL;
-	if(nat_1_1_enabled) {
-		/* A 1:1 NAT mapping was specified, overwrite all the host addresses with the public IP */
-		host_ip = janus_get_public_ip();
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Public IP specified and 1:1 NAT mapping enabled (%s), using that as host address in the candidates\n", handle->handle_id, host_ip);
-	}
+	NiceAgent *agent = handle->agent;
+	/* Iterate on all */
+	gchar buffer[200];
 	GSList *candidates, *i;
 	candidates = nice_agent_get_local_candidates (agent, stream_id, component_id);
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] We have %d candidates for Stream #%d, Component #%d\n", handle->handle_id, g_slist_length(candidates), stream_id, component_id);
 	gboolean log_candidates = (component->local_candidates == NULL);
 	for (i = candidates; i; i = i->next) {
 		NiceCandidate *c = (NiceCandidate *) i->data;
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Stream #%d, Component #%d\n", handle->handle_id, c->stream_id, c->component_id);
-		gchar address[NICE_ADDRESS_STRING_LEN], base_address[NICE_ADDRESS_STRING_LEN];
-		gint port = 0, base_port = 0;
-		nice_address_to_string(&(c->addr), (gchar *)&address);
-		port = nice_address_get_port(&(c->addr));
-		nice_address_to_string(&(c->base_addr), (gchar *)&base_address);
-		base_port = nice_address_get_port(&(c->base_addr));
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"]   Address:    %s:%d\n", handle->handle_id, address, port);
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"]   Priority:   %d\n", handle->handle_id, c->priority);
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"]   Foundation: %s\n", handle->handle_id, c->foundation);
-		/* SDP time */
-		gchar buffer[200];
-		if(c->type == NICE_CANDIDATE_TYPE_HOST) {
-			/* 'host' candidate */
-			if(c->transport == NICE_CANDIDATE_TRANSPORT_UDP) {
-				g_snprintf(buffer, sizeof(buffer),
-					"%s %d %s %d %s %d typ host",
-						c->foundation,
-						c->component_id,
-						"udp",
-						c->priority,
-						host_ip ? host_ip : address,
-						port);
+		if(janus_ice_candidate_to_string(handle, c, buffer, sizeof(buffer), log_candidates) == 0) {
+			/* Candidate encoded, add to the SDP (but only if it's not a 'prflx') */
+			if(c->type == NICE_CANDIDATE_TYPE_PEER_REFLEXIVE) {
+				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping prflx candidate...\n", handle->handle_id);
 			} else {
-				if(!janus_ice_tcp_enabled) {
-					/* ICE-TCP support disabled */
-					JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping host TCP candidate, ICE-TCP support disabled...\n", handle->handle_id);
-					nice_candidate_free(c);
-					continue;
-				}
-#ifndef HAVE_LIBNICE_TCP
-				/* TCP candidates are only supported since libnice 0.1.8 */
-				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping host TCP candidate, the libnice version doesn't support it...\n", handle->handle_id);
-				nice_candidate_free(c);
-				continue;
-#else
-				const char *type = NULL;
-				switch(c->transport) {
-					case NICE_CANDIDATE_TRANSPORT_TCP_ACTIVE:
-						type = "active";
-						break;
-					case NICE_CANDIDATE_TRANSPORT_TCP_PASSIVE:
-						type = "passive";
-						break;
-					case NICE_CANDIDATE_TRANSPORT_TCP_SO:
-						type = "so";
-						break;
-					default:
-						break;
-				}
-				if(type == NULL) {
-					/* FIXME Unsupported transport */
-					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Unsupported transport, skipping non-UDP/TCP host candidate...\n", handle->handle_id);
-					nice_candidate_free(c);
-					continue;
-				} else {
-					g_snprintf(buffer, sizeof(buffer),
-						"%s %d %s %d %s %d typ host tcptype %s",
-							c->foundation,
-							c->component_id,
-							"tcp",
-							c->priority,
-							host_ip ? host_ip : address,
-							port,
-							type);
-				}
-#endif
-			}
-		} else if(c->type == NICE_CANDIDATE_TYPE_SERVER_REFLEXIVE) {
-			/* 'srflx' candidate */
-			if(c->transport == NICE_CANDIDATE_TRANSPORT_UDP) {
-				nice_address_to_string(&(c->base_addr), (gchar *)&base_address);
-				gint base_port = nice_address_get_port(&(c->base_addr));
-				g_snprintf(buffer, sizeof(buffer),
-					"%s %d %s %d %s %d typ srflx raddr %s rport %d",
-						c->foundation,
-						c->component_id,
-						"udp",
-						c->priority,
-						address,
-						port,
-						base_address,
-						base_port);
-			} else {
-				if(!janus_ice_tcp_enabled) {
-					/* ICE-TCP support disabled */
-					JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping srflx TCP candidate, ICE-TCP support disabled...\n", handle->handle_id);
-					nice_candidate_free(c);
-					continue;
-				}
-#ifndef HAVE_LIBNICE_TCP
-				/* TCP candidates are only supported since libnice 0.1.8 */
-				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping srflx TCP candidate, the libnice version doesn't support it...\n", handle->handle_id);
-				nice_candidate_free(c);
-				continue;
-#else
-				const char *type = NULL;
-				switch(c->transport) {
-					case NICE_CANDIDATE_TRANSPORT_TCP_ACTIVE:
-						type = "active";
-						break;
-					case NICE_CANDIDATE_TRANSPORT_TCP_PASSIVE:
-						type = "passive";
-						break;
-					case NICE_CANDIDATE_TRANSPORT_TCP_SO:
-						type = "so";
-						break;
-					default:
-						break;
-				}
-				if(type == NULL) {
-					/* FIXME Unsupported transport */
-					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Unsupported transport, skipping non-UDP/TCP srflx candidate...\n", handle->handle_id);
-					nice_candidate_free(c);
-					continue;
-				} else {
-					g_snprintf(buffer, sizeof(buffer),
-						"%s %d %s %d %s %d typ srflx raddr %s rport %d tcptype %s",
-							c->foundation,
-							c->component_id,
-							"tcp",
-							c->priority,
-							address,
-							port,
-							base_address,
-							base_port,
-							type);
-				}
-#endif
-			}
-		} else if(c->type == NICE_CANDIDATE_TYPE_PEER_REFLEXIVE) {
-			/* 'prflx' candidate: skip it, we don't add them to the SDP */
-			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping prflx candidate...\n", handle->handle_id);
-			nice_candidate_free(c);
-			continue;
-		} else if(c->type == NICE_CANDIDATE_TYPE_RELAYED) {
-			/* 'relay' candidate */
-			if(c->transport == NICE_CANDIDATE_TRANSPORT_UDP) {
-				g_snprintf(buffer, sizeof(buffer),
-					"%s %d %s %d %s %d typ relay raddr %s rport %d",
-						c->foundation,
-						c->component_id,
-						"udp",
-						c->priority,
-						address,
-						port,
-						base_address,
-						base_port);
-			} else {
-				if(!janus_ice_tcp_enabled) {
-					/* ICE-TCP support disabled */
-					JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping relay TCP candidate, ICE-TCP support disabled...\n", handle->handle_id);
-					nice_candidate_free(c);
-					continue;
-				}
-#ifndef HAVE_LIBNICE_TCP
-				/* TCP candidates are only supported since libnice 0.1.8 */
-				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Skipping relay TCP candidate, the libnice version doesn't support it...\n", handle->handle_id);
-				nice_candidate_free(c);
-				continue;
-#else
-				const char *type = NULL;
-				switch(c->transport) {
-					case NICE_CANDIDATE_TRANSPORT_TCP_ACTIVE:
-						type = "active";
-						break;
-					case NICE_CANDIDATE_TRANSPORT_TCP_PASSIVE:
-						type = "passive";
-						break;
-					case NICE_CANDIDATE_TRANSPORT_TCP_SO:
-						type = "so";
-						break;
-					default:
-						break;
-				}
-				if(type == NULL) {
-					/* FIXME Unsupported transport */
-					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Unsupported transport, skipping non-UDP/TCP relay candidate...\n", handle->handle_id);
-					nice_candidate_free(c);
-					continue;
-				} else {
-					g_snprintf(buffer, sizeof(buffer),
-						"%s %d %s %d %s %d typ relay raddr %s rport %d tcptype %s",
-							c->foundation,
-							c->component_id,
-							"tcp",
-							c->priority,
-							address,
-							port,
-							base_address,
-							base_port,
-							type);
-				}
-#endif
-			}
-		}
-		janus_sdp_attribute *a = janus_sdp_attribute_create("candidate", "%s", buffer);
-		mline->attributes = g_list_append(mline->attributes, a);
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"]     %s", handle->handle_id, buffer); /* buffer already newline terminated */
-		if(log_candidates) {
-			/* Save for the summary, in case we need it */
-			component->local_candidates = g_slist_append(component->local_candidates, g_strdup(buffer));
-			/* Notify event handlers */
-			if(janus_events_is_enabled()) {
-				janus_session *session = (janus_session *)handle->session;
-				json_t *info = json_object();
-				json_object_set_new(info, "local-candidate", json_string(buffer));
-				json_object_set_new(info, "stream_id", json_integer(stream_id));
-				json_object_set_new(info, "component_id", json_integer(component_id));
-				janus_events_notify_handlers(JANUS_EVENT_TYPE_WEBRTC, session->session_id, handle->handle_id, info);
+				janus_sdp_attribute *a = janus_sdp_attribute_create("candidate", "%s", buffer);
+				mline->attributes = g_list_append(mline->attributes, a);
 			}
 		}
 		nice_candidate_free(c);
@@ -2743,6 +2823,7 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AUDIO);
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO);
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
+	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RESEND_TRICKLES);
 
 	/* Note: in case this is not an OFFER, we don't know whether any medium are supported on the other side or not yet */
 	if(audio) {
@@ -2826,6 +2907,14 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 	g_signal_connect (G_OBJECT (handle->agent), "new-selected-pair-full",
 #endif
 		G_CALLBACK (janus_ice_cb_new_selected_pair), handle);
+	if(janus_full_trickle_enabled) {
+#ifndef HAVE_LIBNICE_TCP
+		g_signal_connect (G_OBJECT (handle->agent), "new-candidate",
+#else
+		g_signal_connect (G_OBJECT (handle->agent), "new-candidate-full",
+#endif
+			G_CALLBACK (janus_ice_cb_new_local_candidate), handle);
+	}
 #ifndef HAVE_LIBNICE_TCP
 	g_signal_connect (G_OBJECT (handle->agent), "new-remote-candidate",
 #else
@@ -2891,6 +2980,29 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 
 	handle->cdone = 0;
 	handle->stream_id = 0;
+	/* If this is our first offer, let's generate some mids */
+	if(!offer) {
+		if(audio) {
+			if(handle->audio_mid == NULL)
+				handle->audio_mid = g_strdup("audio");
+			if(handle->stream_mid == NULL)
+				handle->stream_mid = handle->audio_mid;
+		}
+		if(video) {
+			if(handle->video_mid == NULL)
+				handle->video_mid = g_strdup("video");
+			if(handle->stream_mid == NULL)
+				handle->stream_mid = handle->video_mid;
+		}
+#ifdef HAVE_SCTP
+		if(data) {
+			if(handle->data_mid == NULL)
+				handle->data_mid = g_strdup("data");
+			if(handle->stream_mid == NULL)
+				handle->stream_mid = handle->data_mid;
+		}
+#endif
+	}
 	/* Now create an ICE stream for all the media we'll handle */
 	handle->stream_id = nice_agent_add_stream(handle->agent, 1);
 	janus_ice_stream *stream = (janus_ice_stream *)g_malloc0(sizeof(janus_ice_stream));
@@ -2988,6 +3100,37 @@ void janus_ice_restart(janus_ice_handle *handle) {
 		JANUS_LOG(LOG_WARN, "[%"SCNu64"] ICE restart failed...\n", handle->handle_id);
 	}
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
+}
+
+void janus_ice_resend_trickles(janus_ice_handle *handle) {
+	if(!handle || !handle->agent)
+		return;
+	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RESEND_TRICKLES);
+	janus_ice_stream *stream = handle->stream;
+	if(!stream)
+		return;
+	janus_ice_component *component = stream->component;
+	if(!component)
+		return;
+	NiceAgent *agent = handle->agent;
+	/* Iterate on all existing local candidates */
+	gchar buffer[200];
+	GSList *candidates, *i;
+	candidates = nice_agent_get_local_candidates (agent, stream->stream_id, component->component_id);
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"] We have %d candidates for Stream #%d, Component #%d\n",
+		handle->handle_id, g_slist_length(candidates), stream->stream_id, component->component_id);
+	for (i = candidates; i; i = i->next) {
+		NiceCandidate *c = (NiceCandidate *) i->data;
+		if(c->type == NICE_CANDIDATE_TYPE_PEER_REFLEXIVE)
+			continue;
+		if(janus_ice_candidate_to_string(handle, c, buffer, sizeof(buffer), FALSE) == 0) {
+			/* Candidate encoded, send a "trickle" event to the browser */
+			janus_ice_notify_trickle(handle, buffer);
+		}
+		nice_candidate_free(c);
+	}
+	/* Send a "completed" trickle at the end */
+	janus_ice_notify_trickle(handle, NULL);
 }
 
 static gint rtcp_transport_wide_cc_stats_comparator(gconstpointer item1, gconstpointer item2) {

--- a/ice.h
+++ b/ice.h
@@ -32,10 +32,11 @@
 /*! \brief ICE stuff initialization
  * @param[in] ice_lite Whether the ICE Lite mode should be enabled or not
  * @param[in] ice_tcp Whether ICE-TCP support should be enabled or not (only libnice >= 0.1.8, currently broken)
+ * @param[in] full_trickle Whether full-trickle must be used (instead of half-trickle)
  * @param[in] ipv6 Whether IPv6 candidates must be negotiated or not
  * @param[in] rtp_min_port Minimum port to use for RTP/RTCP, if a range is to be used
  * @param[in] rtp_max_port Maximum port to use for RTP/RTCP, if a range is to be used */
-void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean ipv6, uint16_t rtp_min_port, uint16_t rtp_max_port);
+void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean full_trickle, gboolean ipv6, uint16_t rtp_min_port, uint16_t rtp_max_port);
 /*! \brief ICE stuff de-initialization */
 void janus_ice_deinit(void);
 /*! \brief Method to force Janus to use a STUN server when gathering candidates
@@ -105,6 +106,9 @@ gboolean janus_ice_is_ice_lite_enabled(void);
 /*! \brief Method to check whether ICE-TCP support is enabled/supported or not (still WIP)
  * @returns true if ICE-TCP support is enabled/supported, false otherwise */
 gboolean janus_ice_is_ice_tcp_enabled(void);
+/*! \brief Method to check whether full-trickle support is enabled or not
+ * @returns true if full-trickle support is enabled, false otherwise */
+gboolean janus_ice_is_full_trickle_enabled(void);
 /*! \brief Method to check whether IPv6 candidates are enabled/supported or not (still WIP)
  * @returns true if IPv6 candidates are enabled/supported, false otherwise */
 gboolean janus_ice_is_ipv6_enabled(void);
@@ -166,6 +170,7 @@ typedef struct janus_ice_trickle janus_ice_trickle;
 #define JANUS_ICE_HANDLE_WEBRTC_GOT_ANSWER			(1 << 15)
 #define JANUS_ICE_HANDLE_WEBRTC_HAS_AGENT			(1 << 16)
 #define JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART			(1 << 17)
+#define JANUS_ICE_HANDLE_WEBRTC_RESEND_TRICKLES		(1 << 18)
 
 
 /*! \brief Janus media statistics
@@ -267,6 +272,8 @@ struct janus_ice_handle {
 	gchar *video_mid;
 	/*! \brief Data channel mid (media ID) */
 	gchar *data_mid;
+	/*! \brief Main mid (will be a pointer to one of the above) */
+	gchar *stream_mid;
 	/*! \brief ICE Stream ID */
 	guint stream_id;
 	/*! \brief ICE stream */
@@ -584,6 +591,9 @@ void janus_ice_dtls_handshake_done(janus_ice_handle *handle, janus_ice_component
 /*! \brief Method to restart ICE and the connectivity checks
  * @param[in] handle The Janus ICE handle this method refers to */
 void janus_ice_restart(janus_ice_handle *handle);
+/*! \brief Method to resend all the existing candidates via trickle (e.g., after an ICE restart)
+ * @param[in] handle The Janus ICE handle this method refers to */
+void janus_ice_resend_trickles(janus_ice_handle *handle);
 ///@}
 
 #endif

--- a/janus.c
+++ b/janus.c
@@ -212,6 +212,7 @@ static json_t *janus_info(const char *transaction) {
 	json_object_set_new(info, "ipv6", janus_ice_is_ipv6_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "ice-lite", janus_ice_is_ice_lite_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "ice-tcp", janus_ice_is_ice_tcp_enabled() ? json_true() : json_false());
+	json_object_set_new(info, "full-trickle", janus_ice_is_full_trickle_enabled() ? json_true() : json_false());
 	if(janus_ice_get_stun_server() != NULL) {
 		char server[255];
 		g_snprintf(server, 255, "%s:%"SCNu16, janus_ice_get_stun_server(), janus_ice_get_stun_port());
@@ -1187,6 +1188,10 @@ int janus_process_incoming_request(janus_request *request) {
 						janus_ice_restart(handle);
 					} else {
 						janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
+					}
+					/* If we're full-trickling, we'll need to resend the candidates later */
+					if(janus_ice_is_full_trickle_enabled()) {
+						janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RESEND_TRICKLES);
 					}
 				}
 #ifdef HAVE_SCTP
@@ -2174,6 +2179,7 @@ int janus_process_incoming_admin_request(janus_request *request) {
 		json_object_set_new(flags, "alert", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT) ? json_true() : json_false());
 		json_object_set_new(flags, "trickle", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_TRICKLE) ? json_true() : json_false());
 		json_object_set_new(flags, "all-trickles", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALL_TRICKLES) ? json_true() : json_false());
+		json_object_set_new(flags, "resend-trickles", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RESEND_TRICKLES) ? json_true() : json_false());
 		json_object_set_new(flags, "trickle-synced", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_TRICKLE_SYNCED) ? json_true() : json_false());
 		json_object_set_new(flags, "data-channels", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_DATA_CHANNELS) ? json_true() : json_false());
 		json_object_set_new(flags, "has-audio", janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AUDIO) ? json_true() : json_false());
@@ -2682,6 +2688,12 @@ int janus_plugin_push_event(janus_plugin_session *plugin_session, janus_plugin *
 	/* Send the event */
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Sending event to transport...\n", ice_handle->handle_id);
 	janus_session_notify_event(session, event);
+
+	if((restart || janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RESEND_TRICKLES))
+			&& janus_ice_is_full_trickle_enabled()) {
+		/* We're restarting ICE, send our trickle candidates again */
+		janus_ice_resend_trickles(ice_handle);
+	}
 
 	if(jsep != NULL && janus_events_is_enabled()) {
 		/* Notify event handlers as well */
@@ -3311,6 +3323,9 @@ gint main(int argc, char *argv[])
 	if(args_info.libnice_debug_given) {
 		janus_config_add_item(config, "nat", "nice_debug", "true");
 	}
+	if(args_info.full_trickle_given) {
+		janus_config_add_item(config, "nat", "full_trickle", "true");
+	}
 	if(args_info.ice_lite_given) {
 		janus_config_add_item(config, "nat", "ice_lite", "true");
 	}
@@ -3470,7 +3485,7 @@ gint main(int argc, char *argv[])
 #endif
 	const char *nat_1_1_mapping = NULL;
 	uint16_t rtp_min_port = 0, rtp_max_port = 0;
-	gboolean ice_lite = FALSE, ice_tcp = FALSE, ipv6 = FALSE;
+	gboolean ice_lite = FALSE, ice_tcp = FALSE, full_trickle = FALSE, ipv6 = FALSE;
 	item = janus_config_get_item_drilldown(config, "media", "ipv6");
 	ipv6 = (item && item->value) ? janus_is_true(item->value) : FALSE;
 	item = janus_config_get_item_drilldown(config, "media", "rtp_port_range");
@@ -3500,6 +3515,9 @@ gint main(int argc, char *argv[])
 	/* Check if we need to enable ICE-TCP support (warning: still broken, for debugging only) */
 	item = janus_config_get_item_drilldown(config, "nat", "ice_tcp");
 	ice_tcp = (item && item->value) ? janus_is_true(item->value) : FALSE;
+	/* Check if we need to do full-trickle instead of half-trickle */
+	item = janus_config_get_item_drilldown(config, "nat", "full_trickle");
+	full_trickle = (item && item->value) ? janus_is_true(item->value) : FALSE;
 	/* Any STUN server to use in Janus? */
 	item = janus_config_get_item_drilldown(config, "nat", "stun_server");
 	if(item && item->value)
@@ -3548,7 +3566,7 @@ gint main(int argc, char *argv[])
 		turn_rest_api_method = (char *)item->value;
 #endif
 	/* Initialize the ICE stack now */
-	janus_ice_init(ice_lite, ice_tcp, ipv6, rtp_min_port, rtp_max_port);
+	janus_ice_init(ice_lite, ice_tcp, full_trickle, ipv6, rtp_min_port, rtp_max_port);
 	if(janus_ice_set_stun_server(stun_server, stun_port) < 0) {
 		JANUS_LOG(LOG_FATAL, "Invalid STUN address %s:%u\n", stun_server, stun_port);
 		exit(1);

--- a/janus.ggo
+++ b/janus.ggo
@@ -15,6 +15,7 @@ option "ice-enforce-list" E "Comma-separated list of the only interfaces to use 
 option "ice-ignore-list" X "Comma-separated list of interfaces or IP addresses to ignore for ICE gathering; partial strings are supported (e.g., vmnet8,192.168.0.1,10.0.0.1 or vmnet,192.168., default=vmnet)" string typestr="list" optional
 option "ipv6-candidates" 6 "Whether to enable IPv6 candidates or not (experimental)" flag off
 option "libnice-debug" l "Whether to enable libnice debugging or not" flag off
+option "full-trickle" f "Do full-trickle instead of half-trickle" flag off
 option "ice-lite" I "Whether to enable the ICE Lite mode or not" flag off
 option "ice-tcp" T "Whether to enable ICE-TCP or not (warning: only works with ICE Lite)" flag off
 option "max-nack-queue" q "Maximum size of the NACK queue (in ms) per user for retransmissions" int typestr="number" optional

--- a/sdp.c
+++ b/sdp.c
@@ -236,14 +236,23 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 					/* Found mid attribute */
 					if(m->type == JANUS_SDP_AUDIO && m->port > 0) {
 						JANUS_LOG(LOG_VERB, "[%"SCNu64"] Audio mid: %s\n", handle->handle_id, a->value);
-						handle->audio_mid = g_strdup(a->value);
+						if(handle->audio_mid == NULL)
+							handle->audio_mid = g_strdup(a->value);
+						if(handle->stream_mid == NULL)
+							handle->stream_mid = handle->audio_mid;
 					} else if(m->type == JANUS_SDP_VIDEO && m->port > 0) {
 						JANUS_LOG(LOG_VERB, "[%"SCNu64"] Video mid: %s\n", handle->handle_id, a->value);
-						handle->video_mid = g_strdup(a->value);
+						if(handle->video_mid == NULL)
+							handle->video_mid = g_strdup(a->value);
+						if(handle->stream_mid == NULL)
+							handle->stream_mid = handle->video_mid;
 #ifdef HAVE_SCTP
 					} else if(m->type == JANUS_SDP_APPLICATION) {
 						JANUS_LOG(LOG_VERB, "[%"SCNu64"] Data Channel mid: %s\n", handle->handle_id, a->value);
-						handle->data_mid = g_strdup(a->value);
+						if(handle->data_mid == NULL)
+							handle->data_mid = g_strdup(a->value);
+						if(handle->stream_mid == NULL)
+							handle->stream_mid = handle->data_mid;
 #endif
 					}
 				} else if(!strcasecmp(a->name, "fingerprint")) {
@@ -1099,17 +1108,17 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 		}
 		/* a=mid:(audio|video|data) */
 		if(m->type == JANUS_SDP_AUDIO) {
-			a = janus_sdp_attribute_create("mid", "%s", handle->audio_mid ? handle->audio_mid : "audio");
+			a = janus_sdp_attribute_create("mid", "%s", handle->audio_mid);
 			m->attributes = g_list_insert_before(m->attributes, first, a);
 		} else if(m->type == JANUS_SDP_VIDEO) {
-			a = janus_sdp_attribute_create("mid", "%s", handle->video_mid ? handle->video_mid : "video");
+			a = janus_sdp_attribute_create("mid", "%s", handle->video_mid);
 			m->attributes = g_list_insert_before(m->attributes, first, a);
 #ifdef HAVE_SCTP
 		} else if(m->type == JANUS_SDP_APPLICATION) {
 			/* FIXME sctpmap and webrtc-datachannel should be dynamic */
 			a = janus_sdp_attribute_create("sctpmap", "5000 webrtc-datachannel 16");
 			m->attributes = g_list_insert_before(m->attributes, first, a);
-			a = janus_sdp_attribute_create("mid", "%s", handle->data_mid ? handle->data_mid : "data");
+			a = janus_sdp_attribute_create("mid", "%s", handle->data_mid);
 			m->attributes = g_list_insert_before(m->attributes, first, a);
 #endif
 		}
@@ -1175,13 +1184,15 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 			a = janus_sdp_attribute_create("simulcast", " recv rid=%s", rids);
 			m->attributes = g_list_append(m->attributes, a);
 		}
-		/* And now the candidates */
-		janus_ice_candidates_to_sdp(handle, m, stream->stream_id, 1);
-		/* Since we're half-trickling, we need to notify the peer that these are all the
-		 * candidates we have for this media stream, via an end-of-candidates attribute:
-		 * https://tools.ietf.org/html/draft-ietf-mmusic-trickle-ice-02#section-4.1 */
-		janus_sdp_attribute *end = janus_sdp_attribute_create("end-of-candidates", NULL);
-		m->attributes = g_list_append(m->attributes, end);
+		if(!janus_ice_is_full_trickle_enabled()) {
+			/* And now the candidates (but only if we're half-trickling) */
+			janus_ice_candidates_to_sdp(handle, m, stream->stream_id, 1);
+			/* Since we're half-trickling, we need to notify the peer that these are all the
+			 * candidates we have for this media stream, via an end-of-candidates attribute:
+			 * https://tools.ietf.org/html/draft-ietf-mmusic-trickle-ice-02#section-4.1 */
+			janus_sdp_attribute *end = janus_sdp_attribute_create("end-of-candidates", NULL);
+			m->attributes = g_list_append(m->attributes, end);
+		}
 		/* Next */
 		temp = temp->next;
 	}


### PR DESCRIPTION
As those more familiar with ICE and WebRTC may know, Janus does half-trickling: this means that it accepts [trickle](https://webrtchacks.com/trickle-ice/) candidates from peers, but always puts its own candidates in the SDP instead. This means that we need to wait for all Janus candidates to have been gathered, before Janus can send its SDP offer or answer. 

In general, this is not an issue at all. Janus is not like a browser on a desktop, which may have a ton of interfaces, STUN and TURN configured, and a lot of candidates to gather and shoot around. Most of the times, Janus is on a public address with maybe 1-2 interfaces, which means the gathering process is typically very quick. As a result, there's no impact at all for doing half-trickling, which greatly simplifies things. That said, if you're in a situation where you'd benefit from full trickling instead, then this patch adds support for it.

From a Janus perspective, you enable it (it's disabled by default) either by setting `full_trickle=yes` in `janus.cfg`, or by passing `-f` on the command line. When enabled, Janus will send "trickle" candidates as events, and in the same format as users currently send their own trickle candidates to Janus instead:

```
{
   "janus": "trickle",
   "session_id": 103912560900294,
   "sender": 1030472959325354,
   "candidate": {
      "sdpMLineIndex": 0,
      "candidate": "candidate:1 1 udp 2013266431 192.168.1.80 35584 typ host"
   }
}
```

The last candidate is notified with the usual `completed:true` just as the [documentation](https://janus.conf.meetecho.com/docs/rest) explains users do:

```
{
   "janus": "trickle",
   "session_id": 103912560900294,
   "sender": 1030472959325354,
   "candidate": {
      "completed": true
   }
}
```

We already modified `janus.js` to handle incoming trickle candidates automatically, so if you want to use full-trickling, you just need to make sure you use the updated version. If you're not using `janus.js` but are handling the WebRTC part yourself, you'll need to make sure you're prepared to handle incoming trickle candidates and enforce them the way regular WebRTC applications do.

As usual, I've tested briefly and it seems to be working fine, but of course feedback is more than welcome! Nothing should change if you don't care about full-trickling and want to keep on doing things as Janus always did (half-trickling is still the default), but I encourage you to test anyway, as some of the code there changed and so I want to be 100% sure there are no regressions (don't say I didn't warn you in case...).