### PR TITLE
Claim Session Feature

### DIFF
--- a/conf/janus.cfg.sample.in
+++ b/conf/janus.cfg.sample.in
@@ -50,6 +50,16 @@ admin_secret = janusoverlord	; String that all Janus requests must contain
 ;							risk having orphaned sessions (sessions not
 ;							controlled by any transport and never freed).
 ;							To avoid timeouts, keep-alives can be used.
+;
+;reclaim_session_timeout = 5		; How long (in seconds) we should wait for a
+;							janus session to be reclaimed after the transport
+;							is gone. After the transport is gone, a session 
+;							times out when no request is received for 
+;							reclaim_session_timeout seconds (default=5s).
+;							Setting this to 0 will disable the timeout
+;							mechanism, and sessions will be destroyed immediately
+;							if the transport is gone.
+;
 ;recordings_tmp_ext = tmp	; The extension for recordings, in Janus, is
 ;							.mjr, a custom format we devised ourselves.
 ;							By default, we save to .mjr directly. If you'd

--- a/janus.c
+++ b/janus.c
@@ -515,7 +515,7 @@ static gpointer janus_sessions_watchdog(gpointer user_data) {
 }
 
 
-janus_session *janus_session_create(guint64 session_id) {
+janus_session *janus_session_create(guint64 session_id, guint64 secret_session_id) {
 	janus_session *session = NULL;
 	if(session_id == 0) {
 		while(session_id == 0) {
@@ -528,9 +528,13 @@ janus_session *janus_session_create(guint64 session_id) {
 			}
 		}
 	}
+	if(secret_session_id == 0) {
+		JANUS_LOG(LOG_INFO, "No secret ID specified for session %"SCNu64"\n", session_id);
+	}
 	session = (janus_session *)g_malloc(sizeof(janus_session));
 	JANUS_LOG(LOG_INFO, "Creating new session: %"SCNu64"; %p\n", session_id, session);
 	session->session_id = session_id;
+	session->secret_session_id = secret_session_id;
 	janus_refcount_init(&session->ref, janus_session_free);
 	session->source = NULL;
 	g_atomic_int_set(&session->destroyed, 0);
@@ -774,10 +778,13 @@ int janus_process_incoming_request(janus_request *request) {
 	char error_cause[100];
 	json_t *root = request->message;
 	/* Ok, let's start with the ids */
-	guint64 session_id = 0, handle_id = 0;
+	guint64 session_id = 0, handle_id = 0, secret_session_id = 0;
 	json_t *s = json_object_get(root, "session_id");
 	if(s && json_is_integer(s))
 		session_id = json_integer_value(s);
+	json_t *ss = json_object_get(root, "secret_session_id");
+	if(ss && json_is_integer(ss))
+		secret_session_id = json_integer_value(s);
 	json_t *h = json_object_get(root, "handle_id");
 	if(h && json_is_integer(h))
 		handle_id = json_integer_value(h);
@@ -830,8 +837,12 @@ int janus_process_incoming_request(janus_request *request) {
 				goto jsondone;
 			}
 		}
+		json_t *secret_id = json_object_get(root, "secret_id");
+		if(secret_id != NULL) {
+			secret_session_id = json_integer_value(id);
+		}
 		/* Handle it */
-		session = janus_session_create(session_id);
+		session = janus_session_create(session_id, secret_session_id);
 		if(session == NULL) {
 			ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_UNKNOWN, "Memory error");
 			goto jsondone;
@@ -1025,11 +1036,12 @@ int janus_process_incoming_request(janus_request *request) {
 		/* Send the success reply */
 		ret = janus_process_success(request, reply);
 	} else if(!strcasecmp(message_text, "claim")) {
-		if(reclaim_session_timeout == 0) {
-			ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_UNAUTHORIZED, "Claiming sessions is not enabled");
+		janus_mutex_lock(&session->mutex);
+		if(session->secret_session_id == 0 || secret_session_id != session->secret_session_id) {
+			janus_mutex_unlock(&session->mutex);
+			ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_UNAUTHORIZED, "Unauthorized to claim this session");
 			goto jsondone;
 		}
-		janus_mutex_lock(&session->mutex);
 		if(session->source != NULL) {
 			/* Give old tranport a timeout -- is this the right thing to do? */
 			session->source->transport->session_over(session->source->instance, session->session_id, TRUE);

--- a/janus.c
+++ b/janus.c
@@ -784,7 +784,7 @@ int janus_process_incoming_request(janus_request *request) {
 		session_id = json_integer_value(s);
 	json_t *ss = json_object_get(root, "secret_session_id");
 	if(ss && json_is_integer(ss))
-		secret_session_id = json_integer_value(s);
+		secret_session_id = json_integer_value(ss);
 	json_t *h = json_object_get(root, "handle_id");
 	if(h && json_is_integer(h))
 		handle_id = json_integer_value(h);
@@ -839,7 +839,7 @@ int janus_process_incoming_request(janus_request *request) {
 		}
 		json_t *secret_id = json_object_get(root, "secret_id");
 		if(secret_id != NULL) {
-			secret_session_id = json_integer_value(id);
+			secret_session_id = json_integer_value(secret_id);
 		}
 		/* Handle it */
 		session = janus_session_create(session_id, secret_session_id);

--- a/janus.c
+++ b/janus.c
@@ -1025,6 +1025,10 @@ int janus_process_incoming_request(janus_request *request) {
 		/* Send the success reply */
 		ret = janus_process_success(request, reply);
 	} else if(!strcasecmp(message_text, "claim")) {
+		if(reclaim_session_timeout == 0) {
+			ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_UNAUTHORIZED, "Claiming sessions is not enabled");
+			goto jsondone;
+		}
 		janus_mutex_lock(&session->mutex);
 		if(session->source != NULL) {
 			/* Give old tranport a timeout -- is this the right thing to do? */

--- a/janus.ggo
+++ b/janus.ggo
@@ -25,6 +25,7 @@ option "no-media-timer" t "Time (in s) that should pass with no media (audio or 
 option "rtp-port-range" r "Port range to use for RTP/RTCP" string typestr="min-max" optional
 option "server-name" n "Public name of this Janus instance (default=MyJanusInstance)" string typestr="name" optional
 option "session-timeout" s "Session timeout value, in seconds (default=60)" int typestr="number" optional
+option "reclaim-session-timeout" - "Reclaim session timeout value, in seconds (default=5)" int typestr="number" optional
 option "debug-level" d "Debug/logging level (0=disable debugging, 7=maximum debug level; default=4)" int typestr="1-7" optional
 option "debug-timestamps" D "Enable debug/logging timestamps" flag off
 option "disable-colors" o "Disable color in the logging" flag off

--- a/janus.ggo
+++ b/janus.ggo
@@ -25,7 +25,7 @@ option "no-media-timer" t "Time (in s) that should pass with no media (audio or 
 option "rtp-port-range" r "Port range to use for RTP/RTCP" string typestr="min-max" optional
 option "server-name" n "Public name of this Janus instance (default=MyJanusInstance)" string typestr="name" optional
 option "session-timeout" s "Session timeout value, in seconds (default=60)" int typestr="number" optional
-option "reclaim-session-timeout" - "Reclaim session timeout value, in seconds (default=5)" int typestr="number" optional
+option "reclaim-session-timeout" - "Reclaim session timeout value, in seconds (default=0)" int typestr="number" optional
 option "debug-level" d "Debug/logging level (0=disable debugging, 7=maximum debug level; default=4)" int typestr="1-7" optional
 option "debug-timestamps" D "Enable debug/logging timestamps" flag off
 option "disable-colors" o "Disable color in the logging" flag off

--- a/janus.h
+++ b/janus.h
@@ -53,6 +53,8 @@ typedef struct janus_session {
 	janus_request *source;
 	/*! \brief Flag to notify there's been a session timeout */
 	volatile gint timeout;
+	/*! \brief Flag to notify that transport is gone */
+	volatile gint transport_gone;
 	/*! \brief Mutex to lock/unlock this session */
 	janus_mutex mutex;
 	/*! \brief Atomic flag to check if this instance has been destroyed */

--- a/janus.h
+++ b/janus.h
@@ -45,6 +45,8 @@ typedef struct janus_request janus_request;
 typedef struct janus_session {
 	/*! \brief Janus Gateway-Client session ID */
 	guint64 session_id;
+	/*! \brief Janus Gateway-Client secret session ID */
+	guint64 secret_session_id;
 	/*! \brief Map of handles this session is managing */
 	GHashTable *ice_handles;
 	/*! \brief Time of the last activity on the session */
@@ -70,7 +72,7 @@ typedef struct janus_session {
 /*! \brief Method to create a new Janus Gateway-Client session
  * @param[in] session_id The desired Janus Gateway-Client session ID, or 0 if it needs to be generated randomly
  * @returns The created Janus Gateway-Client session if successful, NULL otherwise */
-janus_session *janus_session_create(guint64 session_id);
+janus_session *janus_session_create(guint64 session_id,  guint64 secret_session_id);
 /*! \brief Method to find an existing Janus Gateway-Client session from its ID
  * @param[in] session_id The Janus Gateway-Client session ID
  * @returns The created Janus Gateway-Client session if successful, NULL otherwise */


### PR DESCRIPTION
This is my attempt at implementing "session claims" to solve the issue discussed  in https://github.com/meetecho/janus-gateway/issues/979 and in this post: https://groups.google.com/forum/#!topic/meetecho-janus/5ZkzlZiRfU8. 

A new transport can claim a session by making a `claim` request that contains the correct `secret_session_id`. This id must be specified when the session is created, or no users will be authorized to make `claim` requests.

The `--reclaim_session_timeout` flag sets a grace period where a session can be reclaimed by another transport before the session is cleaned up. The default value is `0`, so the timeout must be set in the janus config file, or with the flag, to create a grace period.

I am not sure if the way I implemented `secret_session_id` makes sense. I only added it because a post mentioned the potential of "stealing" sessions, but I'm not sure why a client would know another clients session id.

This is my first Janus PR, so proceed with caution. I figured that I would push it since it helped me solve an issue I was having with websocket disconnects and another user was having similar issues: https://groups.google.com/forum/#!topic/meetecho-janus/bhyK0ldvd9Q