### PR TITLE
sipre: update sipreg_register to re 0.5.7

### DIFF
--- a/plugins/janus_sipre.c
+++ b/plugins/janus_sipre.c
@@ -4021,7 +4021,7 @@ void janus_sipre_mqueue_handler(int id, void *data, void *arg) {
 			/* Send the REGISTER */
 			int err = sipreg_register(&session->stack.reg, session->stack.sipstack,
 				session->account.proxy,
-				session->account.identity, session->account.identity, session->stack.expires,
+				session->account.identity, NULL, session->account.identity, session->stack.expires,
 				session->account.username,
 				outbound_proxy, (outbound_proxy[0] ? 1 : 0), 0,
 				janus_sipre_cb_auth, session, FALSE,


### PR DESCRIPTION
This patch updates the sipre plugin to use the latest api of libre 0.5.7

in 0.5.7 the sipreg api was changed:

https://github.com/creytiv/re/releases/tag/v0.5.7

please merge to master.
