### PR TITLE
RTP compensation for clock skew and mountpoint collision detection

### DIFF
--- a/conf/janus.plugin.streaming.cfg.sample.in
+++ b/conf/janus.plugin.streaming.cfg.sample.in
@@ -25,6 +25,8 @@
 ; audioiface = network interface or IP address to bind to, if any (binds to all otherwise)
 ; audiopt = <audio RTP payload type> (e.g., 111)
 ; audiortpmap = RTP map of the audio codec (e.g., opus/48000/2)
+; audioskew = yes|no (whether the plugin should perform skew
+;		analisys and compensation on incoming audio RTP stream, EXPERIMENTAL)
 ; videoport = local port for receiving video frames
 ; videomcast = multicast group port for receiving video frames, if any
 ; videoiface = network interface or IP address to bind to, if any (binds to all otherwise)
@@ -35,6 +37,11 @@
 ; videosimulcast = yes|no (do|don't enable video simulcasting)
 ; videoport2 = second local port for receiving video frames (only for rtp, and simulcasting)
 ; videoport3 = third local port for receiving video frames (only for rtp, and simulcasting)
+; videoskew = yes|no (whether the plugin should perform skew
+;		analisys and compensation on incoming video RTP stream, EXPERIMENTAL)
+; collision = in case of collision (more than one SSRC hitting the same port), the plugin
+;		will discard incoming RTP packets with a new SSRC unless this many milliseconds
+;		passed, which would then change the current SSRC (0=disabled)
 ; dataport = local port for receiving data messages to relay
 ; dataiface = network interface or IP address to bind to, if any (binds to all otherwise)
 ; databuffermsg = yes|no (whether the plugin should store the latest

--- a/ice.c
+++ b/ice.c
@@ -3575,7 +3575,6 @@ void *janus_ice_send_thread(void *data) {
 					/* Encrypt SRTP */
 					int protected = pkt->length;
 					int res = srtp_protect(component->dtls->srtp_out, sbuf, &protected);
-
 					if(res != srtp_err_status_ok) {
 						/* We don't spam the logs for every SRTP error: just take note of this, and print a summary later */
 						handle->srtp_errors_count++;

--- a/ice.c
+++ b/ice.c
@@ -3127,7 +3127,7 @@ void *janus_ice_send_thread(void *data) {
 					sr->si.rtp_ts = htonl(stream->audio_last_ts);	/* FIXME */
 				} else {
 					int64_t ntp = tv.tv_sec*G_USEC_PER_SEC + tv.tv_usec;
-					uint32_t rtp_ts = ((ntp-stream->audio_first_ntp_ts)/1000)*(rtcp_ctx->tb/1000) + stream->audio_first_rtp_ts;
+					uint32_t rtp_ts = ((ntp-stream->audio_first_ntp_ts)*(rtcp_ctx->tb))/1000000 + stream->audio_first_rtp_ts;
 					sr->si.rtp_ts = htonl(rtp_ts);
 				}
 				sr->si.s_packets = htonl(stream->component->out_stats.audio.packets);
@@ -3180,7 +3180,7 @@ void *janus_ice_send_thread(void *data) {
 					sr->si.rtp_ts = htonl(stream->video_last_ts);	/* FIXME */
 				} else {
 					int64_t ntp = tv.tv_sec*G_USEC_PER_SEC + tv.tv_usec;
-					uint32_t rtp_ts = ((ntp-stream->video_first_ntp_ts[0])/1000)*(rtcp_ctx->tb/1000) + stream->video_first_rtp_ts[0];
+					uint32_t rtp_ts = ((ntp-stream->video_first_ntp_ts[0])*(rtcp_ctx->tb))/1000000 + stream->video_first_rtp_ts[0];
 					sr->si.rtp_ts = htonl(rtp_ts);
 				}
 				sr->si.s_packets = htonl(stream->component->out_stats.video[0].packets);
@@ -3575,6 +3575,7 @@ void *janus_ice_send_thread(void *data) {
 					/* Encrypt SRTP */
 					int protected = pkt->length;
 					int res = srtp_protect(component->dtls->srtp_out, sbuf, &protected);
+
 					if(res != srtp_err_status_ok) {
 						/* We don't spam the logs for every SRTP error: just take note of this, and print a summary later */
 						handle->srtp_errors_count++;

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2046,6 +2046,10 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					if(source->vskew)
 						janus_config_add_item(config, mp->name, "vskew", "yes");
 				}
+				if(source->rtp_collision > 0) {
+					g_snprintf(value, BUFSIZ, "%d", source->rtp_collision);
+					janus_config_add_item(config, mp->name, "collision", value);
+				}
 				janus_config_add_item(config, mp->name, "data", mp->data ? "yes" : "no");
 				if(source->data_port > -1) {
 					g_snprintf(value, BUFSIZ, "%d", source->data_port);

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2014,7 +2014,6 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 						janus_config_add_item(config, mp->name, "audioiface", json_string_value(aiface));
 					if(source->askew)
 						janus_config_add_item(config, mp->name, "askew", "yes");
-
 				}
 				janus_config_add_item(config, mp->name, "video", mp->codecs.video_pt >= 0? "yes" : "no");
 				if(mp->codecs.video_pt >= 0) {

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -71,6 +71,8 @@ audioiface = network interface or IP address to bind to, if any (binds to all ot
 audiopt = <audio RTP payload type> (e.g., 111)
 audiortpmap = RTP map of the audio codec (e.g., opus/48000/2)
 audiofmtp = Codec specific parameters, if any
+audioskew = yes|no (whether the plugin should perform skew
+	analisys and compensation on incoming audio RTP stream, EXPERIMENTAL)
 videoport = local port for receiving video frames (only for rtp)
 videomcast = multicast group port for receiving video frames, if any
 videoiface = network interface or IP address to bind to, if any (binds to all otherwise)
@@ -82,6 +84,11 @@ videobufferkf = yes|no (whether the plugin should store the latest
 videosimulcast = yes|no (do|don't enable video simulcasting)
 videoport2 = second local port for receiving video frames (only for rtp, and simulcasting)
 videoport3 = third local port for receiving video frames (only for rtp, and simulcasting)
+videoskew = yes|no (whether the plugin should perform skew
+	analisys and compensation on incoming video RTP stream, EXPERIMENTAL)
+collision = in case of collision (more than one SSRC hitting the same port), the plugin
+	will discard incoming RTP packets with a new SSRC unless this many milliseconds
+	passed, which would then change the current SSRC (0=disabled)
 dataport = local port for receiving data messages to relay
 dataiface = network interface or IP address to bind to, if any (binds to all otherwise)
 databuffermsg = yes|no (whether the plugin should store the latest
@@ -259,6 +266,7 @@ static struct janus_json_parameter rtp_parameters[] = {
 	{"audio", JANUS_JSON_BOOL, 0},
 	{"video", JANUS_JSON_BOOL, 0},
 	{"data", JANUS_JSON_BOOL, 0},
+	{"collision", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"srtpsuite", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"srtpcrypto", JSON_STRING, 0}
 };
@@ -304,7 +312,8 @@ static struct janus_json_parameter rtp_audio_parameters[] = {
 	{"audiopt", JSON_INTEGER, JANUS_JSON_PARAM_REQUIRED | JANUS_JSON_PARAM_POSITIVE},
 	{"audiortpmap", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
 	{"audiofmtp", JSON_STRING, 0},
-	{"audioiface", JSON_STRING, 0}
+	{"audioiface", JSON_STRING, 0},
+	{"audioskew", JANUS_JSON_BOOL, 0},
 };
 static struct janus_json_parameter rtp_video_parameters[] = {
 	{"videomcast", JSON_STRING, 0},
@@ -317,6 +326,7 @@ static struct janus_json_parameter rtp_video_parameters[] = {
 	{"videosimulcast", JANUS_JSON_BOOL, 0},
 	{"videoport2", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"videoport3", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"videoskew", JANUS_JSON_BOOL, 0},
 };
 static struct janus_json_parameter rtp_data_parameters[] = {
 	{"dataport", JSON_INTEGER, JANUS_JSON_PARAM_REQUIRED | JANUS_JSON_PARAM_POSITIVE},
@@ -416,6 +426,7 @@ typedef struct janus_streaming_rtp_source {
 	int video_fd[3];
 	int data_fd;
 	gboolean simulcast;
+	gboolean askew, vskew;
 	gint64 last_received_audio;
 	gint64 last_received_video;
 	gint64 last_received_data;
@@ -434,6 +445,7 @@ typedef struct janus_streaming_rtp_source {
 #endif
 	janus_streaming_rtp_keyframe keyframe;
 	gboolean buffermsg;
+	int rtp_collision;
 	void *last_msg;
 	janus_mutex buffermsg_mutex;
 	janus_network_address audio_iface;
@@ -498,9 +510,9 @@ static void janus_streaming_mountpoint_free(janus_streaming_mountpoint *mp);
 janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 		uint64_t id, char *name, char *desc,
 		int srtpsuite, char *srtpcrypto,
-		gboolean doaudio, char *amcast, const janus_network_address *aiface, uint16_t aport, uint8_t acodec, char *artpmap, char *afmtp,
+		gboolean doaudio, char *amcast, const janus_network_address *aiface, uint16_t aport, uint8_t acodec, char *artpmap, char *afmtp, gboolean doaskew,
 		gboolean dovideo, char *vmcast, const janus_network_address *viface, uint16_t vport, uint8_t vcodec, char *vrtpmap, char *vfmtp, gboolean bufferkf,
-			gboolean simulcast, uint16_t vport2, uint16_t vport3,
+			gboolean simulcast, uint16_t vport2, uint16_t vport3, gboolean dovskew, int rtp_collision,
 		gboolean dodata, const janus_network_address *diface, uint16_t dport, gboolean buffermsg);
 /* Helper to create a file/ondemand live source */
 janus_streaming_mountpoint *janus_streaming_create_file_source(
@@ -727,7 +739,9 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				janus_config_item *secret = janus_config_get_item(cat, "secret");
 				janus_config_item *pin = janus_config_get_item(cat, "pin");
 				janus_config_item *audio = janus_config_get_item(cat, "audio");
+				janus_config_item *askew = janus_config_get_item(cat, "audioskew");
 				janus_config_item *video = janus_config_get_item(cat, "video");
+				janus_config_item *vskew = janus_config_get_item(cat, "videoskew");
 				janus_config_item *data = janus_config_get_item(cat, "data");
 				janus_config_item *diface = janus_config_get_item(cat, "dataiface");
 				janus_config_item *amcast = janus_config_get_item(cat, "audiomcast");
@@ -748,11 +762,14 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				janus_config_item *vport3 = janus_config_get_item(cat, "videoport3");
 				janus_config_item *dport = janus_config_get_item(cat, "dataport");
 				janus_config_item *dbm = janus_config_get_item(cat, "databuffermsg");
+				janus_config_item *rtpcollision = janus_config_get_item(cat, "collision");
 				janus_config_item *ssuite = janus_config_get_item(cat, "srtpsuite");
 				janus_config_item *scrypto = janus_config_get_item(cat, "srtpcrypto");
 				gboolean is_private = priv && priv->value && janus_is_true(priv->value);
 				gboolean doaudio = audio && audio->value && janus_is_true(audio->value);
+				gboolean doaskew = audio && askew && askew->value && janus_is_true(askew->value);
 				gboolean dovideo = video && video->value && janus_is_true(video->value);
+				gboolean dovskew = video && vskew && vskew->value && janus_is_true(vskew->value);
 				gboolean dodata = data && data->value && janus_is_true(data->value);
 				gboolean bufferkf = video && vkf && vkf->value && janus_is_true(vkf->value);
 				gboolean simulcast = video && vsc && vsc->value && janus_is_true(vsc->value);
@@ -867,6 +884,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 						(acodec && acodec->value) ? atoi(acodec->value) : 0,
 						artpmap ? (char *)artpmap->value : NULL,
 						afmtp ? (char *)afmtp->value : NULL,
+						doaskew,
 						dovideo,
 						vmcast ? (char *)vmcast->value : NULL,
 						dovideo && viface && viface->value ? &video_iface : NULL,
@@ -878,6 +896,8 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 						simulcast,
 						(vport2 && vport2->value) ? atoi(vport2->value) : 0,
 						(vport3 && vport3->value) ? atoi(vport3->value) : 0,
+						dovskew,
+						(rtpcollision && rtpcollision->value) ?  atoi(rtpcollision->value) : 0,
 						dodata,
 						dodata && diface && diface->value ? &data_iface : NULL,
 						(dport && dport->value) ? atoi(dport->value) : 0,
@@ -1489,6 +1509,12 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			if(source->simulcast) {
 				json_object_set_new(ml, "videosimulcast", json_true());
 			}
+			if(source->askew)
+				json_object_set_new(ml, "audioskew", json_true());
+			if(source->vskew)
+				json_object_set_new(ml, "videoskew", json_true());
+			if(source->rtp_collision > 0)
+				json_object_set_new(ml, "collision", json_integer(source->rtp_collision));
 			if(admin) {
 				if(mp->audio)
 					json_object_set_new(ml, "audioport", json_integer(source->audio_port));
@@ -1579,11 +1605,13 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			json_t *audio = json_object_get(root, "audio");
 			json_t *video = json_object_get(root, "video");
 			json_t *data = json_object_get(root, "data");
+			json_t *rtpcollision = json_object_get(root, "collision");
 			json_t *ssuite = json_object_get(root, "srtpsuite");
 			json_t *scrypto = json_object_get(root, "srtpcrypto");
 			gboolean doaudio = audio ? json_is_true(audio) : FALSE;
 			gboolean dovideo = video ? json_is_true(video) : FALSE;
 			gboolean dodata = data ? json_is_true(data) : FALSE;
+			gboolean doaskew = FALSE, dovskew = FALSE;
 			if(!doaudio && !dovideo && !dodata) {
 				JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream, no audio, video or data have to be streamed...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
@@ -1627,6 +1655,8 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				} else {
 					janus_network_address_nullify(&audio_iface);
 				}
+				json_t *askew = json_object_get(root, "audioskew");
+				doaskew = askew ? json_is_true(askew) : FALSE;
 			}
 			uint16_t vport = 0, vport2 = 0, vport3 = 0;
 			uint8_t vcodec = 0;
@@ -1673,6 +1703,8 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				} else {
 					janus_network_address_nullify(&video_iface);
 				}
+				json_t *vskew = json_object_get(root, "videoskew");
+				dovskew = vskew ? json_is_true(vskew) : FALSE;
 			}
 			uint16_t dport = 0;
 			gboolean buffermsg = FALSE;
@@ -1727,9 +1759,10 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					desc ? (char *)json_string_value(desc) : NULL,
 					ssuite ? json_integer_value(ssuite) : 0,
 					scrypto ? (char *)json_string_value(scrypto) : NULL,
-					doaudio, amcast, &audio_iface, aport, acodec, artpmap, afmtp,
+					doaudio, amcast, &audio_iface, aport, acodec, artpmap, afmtp, doaskew,
 					dovideo, vmcast, &video_iface, vport, vcodec, vrtpmap, vfmtp, bufferkf,
-					simulcast, vport2, vport3,
+					simulcast, vport2, vport3, dovskew,
+					rtpcollision ? json_integer_value(rtpcollision) : 0,
 					dodata, &data_iface, dport, buffermsg);
 			if(mp == NULL) {
 				JANUS_LOG(LOG_ERR, "Error creating 'rtp' stream...\n");
@@ -1979,6 +2012,9 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					json_t *aiface = json_object_get(root, "audioiface");
 					if(aiface)
 						janus_config_add_item(config, mp->name, "audioiface", json_string_value(aiface));
+					if(source->askew)
+						janus_config_add_item(config, mp->name, "askew", "yes");
+
 				}
 				janus_config_add_item(config, mp->name, "video", mp->codecs.video_pt >= 0? "yes" : "no");
 				if(mp->codecs.video_pt >= 0) {
@@ -2008,6 +2044,8 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					json_t *viface = json_object_get(root, "videoiface");
 					if(viface)
 						janus_config_add_item(config, mp->name, "videoiface", json_string_value(viface));
+					if(source->vskew)
+						janus_config_add_item(config, mp->name, "vskew", "yes");
 				}
 				janus_config_add_item(config, mp->name, "data", mp->data ? "yes" : "no");
 				if(source->data_port > -1) {
@@ -3328,9 +3366,9 @@ static void janus_streaming_mountpoint_free(janus_streaming_mountpoint *mp) {
 janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 		uint64_t id, char *name, char *desc,
 		int srtpsuite, char *srtpcrypto,
-		gboolean doaudio, char *amcast, const janus_network_address *aiface, uint16_t aport, uint8_t acodec, char *artpmap, char *afmtp,
+		gboolean doaudio, char *amcast, const janus_network_address *aiface, uint16_t aport, uint8_t acodec, char *artpmap, char *afmtp, gboolean doaskew,
 		gboolean dovideo, char *vmcast, const janus_network_address *viface, uint16_t vport, uint8_t vcodec, char *vrtpmap, char *vfmtp, gboolean bufferkf,
-			gboolean simulcast, uint16_t vport2, uint16_t vport3,
+			gboolean simulcast, uint16_t vport2, uint16_t vport3, gboolean dovskew, int rtp_collision,
 		gboolean dodata, const janus_network_address *diface, uint16_t dport, gboolean buffermsg) {
 	janus_mutex_lock(&mountpoints_mutex);
 	if(id == 0) {
@@ -3529,12 +3567,14 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 	live_rtp_source->audio_mcast = doaudio ? (amcast ? inet_addr(amcast) : INADDR_ANY) : INADDR_ANY;
 	live_rtp_source->audio_iface = doaudio && !janus_network_address_is_null(aiface) ? *aiface : nil;
 	live_rtp_source->audio_port = doaudio ? aport : -1;
+	live_rtp_source->askew = doaskew;
 	live_rtp_source->video_mcast = dovideo ? (vmcast ? inet_addr(vmcast) : INADDR_ANY) : INADDR_ANY;
 	live_rtp_source->video_port[0] = dovideo ? vport : -1;
 	live_rtp_source->simulcast = dovideo && simulcast;
 	live_rtp_source->video_port[1] = live_rtp_source->simulcast ? vport2 : -1;
 	live_rtp_source->video_port[2] = live_rtp_source->simulcast ? vport3 : -1;
 	live_rtp_source->video_iface = dovideo && !janus_network_address_is_null(viface) ? *viface : nil;
+	live_rtp_source->vskew = dovskew;
 	live_rtp_source->data_port = dodata ? dport : -1;
 	live_rtp_source->data_iface = dodata && !janus_network_address_is_null(diface) ? *diface : nil;
 	live_rtp_source->arc = NULL;
@@ -3557,6 +3597,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 	live_rtp_source->keyframe.temp_keyframe = NULL;
 	live_rtp_source->keyframe.temp_ts = 0;
 	janus_mutex_init(&live_rtp_source->keyframe.mutex);
+	live_rtp_source->rtp_collision = rtp_collision;
 	live_rtp_source->buffermsg = buffermsg;
 	live_rtp_source->last_msg = NULL;
 	janus_mutex_init(&live_rtp_source->buffermsg_mutex);
@@ -4550,9 +4591,10 @@ static void *janus_streaming_relay_thread(void *data) {
 					/* Got something audio (RTP) */
 					if(mountpoint->active == FALSE)
 						mountpoint->active = TRUE;
-					source->last_received_audio = janus_get_monotonic_time();
+					gint64 now = janus_get_monotonic_time();
+					gint64 real_time = janus_get_real_time();
 #ifdef HAVE_LIBCURL
-					source->reconnect_timer = janus_get_monotonic_time();
+					source->reconnect_timer = now;
 #endif
 					addrlen = sizeof(remote);
 					bytes = recvfrom(audio_fd, buffer, 1500, 0, (struct sockaddr*)&remote, &addrlen);
@@ -4560,11 +4602,18 @@ static void *janus_streaming_relay_thread(void *data) {
 						/* Failed to read? */
 						continue;
 					}
+					janus_rtp_header *rtp = (janus_rtp_header *)buffer;
+					ssrc = ntohl(rtp->ssrc);
+					if(source->rtp_collision > 0 && a_last_ssrc && ssrc != a_last_ssrc &&
+							(now-source->last_received_audio) < 1000*source->rtp_collision) {
+						JANUS_LOG(LOG_WARN, "[%s] RTP collision on audio mountpoint, dropping packet (ssrc=%u)\n", name, ssrc);
+						continue;
+					}
+					source->last_received_audio = now;
 					//~ JANUS_LOG(LOG_VERB, "************************\nGot %d bytes on the audio channel...\n", bytes);
 					/* If paused, ignore this packet */
 					if(!mountpoint->enabled)
 						continue;
-					janus_rtp_header *rtp = (janus_rtp_header *)buffer;
 					/* Is this SRTP? */
 					if(source->is_srtp) {
 						int buflen = bytes;
@@ -4588,17 +4637,25 @@ static void *janus_streaming_relay_thread(void *data) {
 					packet.is_video = FALSE;
 					packet.is_keyframe = FALSE;
 					/* Do we have a new stream? */
-					if(ntohl(packet.data->ssrc) != a_last_ssrc) {
-						a_last_ssrc = ntohl(packet.data->ssrc);
+					if(ssrc != a_last_ssrc) {
+						a_last_ssrc = ssrc;
 						JANUS_LOG(LOG_INFO, "[%s] New audio stream! (ssrc=%u)\n", name, a_last_ssrc);
 					}
 					packet.data->type = mountpoint->codecs.audio_pt;
 					/* Is there a recorder? */
 					janus_rtp_header_update(packet.data, &source->context[0], FALSE, 0);
-					ssrc = ntohl(packet.data->ssrc);
+					if (source->askew) {
+						int ret = janus_rtp_skew_compensate_audio(packet.data, &source->context[0], real_time);
+						if (ret < 0) {
+							JANUS_LOG(LOG_WARN, "[%s] Dropping %d packets, audio source clock is too fast (ssrc=%u)\n", name, -ret, a_last_ssrc);
+							continue;
+						} else if (ret > 0) {
+							JANUS_LOG(LOG_WARN, "[%s] Jumping %d RTP sequence numbers, audio source clock is too slow (ssrc=%u)\n", name, ret, a_last_ssrc);
+						}
+					}
 					packet.data->ssrc = ntohl((uint32_t)mountpoint->id);
 					janus_recorder_save_frame(source->arc, buffer, bytes);
-					packet.data->ssrc = ntohl(ssrc);
+					packet.data->ssrc = ssrc;
 					/* Backup the actual timestamp and sequence number set by the restreamer, in case switching is involved */
 					packet.timestamp = ntohl(packet.data->timestamp);
 					packet.seq_number = ntohs(packet.data->seq_number);
@@ -4620,9 +4677,10 @@ static void *janus_streaming_relay_thread(void *data) {
 						index = 2;
 					if(mountpoint->active == FALSE)
 						mountpoint->active = TRUE;
-					source->last_received_video = janus_get_monotonic_time();
+					gint64 now = janus_get_monotonic_time();
+					gint64 real_time = janus_get_real_time();
 #ifdef HAVE_LIBCURL
-					source->reconnect_timer = janus_get_monotonic_time();
+					source->reconnect_timer = now;
 #endif
 					addrlen = sizeof(remote);
 					bytes = recvfrom(fds[i].fd, buffer, 1500, 0, (struct sockaddr*)&remote, &addrlen);
@@ -4630,8 +4688,15 @@ static void *janus_streaming_relay_thread(void *data) {
 						/* Failed to read? */
 						continue;
 					}
-					//~ JANUS_LOG(LOG_VERB, "************************\nGot %d bytes on the video channel...\n", bytes);
 					janus_rtp_header *rtp = (janus_rtp_header *)buffer;
+					ssrc = ntohl(rtp->ssrc);
+					if(source->rtp_collision > 0 && v_last_ssrc[index] && ssrc != v_last_ssrc[index] &&
+							(now-source->last_received_video) < 1000*source->rtp_collision) {
+						JANUS_LOG(LOG_WARN, "[%s] RTP collision on video mountpoint, dropping packet (ssrc=%u)\n", name, ssrc);
+						continue;
+					}
+					source->last_received_video = now;
+					//~ JANUS_LOG(LOG_VERB, "************************\nGot %d bytes on the video channel...\n", bytes);
 					/* Is this SRTP? */
 					if(source->is_srtp) {
 						int buflen = bytes;
@@ -4744,18 +4809,26 @@ static void *janus_streaming_relay_thread(void *data) {
 					packet.substream = index;
 					packet.codec = mountpoint->codecs.video_codec;
 					/* Do we have a new stream? */
-					if(ntohl(packet.data->ssrc) != v_last_ssrc[index]) {
-						v_last_ssrc[index] = ntohl(packet.data->ssrc);
+					if(ssrc != v_last_ssrc[index]) {
+						v_last_ssrc[index] = ssrc;
 						JANUS_LOG(LOG_INFO, "[%s] New video stream! (ssrc=%u, index %d)\n", name, v_last_ssrc[index], index);
 					}
 					packet.data->type = mountpoint->codecs.video_pt;
 					/* Is there a recorder? (FIXME notice we only record the first substream, if simulcasting) */
 					janus_rtp_header_update(packet.data, &source->context[index], TRUE, 0);
+					if (source->vskew) {
+						int ret = janus_rtp_skew_compensate_video(packet.data, &source->context[index], real_time);
+						if (ret < 0) {
+							JANUS_LOG(LOG_WARN, "[%s] Dropping %d packets, video source clock is too fast (ssrc=%u, index %d)\n", name, -ret, v_last_ssrc[index], index);
+							continue;
+						} else if (ret > 0) {
+							JANUS_LOG(LOG_WARN, "[%s] Jumping %d RTP sequence numbers, video source clock is too slow (ssrc=%u, index %d)\n", name, ret, v_last_ssrc[index], index);
+						}
+					}
 					if(index == 0) {
-						ssrc = ntohl(packet.data->ssrc);
 						packet.data->ssrc = ntohl((uint32_t)mountpoint->id);
 						janus_recorder_save_frame(source->vrc, buffer, bytes);
-						packet.data->ssrc = ntohl(ssrc);
+						packet.data->ssrc = ssrc;
 					}
 					/* Backup the actual timestamp and sequence number set by the restreamer, in case switching is involved */
 					packet.timestamp = ntohl(packet.data->timestamp);

--- a/rtp.c
+++ b/rtp.c
@@ -244,6 +244,192 @@ void janus_rtp_switching_context_reset(janus_rtp_switching_context *context) {
 	memset(context, 0, sizeof(*context));
 }
 
+int janus_rtp_skew_compensate_audio(janus_rtp_header *header, janus_rtp_switching_context *context, gint64 now) {
+	/* Reset values if a new ssrc has been detected */
+	if (context->a_new_ssrc) {
+		context->a_reference_time = now;
+		context->a_start_ts = 0;
+		context->a_start_time = 0;
+		context->a_active_delay = 0;
+		context->a_prev_delay = 0;
+		context->a_seq_offset = 0;
+		context->a_ts_offset = 0;
+		context->a_target_ts = 0;
+		context->a_new_ssrc = FALSE;
+	}
+
+	/* N 	: a N sequence number jump has been performed */
+	/* 0  	: any new skew compensation has been applied */
+	/* -N  	: a N packet drop must be performed */
+	int exit_status = 0;
+
+	/* Do not execute skew analysis in the first seconds */
+	if (now-context->a_reference_time < SKEW_DETECTION_WAIT_TIME_SECS*G_USEC_PER_SEC) {
+		return 0;
+	} else if (!context->a_start_time) {
+		context->a_start_time = now;
+		context->a_start_ts = context->a_last_ts;
+	}
+
+	/* Skew analysis */
+	/* Are we waiting for a target timestamp? (a negative skew has been evaluated in a previous iteration) */
+	if (context->a_target_ts > 0 && (gint32)(context->a_target_ts - context->a_last_ts) > 0) {
+		context->a_seq_offset--;
+		exit_status = -1;
+	} else {
+		context->a_target_ts = 0;
+		/* Do not execute analysis for out of order packets or multi-packets frame */
+		if (context->a_last_seq == context->a_prev_seq + 1 && context->a_last_ts != context->a_prev_ts) {
+			/* Set the sample rate according to the header */
+			guint32 akhz = 48; /* 48khz for Opus */
+			if(header->type == 0 || header->type == 8 || header->type == 9)
+				akhz = 8;
+			/* Evaluate the local RTP timestamp according to the local clock */
+			guint32 expected_ts = ((now - context->a_start_time)*akhz)/1000 + context->a_start_ts;
+			/* Evaluate current delay */
+			gint32 delay_now = context->a_last_ts - expected_ts;
+			/* Exponentially weighted moving average estimation */
+			gint32 delay_estimate = (31*context->a_prev_delay + delay_now)/32;
+			/* Save previous delay for the next iteration*/
+			context->a_prev_delay = delay_estimate;
+			/* Evaluate the distance between active delay and current delay estimate */
+			gint32 offset = context->a_active_delay - delay_estimate;
+			JANUS_LOG(LOG_HUGE, "audio skew status SSRC=%"SCNu32" RECVD_TS=%"SCNu32" EXPTD_TS=%"SCNu32" OFFSET=%"SCNi32" TS_OFFSET=%"SCNi32" SEQ_OFFSET=%"SCNi16"\n", context->a_last_ssrc, context->a_last_ts, expected_ts, offset, context->a_ts_offset, context->a_seq_offset);
+			/* Check if the offset has surpassed the threshold */
+			gint32 skew_th = RTP_AUDIO_SKEW_TH_MS*akhz;
+			if (offset >= skew_th) {
+				/* The source is slowing down */
+				/* Update active delay */
+				context->a_active_delay = delay_estimate;
+				/* Adjust ts offset */
+				context->a_ts_offset += skew_th;
+				/* Calculate last ts increase */
+				guint32 ts_incr = context->a_last_ts-context->a_prev_ts;
+				/* Evaluate sequence number jump */
+				guint16 jump = (skew_th+ts_incr-1)/ts_incr;
+				/* Adjust seq num offset */
+				context->a_seq_offset += jump;
+				exit_status = jump;
+			} else if (offset <= -skew_th) {
+				/* The source is speeding up*/
+				/* Update active delay */
+				context->a_active_delay = delay_estimate;
+				/* Adjust ts offset */
+				context->a_ts_offset -= skew_th;
+				/* Set target ts */
+				context->a_target_ts = context->a_last_ts + skew_th;
+				if (context->a_target_ts == 0)
+					context->a_target_ts = 1;
+				/* Adjust seq num offset */
+				context->a_seq_offset--;
+				exit_status = -1;
+			}
+		}
+	}
+
+	/* Skew compensation */
+	/* Fix header timestamp considering the active offset */
+	guint32 fixed_rtp_ts = context->a_last_ts + context->a_ts_offset;
+	header->timestamp = htonl(fixed_rtp_ts);
+	/* Fix header sequence number considering the total offset */
+	guint16 fixed_rtp_seq = context->a_last_seq + context->a_seq_offset;
+	header->seq_number = htons(fixed_rtp_seq);
+
+	return exit_status;
+}
+
+int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switching_context *context, gint64 now) {
+	/* Reset values if a new ssrc has been detected */
+	if (context->v_new_ssrc) {
+		context->v_reference_time = now;
+		context->v_start_ts = 0;
+		context->v_start_time = 0;
+		context->v_active_delay = 0;
+		context->v_prev_delay = 0;
+		context->v_seq_offset = 0;
+		context->v_ts_offset = 0;
+		context->v_target_ts = 0;
+		context->v_new_ssrc = FALSE;	}
+
+	/* N 	: a N sequence numbers jump has been performed */
+	/* 0  	: any new skew compensation has been applied */
+	/* -N  	: a N packets drop must be performed */
+	int exit_status = 0;
+
+	/* Do not execute skew analysis in the first seconds */
+	if (now-context->v_reference_time < SKEW_DETECTION_WAIT_TIME_SECS*G_USEC_PER_SEC) {
+		return 0;
+	} else if (!context->v_start_time) {
+		context->v_start_time = now;
+		context->v_start_ts = context->v_last_ts;
+	}
+
+	/* Skew analysis */
+	/* Are we waiting for a target timestamp? (a negative skew has been evaluated in a previous iteration) */
+	if (context->v_target_ts > 0 && (gint32)(context->v_target_ts - context->v_last_ts) > 0) {
+		context->v_seq_offset--;
+		exit_status = -1;
+	} else {
+		context->v_target_ts = 0;
+		/* Do not execute analysis for out of order packets or multi-packets frame */
+		if (context->v_last_seq == context->v_prev_seq + 1 && context->v_last_ts != context->v_prev_ts) {
+			/* Set the sample rate */
+			guint32 vkhz = 90; /* 90khz */
+			/* Evaluate the local RTP timestamp according to the local clock */
+			guint32 expected_ts = ((now - context->v_start_time)*vkhz)/1000 + context->v_start_ts;
+			/* Evaluate current delay */
+			gint32 delay_now = context->v_last_ts - expected_ts;
+			/* Exponentially weighted moving average estimation */
+			gint32 delay_estimate = (31*context->v_prev_delay + delay_now)/32;
+			/* Save previous delay for the next iteration*/
+			context->v_prev_delay = delay_estimate;
+			/* Evaluate the distance between active delay and current delay estimate */
+			gint32 offset = context->v_active_delay - delay_estimate;
+			JANUS_LOG(LOG_HUGE, "video skew status SSRC=%"SCNu32" RECVD_TS=%"SCNu32" EXPTD_TS=%"SCNu32" OFFSET=%"SCNi32" TS_OFFSET=%"SCNi32" SEQ_OFFSET=%"SCNi16"\n", context->v_last_ssrc, context->v_last_ts, expected_ts, offset, context->v_ts_offset, context->v_seq_offset);
+			/* Check if the offset has surpassed the threshold */
+			gint32 skew_th = RTP_VIDEO_SKEW_TH_MS*vkhz;
+			if (offset >= skew_th) {
+				/* The source is slowing down */
+				/* Update active delay */
+				context->v_active_delay = delay_estimate;
+				/* Adjust ts offset */
+				context->v_ts_offset += skew_th;
+				/* Calculate last ts increase */
+				guint32 ts_incr = context->v_last_ts-context->v_prev_ts;
+				/* Evaluate sequence number jump */
+				guint16 jump = (skew_th+ts_incr-1)/ts_incr;
+				/* Adjust seq num offset */
+				context->v_seq_offset += jump;
+				exit_status = jump;
+			} else if (offset <= -skew_th) {
+				/* The source is speeding up*/
+				/* Update active delay */
+				context->v_active_delay = delay_estimate;
+				/* Adjust ts offset */
+				context->v_ts_offset -= skew_th;
+				/* Set target ts */
+				context->v_target_ts = context->v_last_ts + skew_th;
+				if (context->v_target_ts == 0)
+					context->v_target_ts = 1;
+				/* Adjust seq num offset */
+				context->v_seq_offset--;
+				exit_status = -1;
+			}
+		}
+	}
+
+	/* Skew compensation */
+	/* Fix header timestamp considering the active offset */
+	guint32 fixed_rtp_ts = context->v_last_ts + context->v_ts_offset;
+	header->timestamp = htonl(fixed_rtp_ts);
+	/* Fix header sequence number considering the total offset */
+	guint16 fixed_rtp_seq = context->v_last_seq + context->v_seq_offset;
+	header->seq_number = htons(fixed_rtp_seq);
+
+	return exit_status;
+}
+
+
 void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_context *context, gboolean video, int step) {
 	if(header == NULL || context == NULL)
 		return;
@@ -267,13 +453,15 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 			/* How much time since the last video RTP packet? We compute an offset accordingly */
 			if(context->v_last_time > 0) {
 				gint64 time_diff = janus_get_monotonic_time() - context->v_last_time;
-				time_diff = (time_diff/1000)*90;	/* We're assuming 90khz here */
+				time_diff = (time_diff*90)/1000; 	/* We're assuming 90khz here */
 				if(time_diff == 0)
 					time_diff = 1;
 				context->v_base_ts_prev += (guint32)time_diff;
 				context->v_last_ts += (guint32)time_diff;
 				JANUS_LOG(LOG_VERB, "Computed offset for video RTP timestamp: %"SCNu32"\n", (guint32)time_diff);
 			}
+			/* Reset skew compensation data */
+			context->v_new_ssrc = TRUE;
 		}
 		if(context->v_seq_reset) {
 			/* Video sequence number was paused for a while: just update that */
@@ -282,8 +470,11 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 			context->v_base_seq = seq;
 		}
 		/* Compute a coherent timestamp and sequence number */
+		context->v_prev_ts = context->v_last_ts;
 		context->v_last_ts = (timestamp-context->v_base_ts) + context->v_base_ts_prev;
+		context->v_prev_seq = context->v_last_seq;
 		context->v_last_seq = (seq-context->v_base_seq)+context->v_base_seq_prev+1;
+
 		/* Update the timestamp and sequence number in the RTP packet */
 		header->timestamp = htonl(context->v_last_ts);
 		header->seq_number = htons(context->v_last_seq);
@@ -305,13 +496,16 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 				int akhz = 48;
 				if(header->type == 0 || header->type == 8 || header->type == 9)
 					akhz = 8;	/* We're assuming 48khz here (Opus), unless it's G.711/G.722 (8khz) */
-				time_diff = (time_diff/1000)*(akhz);
+				time_diff = (time_diff*akhz)/1000;
 				if(time_diff == 0)
 					time_diff = 1;
 				context->a_base_ts_prev += (guint32)time_diff;
+				context->a_prev_ts += (guint32)time_diff;
 				context->a_last_ts += (guint32)time_diff;
 				JANUS_LOG(LOG_VERB, "Computed offset for audio RTP timestamp: %"SCNu32"\n", (guint32)time_diff);
 			}
+			/* Reset skew compensation data */
+			context->a_new_ssrc = TRUE;
 		}
 		if(context->a_seq_reset) {
 			/* Audio sequence number was paused for a while: just update that */
@@ -320,8 +514,11 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 			context->a_base_seq = seq;
 		}
 		/* Compute a coherent timestamp and sequence number */
+		context->a_prev_ts = context->a_last_ts;
 		context->a_last_ts = (timestamp-context->a_base_ts) + context->a_base_ts_prev;
+		context->a_prev_seq = context->a_last_seq;
 		context->a_last_seq = (seq-context->a_base_seq)+context->a_base_seq_prev+1;
+
 		/* Update the timestamp and sequence number in the RTP packet */
 		header->timestamp = htonl(context->a_last_ts);
 		header->seq_number = htons(context->a_last_seq);

--- a/rtp.c
+++ b/rtp.c
@@ -429,7 +429,6 @@ int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switchin
 	return exit_status;
 }
 
-
 void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_context *context, gboolean video, int step) {
 	if(header == NULL || context == NULL)
 		return;
@@ -474,7 +473,6 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 		context->v_last_ts = (timestamp-context->v_base_ts) + context->v_base_ts_prev;
 		context->v_prev_seq = context->v_last_seq;
 		context->v_last_seq = (seq-context->v_base_seq)+context->v_base_seq_prev+1;
-
 		/* Update the timestamp and sequence number in the RTP packet */
 		header->timestamp = htonl(context->v_last_ts);
 		header->seq_number = htons(context->v_last_seq);
@@ -518,7 +516,6 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 		context->a_last_ts = (timestamp-context->a_base_ts) + context->a_base_ts_prev;
 		context->a_prev_seq = context->a_last_seq;
 		context->a_last_seq = (seq-context->a_base_seq)+context->a_base_seq_prev+1;
-
 		/* Update the timestamp and sequence number in the RTP packet */
 		header->timestamp = htonl(context->a_last_ts);
 		header->seq_number = htons(context->a_last_seq);

--- a/rtp.h
+++ b/rtp.h
@@ -153,12 +153,18 @@ int janus_rtp_header_extension_parse_transport_wide_cc(char *buf, int len, int i
 
 /*! \brief RTP context, in order to make sure SSRC changes result in coherent seq/ts increases */
 typedef struct janus_rtp_switching_context {
-	uint32_t a_last_ssrc, a_last_ts, a_base_ts, a_base_ts_prev,
-			v_last_ssrc, v_last_ts, v_base_ts, v_base_ts_prev;
-	uint16_t a_last_seq, a_base_seq, a_base_seq_prev,
-			v_last_seq, v_base_seq, v_base_seq_prev;
-	gboolean a_seq_reset, v_seq_reset;
-	gint64 a_last_time, v_last_time;
+	uint32_t a_last_ssrc, a_last_ts, a_base_ts, a_base_ts_prev, a_prev_ts, a_target_ts, a_start_ts,
+			v_last_ssrc, v_last_ts, v_base_ts, v_base_ts_prev, v_prev_ts, v_target_ts, v_start_ts;
+	uint16_t a_last_seq, a_prev_seq, a_base_seq, a_base_seq_prev,
+			v_last_seq, v_prev_seq, v_base_seq, v_base_seq_prev;
+	gboolean a_seq_reset, a_new_ssrc,
+			v_seq_reset, v_new_ssrc;
+	gint16 a_seq_offset,
+			v_seq_offset;
+	gint32 a_prev_delay, a_active_delay, a_ts_offset,
+			v_prev_delay, v_active_delay, v_ts_offset;
+	gint64 a_last_time, a_reference_time, a_start_time,
+			v_last_time, v_reference_time, v_start_time;
 } janus_rtp_switching_context;
 
 /*! \brief Set (or reset) the context fields to their default values
@@ -171,5 +177,22 @@ void janus_rtp_switching_context_reset(janus_rtp_switching_context *context);
  * @param[in] video Whether this is an audio or a video packet
  * @param[in] step \b deprecated The expected timestamp step */
 void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_context *context, gboolean video, int step);
+
+#define RTP_AUDIO_SKEW_TH_MS 40
+#define RTP_VIDEO_SKEW_TH_MS 40
+#define SKEW_DETECTION_WAIT_TIME_SECS 15
+
+/*! \brief Use the context info to compensate for audio source skew, if needed
+ * @param[in] header The RTP header to update
+ * @param[in] context The context to use as a reference
+ * @param[in] now \b The packet arrival monotonic time
+ * @returns 0 if no compensation is needed, -N if a N packets drop must be performed, N if a N sequence numbers jump has been performed */
+int janus_rtp_skew_compensate_audio(janus_rtp_header *header, janus_rtp_switching_context *context, gint64 now);
+/*! \brief Use the context info to compensate for video source skew, if needed
+ * @param[in] header The RTP header to update
+ * @param[in] context The context to use as a reference
+ * @param[in] now \b The packet arrival monotonic time
+ * @returns 0 if no compensation is needed, -N if a N packets drop must be performed, N if a N sequence numbers jump has been performed */
+int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switching_context *context, gint64 now);
 
 #endif


### PR DESCRIPTION
This PR contains two very sensible features:

1) The **detection on a RTP streaming mountpoint of a collision with a different SSRC**. This means that if a RTP mountpoint is being fed by a live RTP stream, and another stream with a different SSRC tries to feed the same mountpoint (e.g. same UDP port), Janus will now discard the packets incoming from the new feed and will notice the user with a warning. This feature can be enabled using a new attribute in the mountpoint configuration: `collision` (expressed in milliseconds). In case of collision (more than one SSRC hitting the same port), the plugin will discard incoming RTP packets with a new SSRC unless this many milliseconds passed from the last packet with the old SSRC, which would then switch the current SSRC to the new one. While this feature could be intended like a very basic hijacking protection, it is more designed to protect Janus mountpoints from streamers misconfiguration or human errors at runtime (e.g. launch twice the same streamer).

2) A **counter-measure for RTP feeders' clock skew**. 
We noticed that very long (> 4 hours) recordings of a mountpoint in the streaming plugin occasionally showed a **lip-sync** issue. It come up that using different devices to feed the audio stream and video stream of a mountpoint is the cause of this lip-sync error. Specifically the differences among the sources clock generate a clock skew problem on Janus. This means e.g. that the video source RTP is arriving to Janus faster than the nominal rate (that depends upon video format), while the audio source RTP is arriving slower than the nominal rate, and Janus do its best to relay and record these packets exactly with the same timing it received them. This is always true for setups that involve different clock sources to stream audio and video related to same mountpoint, including for example setups with one board/laptop with two USB devices (camera and audio card).
The issue is present for online viewers too (the browsers). While the playout buffers management and Sender Reports coming from Janus permit the browsers to adjust the lip-sync, eventually the issue shows up after some hours. 
The proposed solution is a routine acting at the mountpoint entrance that compares the received RTP timestamp with an expected local RTP timestamp, in order to evaluate the current offset and compensate with incremental adjustments. The implementation is largely inspired by the pseudo-code found in [Colin Perkins' book, Chapter 6, par. Compensation for clock skew](https://books.google.it/books?id=OM7YJAy9_m8C&printsec=frontcover&hl=it&source=gbs_ge_summary_r&cad=0#v=onepage&q&f=false). The only difference is that we do not have a receiving buffer, so instead of working on a buffer we have to react _online_ in case of a compensation is needed. Specifically:
- If the sender is faster than the nominal rate, we drop N incoming packets and adjust subsequent RTP timestamps and sequence number taking them _back in time_. Online viewers will detect a little spike in inter-frame arrival time (should not be a problem), while offline postprocessors like `janus-pp-rec` will not be affected by this correction.
- If the sender is slower than the nominal rate, we simulate a loss, performing a RTP timestamp and sequence number jump _ahead in the future_. Online viewers will detect a packet loss (unless the code is changed to burst sending dummy packets), while postprocessors should insert missing packets (like `janus-pp-rec` already does).

By doing this for audio and video packets, we are sure that the audio and video streams are synchronized with the local clock (that should be synchronized in turn with NTP).
Our results are encouraging: we tested the algorithm with very long streaming sessions (>12h) using devices that showed the skew issue, and the lip-sync is perfect both for recordings and online viewers.
The feature is managed in the mountpoint configuration with the boolean attributes `audioskew` and `videoskew`. As of now, the operational thresholds are hardcoded to 40ms.

Sorry for the long post, I did my best to summarize the details.
Any question for further details or feedback is very very welcome.