### PR TITLE
Keep ICE component alive while SCTP thread is running.

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -1225,6 +1225,7 @@ void janus_ice_component_destroy(janus_ice_component *component) {
 		janus_refcount_decrease(&stream->ref);
 		component->stream = NULL;
 	}
+	janus_dtls_srtp_destroy(component->dtls);
 	janus_refcount_decrease(&component->ref);
 }
 

--- a/sctp.c
+++ b/sctp.c
@@ -261,7 +261,7 @@ janus_sctp_association *janus_sctp_association_create(void *dtls, uint64_t handl
 	g_snprintf(tname, sizeof(tname), "sctp %"SCNu64, sctp->handle_id);
 	void *component = ((janus_dtls_srtp *)dtls)->component;
 	if (component) {
-		janus_refcount_increase(&((janus_ice_component*)component)->ref);
+		janus_refcount_increase(&((janus_ice_component *)component)->ref);
 	}
 	janus_refcount_increase(&sctp->ref);
 	sctp->thread = g_thread_try_new(tname, &janus_sctp_thread, sctp, &error);
@@ -270,7 +270,7 @@ janus_sctp_association *janus_sctp_association_create(void *dtls, uint64_t handl
 		janus_mutex_unlock(&sctp->mutex);
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] Got error %d (%s) trying to launch the SCTP thread...\n", handle_id, error->code, error->message ? error->message : "??");
 		if (component) {
-			janus_refcount_decrease(&((janus_ice_component*)component)->ref);
+			janus_refcount_decrease(&((janus_ice_component *)component)->ref);
 		}
 		janus_refcount_decrease(&sctp->ref);	/* This is for the failed thread */
 		janus_refcount_decrease(&sctp->ref);
@@ -1288,7 +1288,7 @@ void *janus_sctp_thread(void *data) {
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Starting thread for SCTP association\n", sctp->handle_id);
 	janus_sctp_message *message = NULL;
 	janus_dtls_srtp *dtls = (janus_dtls_srtp *)sctp->dtls;
-	janus_ice_component *component = dtls ? (janus_ice_component*)dtls->component : NULL;
+	janus_ice_component *component = dtls ? (janus_ice_component *)dtls->component : NULL;
 	gboolean sent_data = FALSE;
 	while(!g_atomic_int_get(&sctp->destroyed) && sctp_running) {
 		/* Anything to do at all? */

--- a/sctp.c
+++ b/sctp.c
@@ -259,12 +259,19 @@ janus_sctp_association *janus_sctp_association_create(void *dtls, uint64_t handl
 	GError *error = NULL;
 	char tname[16];
 	g_snprintf(tname, sizeof(tname), "sctp %"SCNu64, sctp->handle_id);
+	void *component = ((janus_dtls_srtp *)dtls)->component;
+	if (component) {
+		janus_refcount_increase(&((janus_ice_component*)component)->ref);
+	}
 	janus_refcount_increase(&sctp->ref);
 	sctp->thread = g_thread_try_new(tname, &janus_sctp_thread, sctp, &error);
 	if(error != NULL) {
 		/* Something went wrong... */
 		janus_mutex_unlock(&sctp->mutex);
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] Got error %d (%s) trying to launch the SCTP thread...\n", handle_id, error->code, error->message ? error->message : "??");
+		if (component) {
+			janus_refcount_decrease(&((janus_ice_component*)component)->ref);
+		}
 		janus_refcount_decrease(&sctp->ref);	/* This is for the failed thread */
 		janus_refcount_decrease(&sctp->ref);
 		return NULL;
@@ -1280,6 +1287,8 @@ void *janus_sctp_thread(void *data) {
 	}
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Starting thread for SCTP association\n", sctp->handle_id);
 	janus_sctp_message *message = NULL;
+	janus_dtls_srtp *dtls = (janus_dtls_srtp *)sctp->dtls;
+	janus_ice_component *component = dtls ? (janus_ice_component*)dtls->component : NULL;
 	gboolean sent_data = FALSE;
 	while(!g_atomic_int_get(&sctp->destroyed) && sctp_running) {
 		/* Anything to do at all? */
@@ -1338,6 +1347,9 @@ void *janus_sctp_thread(void *data) {
 	}
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Leaving SCTP association thread\n", sctp->handle_id);
 	janus_refcount_decrease(&sctp->ref);
+	if (component) {
+		janus_refcount_decrease(&component->ref);
+	}
 	g_thread_unref(g_thread_self());
 	return NULL;
 }


### PR DESCRIPTION
This should fix the following error (line numbers might be a bit off due to debugging code added):
```
==1543==ERROR: AddressSanitizer: heap-use-after-free on address 0x61700182428c at pc 0x000000521f2e bp 0x7fa259c4fcf0 sp 0x7fa259c4fce8
READ of size 4 at 0x61700182428c thread T4044 (sctp 6012426324)
    #0 0x521f2d in janus_dtls_fd_bridge /path/to/janus-gateway/dtls.c:1043:4
    #1 0x531a8b in janus_dtls_send_sctp_data /path/to/janus-gateway/dtls.c:1082:3
    #2 0x62af1a in janus_sctp_thread /path/to/janus-gateway/sctp.c:1310:4
    #3 0x7fa396faff04  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x6df04)
    #4 0x7fa395ed5183 in start_thread /build/eglibc-ripdx6/eglibc-2.19/nptl/pthread_create.c:312
    #5 0x7fa3957e303c in clone /build/eglibc-ripdx6/eglibc-2.19/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:111

0x61700182428c is located 12 bytes inside of 736-byte region [0x617001824280,0x617001824560)
freed by thread T3886 (iceloop 6012426) here:
    #0 0x4cca82 in __interceptor_free /b/build/slave/linux_upload_clang/build/src/third_party/llvm/compiler-rt/lib/asan/asan_malloc_linux.cc:78:3
    #1 0x557c26 in janus_ice_component_free /path/to/janus-gateway/ice.c:1321:2
    #2 0x5558b7 in janus_ice_component_destroy /path/to/janus-gateway/ice.c:1228:2
    #3 0x554e8b in janus_ice_stream_destroy /path/to/janus-gateway/ice.c:1147:3
    #4 0x553fa2 in janus_ice_webrtc_free /path/to/janus-gateway/ice.c:1099:3
    #5 0x55994d in janus_ice_thread /path/to/janus-gateway/ice.c:2589:2
    #6 0x7fa396faff04  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x6df04)
```