### PR TITLE
Reduce keepalive time to less then 30 seconds

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -691,7 +691,7 @@ function Janus(gatewayCallbacks) {
 	function keepAlive() {
 		if(server === null || !websockets || !connected)
 			return;
-		wsKeepaliveTimeoutId = setTimeout(keepAlive, 30000);
+		wsKeepaliveTimeoutId = setTimeout(keepAlive, 25000);
 		var request = { "janus": "keepalive", "session_id": sessionId, "transaction": Janus.randomString(12) };
 		if(token !== null && token !== undefined)
 			request["token"] = token;
@@ -766,7 +766,7 @@ function Janus(gatewayCallbacks) {
 							callbacks.error(json["error"].reason);
 							return;
 						}
-						wsKeepaliveTimeoutId = setTimeout(keepAlive, 30000);
+						wsKeepaliveTimeoutId = setTimeout(keepAlive, 25000);
 						connected = true;
 						sessionId = json["session_id"] ? json["session_id"] : json.data["id"];
 						if(callbacks["reconnect"]) {


### PR DESCRIPTION
We have encountered environments where the WebSocket connection is closed after 30 seconds of inactivity. The current Janus keepalive is set to 30 seconds so we have a race condition and we often see the Jauns WebSocket closed in these environments. I have changed this to 25 seconds as this is the default that Socket IO uses (pingInterval):

https://socket.io/docs/server-api/

This change solves the issue for us so I'm proposing it for everyone in case others come across similar environments.