### PR TITLE
Opus FEC implementation proposal

### DIFF
--- a/conf/janus.plugin.audiobridge.cfg.sample
+++ b/conf/janus.plugin.audiobridge.cfg.sample
@@ -30,6 +30,7 @@
 								; if this key is provided in the request
 ;events = no					; Whether events should be sent to event
 								; handlers (default is yes)
+use_fec = false                 ; enable or disable FEC feature (opus)
 
 [1234]
 description = Demo Room

--- a/conf/janus.plugin.audiobridge.cfg.sample
+++ b/conf/janus.plugin.audiobridge.cfg.sample
@@ -30,7 +30,7 @@
 								; if this key is provided in the request
 ;events = no					; Whether events should be sent to event
 								; handlers (default is yes)
-use_fec = false                 ; enable or disable FEC feature (opus)
+use_fec = false					; enable or disable FEC feature (opus)
 
 [1234]
 description = Demo Room

--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -641,6 +641,38 @@ int janus_sdp_get_codec_pt(janus_sdp *sdp, const char *codec) {
 	return -1;
 }
 
+gboolean janus_sdp_attribute_fec_enable(janus_sdp *sdp, const int codec_pt) {
+	if(sdp == NULL)
+		return FALSE;
+	/* Check all m->lines */
+	GList *ml = sdp->m_lines;
+	while(ml) {
+		janus_sdp_mline *m = (janus_sdp_mline *)ml->data;
+		if(m->type != JANUS_SDP_AUDIO) {
+			ml = ml->next;
+			continue;
+		}
+		/* Look in all rtpmap attributes */
+		GList *ma = m->attributes;
+		while(ma) {
+			janus_sdp_attribute *a = (janus_sdp_attribute *)ma->data;
+			if(a->name != NULL && a->value != NULL && !strcasecmp(a->name, "fmtp")) {
+				if(codec_pt == atoi(a->value)){
+					char *inband = strstr(a->value, "useinbandfec=");
+					if(inband){
+						if(*(inband+13) == '1')
+							return TRUE;
+					}
+					return FALSE;
+				}
+			}
+			ma = ma->next;
+		}
+		ml = ml->next;
+	}
+	return FALSE;
+}
+
 const char *janus_sdp_get_codec_name(janus_sdp *sdp, int pt) {
 	if(sdp == NULL || pt < 0)
 		return NULL;

--- a/sdp-utils.h
+++ b/sdp-utils.h
@@ -228,6 +228,12 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen);
  * @returns 0 in case of success, a negative integer otherwise */
 int janus_sdp_remove_payload_type(janus_sdp *sdp, int pt);
 
+/*! \brief Helper method to check from attribute status of FEC associate to  specific codec
+ * @param[in] sdp The janus_sdp object to parse
+ * @param[in] codec_pt The payload type to check
+ * @returns true in case of fec enable, false otherwise */
+gboolean janus_sdp_attribute_fec_enable(janus_sdp *sdp, const int codec_pt);
+
 /*! \brief Method to serialize a janus_sdp object to an SDP string
  * @param[in] sdp The janus_sdp object to serialize
  * @returns A pointer to a string with the serialized SDP, if successful, NULL otherwise */


### PR DESCRIPTION
It's an implementation of 'Forward Error Correction' featue to improve  poor audio quality due to packets dropped or lost.
We use Opus encoder capability to embed redundant data and decoder one to rebuild lost packet from FEC data obtain in next packet it receives. We also use 'Packet lost concealment' feature by passing null information to decoder in case of multiple consecutive sequences losts.

Tested on 0.3.0 release, audio quality improvement verified (subjective).