### PR TITLE
Janus.js  'prepareWebrtc' function optimisations 

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1772,69 +1772,71 @@ function Janus(gatewayCallbacks) {
 				if(simulcast && !jsep && (media.video === undefined || media.video === false))
 					media.video = "hires";
 				if(media.video && media.video != 'screen' && media.video != 'window') {
-					var width = 0;
-					var height = 0, maxHeight = 0;
-					if(media.video === 'lowres') {
-						// Small resolution, 4:3
-						height = 240;
-						maxHeight = 240;
-						width = 320;
-					} else if(media.video === 'lowres-16:9') {
-						// Small resolution, 16:9
-						height = 180;
-						maxHeight = 180;
-						width = 320;
-					} else if(media.video === 'hires' || media.video === 'hires-16:9' ) {
-						// High resolution is only 16:9
-						height = 720;
-						maxHeight = 720;
-						width = 1280;
-					} else if(media.video === 'stdres') {
-						// Normal resolution, 4:3
-						height = 480;
-						maxHeight = 480;
-						width  = 640;
-					} else if(media.video === 'stdres-16:9') {
-						// Normal resolution, 16:9
-						height = 360;
-						maxHeight = 360;
-						width = 640;
-					} else {
-						Janus.log("Default video setting is stdres 4:3");
-						height = 480;
-						maxHeight = 480;
-						width = 640;
-					}
-					Janus.log("Adding media constraint:", media.video);
+					if(typeof media.video === 'object') {
+						videoSupport = media.video;
+					}else{
+						var width = 0;
+						var height = 0, maxHeight = 0;
+						if(media.video === 'lowres') {
+							// Small resolution, 4:3
+							height = 240;
+							maxHeight = 240;
+							width = 320;
+						} else if(media.video === 'lowres-16:9') {
+							// Small resolution, 16:9
+							height = 180;
+							maxHeight = 180;
+							width = 320;
+						} else if(media.video === 'hires' || media.video === 'hires-16:9' ) {
+							// High resolution is only 16:9
+							height = 720;
+							maxHeight = 720;
+							width = 1280;
+						} else if(media.video === 'stdres') {
+							// Normal resolution, 4:3
+							height = 480;
+							maxHeight = 480;
+							width  = 640;
+						} else if(media.video === 'stdres-16:9') {
+							// Normal resolution, 16:9
+							height = 360;
+							maxHeight = 360;
+							width = 640;
+						} else {
+							Janus.log("Default video setting is stdres 4:3");
+							height = 480;
+							maxHeight = 480;
+							width = 640;
+						}
+						Janus.log("Adding media constraint:", media.video);
 
-					if(Janus.webRTCAdapter.browserDetails.browser == 'firefox') {
-						videoSupport = {
-							'height': {'ideal': height},
-							'width':  {'ideal': width}
-						};
-					} else {
-						var chromeVer = Janus.webRTCAdapter.browserDetails.version;
-				    if(chromeVer >= 59) {
+						if(Janus.webRTCAdapter.browserDetails.browser == 'firefox') {
 							videoSupport = {
 								'height': {'ideal': height},
 								'width':  {'ideal': width}
 							};
-						}else{
-							// The old spec is supported by Chrome until Chrome 59 (June 2017)
-							videoSupport = {
-									'mandatory': {
-											'maxHeight': maxHeight,
-											'minHeight': height,
-											'maxWidth':  width,
-											'minWidth':  width
-									},
-									'optional': []
-							};
+						} else {
+							var chromeVer = Janus.webRTCAdapter.browserDetails.version;
+					    if(chromeVer >= 59) {
+								videoSupport = {
+									'height': {'ideal': height},
+									'width':  {'ideal': width}
+								};
+							}else{
+								// The old spec is supported by Chrome until Chrome 59 (June 2017)
+								videoSupport = {
+										'mandatory': {
+												'maxHeight': maxHeight,
+												'minHeight': height,
+												'maxWidth':  width,
+												'minWidth':  width
+										},
+										'optional': []
+								};
+							}
 						}
 					}
-					if(typeof media.video === 'object') {
-						videoSupport = media.video;
-					}
+
 					Janus.debug(videoSupport);
 				} else if(media.video === 'screen' || media.video === 'window') {
 					if(!media.screenshareFrameRate) {

--- a/html/janus.js
+++ b/html/janus.js
@@ -1816,8 +1816,8 @@ function Janus(gatewayCallbacks) {
 						var chromeVer = Janus.webRTCAdapter.browserDetails.version;
 				    if(chromeVer >= 59) {
 							videoSupport = {
-								'height': height,
-								'width':  width
+								'height': {'ideal': height},
+								'width':  {'ideal': width}
 							};
 						}else{
 							// The old spec is supported by Chrome until Chrome 59 (June 2017)

--- a/html/janus.js
+++ b/html/janus.js
@@ -1806,21 +1806,31 @@ function Janus(gatewayCallbacks) {
 						width = 640;
 					}
 					Janus.log("Adding media constraint:", media.video);
-					if(navigator.mozGetUserMedia) {
+
+					if(Janus.webRTCAdapter.browserDetails.browser == 'firefox') {
 						videoSupport = {
 							'height': {'ideal': height},
 							'width':  {'ideal': width}
 						};
 					} else {
-						videoSupport = {
-						    'mandatory': {
-						        'maxHeight': maxHeight,
-						        'minHeight': height,
-						        'maxWidth':  width,
-						        'minWidth':  width
-						    },
-						    'optional': []
-						};
+						var chromeVer = Janus.webRTCAdapter.browserDetails.version;
+				    if(chromeVer >= 59) {
+							videoSupport = {
+								'height': height,
+								'width':  width
+							};
+						}else{
+							// The old spec is supported by Chrome until Chrome 59 (June 2017)
+							videoSupport = {
+									'mandatory': {
+											'maxHeight': maxHeight,
+											'minHeight': height,
+											'maxWidth':  width,
+											'minWidth':  width
+									},
+									'optional': []
+							};
+						}
 					}
 					if(typeof media.video === 'object') {
 						videoSupport = media.video;

--- a/html/janus.js
+++ b/html/janus.js
@@ -1817,21 +1817,10 @@ function Janus(gatewayCallbacks) {
 					}
 					Janus.log("Adding media constraint:", media.video);
 					if(navigator.mozGetUserMedia) {
-						var firefoxVer = parseInt(window.navigator.userAgent.match(/Firefox\/(.*)/)[1], 10);
-						if(firefoxVer < 38) {
-							videoSupport = {
-								'require': ['height', 'width'],
-								'height': {'max': maxHeight, 'min': height},
-								'width':  {'max': width,  'min': width}
-							};
-						} else {
-							// http://stackoverflow.com/questions/28282385/webrtc-firefox-constraints/28911694#28911694
-							// https://github.com/meetecho/janus-gateway/pull/246
-							videoSupport = {
-								'height': {'ideal': height},
-								'width':  {'ideal': width}
-							};
-						}
+						videoSupport = {
+							'height': {'ideal': height},
+							'width':  {'ideal': width}
+						};
 					} else {
 						videoSupport = {
 						    'mandatory': {
@@ -1874,7 +1863,7 @@ function Janus(gatewayCallbacks) {
 						Janus.log("Adding media constraint (screen capture)");
 						Janus.debug(constraints);
 						navigator.mediaDevices.getUserMedia(constraints)
-							.then(function(stream) { 
+							.then(function(stream) {
 								if(useAudio){
 									navigator.mediaDevices.getUserMedia({ audio: true, video: false })
 									.then(function (audioStream) {
@@ -1883,7 +1872,7 @@ function Janus(gatewayCallbacks) {
 									})
 								} else {
 									gsmCallback(null, stream);
-								} 
+								}
 							})
 							.catch(function(error) { pluginHandle.consentDialog(false); gsmCallback(error); });
 					};

--- a/html/janus.js
+++ b/html/janus.js
@@ -1789,16 +1789,6 @@ function Janus(gatewayCallbacks) {
 						height = 720;
 						maxHeight = 720;
 						width = 1280;
-						if(navigator.mozGetUserMedia) {
-							var firefoxVer = parseInt(window.navigator.userAgent.match(/Firefox\/(.*)/)[1], 10);
-							if(firefoxVer < 38) {
-								// Unless this is and old Firefox, which doesn't support it
-								Janus.warn(media.video + " unsupported, falling back to stdres (old Firefox)");
-								height = 480;
-								maxHeight = 480;
-								width  = 640;
-							}
-						}
 					} else if(media.video === 'stdres') {
 						// Normal resolution, 4:3
 						height = 480;

--- a/html/janus.js
+++ b/html/janus.js
@@ -1774,7 +1774,7 @@ function Janus(gatewayCallbacks) {
 				if(media.video && media.video != 'screen' && media.video != 'window') {
 					if(typeof media.video === 'object') {
 						videoSupport = media.video;
-					}else{
+					} else {
 						var width = 0;
 						var height = 0, maxHeight = 0;
 						if(media.video === 'lowres') {
@@ -1809,35 +1809,12 @@ function Janus(gatewayCallbacks) {
 							width = 640;
 						}
 						Janus.log("Adding media constraint:", media.video);
-
-						if(Janus.webRTCAdapter.browserDetails.browser == 'firefox') {
-							videoSupport = {
-								'height': {'ideal': height},
-								'width':  {'ideal': width}
-							};
-						} else {
-							var chromeVer = Janus.webRTCAdapter.browserDetails.version;
-					    if(chromeVer >= 59) {
-								videoSupport = {
-									'height': {'ideal': height},
-									'width':  {'ideal': width}
-								};
-							}else{
-								// The old spec is supported by Chrome until Chrome 59 (June 2017)
-								videoSupport = {
-										'mandatory': {
-												'maxHeight': maxHeight,
-												'minHeight': height,
-												'maxWidth':  width,
-												'minWidth':  width
-										},
-										'optional': []
-								};
-							}
-						}
+						videoSupport = {
+							'height': {'ideal': height},
+							'width':  {'ideal': width}
+						};
+						Janus.log("Adding video constraint:", videoSupport);
 					}
-
-					Janus.debug(videoSupport);
 				} else if(media.video === 'screen' || media.video === 'window') {
 					if(!media.screenshareFrameRate) {
 						media.screenshareFrameRate = 3;
@@ -2027,10 +2004,12 @@ function Janus(gatewayCallbacks) {
 						}
 					}
 
-					navigator.mediaDevices.getUserMedia({
+					var gumConstraints = {
 						audio: audioExist ? audioSupport : false,
 						video: videoExist ? videoSupport : false
-					})
+					};
+					Janus.debug("getUserMedia constraints", gumConstraints);
+					navigator.mediaDevices.getUserMedia(gumConstraints)
 					.then(function(stream) { pluginHandle.consentDialog(false); streamsDone(handleId, jsep, media, callbacks, stream); })
 					.catch(function(error) { pluginHandle.consentDialog(false); callbacks.error({code: error.code, name: error.name, message: error.message}); });
 				})


### PR DESCRIPTION
1) Drop pre Firefox 38 support. According to this stat https://en.wikipedia.org/wiki/Template:Firefox_usage_share it's only 0.02%
2) Added support for Chrome 59 getUserMedia constraints format
3) Optimized a case where 'media.video' is an object, so we do not calculate height+width in this case.