### PR TITLE
Only log SCTP message bodies at >= HUGE level

### DIFF
--- a/sctp.c
+++ b/sctp.c
@@ -920,8 +920,10 @@ void janus_sctp_handle_data_message(janus_sctp_association *sctp, char *buffer, 
 	} else {
 		/* Assuming DATA_CHANNEL_PPID_DOMSTRING */
 		/* XXX: Protect for non 0 terminated buffer */
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Message received of length %zu on channel with id %d: %.*s\n",
-		       sctp->handle_id, length, channel->id, (int)length, buffer);
+		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Message received of length %zu on channel with id %d.\n",
+		       sctp->handle_id, length, channel->id);
+		JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Message contents: %.*s\n",
+		       sctp->handle_id, (int)length, buffer);
 		/* FIXME: notify this to the core */
 		janus_dtls_notify_data((janus_dtls_srtp *)sctp->dtls, buffer, (int)length);
 	}


### PR DESCRIPTION
VERB log level is very useful for diagnosing a lot of things, but if you are using a data-traffic intensive application then SCTP message bodies are going to take up the vast majority of your VERB-level log. Unless there is some really specific use case for why it's good to log them, moving them to HUGE level seems reasonable.

(In addition, I imagine that data channel message bodies are likely to be more private or more security-relevant than a lot of the other metadata in the log, so that's another reason you might want to be more conservative about logging them. That's certainly true for our product.)