### PR TITLE
Add support for SRTP with AES-GCM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -264,6 +264,10 @@ AS_IF([test "x$enable_libsrtp2" != "xno"],
                                         JANUS_MANUAL_LIBS+=" -lsrtp2"
                                         enable_libsrtp2=yes
                                         AM_CONDITIONAL([ENABLE_LIBSRTP_2], true)
+                                        AC_CHECK_LIB([srtp2],
+                                                     [srtp_crypto_policy_set_aes_gcm_256_16_auth],
+                                                     [AC_DEFINE(HAVE_SRTP_AESGCM)],
+                                                     [AC_MSG_NOTICE([libsrtp2 does not have support for AES-GCM profiles])])
                                       ],
                                       [
                                         AS_IF([test "x$enable_libsrtp2" = "xyes"],
@@ -288,7 +292,10 @@ AM_COND_IF([ENABLE_LIBSRTP_2],
                                                                [
                                                                  libsrtp >= 1.5.0
                                                                ])
-
+                                             AC_CHECK_LIB([srtp],
+                                                          [crypto_policy_set_aes_gcm_256_16_auth],
+                                                          [AC_DEFINE(HAVE_SRTP_AESGCM)],
+                                                          [AC_MSG_NOTICE([libsrtp does not have support for AES-GCM profiles])])
                                            ],
                                            [AC_MSG_ERROR([libsrtp and libsrtp2 headers not found. See README.md for installation instructions])])
                          ],

--- a/dtls.c
+++ b/dtls.c
@@ -55,21 +55,6 @@ const gchar *janus_get_dtls_srtp_role(janus_dtls_role role) {
 	return NULL;
 }
 
