### PR TITLE
Request/response mechanism for Event Handlers (via Admin API)

### DIFF
--- a/events/eventhandler.h
+++ b/events/eventhandler.h
@@ -101,7 +101,7 @@ janus_eventhandler *create(void) {
 
 
 /*! \brief Version of the API, to match the one event handler plugins were compiled against */
-#define JANUS_EVENTHANDLER_API_VERSION	1
+#define JANUS_EVENTHANDLER_API_VERSION	2
 
 /*! \brief Initialization of all event handler plugin properties to NULL
  * 
@@ -163,8 +163,6 @@ static janus_eventhandler janus_fake_eventhandler handler plugin =
 		## __VA_ARGS__ }
 
 
-/*! \brief Callbacks to contact the gateway */
-typedef struct janus_eventhandler_callbacks janus_eventhandler_callbacks;
 /*! \brief The event handler plugin session and callbacks interface */
 typedef struct janus_eventhandler janus_eventhandler;
 
@@ -215,6 +213,19 @@ struct janus_eventhandler {
 	 * object once you're done with it: a failure to do so will result in memory leaks.
 	 * @param[in] event Jansson object containing the event details */
 	void (* const incoming_event)(json_t *event);
+
+	/*! \brief Method to send a request to this specific event handler plugin
+	 * \details The method takes a Jansson json_t, that contains all the info related
+	 * to the request. This object will come from an Admin API request, and is
+	 * meant to represent a synchronous request. Since each handler can have
+	 * its own bells and whistles, there's no constraint on what this object should
+	 * contain, which is entirely handler specific. A json_t object needs to be
+	 * returned as a response, which will be sent in response to the Admin API call.
+	 * This can be useful to tweak settings in real-time, or to probe the internals
+	 * of the handler plugin for monitoring purposes.
+	 * @param[in] event Jansson object containing the request
+	 * @returns A Jansson object containing the response for the client */
+	json_t *(* const handle_request)(json_t *request);
 
 	/*! \brief Mask of events this handler is interested in, as a janus_flags object */
 	janus_flags events_mask;


### PR DESCRIPTION
This PR adds a new mechanism to implement a request/response conversation with Event Handlers, using the Admin API. The concept is simple: via Admin API you can send a message to a specific event handler, and the event handler can respond if it supports the new feature. The syntax is trivial: you send a `janus: "query_eventhandler"` request to the Admin API, and pass the content of the request in a `request` object. Whatever the handler sends back is put in the `response` object in the API response.

Considering the nature of this messaging is entirely event handler specific, it can be used for a variety of things, like querying the internals of the handler, or tweaking some of the settings at runtime: it all depends on what the handler itself exposes.

As an example, I implemented this in the HTTP event handler, which allows you to use this new mechanism to change the settings you configured at startup, e.g., choose a different backend while Janus is running, or enable/disable the delivery of some type of events. A couple of curl-based examples are provided here:

	curl -X POST -H "Content-Type: application/json" -d '{"janus": "query_eventhandler", "transaction": "123", "admin_secret": "janusoverlord", "handler": "janus.eventhandler.sampleevh", "request": {"request": "tweak", "backend_user": "myuser", "backend_pwd": "mypwd"}}' http://localhost:7088/admin

to change the credentials to contact the backend, or:

	curl -X POST -H "Content-Type: application/json" -d '{"janus": "query_eventhandler", "transaction": "123", "admin_secret": "janusoverlord", "handler": "janus.eventhandler.sampleevh", "request": {"request": "tweak", "events": "core,sessions,handles,jsep,webrtc,plugins,transports"}}' http://localhost:7088/admin

to disable the delivery of `media` events (e.g., RTCP stats). If successful, the plugin simply response with a `result: 200` property, i.e.:

	{
	   "janus": "success",
	   "transaction": "123",
	   "response": {
	      "result": 200
	   }
	}

Of course, these tweaks are kind of trivial and may or may not be useful. The real purpose of this PR is to lay the grounds for a much more sophisticated way of tweaking the internals of a handler. Think changing the events for a single handle, for instance (e.g., to have sparse events for everybody, but more events for a handle you know is having issues), or change the frequency of RTCP stats for some or all of the sessions.

As usual, feedback is welcome!