### PR TITLE
fixed warning when used from C++ plugin

### DIFF
--- a/debug.h
+++ b/debug.h
@@ -67,9 +67,9 @@ static const char *janus_log_prefix[] = {
 	"",
 /* with colors */
 	"",
-	ANSI_COLOR_MAGENTA"[FATAL]"ANSI_COLOR_RESET" ",
-	ANSI_COLOR_RED"[ERR]"ANSI_COLOR_RESET" ",
-	ANSI_COLOR_YELLOW"[WARN]"ANSI_COLOR_RESET" ",
+	ANSI_COLOR_MAGENTA "[FATAL]" ANSI_COLOR_RESET " ",
+	ANSI_COLOR_RED "[ERR]" ANSI_COLOR_RESET " ",
+	ANSI_COLOR_YELLOW "[WARN]" ANSI_COLOR_RESET " ",
 	"",
 	"",
 	"",


### PR DESCRIPTION
It's annoying a little bit...