### PR TITLE
WIP: include janus mjr metadata into postprocessed video

### DIFF
--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -17,15 +17,15 @@
  * G.711 (mu-law or a-law) frames. In case the recording contains text
  * frames as received via data channels, instead, a .srt file will be
  * generated with the text content and the related timing information.
- * 
+ *
  * Using the utility is quite simple. Just pass, as arguments to the tool,
  * the path to the .mjr source file you want to post-process, and the
  * path to the destination file, e.g.:
- * 
+ *
 \verbatim
 ./janus-pp-rec /path/to/source.mjr /path/to/destination.[opus|wav|webm|h264|srt]
-\endverbatim 
- * 
+\endverbatim
+ *
  * An attempt to specify an output format that is not compliant with the
  * recording content (e.g., a .webm for H.264 frames) will result in an
  * error since, again, no transcoding is involved.
@@ -44,7 +44,7 @@
  * the frames in a valid container. Any further post-processing (e.g.,
  * muxing audio and video belonging to the same media session in a single
  * .webm file) is up to third-party applications.
- * 
+ *
  * \ingroup postprocessing
  * \ref postprocessing
  */
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
 			post_reset_trigger = val;
 		JANUS_LOG(LOG_INFO, "Post reset trigger: %d\n", post_reset_trigger);
 	}
-	
+
 	/* Evaluate arguments */
 	if(argc != 3) {
 		JANUS_LOG(LOG_INFO, "Usage: %s source.mjr destination.[opus|wav|webm|mp4|srt]\n", argv[0]);
@@ -177,6 +177,7 @@ int main(int argc, char *argv[])
 	uint32_t ssrc = 0;
 	char prebuffer[1500];
 	memset(prebuffer, 0, 1500);
+	json_t *info = NULL;
 	/* Let's look for timestamp resets first */
 	while(working && offset < fsize) {
 		if(header_only && parsed_header) {
@@ -254,7 +255,7 @@ int main(int argc, char *argv[])
 				parsed_header = TRUE;
 				prebuffer[len] = '\0';
 				json_error_t error;
-				json_t *info = json_loads(prebuffer, 0, &error);
+				info = json_loads(prebuffer, 0, &error);
 				if(!info) {
 					JANUS_LOG(LOG_ERR, "JSON error: on line %d: %s\n", error.line, error.text);
 					JANUS_LOG(LOG_WARN, "Error parsing info header...\n");
@@ -611,7 +612,7 @@ int main(int argc, char *argv[])
 	}
 	if(!working)
 		exit(0);
-	
+
 	JANUS_LOG(LOG_INFO, "Counted %"SCNu32" RTP packets\n", count);
 	janus_pp_frame_packet *tmp = list;
 	count = 0;
@@ -675,13 +676,13 @@ int main(int argc, char *argv[])
 				exit(1);
 			}
 		} else if(h264) {
-			if(janus_pp_h264_create(destination) < 0) {
+			if(janus_pp_h264_create(destination, info) < 0) {
 				JANUS_LOG(LOG_ERR, "Error creating .mp4 file...\n");
 				exit(1);
 			}
 		}
 	}
-	
+
 	/* Loop */
 	if(!video && !data) {
 		if(opus) {
@@ -732,7 +733,7 @@ int main(int argc, char *argv[])
 		}
 	}
 	fclose(file);
-	
+
 	file = fopen(destination, "rb");
 	if(file == NULL) {
 		JANUS_LOG(LOG_INFO, "No destination file %s??\n", destination);

--- a/postprocessing/pp-h264.h
+++ b/postprocessing/pp-h264.h
@@ -4,7 +4,7 @@
  * \brief    Post-processing to generate .mp4 files (headers)
  * \details  Implementation of the post-processing code (based on FFmpeg)
  * needed to generate .mp4 files out of H.264 RTP frames.
- * 
+ *
  * \ingroup postprocessing
  * \ref postprocessing
  */
@@ -13,11 +13,12 @@
 #define _JANUS_PP_H264
 
 #include <stdio.h>
+#include <jansson.h>
 
 #include "pp-rtp.h"
 
 /* H.264 stuff */
-int janus_pp_h264_create(char *destination);
+int janus_pp_h264_create(char *destination, json_t *info);
 int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list);
 int janus_pp_h264_process(FILE *file, janus_pp_frame_packet *list, int *working);
 void janus_pp_h264_close(void);


### PR DESCRIPTION
Opening this PR for discussion, if ok, I'll complete and clean up it before merge.

Problem:
under normal circumstances, the joins into a recorded room are not simultaneous, so each stream will start and end at different times.

When you need to postprocess files (play them back in a synced way, pad with blank video at beginning and/or end of the stream), is difficult to get when each stream starts, because janus-pp-rec output is not formatted (ie machine readable) and you don't know when each stream ends.

So you have to parse janus-pp-rec output (hoping for no log format changes between releases) to get start and using generated video metadata (using for example ffprobe) to get the duration of each file.

Thankfully, ffprobe output can be formatted in json/xml.

So why not add .mjr header into the generated .mp4/webm/whatever metadata? Doing that, and thanks to ffproble parsable output, is possibile to get all informations in one pass.

The tag choosen is the `comment`, which seems to be common between all formats.

In this PR I've done only for h264, just to experiment a bit.

If it is interesting, I'll be happy to complete it for the other containers.