### PR TITLE
Add `mountpoint_listeners` to Streaming Plugin

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -1331,6 +1331,9 @@ json_t *janus_streaming_query_session(janus_plugin_session *handle) {
 	if(mp) {
 		json_object_set_new(info, "mountpoint_id", json_integer(mp->id));
 		json_object_set_new(info, "mountpoint_name", mp->name ? json_string(mp->name) : NULL);
+		janus_mutex_lock(&mp->mutex);
+		json_object_set_new(info, "mountpoint_listeners", json_integer(mp->listeners ? g_list_length(mp->listeners) : 0);
+		janus_mutex_unlock(&mp->mutex);
 	}
 	json_object_set_new(info, "destroyed", json_integer(session->destroyed));
 	janus_mutex_unlock(&sessions_mutex);


### PR DESCRIPTION
- Adds `mountpoint_listeners` to Streaming Plugin handle info / session query JSON

This is my super small contribution as a web dev that partly fears c+ besides `./autogen.sh`, `./configure`, `make` and `make install` xD. I don't even have Janus out in production, but hope too. I've seen great super low latency after waging battle against `ffmpeg` and `gstreamer`. Stuff like this is useful to web devs like me. This should be similar to the video room's `viewers` property.  This commit might not make sense in a larger scope, review softly.

👍 