-static const char *janus_get_srtp_profile(SRTP_PROTECTION_PROFILE *srtp_profile) {
-	switch(srtp_profile->id) {
-		case SRTP_AES128_CM_SHA1_80:
-			return "SRTP_AES128_CM_SHA1_80";
-		case SRTP_AES128_CM_SHA1_32:
-			return "SRTP_AES128_CM_SHA1_32";
-		case SRTP_AEAD_AES_256_GCM:
-			return "SRTP_AEAD_AES_256_GCM";
-		case SRTP_AEAD_AES_128_GCM:
-			return "SRTP_AEAD_AES_128_GCM";
-		default:
-			return "(unknown)";
-	}
-}
-
 /* Helper to notify DTLS state changes to the event handlers */
 static void janus_dtls_notify_state_change(janus_dtls_srtp *dtls) {
 	if(!janus_events_is_enabled())
@@ -703,7 +688,7 @@ void janus_dtls_srtp_incoming_msg(janus_dtls_srtp *dtls, char *buf, uint16_t len
 			if(dtls->dtls_state == JANUS_DTLS_STATE_CONNECTED) {
 				/* Which SRTP profile is being negotiated? */
 				SRTP_PROTECTION_PROFILE *srtp_profile = SSL_get_selected_srtp_profile(dtls->ssl);
-				JANUS_LOG(LOG_VERB, "[%"SCNu64"] %s\n", handle->handle_id, janus_get_srtp_profile(srtp_profile));
+				JANUS_LOG(LOG_VERB, "[%"SCNu64"] %s\n", handle->handle_id, srtp_profile->name);
 				int key_length = 0, salt_length = 0, master_length = 0;
 				switch(srtp_profile->id) {
 					case SRTP_AES128_CM_SHA1_80:

--- a/html/sipretest.js
+++ b/html/sipretest.js
@@ -261,7 +261,10 @@ $(document).ready(function() {
 																		//		var body = { request: "accept", srtp: "sdes_mandatory" };
 																		// This way you'll tell the plugin to accept the call, but ONLY
 																		// if SDES is available, and you don't want plain RTP. If it
-																		// is not available, you'll get an error (452) back.
+																		// is not available, you'll get an error (452) back. You can
+																		// also specify the SRTP profile to negotiate by setting the
+																		// "srtp_profile" property accordingly (the default if not
+																		// set in the request is "AES_CM_128_HMAC_SHA1_80")
 																		sipcall.send({"message": body, "jsep": jsep});
 																		$('#call').removeAttr('disabled').html('Hangup')
 																			.removeClass("btn-success").addClass("btn-danger")

--- a/html/siptest.js
+++ b/html/siptest.js
@@ -264,7 +264,10 @@ $(document).ready(function() {
 																		//		var body = { request: "accept", srtp: "sdes_mandatory" };
 																		// This way you'll tell the plugin to accept the call, but ONLY
 																		// if SDES is available, and you don't want plain RTP. If it
-																		// is not available, you'll get an error (452) back.
+																		// is not available, you'll get an error (452) back. You can
+																		// also specify the SRTP profile to negotiate by setting the
+																		// "srtp_profile" property accordingly (the default if not
+																		// set in the request is "AES_CM_128_HMAC_SHA1_80")
 																		sipcall.send({"message": body, "jsep": jsep});
 																		$('#call').removeAttr('disabled').html('Hangup')
 																			.removeClass("btn-success").addClass("btn-danger")

--- a/plugins/janus_nosip.c
+++ b/plugins/janus_nosip.c
@@ -137,6 +137,7 @@ static struct janus_json_parameter request_parameters[] = {
 static struct janus_json_parameter generate_parameters[] = {
 	{"info", JSON_STRING, 0},
 	{"srtp", JSON_STRING, 0},
+	{"srtp_profile", JSON_STRING, 0},
 	{"update", JANUS_JSON_BOOL, 0}
 };
 static struct janus_json_parameter process_parameters[] = {
@@ -144,6 +145,7 @@ static struct janus_json_parameter process_parameters[] = {
 	{"sdp", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
 	{"info", JSON_STRING, 0},
 	{"srtp", JSON_STRING, 0},
+	{"srtp_profile", JSON_STRING, 0},
 	{"update", JANUS_JSON_BOOL, 0}
 };
 static struct janus_json_parameter recording_parameters[] = {
@@ -202,6 +204,7 @@ typedef struct janus_nosip_media {
 	int ready:1;
 	gboolean autoack;
 	gboolean require_srtp, has_srtp_local, has_srtp_remote;
+	janus_srtp_profile srtp_profile;
 	int has_audio:1;
 	int audio_rtp_fd, audio_rtcp_fd;
 	int local_audio_rtp_port, remote_audio_rtp_port;
@@ -211,7 +214,6 @@ typedef struct janus_nosip_media {
 	const char *audio_pt_name;
 	srtp_t audio_srtp_in, audio_srtp_out;
 	srtp_policy_t audio_remote_policy, audio_local_policy;
-	int audio_srtp_suite_in, audio_srtp_suite_out;
 	gboolean audio_send;
 	int has_video:1;
 	int video_rtp_fd, video_rtcp_fd;
@@ -222,7 +224,6 @@ typedef struct janus_nosip_media {
 	const char *video_pt_name;
 	srtp_t video_srtp_in, video_srtp_out;
 	srtp_policy_t video_remote_policy, video_local_policy;
-	int video_srtp_suite_in, video_srtp_suite_out;
 	gboolean video_send;
 	janus_rtp_switching_context context;
 	int pipefd[2];
@@ -249,16 +250,65 @@ static janus_mutex sessions_mutex = JANUS_MUTEX_INITIALIZER;
 
 
 /* SRTP stuff (in case we need SDES) */
-static int janus_nosip_srtp_set_local(janus_nosip_session *session, gboolean video, char **crypto) {
+static int janus_nosip_srtp_set_local(janus_nosip_session *session, gboolean video, char **profile, char **crypto) {
 	if(session == NULL)
 		return -1;
+	/* Which SRTP profile are we going to negotiate? */
+	int key_length = 0, salt_length = 0, master_length = 0;
+	if(session->media.srtp_profile == JANUS_SRTP_AES128_CM_SHA1_32) {
+		key_length = SRTP_MASTER_KEY_LENGTH;
+		salt_length = SRTP_MASTER_SALT_LENGTH;
+		master_length = SRTP_MASTER_LENGTH;
+		*profile = g_strdup("AES_CM_128_HMAC_SHA1_32");
+	} else if(session->media.srtp_profile == JANUS_SRTP_AES128_CM_SHA1_80) {
+		key_length = SRTP_MASTER_KEY_LENGTH;
+		salt_length = SRTP_MASTER_SALT_LENGTH;
+		master_length = SRTP_MASTER_LENGTH;
+		*profile = g_strdup("AES_CM_128_HMAC_SHA1_80");
+	} else if(session->media.srtp_profile == JANUS_SRTP_AEAD_AES_128_GCM) {
+		key_length = SRTP_AESGCM128_MASTER_KEY_LENGTH;
+		salt_length = SRTP_AESGCM128_MASTER_SALT_LENGTH;
+		master_length = SRTP_AESGCM128_MASTER_LENGTH;
+		*profile = g_strdup("AEAD_AES_128_GCM");
+	} else if(session->media.srtp_profile == JANUS_SRTP_AEAD_AES_256_GCM) {
+		key_length = SRTP_AESGCM256_MASTER_KEY_LENGTH;
+		salt_length = SRTP_AESGCM256_MASTER_SALT_LENGTH;
+		master_length = SRTP_AESGCM256_MASTER_LENGTH;
+		*profile = g_strdup("AEAD_AES_256_GCM");
+	} else {
+		JANUS_LOG(LOG_ERR, "[NoSIP-%p] Unknown SRTP profile\n", session);
+		return -2;
+	}
+	JANUS_LOG(LOG_WARN, "[NoSIP-%p] %s\n", session, *profile);
+	JANUS_LOG(LOG_WARN, "[NoSIP-%p] Key/Salt/Master: %d/%d/%d\n",
+		session, master_length, key_length, salt_length);
 	/* Generate key/salt */
-	uint8_t *key = g_malloc0(SRTP_MASTER_LENGTH);
-	srtp_crypto_get_random(key, SRTP_MASTER_LENGTH);
+	uint8_t *key = g_malloc0(master_length);
+	srtp_crypto_get_random(key, master_length);
 	/* Set SRTP policies */
 	srtp_policy_t *policy = video ? &session->media.video_local_policy : &session->media.audio_local_policy;
-	srtp_crypto_policy_set_rtp_default(&(policy->rtp));
-	srtp_crypto_policy_set_rtcp_default(&(policy->rtcp));
+	switch(session->media.srtp_profile) {
+		case JANUS_SRTP_AES128_CM_SHA1_32:
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(&(policy->rtp));
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
+			break;
+		case JANUS_SRTP_AES128_CM_SHA1_80:
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtp));
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
+			break;
+		case JANUS_SRTP_AEAD_AES_128_GCM:
+			srtp_crypto_policy_set_aes_gcm_128_16_auth(&(policy->rtp));
+			srtp_crypto_policy_set_aes_gcm_128_16_auth(&(policy->rtcp));
+			break;
+		case JANUS_SRTP_AEAD_AES_256_GCM:
+			srtp_crypto_policy_set_aes_gcm_256_16_auth(&(policy->rtp));
+			srtp_crypto_policy_set_aes_gcm_256_16_auth(&(policy->rtcp));
+			break;
+		default:
+			/* Will never happen? */
+			JANUS_LOG(LOG_WARN, "[NoSIP-%p] Unknown SRTP profile\n", session);
+			break;
+	}
 	policy->ssrc.type = ssrc_any_inbound;
 	policy->key = key;
 	policy->next = NULL;
@@ -267,38 +317,82 @@ static int janus_nosip_srtp_set_local(janus_nosip_session *session, gboolean vid
 	if(res != srtp_err_status_ok) {
 		/* Something went wrong... */
 		JANUS_LOG(LOG_ERR, "Oops, error creating outbound SRTP session: %d (%s)\n", res, janus_srtp_error_str(res));
+		g_free(*profile);
+		*profile = NULL;
 		g_free(key);
 		policy->key = NULL;
 		return -2;
 	}
 	/* Base64 encode the salt */
-	*crypto = g_base64_encode(key, SRTP_MASTER_LENGTH);
+	*crypto = g_base64_encode(key, master_length);
 	if((video && session->media.video_srtp_out) || (!video && session->media.audio_srtp_out)) {
 		JANUS_LOG(LOG_VERB, "%s outbound SRTP session created\n", video ? "Video" : "Audio");
 	}
 	return 0;
 }
-static int janus_nosip_srtp_set_remote(janus_nosip_session *session, gboolean video, const char *crypto, int suite) {
-	if(session == NULL || crypto == NULL)
+static int janus_nosip_srtp_set_remote(janus_nosip_session *session, gboolean video, const char *profile, const char *crypto) {
+	if(session == NULL || profile == NULL || crypto == NULL)
 		return -1;
+	/* Which SRTP profile is being negotiated? */
+	JANUS_LOG(LOG_WARN, "[NoSIP-%p] %s\n", session, profile);
+	gsize key_length = 0, salt_length = 0, master_length = 0;
+	if(!strcasecmp(profile, "AES_CM_128_HMAC_SHA1_32")) {
+		session->media.srtp_profile = JANUS_SRTP_AES128_CM_SHA1_32;
+		key_length = SRTP_MASTER_KEY_LENGTH;
+		salt_length = SRTP_MASTER_SALT_LENGTH;
+		master_length = SRTP_MASTER_LENGTH;
+	} else if(!strcasecmp(profile, "AES_CM_128_HMAC_SHA1_80")) {
+		session->media.srtp_profile = JANUS_SRTP_AES128_CM_SHA1_80;
+		key_length = SRTP_MASTER_KEY_LENGTH;
+		salt_length = SRTP_MASTER_SALT_LENGTH;
+		master_length = SRTP_MASTER_LENGTH;
+	} else if(!strcasecmp(profile, "AEAD_AES_128_GCM")) {
+		session->media.srtp_profile = JANUS_SRTP_AEAD_AES_128_GCM;
+		key_length = SRTP_AESGCM128_MASTER_KEY_LENGTH;
+		salt_length = SRTP_AESGCM128_MASTER_SALT_LENGTH;
+		master_length = SRTP_AESGCM128_MASTER_LENGTH;
+	} else if(!strcasecmp(profile, "AEAD_AES_256_GCM")) {
+		session->media.srtp_profile = JANUS_SRTP_AEAD_AES_256_GCM;
+		key_length = SRTP_AESGCM256_MASTER_KEY_LENGTH;
+		salt_length = SRTP_AESGCM256_MASTER_SALT_LENGTH;
+		master_length = SRTP_AESGCM256_MASTER_LENGTH;
+	} else {
+		JANUS_LOG(LOG_ERR, "[NoSIP-%p] Unknown SRTP profile %s\n", session, profile);
+		return -2;
+	}
+	JANUS_LOG(LOG_WARN, "[NoSIP-%p] Key/Salt/Master: %zu/%zu/%zu\n",
+		session, master_length, key_length, salt_length);
 	/* Base64 decode the crypto string and set it as the remote SRTP context */
 	gsize len = 0;
 	guchar *decoded = g_base64_decode(crypto, &len);
-	if(len < SRTP_MASTER_LENGTH) {
+	if(len < master_length) {
 		/* FIXME Can this happen? */
 		g_free(decoded);
-		return -2;
+		return -3;
 	}
 	/* Set SRTP policies */
 	srtp_policy_t *policy = video ? &session->media.video_remote_policy : &session->media.audio_remote_policy;
-	srtp_crypto_policy_set_rtp_default(&(policy->rtp));
-	srtp_crypto_policy_set_rtcp_default(&(policy->rtcp));
-	if(suite == 32) {
-		srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(&(policy->rtp));
-		srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(&(policy->rtcp));
-	} else if(suite == 80) {
-		srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtp));
-		srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
+	switch(session->media.srtp_profile) {
+		case JANUS_SRTP_AES128_CM_SHA1_32:
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(&(policy->rtp));
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
+			break;
+		case JANUS_SRTP_AES128_CM_SHA1_80:
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtp));
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
+			break;
+		case JANUS_SRTP_AEAD_AES_128_GCM:
+			srtp_crypto_policy_set_aes_gcm_128_16_auth(&(policy->rtp));
+			srtp_crypto_policy_set_aes_gcm_128_16_auth(&(policy->rtcp));
+			break;
+		case JANUS_SRTP_AEAD_AES_256_GCM:
+			srtp_crypto_policy_set_aes_gcm_256_16_auth(&(policy->rtp));
+			srtp_crypto_policy_set_aes_gcm_256_16_auth(&(policy->rtcp));
+			break;
+		default:
+			/* Will never happen? */
+			JANUS_LOG(LOG_WARN, "[NoSIP-%p] Unknown SRTP profile\n", session);
+			break;
 	}
 	policy->ssrc.type = ssrc_any_inbound;
 	policy->key = decoded;
@@ -324,32 +418,29 @@ static void janus_nosip_srtp_cleanup(janus_nosip_session *session) {
 	session->media.require_srtp = FALSE;
 	session->media.has_srtp_local = FALSE;
 	session->media.has_srtp_remote = FALSE;
+	session->media.srtp_profile = 0;
 	/* Audio */
 	if(session->media.audio_srtp_out)
 		srtp_dealloc(session->media.audio_srtp_out);
 	session->media.audio_srtp_out = NULL;
 	g_free(session->media.audio_local_policy.key);
 	session->media.audio_local_policy.key = NULL;
-	session->media.audio_srtp_suite_out = 0;
 	if(session->media.audio_srtp_in)
 		srtp_dealloc(session->media.audio_srtp_in);
 	session->media.audio_srtp_in = NULL;
 	g_free(session->media.audio_remote_policy.key);
 	session->media.audio_remote_policy.key = NULL;
-	session->media.audio_srtp_suite_in = 0;
 	/* Video */
 	if(session->media.video_srtp_out)
 		srtp_dealloc(session->media.video_srtp_out);
 	session->media.video_srtp_out = NULL;
 	g_free(session->media.video_local_policy.key);
 	session->media.video_local_policy.key = NULL;
-	session->media.video_srtp_suite_out = 0;
 	if(session->media.video_srtp_in)
 		srtp_dealloc(session->media.video_srtp_in);
 	session->media.video_srtp_in = NULL;
 	g_free(session->media.video_remote_policy.key);
 	session->media.video_remote_policy.key = NULL;
-	session->media.video_srtp_suite_in = 0;
 }
 
 
@@ -613,6 +704,7 @@ void janus_nosip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.require_srtp = FALSE;
 	session->media.has_srtp_local = FALSE;
 	session->media.has_srtp_remote = FALSE;
+	session->media.srtp_profile = 0;
 	session->media.has_audio = 0;
 	session->media.audio_rtp_fd = -1;
 	session->media.audio_rtcp_fd = -1;
@@ -624,8 +716,6 @@ void janus_nosip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.audio_ssrc_peer = 0;
 	session->media.audio_pt = -1;
 	session->media.audio_pt_name = NULL;
-	session->media.audio_srtp_suite_in = 0;
-	session->media.audio_srtp_suite_out = 0;
 	session->media.audio_send = TRUE;
 	session->media.has_video = 0;
 	session->media.video_rtp_fd = -1;
@@ -638,8 +728,6 @@ void janus_nosip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.video_ssrc_peer = 0;
 	session->media.video_pt = -1;
 	session->media.video_pt_name = NULL;
-	session->media.video_srtp_suite_in = 0;
-	session->media.video_srtp_suite_out = 0;
 	session->media.video_send = TRUE;
 	/* Initialize the RTP context */
 	janus_rtp_switching_context_reset(&session->media.context);
@@ -1022,6 +1110,7 @@ static void *janus_nosip_handler(void *data) {
 			const char *info = json_string_value(json_object_get(root, "info"));
 			/* SDES-SRTP is disabled by default, let's see if we need to enable it */
 			gboolean do_srtp = FALSE, require_srtp = FALSE;
+			janus_srtp_profile srtp_profile = JANUS_SRTP_AES128_CM_SHA1_80;
 			if(generate) {
 				json_t *srtp = json_object_get(root, "srtp");
 				if(srtp) {
@@ -1039,6 +1128,27 @@ static void *janus_nosip_handler(void *data) {
 						g_snprintf(error_cause, 512, "Invalid element (srtp can only be sdes_optional or sdes_mandatory)");
 						goto error;
 					}
+					if(do_srtp) {
+						/* Any SRTP profile different from the default? */
+						srtp_profile = JANUS_SRTP_AES128_CM_SHA1_80;
+						const char *profile = json_string_value(json_object_get(root, "srtp_profile"));
+						if(profile) {
+							if(!strcmp(profile, "AES_CM_128_HMAC_SHA1_32")) {
+								srtp_profile = JANUS_SRTP_AES128_CM_SHA1_32;
+							} else if(!strcmp(profile, "AES_CM_128_HMAC_SHA1_80")) {
+								srtp_profile = JANUS_SRTP_AES128_CM_SHA1_80;
+							} else if(!strcmp(profile, "AEAD_AES_128_GCM")) {
+								srtp_profile = JANUS_SRTP_AEAD_AES_128_GCM;
+							} else if(!strcmp(profile, "AEAD_AES_256_GCM")) {
+								srtp_profile = JANUS_SRTP_AEAD_AES_256_GCM;
+							} else {
+								JANUS_LOG(LOG_ERR, "Invalid element (unsupported SRTP profile)\n");
+								error_code = JANUS_NOSIP_ERROR_INVALID_ELEMENT;
+								g_snprintf(error_cause, 512, "Invalid element (unsupported SRTP profile)");
+								goto error;
+							}
+						}
+					}
 				}
 				if(!sdp_update) {
 					if(offer) {
@@ -1046,6 +1156,7 @@ static void *janus_nosip_handler(void *data) {
 						janus_nosip_srtp_cleanup(session);
 						session->media.require_srtp = require_srtp;
 						session->media.has_srtp_local = do_srtp;
+						session->media.srtp_profile = srtp_profile;
 						if(do_srtp) {
 							JANUS_LOG(LOG_VERB, "Going to negotiate SDES-SRTP (%s)...\n", require_srtp ? "mandatory" : "optional");
 						}
@@ -1477,27 +1588,16 @@ void janus_nosip_sdp_process(janus_nosip_session *session, janus_sdp *sdp, gbool
 				if(!strcasecmp(a->name, "crypto")) {
 					if(m->type == JANUS_SDP_AUDIO || m->type == JANUS_SDP_VIDEO) {
 						gint32 tag = 0;
-						int suite;
-						char crypto[81];
+						char profile[101], crypto[101];
 						/* FIXME inline can be more complex than that, and we're currently only offering SHA1_80 */
-						int res = sscanf(a->value, "%"SCNi32" AES_CM_128_HMAC_SHA1_%2d inline:%80s",
-							&tag, &suite, crypto);
+						int res = sscanf(a->value, "%"SCNi32" %100s inline:%100s",
+							&tag, profile, crypto);
 						if(res != 3) {
 							JANUS_LOG(LOG_WARN, "Failed to parse crypto line, ignoring... %s\n", a->value);
 						} else {
 							gboolean video = (m->type == JANUS_SDP_VIDEO);
-							int current_suite = video ? session->media.video_srtp_suite_in : session->media.audio_srtp_suite_in;
-							if(current_suite == 0) {
-								if(video)
-									session->media.video_srtp_suite_in = suite;
-								else
-									session->media.audio_srtp_suite_in = suite;
-								janus_nosip_srtp_set_remote(session, video, crypto, suite);
-								session->media.has_srtp_remote = TRUE;
-							} else {
-								JANUS_LOG(LOG_WARN, "We already configured a %s crypto context (AES_CM_128_HMAC_SHA1_%d), skipping additional crypto line\n",
-									video ? "video" : "audio", current_suite);
-							}
+							janus_nosip_srtp_set_remote(session, video, profile, crypto);
+							session->media.has_srtp_remote = TRUE;
 						}
 					}
 				}
@@ -1545,22 +1645,22 @@ char *janus_nosip_sdp_manipulate(janus_nosip_session *session, janus_sdp *sdp, g
 		if(m->type == JANUS_SDP_AUDIO) {
 			m->port = session->media.local_audio_rtp_port;
 			if(session->media.has_srtp_local) {
+				char *profile = NULL;
 				char *crypto = NULL;
-				session->media.audio_srtp_suite_out = 80;
-				janus_nosip_srtp_set_local(session, FALSE, &crypto);
-				/* FIXME 32? 80? Both? */
-				janus_sdp_attribute *a = janus_sdp_attribute_create("crypto", "1 AES_CM_128_HMAC_SHA1_80 inline:%s", crypto);
+				janus_nosip_srtp_set_local(session, FALSE, &profile, &crypto);
+				janus_sdp_attribute *a = janus_sdp_attribute_create("crypto", "1 %s inline:%s", profile, crypto);
+				g_free(profile);
 				g_free(crypto);
 				m->attributes = g_list_append(m->attributes, a);
 			}
 		} else if(m->type == JANUS_SDP_VIDEO) {
 			m->port = session->media.local_video_rtp_port;
 			if(session->media.has_srtp_local) {
+				char *profile = NULL;
 				char *crypto = NULL;
-				session->media.audio_srtp_suite_out = 80;
-				janus_nosip_srtp_set_local(session, TRUE, &crypto);
-				/* FIXME 32? 80? Both? */
-				janus_sdp_attribute *a = janus_sdp_attribute_create("crypto", "1 AES_CM_128_HMAC_SHA1_80 inline:%s", crypto);
+				janus_nosip_srtp_set_local(session, TRUE, &profile, &crypto);
+				janus_sdp_attribute *a = janus_sdp_attribute_create("crypto", "1 %s inline:%s", profile, crypto);
+				g_free(profile);
 				g_free(crypto);
 				m->attributes = g_list_append(m->attributes, a);
 			}

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -163,6 +163,7 @@ static struct janus_json_parameter call_parameters[] = {
 	{"autoack", JANUS_JSON_BOOL, 0},
 	{"headers", JSON_OBJECT, 0},
 	{"srtp", JSON_STRING, 0},
+	{"srtp_profile", JSON_STRING, 0},
 	/* The following are only needed in case "guest" registrations
 	 * still need an authenticated INVITE for some reason */
 	{"secret", JSON_STRING, 0},
@@ -327,6 +328,7 @@ typedef struct janus_sip_media {
 	gboolean ready;
 	gboolean autoack;
 	gboolean require_srtp, has_srtp_local, has_srtp_remote;
+	janus_srtp_profile srtp_profile;
 	gboolean on_hold;
 	gboolean has_audio;
 	int audio_rtp_fd, audio_rtcp_fd;
@@ -337,7 +339,6 @@ typedef struct janus_sip_media {
 	const char *audio_pt_name;
 	srtp_t audio_srtp_in, audio_srtp_out;
 	srtp_policy_t audio_remote_policy, audio_local_policy;
-	int audio_srtp_suite_in, audio_srtp_suite_out;
 	gboolean audio_send;
 	janus_sdp_mdirection pre_hold_audio_dir;
 	gboolean has_video;
@@ -350,7 +351,6 @@ typedef struct janus_sip_media {
 	const char *video_pt_name;
 	srtp_t video_srtp_in, video_srtp_out;
 	srtp_policy_t video_remote_policy, video_local_policy;
-	int video_srtp_suite_in, video_srtp_suite_out;
 	gboolean video_send;
 	janus_sdp_mdirection pre_hold_video_dir;
 	janus_rtp_switching_context context;
@@ -401,16 +401,65 @@ struct ssip_s {
 
 
 /* SRTP stuff (in case we need SDES) */
-static int janus_sip_srtp_set_local(janus_sip_session *session, gboolean video, char **crypto) {
+static int janus_sip_srtp_set_local(janus_sip_session *session, gboolean video, char **profile, char **crypto) {
 	if(session == NULL)
 		return -1;
+	/* Which SRTP profile are we going to negotiate? */
+	int key_length = 0, salt_length = 0, master_length = 0;
+	if(session->media.srtp_profile == JANUS_SRTP_AES128_CM_SHA1_32) {
+		key_length = SRTP_MASTER_KEY_LENGTH;
+		salt_length = SRTP_MASTER_SALT_LENGTH;
+		master_length = SRTP_MASTER_LENGTH;
+		*profile = g_strdup("AES_CM_128_HMAC_SHA1_32");
+	} else if(session->media.srtp_profile == JANUS_SRTP_AES128_CM_SHA1_80) {
+		key_length = SRTP_MASTER_KEY_LENGTH;
+		salt_length = SRTP_MASTER_SALT_LENGTH;
+		master_length = SRTP_MASTER_LENGTH;
+		*profile = g_strdup("AES_CM_128_HMAC_SHA1_80");
+	} else if(session->media.srtp_profile == JANUS_SRTP_AEAD_AES_128_GCM) {
+		key_length = SRTP_AESGCM128_MASTER_KEY_LENGTH;
+		salt_length = SRTP_AESGCM128_MASTER_SALT_LENGTH;
+		master_length = SRTP_AESGCM128_MASTER_LENGTH;
+		*profile = g_strdup("AEAD_AES_128_GCM");
+	} else if(session->media.srtp_profile == JANUS_SRTP_AEAD_AES_256_GCM) {
+		key_length = SRTP_AESGCM256_MASTER_KEY_LENGTH;
+		salt_length = SRTP_AESGCM256_MASTER_SALT_LENGTH;
+		master_length = SRTP_AESGCM256_MASTER_LENGTH;
+		*profile = g_strdup("AEAD_AES_256_GCM");
+	} else {
+		JANUS_LOG(LOG_ERR, "[SIP-%s] Unknown SRTP profile\n", session->account.username);
+		return -2;
+	}
+	JANUS_LOG(LOG_WARN, "[SIP-%s] %s\n", session->account.username, *profile);
+	JANUS_LOG(LOG_WARN, "[SIP-%s] Key/Salt/Master: %d/%d/%d\n",
+		session->account.username, master_length, key_length, salt_length);
 	/* Generate key/salt */
-	uint8_t *key = g_malloc0(SRTP_MASTER_LENGTH);
-	srtp_crypto_get_random(key, SRTP_MASTER_LENGTH);
+	uint8_t *key = g_malloc0(master_length);
+	srtp_crypto_get_random(key, master_length);
 	/* Set SRTP policies */
 	srtp_policy_t *policy = video ? &session->media.video_local_policy : &session->media.audio_local_policy;
-	srtp_crypto_policy_set_rtp_default(&(policy->rtp));
-	srtp_crypto_policy_set_rtcp_default(&(policy->rtcp));
+	switch(session->media.srtp_profile) {
+		case JANUS_SRTP_AES128_CM_SHA1_32:
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(&(policy->rtp));
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
+			break;
+		case JANUS_SRTP_AES128_CM_SHA1_80:
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtp));
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
+			break;
+		case JANUS_SRTP_AEAD_AES_128_GCM:
+			srtp_crypto_policy_set_aes_gcm_128_16_auth(&(policy->rtp));
+			srtp_crypto_policy_set_aes_gcm_128_16_auth(&(policy->rtcp));
+			break;
+		case JANUS_SRTP_AEAD_AES_256_GCM:
+			srtp_crypto_policy_set_aes_gcm_256_16_auth(&(policy->rtp));
+			srtp_crypto_policy_set_aes_gcm_256_16_auth(&(policy->rtcp));
+			break;
+		default:
+			/* Will never happen? */
+			JANUS_LOG(LOG_WARN, "[SIP-%s] Unknown SRTP profile\n", session->account.username);
+			break;
+	}
 	policy->ssrc.type = ssrc_any_inbound;
 	policy->key = key;
 	policy->next = NULL;
@@ -419,38 +468,82 @@ static int janus_sip_srtp_set_local(janus_sip_session *session, gboolean video, 
 	if(res != srtp_err_status_ok) {
 		/* Something went wrong... */
 		JANUS_LOG(LOG_ERR, "Oops, error creating outbound SRTP session: %d (%s)\n", res, janus_srtp_error_str(res));
+		g_free(*profile);
+		*profile = NULL;
 		g_free(key);
 		policy->key = NULL;
 		return -2;
 	}
 	/* Base64 encode the salt */
-	*crypto = g_base64_encode(key, SRTP_MASTER_LENGTH);
+	*crypto = g_base64_encode(key, master_length);
 	if((video && session->media.video_srtp_out) || (!video && session->media.audio_srtp_out)) {
 		JANUS_LOG(LOG_VERB, "%s outbound SRTP session created\n", video ? "Video" : "Audio");
 	}
 	return 0;
 }
-static int janus_sip_srtp_set_remote(janus_sip_session *session, gboolean video, const char *crypto, int suite) {
-	if(session == NULL || crypto == NULL)
+static int janus_sip_srtp_set_remote(janus_sip_session *session, gboolean video, const char *profile, const char *crypto) {
+	if(session == NULL || profile == NULL || crypto == NULL)
 		return -1;
+	/* Which SRTP profile is being negotiated? */
+	JANUS_LOG(LOG_WARN, "[SIP-%s] %s\n", session->account.username, profile);
+	gsize key_length = 0, salt_length = 0, master_length = 0;
+	if(!strcasecmp(profile, "AES_CM_128_HMAC_SHA1_32")) {
+		session->media.srtp_profile = JANUS_SRTP_AES128_CM_SHA1_32;
+		key_length = SRTP_MASTER_KEY_LENGTH;
+		salt_length = SRTP_MASTER_SALT_LENGTH;
+		master_length = SRTP_MASTER_LENGTH;
+	} else if(!strcasecmp(profile, "AES_CM_128_HMAC_SHA1_80")) {
+		session->media.srtp_profile = JANUS_SRTP_AES128_CM_SHA1_80;
+		key_length = SRTP_MASTER_KEY_LENGTH;
+		salt_length = SRTP_MASTER_SALT_LENGTH;
+		master_length = SRTP_MASTER_LENGTH;
+	} else if(!strcasecmp(profile, "AEAD_AES_128_GCM")) {
+		session->media.srtp_profile = JANUS_SRTP_AEAD_AES_128_GCM;
+		key_length = SRTP_AESGCM128_MASTER_KEY_LENGTH;
+		salt_length = SRTP_AESGCM128_MASTER_SALT_LENGTH;
+		master_length = SRTP_AESGCM128_MASTER_LENGTH;
+	} else if(!strcasecmp(profile, "AEAD_AES_256_GCM")) {
+		session->media.srtp_profile = JANUS_SRTP_AEAD_AES_256_GCM;
+		key_length = SRTP_AESGCM256_MASTER_KEY_LENGTH;
+		salt_length = SRTP_AESGCM256_MASTER_SALT_LENGTH;
+		master_length = SRTP_AESGCM256_MASTER_LENGTH;
+	} else {
+		JANUS_LOG(LOG_ERR, "[SIP-%s] Unknown SRTP profile %s\n", session->account.username, profile);
+		return -2;
+	}
+	JANUS_LOG(LOG_WARN, "[SIP-%s] Key/Salt/Master: %zu/%zu/%zu\n",
+		session->account.username, master_length, key_length, salt_length);
 	/* Base64 decode the crypto string and set it as the remote SRTP context */
 	gsize len = 0;
 	guchar *decoded = g_base64_decode(crypto, &len);
-	if(len < SRTP_MASTER_LENGTH) {
+	if(len < master_length) {
 		/* FIXME Can this happen? */
 		g_free(decoded);
-		return -2;
+		return -3;
 	}
 	/* Set SRTP policies */
 	srtp_policy_t *policy = video ? &session->media.video_remote_policy : &session->media.audio_remote_policy;
-	srtp_crypto_policy_set_rtp_default(&(policy->rtp));
-	srtp_crypto_policy_set_rtcp_default(&(policy->rtcp));
-	if(suite == 32) {
-		srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(&(policy->rtp));
-		srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(&(policy->rtcp));
-	} else if(suite == 80) {
-		srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtp));
-		srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
+	switch(session->media.srtp_profile) {
+		case JANUS_SRTP_AES128_CM_SHA1_32:
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(&(policy->rtp));
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
+			break;
+		case JANUS_SRTP_AES128_CM_SHA1_80:
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtp));
+			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
+			break;
+		case JANUS_SRTP_AEAD_AES_128_GCM:
+			srtp_crypto_policy_set_aes_gcm_128_16_auth(&(policy->rtp));
+			srtp_crypto_policy_set_aes_gcm_128_16_auth(&(policy->rtcp));
+			break;
+		case JANUS_SRTP_AEAD_AES_256_GCM:
+			srtp_crypto_policy_set_aes_gcm_256_16_auth(&(policy->rtp));
+			srtp_crypto_policy_set_aes_gcm_256_16_auth(&(policy->rtcp));
+			break;
+		default:
+			/* Will never happen? */
+			JANUS_LOG(LOG_WARN, "[SIP-%s] Unknown SRTP profile\n", session->account.username);
+			break;
 	}
 	policy->ssrc.type = ssrc_any_inbound;
 	policy->key = decoded;
@@ -476,32 +569,29 @@ static void janus_sip_srtp_cleanup(janus_sip_session *session) {
 	session->media.require_srtp = FALSE;
 	session->media.has_srtp_local = FALSE;
 	session->media.has_srtp_remote = FALSE;
+	session->media.srtp_profile = 0;
 	/* Audio */
 	if(session->media.audio_srtp_out)
 		srtp_dealloc(session->media.audio_srtp_out);
 	session->media.audio_srtp_out = NULL;
 	g_free(session->media.audio_local_policy.key);
 	session->media.audio_local_policy.key = NULL;
-	session->media.audio_srtp_suite_out = 0;
 	if(session->media.audio_srtp_in)
 		srtp_dealloc(session->media.audio_srtp_in);
 	session->media.audio_srtp_in = NULL;
 	g_free(session->media.audio_remote_policy.key);
 	session->media.audio_remote_policy.key = NULL;
-	session->media.audio_srtp_suite_in = 0;
 	/* Video */
 	if(session->media.video_srtp_out)
 		srtp_dealloc(session->media.video_srtp_out);
 	session->media.video_srtp_out = NULL;
 	g_free(session->media.video_local_policy.key);
 	session->media.video_local_policy.key = NULL;
-	session->media.video_srtp_suite_out = 0;
 	if(session->media.video_srtp_in)
 		srtp_dealloc(session->media.video_srtp_in);
 	session->media.video_srtp_in = NULL;
 	g_free(session->media.video_remote_policy.key);
 	session->media.video_remote_policy.key = NULL;
-	session->media.video_srtp_suite_in = 0;
 }
 
 
@@ -1027,6 +1117,7 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.require_srtp = FALSE;
 	session->media.has_srtp_local = FALSE;
 	session->media.has_srtp_remote = FALSE;
+	session->media.srtp_profile = 0;
 	session->media.on_hold = FALSE;
 	session->media.has_audio = FALSE;
 	session->media.audio_rtp_fd = -1;
@@ -1039,8 +1130,6 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.audio_ssrc_peer = 0;
 	session->media.audio_pt = -1;
 	session->media.audio_pt_name = NULL;
-	session->media.audio_srtp_suite_in = 0;
-	session->media.audio_srtp_suite_out = 0;
 	session->media.audio_send = TRUE;
 	session->media.pre_hold_audio_dir = JANUS_SDP_DEFAULT;
 	session->media.has_video = FALSE;
@@ -1055,8 +1144,6 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.simulcast_ssrc = 0;
 	session->media.video_pt = -1;
 	session->media.video_pt_name = NULL;
-	session->media.video_srtp_suite_in = 0;
-	session->media.video_srtp_suite_out = 0;
 	session->media.video_send = TRUE;
 	session->media.pre_hold_video_dir = JANUS_SDP_DEFAULT;
 	/* Initialize the RTP context */
@@ -1909,6 +1996,7 @@ static void *janus_sip_handler(void *data) {
 			}
 			/* SDES-SRTP is disabled by default, let's see if we need to enable it */
 			gboolean offer_srtp = FALSE, require_srtp = FALSE;
+			janus_srtp_profile srtp_profile = JANUS_SRTP_AES128_CM_SHA1_80;
 			json_t *srtp = json_object_get(root, "srtp");
 			if(srtp) {
 				const char *srtp_text = json_string_value(srtp);
@@ -1924,6 +2012,27 @@ static void *janus_sip_handler(void *data) {
 					error_code = JANUS_SIP_ERROR_INVALID_ELEMENT;
 					g_snprintf(error_cause, 512, "Invalid element (srtp can only be sdes_optional or sdes_mandatory)");
 					goto error;
+				}
+				if(offer_srtp) {
+					/* Any SRTP profile different from the default? */
+					srtp_profile = JANUS_SRTP_AES128_CM_SHA1_80;
+					const char *profile = json_string_value(json_object_get(root, "srtp_profile"));
+					if(profile) {
+						if(!strcmp(profile, "AES_CM_128_HMAC_SHA1_32")) {
+							srtp_profile = JANUS_SRTP_AES128_CM_SHA1_32;
+						} else if(!strcmp(profile, "AES_CM_128_HMAC_SHA1_80")) {
+							srtp_profile = JANUS_SRTP_AES128_CM_SHA1_80;
+						} else if(!strcmp(profile, "AEAD_AES_128_GCM")) {
+							srtp_profile = JANUS_SRTP_AEAD_AES_128_GCM;
+						} else if(!strcmp(profile, "AEAD_AES_256_GCM")) {
+							srtp_profile = JANUS_SRTP_AEAD_AES_256_GCM;
+						} else {
+							JANUS_LOG(LOG_ERR, "Invalid element (unsupported SRTP profile)\n");
+							error_code = JANUS_SIP_ERROR_INVALID_ELEMENT;
+							g_snprintf(error_cause, 512, "Invalid element (unsupported SRTP profile)");
+							goto error;
+						}
+					}
 				}
 			}
 			/* Parse address */
@@ -1956,6 +2065,7 @@ static void *janus_sip_handler(void *data) {
 			janus_sip_srtp_cleanup(session);
 			session->media.require_srtp = require_srtp;
 			session->media.has_srtp_local = offer_srtp;
+			session->media.srtp_profile = srtp_profile;
 			if(offer_srtp) {
 				JANUS_LOG(LOG_VERB, "Going to negotiate SDES-SRTP (%s)...\n", require_srtp ? "mandatory" : "optional");
 			}
@@ -3569,27 +3679,16 @@ void janus_sip_sdp_process(janus_sip_session *session, janus_sdp *sdp, gboolean 
 				if(!strcasecmp(a->name, "crypto")) {
 					if(m->type == JANUS_SDP_AUDIO || m->type == JANUS_SDP_VIDEO) {
 						gint32 tag = 0;
-						int suite;
-						char crypto[81];
+						char profile[101], crypto[101];
 						/* FIXME inline can be more complex than that, and we're currently only offering SHA1_80 */
-						int res = sscanf(a->value, "%"SCNi32" AES_CM_128_HMAC_SHA1_%2d inline:%80s",
-							&tag, &suite, crypto);
+						int res = sscanf(a->value, "%"SCNi32" %100s inline:%100s",
+							&tag, profile, crypto);
 						if(res != 3) {
 							JANUS_LOG(LOG_WARN, "Failed to parse crypto line, ignoring... %s\n", a->value);
 						} else {
 							gboolean video = (m->type == JANUS_SDP_VIDEO);
-							int current_suite = video ? session->media.video_srtp_suite_in : session->media.audio_srtp_suite_in;
-							if(current_suite == 0) {
-								if(video)
-									session->media.video_srtp_suite_in = suite;
-								else
-									session->media.audio_srtp_suite_in = suite;
-								janus_sip_srtp_set_remote(session, video, crypto, suite);
-								session->media.has_srtp_remote = TRUE;
-							} else {
-								JANUS_LOG(LOG_WARN, "We already configured a %s crypto context (AES_CM_128_HMAC_SHA1_%d), skipping additional crypto line\n",
-									video ? "video" : "audio", current_suite);
-							}
+							janus_sip_srtp_set_remote(session, video, profile, crypto);
+							session->media.has_srtp_remote = TRUE;
 						}
 					}
 				}
@@ -3637,22 +3736,22 @@ char *janus_sip_sdp_manipulate(janus_sip_session *session, janus_sdp *sdp, gbool
 		if(m->type == JANUS_SDP_AUDIO) {
 			m->port = session->media.local_audio_rtp_port;
 			if(session->media.has_srtp_local) {
+				char *profile = NULL;
 				char *crypto = NULL;
-				session->media.audio_srtp_suite_out = 80;
-				janus_sip_srtp_set_local(session, FALSE, &crypto);
-				/* FIXME 32? 80? Both? */
-				janus_sdp_attribute *a = janus_sdp_attribute_create("crypto", "1 AES_CM_128_HMAC_SHA1_80 inline:%s", crypto);
+				janus_sip_srtp_set_local(session, FALSE, &profile, &crypto);
+				janus_sdp_attribute *a = janus_sdp_attribute_create("crypto", "1 %s inline:%s", profile, crypto);
+				g_free(profile);
 				g_free(crypto);
 				m->attributes = g_list_append(m->attributes, a);
 			}
 		} else if(m->type == JANUS_SDP_VIDEO) {
 			m->port = session->media.local_video_rtp_port;
 			if(session->media.has_srtp_local) {
+				char *profile = NULL;
 				char *crypto = NULL;
-				session->media.audio_srtp_suite_out = 80;
-				janus_sip_srtp_set_local(session, TRUE, &crypto);
-				/* FIXME 32? 80? Both? */
-				janus_sdp_attribute *a = janus_sdp_attribute_create("crypto", "1 AES_CM_128_HMAC_SHA1_80 inline:%s", crypto);
+				janus_sip_srtp_set_local(session, TRUE, &profile, &crypto);
+				janus_sdp_attribute *a = janus_sdp_attribute_create("crypto", "1 %s inline:%s", profile, crypto);
+				g_free(profile);
 				g_free(crypto);
 				m->attributes = g_list_append(m->attributes, a);
 			}

--- a/plugins/janus_sipre.c
+++ b/plugins/janus_sipre.c
@@ -551,6 +551,7 @@ static int janus_sipre_srtp_set_local(janus_sipre_session *session, gboolean vid
 		salt_length = SRTP_MASTER_SALT_LENGTH;
 		master_length = SRTP_MASTER_LENGTH;
 		*profile = g_strdup("AES_CM_128_HMAC_SHA1_80");
+#ifdef HAVE_SRTP_AESGCM
 	} else if(session->media.srtp_profile == JANUS_SRTP_AEAD_AES_128_GCM) {
 		key_length = SRTP_AESGCM128_MASTER_KEY_LENGTH;
 		salt_length = SRTP_AESGCM128_MASTER_SALT_LENGTH;
@@ -561,8 +562,9 @@ static int janus_sipre_srtp_set_local(janus_sipre_session *session, gboolean vid
 		salt_length = SRTP_AESGCM256_MASTER_SALT_LENGTH;
 		master_length = SRTP_AESGCM256_MASTER_LENGTH;
 		*profile = g_strdup("AEAD_AES_256_GCM");
+#endif
 	} else {
-		JANUS_LOG(LOG_ERR, "[SIPre-%s] Unknown SRTP profile\n", session->account.username);
+		JANUS_LOG(LOG_ERR, "[SIPre-%s] Unsupported SRTP profile\n", session->account.username);
 		return -2;
 	}
 	JANUS_LOG(LOG_WARN, "[SIPre-%s] %s\n", session->account.username, *profile);
@@ -582,6 +584,7 @@ static int janus_sipre_srtp_set_local(janus_sipre_session *session, gboolean vid
 			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtp));
 			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
 			break;
+#ifdef HAVE_SRTP_AESGCM
 		case JANUS_SRTP_AEAD_AES_128_GCM:
 			srtp_crypto_policy_set_aes_gcm_128_16_auth(&(policy->rtp));
 			srtp_crypto_policy_set_aes_gcm_128_16_auth(&(policy->rtcp));
@@ -590,9 +593,10 @@ static int janus_sipre_srtp_set_local(janus_sipre_session *session, gboolean vid
 			srtp_crypto_policy_set_aes_gcm_256_16_auth(&(policy->rtp));
 			srtp_crypto_policy_set_aes_gcm_256_16_auth(&(policy->rtcp));
 			break;
+#endif
 		default:
 			/* Will never happen? */
-			JANUS_LOG(LOG_WARN, "[SIPre-%s] Unknown SRTP profile\n", session->account.username);
+			JANUS_LOG(LOG_WARN, "[SIPre-%s] Unsupported SRTP profile\n", session->account.username);
 			break;
 	}
 	policy->ssrc.type = ssrc_any_inbound;
@@ -632,6 +636,7 @@ static int janus_sipre_srtp_set_remote(janus_sipre_session *session, gboolean vi
 		key_length = SRTP_MASTER_KEY_LENGTH;
 		salt_length = SRTP_MASTER_SALT_LENGTH;
 		master_length = SRTP_MASTER_LENGTH;
+#ifdef HAVE_SRTP_AESGCM
 	} else if(!strcasecmp(profile, "AEAD_AES_128_GCM")) {
 		session->media.srtp_profile = JANUS_SRTP_AEAD_AES_128_GCM;
 		key_length = SRTP_AESGCM128_MASTER_KEY_LENGTH;
@@ -642,8 +647,9 @@ static int janus_sipre_srtp_set_remote(janus_sipre_session *session, gboolean vi
 		key_length = SRTP_AESGCM256_MASTER_KEY_LENGTH;
 		salt_length = SRTP_AESGCM256_MASTER_SALT_LENGTH;
 		master_length = SRTP_AESGCM256_MASTER_LENGTH;
+#endif
 	} else {
-		JANUS_LOG(LOG_ERR, "[SIPre-%s] Unknown SRTP profile %s\n", session->account.username, profile);
+		JANUS_LOG(LOG_ERR, "[SIPre-%s] Unsupported SRTP profile %s\n", session->account.username, profile);
 		return -2;
 	}
 	JANUS_LOG(LOG_WARN, "[SIPre-%s] Key/Salt/Master: %zu/%zu/%zu\n",
@@ -667,6 +673,7 @@ static int janus_sipre_srtp_set_remote(janus_sipre_session *session, gboolean vi
 			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtp));
 			srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&(policy->rtcp));
 			break;
+#ifdef HAVE_SRTP_AESGCM
 		case JANUS_SRTP_AEAD_AES_128_GCM:
 			srtp_crypto_policy_set_aes_gcm_128_16_auth(&(policy->rtp));
 			srtp_crypto_policy_set_aes_gcm_128_16_auth(&(policy->rtcp));
@@ -675,9 +682,10 @@ static int janus_sipre_srtp_set_remote(janus_sipre_session *session, gboolean vi
 			srtp_crypto_policy_set_aes_gcm_256_16_auth(&(policy->rtp));
 			srtp_crypto_policy_set_aes_gcm_256_16_auth(&(policy->rtcp));
 			break;
+#endif
 		default:
 			/* Will never happen? */
-			JANUS_LOG(LOG_WARN, "[SIPre-%s] Unknown SRTP profile\n", session->account.username);
+			JANUS_LOG(LOG_WARN, "[SIPre-%s] Unsupported SRTP profile\n", session->account.username);
 			break;
 	}
 	policy->ssrc.type = ssrc_any_inbound;
@@ -1907,10 +1915,12 @@ static void *janus_sipre_handler(void *data) {
 							srtp_profile = JANUS_SRTP_AES128_CM_SHA1_32;
 						} else if(!strcmp(profile, "AES_CM_128_HMAC_SHA1_80")) {
 							srtp_profile = JANUS_SRTP_AES128_CM_SHA1_80;
+#ifdef HAVE_SRTP_AESGCM
 						} else if(!strcmp(profile, "AEAD_AES_128_GCM")) {
 							srtp_profile = JANUS_SRTP_AEAD_AES_128_GCM;
 						} else if(!strcmp(profile, "AEAD_AES_256_GCM")) {
 							srtp_profile = JANUS_SRTP_AEAD_AES_256_GCM;
+#endif
 						} else {
 							JANUS_LOG(LOG_ERR, "Invalid element (unsupported SRTP profile)\n");
 							error_code = JANUS_SIPRE_ERROR_INVALID_ELEMENT;

--- a/rtpsrtp.h
+++ b/rtpsrtp.h
@@ -46,6 +46,14 @@ int srtp_crypto_get_random(uint8_t *key, int len);
 #define SRTP_AESGCM256_MASTER_SALT_LENGTH	12
 #define SRTP_AESGCM256_MASTER_LENGTH (SRTP_AESGCM256_MASTER_KEY_LENGTH + SRTP_AESGCM256_MASTER_SALT_LENGTH)
 
+/* SRTP profiles */
+typedef enum janus_srtp_profile {
+	JANUS_SRTP_AES128_CM_SHA1_32 = 1,
+	JANUS_SRTP_AES128_CM_SHA1_80,
+	JANUS_SRTP_AEAD_AES_128_GCM,
+	JANUS_SRTP_AEAD_AES_256_GCM
+} janus_srtp_profile;
+
 
 /*! \brief Helper method to get a string representation of a libsrtp error code
  * @param[in] error The libsrtp error code

--- a/rtpsrtp.h
+++ b/rtpsrtp.h
@@ -29,6 +29,8 @@ int srtp_crypto_get_random(uint8_t *key, int len);
 #define srtp_crypto_policy_set_rtcp_default crypto_policy_set_rtcp_default
 #define srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32 crypto_policy_set_aes_cm_128_hmac_sha1_32
 #define srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80 crypto_policy_set_aes_cm_128_hmac_sha1_80
+#define srtp_crypto_policy_set_aes_gcm_256_16_auth crypto_policy_set_aes_gcm_256_16_auth
+#define srtp_crypto_policy_set_aes_gcm_128_16_auth crypto_policy_set_aes_gcm_128_16_auth
 #define srtp_crypto_get_random crypto_get_random
 #endif
 
@@ -36,6 +38,13 @@ int srtp_crypto_get_random(uint8_t *key, int len);
 #define SRTP_MASTER_KEY_LENGTH	16
 #define SRTP_MASTER_SALT_LENGTH	14
 #define SRTP_MASTER_LENGTH (SRTP_MASTER_KEY_LENGTH + SRTP_MASTER_SALT_LENGTH)
+/* AES-GCM stuff (http://tools.ietf.org/html/rfc7714) */
+#define SRTP_AESGCM128_MASTER_KEY_LENGTH	16
+#define SRTP_AESGCM128_MASTER_SALT_LENGTH	12
+#define SRTP_AESGCM128_MASTER_LENGTH (SRTP_AESGCM128_MASTER_KEY_LENGTH + SRTP_AESGCM128_MASTER_SALT_LENGTH)
+#define SRTP_AESGCM256_MASTER_KEY_LENGTH	32
+#define SRTP_AESGCM256_MASTER_SALT_LENGTH	12
+#define SRTP_AESGCM256_MASTER_LENGTH (SRTP_AESGCM256_MASTER_KEY_LENGTH + SRTP_AESGCM256_MASTER_SALT_LENGTH)
 
 
 /*! \brief Helper method to get a string representation of a libsrtp error code


### PR DESCRIPTION
As the title says, this PR adds support for [SRTP with AES-GCM](https://tools.ietf.org/html/rfc7714), which is something that Chrome is testing behind a flag: `chrome://flags/#enable-webrtc-srtp-aes-gcm`

The support is only in the core, for the moment, which means it only applies to the SRTP setup for WebRTC PeerConnections. The next step is doing the same for the SIP, SIPre and NoSIP plugins, which also allow for SRTP to be negotiated, even though via SDES and not DTLS-SRTP.

Feedback welcome!