### PR TITLE
Only build package to relay if queue exists.

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -4005,7 +4005,7 @@ void *janus_ice_send_thread(void *data) {
 }
 
 void janus_ice_relay_rtp(janus_ice_handle *handle, int video, char *buf, int len) {
-	if(!handle || buf == NULL || len < 1)
+	if(!handle || handle->queued_packets == NULL || buf == NULL || len < 1)
 		return;
 	if((!video && !janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AUDIO))
 			|| (video && !janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO)))
@@ -4019,12 +4019,11 @@ void janus_ice_relay_rtp(janus_ice_handle *handle, int video, char *buf, int len
 	pkt->control = FALSE;
 	pkt->encrypted = FALSE;
 	pkt->retransmission = FALSE;
-	if(handle->queued_packets != NULL)
-		g_async_queue_push(handle->queued_packets, pkt);
+	g_async_queue_push(handle->queued_packets, pkt);
 }
 
 void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, int video, char *buf, int len, gboolean filter_rtcp) {
-	if(!handle || buf == NULL || len < 1)
+	if(!handle || handle->queued_packets == NULL || buf == NULL || len < 1)
 		return;
 	/* We use this internal method to check whether we need to filter RTCP (e.g., to make
 	 * sure we don't just forward any SR/RR from peers/plugins, but use our own) or it has
@@ -4058,8 +4057,7 @@ void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, int video, char *bu
 	pkt->control = TRUE;
 	pkt->encrypted = FALSE;
 	pkt->retransmission = FALSE;
-	if(handle->queued_packets != NULL)
-		g_async_queue_push(handle->queued_packets, pkt);
+	g_async_queue_push(handle->queued_packets, pkt);
 	if(rtcp_buf != buf) {
 		/* We filtered the original packet, deallocate it */
 		g_free(rtcp_buf);
@@ -4072,7 +4070,7 @@ void janus_ice_relay_rtcp(janus_ice_handle *handle, int video, char *buf, int le
 
 #ifdef HAVE_SCTP
 void janus_ice_relay_data(janus_ice_handle *handle, char *buf, int len) {
-	if(!handle || buf == NULL || len < 1)
+	if(!handle || handle->queued_packets == NULL || buf == NULL || len < 1)
 		return;
 	/* Queue this packet */
 	janus_ice_queued_packet *pkt = g_malloc(sizeof(janus_ice_queued_packet));
@@ -4083,8 +4081,7 @@ void janus_ice_relay_data(janus_ice_handle *handle, char *buf, int len) {
 	pkt->control = FALSE;
 	pkt->encrypted = FALSE;
 	pkt->retransmission = FALSE;
-	if(handle->queued_packets != NULL)
-		g_async_queue_push(handle->queued_packets, pkt);
+	g_async_queue_push(handle->queued_packets, pkt);
 }
 #endif
 

--- a/ice.c
+++ b/ice.c
@@ -4019,7 +4019,14 @@ void janus_ice_relay_rtp(janus_ice_handle *handle, int video, char *buf, int len
 	pkt->control = FALSE;
 	pkt->encrypted = FALSE;
 	pkt->retransmission = FALSE;
-	g_async_queue_push(handle->queued_packets, pkt);
+	/* TODO: There is a potential race condition where the "queued_packets"
+	 * could get released between the condition and pushing the packet. */
+	if(handle->queued_packets != NULL) {
+		g_async_queue_push(handle->queued_packets, pkt);
+	} else {
+		g_free(pkt->data);
+		g_free(pkt);
+	}
 }
 
 void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, int video, char *buf, int len, gboolean filter_rtcp) {
@@ -4057,7 +4064,14 @@ void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, int video, char *bu
 	pkt->control = TRUE;
 	pkt->encrypted = FALSE;
 	pkt->retransmission = FALSE;
-	g_async_queue_push(handle->queued_packets, pkt);
+	/* TODO: There is a potential race condition where the "queued_packets"
+	 * could get released between the condition and pushing the packet. */
+	if(handle->queued_packets != NULL) {
+		g_async_queue_push(handle->queued_packets, pkt);
+	} else {
+		g_free(pkt->data);
+		g_free(pkt);
+	}
 	if(rtcp_buf != buf) {
 		/* We filtered the original packet, deallocate it */
 		g_free(rtcp_buf);
@@ -4081,7 +4095,14 @@ void janus_ice_relay_data(janus_ice_handle *handle, char *buf, int len) {
 	pkt->control = FALSE;
 	pkt->encrypted = FALSE;
 	pkt->retransmission = FALSE;
-	g_async_queue_push(handle->queued_packets, pkt);
+	/* TODO: There is a potential race condition where the "queued_packets"
+	 * could get released between the condition and pushing the packet. */
+	if(handle->queued_packets != NULL) {
+		g_async_queue_push(handle->queued_packets, pkt);
+	} else {
+		g_free(pkt->data);
+		g_free(pkt);
+	}
 }
 #endif
 


### PR DESCRIPTION
Fixes memory leaks for cases where the handle exists but doesn't have a packet queue.