### PR TITLE
New Nanomsg transport plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -264,6 +264,16 @@ conf_DATA += conf/janus.transport.pfunix.cfg.sample
 EXTRA_DIST += conf/janus.transport.pfunix.cfg.sample
 endif
 
+if ENABLE_NANOMSG
+transport_LTLIBRARIES += transports/libjanus_nanomsg.la
+transports_libjanus_nanomsg_la_SOURCES = transports/janus_nanomsg.c
+transports_libjanus_nanomsg_la_CFLAGS = $(transports_cflags)
+transports_libjanus_nanomsg_la_LDFLAGS = $(transports_ldflags) -lnanomsg
+transports_libjanus_nanomsg_la_LIBADD = $(transports_libadd)
+conf_DATA += conf/janus.transport.nanomsg.cfg.sample
+EXTRA_DIST += conf/janus.transport.nanomsg.cfg.sample
+endif
+
 ##
 # Event handlers
 ##

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ WebSockets and/or BoringSSL support, as they make use of it)
 you are interested in RabbitMQ support for the Janus API)
 * [paho.mqtt.c](https://eclipse.org/paho/clients/c) (only needed if
 you are interested in MQTT support for the Janus API)
+* [nanomsg](https://nanomsg.org/) (only needed if
+you are interested in Nanomsg support for the Janus API)
 * [libcurl](https://curl.haxx.se/libcurl/) (only needed if you are
 interested in the TURN REST API support)
 
@@ -195,6 +197,13 @@ following steps:
 
 * *Note:* you may want to set up a different install path for the library,
 to achieve that, replace the last command by 'sudo prefix=/usr make install'.
+
+In case you're interested in Nanomsg support, you'll need to install the
+related C library. It is usually available as an easily installable
+package in pretty much all repositories. The following is an example on
+how to install it on Ubuntu:
+
+	aptitude install libnanomsg-dev
 
 Finally, the same can be said for rabbitmq-c as well, which is needed
 for the optional RabbitMQ support. In fact, several different versions

--- a/conf/janus.transport.nanomsg.cfg.sample
+++ b/conf/janus.transport.nanomsg.cfg.sample
@@ -1,0 +1,26 @@
+; You can also control a Janus instance using Nanomsg sockets. The only
+; aspect you need to configure here is the address to use for the
+; communication, and whether the address should be used to bind locally
+; or to connect to a remote endpoint. Notice that the only supported
+; pattern is NN_PAIR, so you'll only be able to have a single client
+; controlling the API with this plugin. As usual, both Janus API and Admin
+; API endpoints can be configured.
+[general]
+enabled = yes					; Whether to enable the Nanomsg interface
+								; for Janus API clients
+json = indented					; Whether the JSON messages should be indented (default),
+								; plain (no indentation) or compact (no indentation and no spaces)
+;mode = bind					; Whether we should 'bind' to the specified
+								; address (default), or connect to it if remote
+address = ipc:///tmp/janus.ipc	; Address to use (Janus API), refer
+								; to the Nanomsg documentation for more info
+								; on different transports you can use here
+
+; As with other transport plugins, you can use Nanomsg to interact with
+; the Admin API as well: in case you're interested in it, a different
+; address needs to be provided.
+[admin]
+admin_enabled = no				; Whether to enable the Nanomsg interface
+								; for Admin API clients
+;admin_mode = bind
+;admin_address = ipc:///tmp/janus-admin.ipc

--- a/configure.ac
+++ b/configure.ac
@@ -127,6 +127,8 @@ AC_ARG_ENABLE([all-transports],
                      [enable_mqtt=no])
                AS_IF([test "x$enable_unix_sockets" != "xyes"],
                      [enable_unix_sockets=no])
+               AS_IF([test "x$enable_nanomsg" != "xyes"],
+                     [enable_nanomsg=no])
               ],
               [])
 
@@ -186,6 +188,13 @@ AC_ARG_ENABLE([unix-sockets],
               [AS_IF([test "x$enable_unix_sockets" != "xyes"],
                      [enable_unix_sockets=no])],
               [enable_unix_sockets=maybe])
+
+AC_ARG_ENABLE([nanomsg],
+              [AS_HELP_STRING([--disable-nanomsg],
+                              [Disable Nanomsg integration])],
+              [AS_IF([test "x$enable_nanomsg" != "xyes"],
+                     [enable_nanomsg=no])],
+              [enable_nanomsg=maybe])
 
 AC_ARG_ENABLE([sample-event-handler],
               [AS_HELP_STRING([--disable-sample-event-handler],
@@ -454,9 +463,23 @@ AC_CHECK_LIB([paho-mqtt3a],
                AS_IF([test "x$enable_mqtt" = "xyes"],
                      [AC_MSG_ERROR([paho c client not found. See README.md for installation instructions or use --disable-mqtt])])
              ])
+AC_CHECK_LIB([nanomsg],
+             [nn_socket],
+             [
+               AS_IF([test "x$enable_nanomsg" != "xno"],
+               [
+                  AC_DEFINE(HAVE_NANOMSG)
+                  enable_nanomsg=yes
+               ])
+             ],
+             [
+               AS_IF([test "x$enable_nanomsg" = "xyes"],
+                     [AC_MSG_ERROR([nanomsg not found. See README.md for installation instructions or use --disable-nanomsg])])
+             ])
 AM_CONDITIONAL([ENABLE_RABBITMQ], [test "x$enable_rabbitmq" = "xyes"])
 AM_CONDITIONAL([ENABLE_RABBITMQEVH], [test "x$enable_rabbitmq_event_handler" = "xyes"])
 AM_CONDITIONAL([ENABLE_MQTT], [test "x$enable_mqtt" = "xyes"])
+AM_CONDITIONAL([ENABLE_NANOMSG], [test "x$enable_nanomsg" = "xyes"])
 
 AC_TRY_COMPILE([
                #include <stdlib.h>
@@ -829,6 +852,9 @@ AM_COND_IF([ENABLE_MQTT],
 AM_COND_IF([ENABLE_PFUNIX],
 	[echo "    Unix Sockets:          yes"],
 	[echo "    Unix Sockets:          no"])
+AM_COND_IF([ENABLE_NANOMSG],
+	[echo "    Nanomsg:               yes"],
+	[echo "    Nanomsg:               no"])
 echo "Plugins:"
 AM_COND_IF([ENABLE_PLUGIN_ECHOTEST],
 	[echo "    Echo Test:             yes"],

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -90,6 +90,7 @@
  * - \b libwebsockets: https://libwebsockets.org/ (\c optional, WebSockets)
  * - \b rabbitmq-c: https://github.com/alanxz/rabbitmq-c (\c optional, v1.0.4, RabbitMQ)
  * - \b paho.mqtt.c: https://eclipse.org/paho/clients/c (\c optional, v1.1.0, MQTT)
+ * - \b nanomsg: https://nanomsg.org/ (\c optional, Nanomsg)
  * - \b Sofia-SIP: http://sofia-sip.sourceforge.net/ (\c optional, only needed for the SIP plugin)
  * - \b libopus: http://opus-codec.org/ (\c optional, only needed for the bridge plugin)
  * - \b libogg: http://xiph.org/ogg/ (\c optional, only needed for the voicemail plugin)
@@ -102,10 +103,10 @@
 
 /*! \page JS JavaScript API
  * The gateway exposes, assuming the HTTP transport has been compiled, a
- * pseudo-RESTful interface, and optionally also WebSocket/RabbitMQ/MQTT/UnixSockets
+ * pseudo-RESTful interface, and optionally also WebSocket/RabbitMQ/MQTT/Nanomsg/UnixSockets
  * interfaces as well, all of which based on JSON messages. These
  * interfaces are described in more detail in the \ref plainhttp \ref WS
- * \ref rabbit \ref mqtt and \ref unix documentation respectively, and all allow clients to
+ * \ref rabbit \ref apimqtt \ref apinanomsg and \ref unix documentation respectively, and all allow clients to
  * take advantage of the features provided by Janus and the functionality
  * made available by its plugins. Considering most clients will be web browsers,
  * a common choice will be to rely on either the REST or the WebSockets
@@ -965,14 +966,14 @@ export const initialiseJanusLibrary = () => Janus.init({dependencies: setupDeps(
  *    otherwise pass an \c Error object like \c callback(error)
  */
 
-/*! \page rest RESTful, WebSockets, RabbitMQ, MQTT and UnixSockets API
+/*! \page rest RESTful, WebSockets, RabbitMQ, MQTT, Nanomsg and UnixSockets API
  *
  * Since version \c 0.0.6, there are three different ways to interact with a
- * Janus instance: a \ref plainhttp (the default), a \ref WS, a \ref rabbit, \ref mqtt
+ * Janus instance: a \ref plainhttp (the default), a \ref WS, a \ref rabbit, \ref apimqtt, \ref apinanomsg
  * and a \ref unix (both optional, need an external library to be available). All of
  * the interfaces use the same messages (in terms of requests, responses
  * and notifications), so almost all the concepts described in the
- * \ref plainhttp section apply to the WebSocket/RabbitMQ/MQTT/UnixSockets interfaces as well.
+ * \ref plainhttp section apply to the WebSocket/RabbitMQ/MQTT/Nanomsg/UnixSockets interfaces as well.
  * Besides, since version \c 0.1.0 the transport mechanism for the Janus API
  * has been made modular, which means other protocols for transporting
  * Janus API messages might become available in the future: considering the
@@ -980,10 +981,10 @@ export const initialiseJanusLibrary = () => Janus.init({dependencies: setupDeps(
  * transported on, the concepts explained in the following sections should
  * apply to those as well.
  *
- * As it will be explained later in the \ref WS, \ref rabbit and \ref unix sections
+ * As it will be explained later in the \ref WS, \ref rabbit, \ref apimqtt, \ref apinanomsg and \ref unix sections
  * below, the only differences come when addressing specific sessions/handles
  * and in part in how you handle notifications using something different than
- * the REST interface: in fact, since with WebSockets, RabbitMQ, MQTT and UnixSockets
+ * the REST interface: in fact, since with WebSockets, RabbitMQ, MQTT, Nanomsg and UnixSockets
  * (and, as anticipated, with other protocols that may be added in the future too)
  * there's no REST-based path involved, you'll need a couple of additional
  * identifiers to bridge the gap.
@@ -1498,7 +1499,7 @@ GET http://host:port/janus/<sessionid>?maxev=5
  * As anticipated in the previous sections, Janus can send events and
  * notifications at any time through the long poll channel (or, as it
  * will be explained later, through the related push mechanisms made
- * available by the \ref WS, \ref rabbit and \ref unix ). While this channel is
+ * available by other transport protocols ). While this channel is
  * mostly used to convey asynchronous notifications originated by
  * plugins as part of the messaging they may have with the application
  * using it, the same channel is actually used by Janus to trigger
@@ -1780,7 +1781,7 @@ var websocket = new WebSocket('ws://1.2.3.4:8188', 'janus-protocol');
  * implemented to do so, by looking at the Janus-level \c transaction
  * identifier.
  *
- * \section mqtt MQTT interface
+ * \section apimqtt MQTT interface
  * The semantics of how the requests have to be built, when compared to
  * the usage of plain HTTP, is exactly the same as for WebSockets, so
  * refer to the \ref WS documentation for details about that.
@@ -1800,10 +1801,20 @@ var websocket = new WebSocket('ws://1.2.3.4:8188', 'janus-protocol');
  * The proper usage of these queues will allow you to implement the kind
  * of bidirectional channel Janus needs.
  *
- * \section unix UnixSockets interface
+ * \section apinanomsg Nanomsg interface
  * The semantics of how the requests have to be built, when compared to
  * the usage of plain HTTP, is exactly the same as for WebSockets, RabbitMQ
  * and MQTT, so refer to the \ref WS documentation for details about that.
+ *
+ * Apart from that, the only configuration needed is related to the Nanomsg
+ * address to use, and whether it should be used to bind locally or to
+ * connect to a remote endpoint. Notice that only the \c NN_PAIR pattern
+ * is supported by the plugin, so no Pub/Sub or other variations.
+ *
+ * \section unix UnixSockets interface
+ * The semantics of how the requests have to be built, when compared to
+ * the usage of plain HTTP, is exactly the same as for WebSockets, RabbitMQ
+ * MQTT and Nanomsg, so refer to the \ref WS documentation for details about that.
  *
  * Apart from that, the only configuration needed is related to the path
  * the client and server will be sharing, and the socket type. Notice that only the
@@ -3260,6 +3271,7 @@ ldd janus | grep asan
  * -# <a href="#rabbitmq">Can I use RabbitMQ instead of HTTP/WebSockets to interact with Janus?</a>\n
  * -# <a href="#unixsockets">Can I use Unix Sockets instead of HTTP/WebSockets/RabbitMQ to interact with Janus?</a>\n
  * -# <a href="#mqtt">Can I use MQTT instead of HTTP/WebSockets/RabbitMQ/Unix Sockets to interact with Janus?</a>\n
+ * -# <a href="#nanomsg">Can I use Nanomsg instead of HTTP/WebSockets/RabbitMQ/MQTT/Unix Sockets to interact with Janus?</a>\n
  * -# <a href="#transports">What about \<my favourite control protocol\> instead?</a>\n
  * -# <a href="#demos">I've launched Janus, how do I try the demos?</a>\n
  * -# <a href="#certificates">I'm trying the demos, but I get "Janus down" or certificate errors!</a>\n
@@ -3517,7 +3529,12 @@ ldd janus | grep asan
  *    .
  *    Since version \c 0.2.1, you can! This was a very welcome contribution by
  *    a Janus user, as it makes it even easier to have Janus interact with IoT deployments.
- *    For more information, check the \ref mqtt page. \n\n
+ *    For more information, check the \ref apimqtt page. \n\n
+ *    .
+ * \anchor nanomsg
+ * -# <b>Can I use Nanomsg instead of HTTP/WebSockets/RabbitMQ/MQTT/Unix Sockets to interact with Janus?</b>\n
+ *    .
+ *    Since version \c 0.4.2, you can! For more information, check the \ref apinanomsg page. \n\n
  *    .
  * \anchor transports
  * -# <b>What about \<my favourite control protocol\> instead?</b>\n

--- a/transports/janus_nanomsg.c
+++ b/transports/janus_nanomsg.c
@@ -1,0 +1,505 @@
+/*! \file   janus_nanomsg.c
+ * \author Lorenzo Miniero <lorenzo@meetecho.com>
+ * \copyright GNU General Public License v3
+ * \brief  Janus Nanomsg transport plugin
+ * \details  This is an implementation of a Nanomsg transport for the
+ * Janus API. This means that, with the help of this module, local and
+ * remote applications can use Nanomsg to make requests to the gateway.
+ * Note that not all the protocols Nanomsg implements are made available
+ * in this plugin: specifically, you'll only be able to use the \c NN_PAIR
+ * transport mechanism. Future versions may implement more, but for the
+ * time being these should be enough to cover most development requirements.
+ *
+ * \ingroup transports
+ * \ref transports
+ */
+
+#include "transport.h"
+
+#include <nanomsg/nn.h>
+#include <nanomsg/pair.h>
+#include <nanomsg/inproc.h>
+#include <nanomsg/ipc.h>
+#include <nanomsg/pipeline.h>
+
+#include "../debug.h"
+#include "../apierror.h"
+#include "../config.h"
+#include "../mutex.h"
+#include "../utils.h"
+
+
+/* Transport plugin information */
+#define JANUS_NANOMSG_VERSION			1
+#define JANUS_NANOMSG_VERSION_STRING	"0.0.1"
+#define JANUS_NANOMSG_DESCRIPTION		"This transport plugin adds Nanomsg support to the Janus API."
+#define JANUS_NANOMSG_NAME				"JANUS Nanomsg transport plugin"
+#define JANUS_NANOMSG_AUTHOR			"Meetecho s.r.l."
+#define JANUS_NANOMSG_PACKAGE			"janus.transport.nanomsg"
+
+/* Transport methods */
+janus_transport *create(void);
+int janus_nanomsg_init(janus_transport_callbacks *callback, const char *config_path);
+void janus_nanomsg_destroy(void);
+int janus_nanomsg_get_api_compatibility(void);
+int janus_nanomsg_get_version(void);
+const char *janus_nanomsg_get_version_string(void);
+const char *janus_nanomsg_get_description(void);
+const char *janus_nanomsg_get_name(void);
+const char *janus_nanomsg_get_author(void);
+const char *janus_nanomsg_get_package(void);
+gboolean janus_nanomsg_is_janus_api_enabled(void);
+gboolean janus_nanomsg_is_admin_api_enabled(void);
+int janus_nanomsg_send_message(janus_transport_session *transport, void *request_id, gboolean admin, json_t *message);
+void janus_nanomsg_session_created(janus_transport_session *transport, guint64 session_id);
+void janus_nanomsg_session_over(janus_transport_session *transport, guint64 session_id, gboolean timeout, gboolean claimed);
+void janus_nanomsg_session_claimed(janus_transport_session *transport, guint64 session_id);
+
+
+/* Transport setup */
+static janus_transport janus_nanomsg_transport =
+	JANUS_TRANSPORT_INIT (
+		.init = janus_nanomsg_init,
+		.destroy = janus_nanomsg_destroy,
+
+		.get_api_compatibility = janus_nanomsg_get_api_compatibility,
+		.get_version = janus_nanomsg_get_version,
+		.get_version_string = janus_nanomsg_get_version_string,
+		.get_description = janus_nanomsg_get_description,
+		.get_name = janus_nanomsg_get_name,
+		.get_author = janus_nanomsg_get_author,
+		.get_package = janus_nanomsg_get_package,
+
+		.is_janus_api_enabled = janus_nanomsg_is_janus_api_enabled,
+		.is_admin_api_enabled = janus_nanomsg_is_admin_api_enabled,
+
+		.send_message = janus_nanomsg_send_message,
+		.session_created = janus_nanomsg_session_created,
+		.session_over = janus_nanomsg_session_over,
+		.session_claimed = janus_nanomsg_session_claimed,
+	);
+
+/* Transport creator */
+janus_transport *create(void) {
+	JANUS_LOG(LOG_VERB, "%s created!\n", JANUS_NANOMSG_NAME);
+	return &janus_nanomsg_transport;
+}
+
+
+/* Useful stuff */
+static gint initialized = 0, stopping = 0;
+static janus_transport_callbacks *gateway = NULL;
+static gboolean notify_events = TRUE;
+
+/* JSON serialization options */
+static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+
+#define BUFFER_SIZE		8192
+
+/* Nanomsg server thread */
+static GThread *nanomsg_thread = NULL;
+void *janus_nanomsg_thread(void *data);
+
+/* Nanomsg servers */
+static int nfd = -1, nfd_addr = -1, admin_nfd = -1, admin_nfd_addr = -1;
+/* Pipeline to notify about the need for outgoing data */
+static int write_nfd[2];
+
+/* Nanomsg client session */
+typedef struct janus_nanomsg_client {
+	gboolean admin;					/* Whether this client is for the Admin or Janus API */
+	GAsyncQueue *messages;			/* Queue of outgoing messages to push */
+	janus_transport_session *ts;	/* Janus core-transport session */
+} janus_nanomsg_client;
+/* We only handle a single client per API, since we use NN_PAIR and we bind locally */
+static janus_nanomsg_client client, admin_client;
+
+
+/* Transport implementation */
+int janus_nanomsg_init(janus_transport_callbacks *callback, const char *config_path) {
+	if(g_atomic_int_get(&stopping)) {
+		/* Still stopping from before */
+		return -1;
+	}
+	if(callback == NULL || config_path == NULL) {
+		/* Invalid arguments */
+		return -1;
+	}
+
+	/* This is the callback we'll need to invoke to contact the gateway */
+	gateway = callback;
+
+	/* Read configuration */
+	char filename[255];
+	g_snprintf(filename, 255, "%s/%s.cfg", config_path, JANUS_NANOMSG_PACKAGE);
+	JANUS_LOG(LOG_VERB, "Configuration file: %s\n", filename);
+	janus_config *config = janus_config_parse(filename);
+	if(config != NULL) {
+		/* Handle configuration */
+		janus_config_print(config);
+
+		janus_config_item *item = janus_config_get_item_drilldown(config, "general", "json");
+		if(item && item->value) {
+			/* Check how we need to format/serialize the JSON output */
+			if(!strcasecmp(item->value, "indented")) {
+				/* Default: indented, we use three spaces for that */
+				json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+			} else if(!strcasecmp(item->value, "plain")) {
+				/* Not indented and no new lines, but still readable */
+				json_format = JSON_INDENT(0) | JSON_PRESERVE_ORDER;
+			} else if(!strcasecmp(item->value, "compact")) {
+				/* Compact, so no spaces between separators */
+				json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
+			} else {
+				JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", item->value);
+				json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+			}
+		}
+
+		/* Check if we need to send events to handlers */
+		janus_config_item *events = janus_config_get_item_drilldown(config, "general", "events");
+		if(events != NULL && events->value != NULL)
+			notify_events = janus_is_true(events->value);
+		if(!notify_events && callback->events_is_enabled()) {
+			JANUS_LOG(LOG_WARN, "Notification of events to handlers disabled for %s\n", JANUS_NANOMSG_NAME);
+		}
+
+		/* First of all, initialize the pipeline for writeable notifications */
+		write_nfd[0] = nn_socket(AF_SP, NN_PULL);
+		write_nfd[1] = nn_socket(AF_SP, NN_PUSH);
+		if(nn_bind(write_nfd[0], "inproc://janus") < 0) {
+			JANUS_LOG(LOG_WARN, "Error configuring internal Nanomsg pipeline... %d (%s)\n", errno, nn_strerror(errno));
+			return -1;	/* No point in keeping the plugin loaded */
+		}
+		if(nn_connect(write_nfd[1], "inproc://janus") < 0) {
+			JANUS_LOG(LOG_WARN, "Error configuring internal Nanomsg pipeline...%d (%s)\n", errno, nn_strerror(errno));
+			return -1;	/* No point in keeping the plugin loaded */
+		}
+
+		/* Setup the Janus API Nanomsg server(s) */
+		item = janus_config_get_item_drilldown(config, "general", "enabled");
+		if(!item || !item->value || !janus_is_true(item->value)) {
+			JANUS_LOG(LOG_WARN, "Nanomsg server disabled (Janus API)\n");
+		} else {
+			item = janus_config_get_item_drilldown(config, "general", "address");
+			const char *address = item && item->value ? item->value : NULL;
+			item = janus_config_get_item_drilldown(config, "general", "mode");
+			const char *mode = item && item->value ? item->value : NULL;
+			if(mode == NULL)
+				mode = "bind";
+			nfd = nn_socket(AF_SP, NN_PAIR);
+			if(nfd < 0) {
+				JANUS_LOG(LOG_ERR, "Error creating Janus API Nanomsg socket: %d (%s)\n", errno, nn_strerror(errno));
+			} else {
+				if(!strcasecmp(mode, "bind")) {
+					/* Bind to this address */
+					nfd_addr = nn_bind(nfd, address);
+					if(nfd_addr < 0) {
+						JANUS_LOG(LOG_ERR, "Error binding Janus API Nanomsg socket to address '%s': %d (%s)\n",
+							address, errno, nn_strerror(errno));
+						nn_close(nfd);
+						nfd = -1;
+					}
+				} else if(!strcasecmp(mode, "connect")) {
+					/* Connect to this address */
+					nfd_addr = nn_connect(nfd, address);
+					if(nfd_addr < 0) {
+						JANUS_LOG(LOG_ERR, "Error connecting Janus API Nanomsg socket to address '%s': %d (%s)\n",
+							address, errno, nn_strerror(errno));
+						nn_close(nfd);
+						nfd = -1;
+					}
+				} else {
+					/* Unsupported mode */
+					JANUS_LOG(LOG_ERR, "Unsupported mode '%s'\n", mode);
+					nn_close(nfd);
+					nfd = -1;
+				}
+			}
+		}
+		/* Do the same for the Admin API, if enabled */
+		item = janus_config_get_item_drilldown(config, "admin", "admin_enabled");
+		if(!item || !item->value || !janus_is_true(item->value)) {
+			JANUS_LOG(LOG_WARN, "Nanomsg server disabled (Admin API)\n");
+		} else {
+			item = janus_config_get_item_drilldown(config, "admin", "admin_address");
+			const char *address = item && item->value ? item->value : NULL;
+			item = janus_config_get_item_drilldown(config, "general", "admin_mode");
+			const char *mode = item && item->value ? item->value : NULL;
+			if(mode == NULL)
+				mode = "bind";
+			admin_nfd = nn_socket(AF_SP, NN_PAIR);
+			if(admin_nfd < 0) {
+				JANUS_LOG(LOG_ERR, "Error creating Admin API Nanomsg socket: %d (%s)\n", errno, nn_strerror(errno));
+			} else {
+				if(!strcasecmp(mode, "bind")) {
+					/* Bind to this address */
+					admin_nfd_addr = nn_bind(admin_nfd, address);
+					if(admin_nfd_addr < 0) {
+						JANUS_LOG(LOG_ERR, "Error binding Admin API Nanomsg socket to address '%s': %d (%s)\n",
+							address, errno, nn_strerror(errno));
+						nn_close(admin_nfd);
+						admin_nfd = -1;
+					}
+				} else if(!strcasecmp(mode, "connect")) {
+					/* Connect to this address */
+					admin_nfd_addr = nn_connect(admin_nfd, address);
+					if(admin_nfd_addr < 0) {
+						JANUS_LOG(LOG_ERR, "Error connecting Admin API Nanomsg socket to address '%s': %d (%s)\n",
+							address, errno, nn_strerror(errno));
+						nn_close(admin_nfd);
+						admin_nfd = -1;
+					}
+				} else {
+					/* Unsupported mode */
+					JANUS_LOG(LOG_ERR, "Unsupported mode '%s'\n", mode);
+					nn_close(admin_nfd);
+					admin_nfd = -1;
+				}
+			}
+		}
+	}
+	janus_config_destroy(config);
+	config = NULL;
+	if(nfd < 0 && admin_nfd < 0) {
+		JANUS_LOG(LOG_WARN, "No Nanomsg server started, giving up...\n");
+		return -1;	/* No point in keeping the plugin loaded */
+	}
+
+	/* Create the clients */
+	memset(&client, 0, sizeof(janus_nanomsg_client));
+	if(nfd > -1) {
+		client.admin = FALSE;
+		client.messages = g_async_queue_new();
+		/* Create a transport instance as well */
+		client.ts = janus_transport_session_create(&client, NULL);
+		/* Notify handlers about this new transport */
+		if(notify_events && gateway->events_is_enabled()) {
+			json_t *info = json_object();
+			json_object_set_new(info, "event", json_string("created"));
+			json_object_set_new(info, "admin_api", json_false());
+			json_object_set_new(info, "socket", json_integer(nfd));
+			gateway->notify_event(&janus_nanomsg_transport, client.ts, info);
+		}
+	}
+	memset(&admin_client, 0, sizeof(janus_nanomsg_client));
+	if(admin_nfd > -1) {
+		admin_client.admin = TRUE;
+		admin_client.messages = g_async_queue_new();
+		/* Create a transport instance as well */
+		admin_client.ts = janus_transport_session_create(&admin_client, NULL);
+		/* Notify handlers about this new transport */
+		if(notify_events && gateway->events_is_enabled()) {
+			json_t *info = json_object();
+			json_object_set_new(info, "event", json_string("created"));
+			json_object_set_new(info, "admin_api", json_true());
+			json_object_set_new(info, "socket", json_integer(admin_nfd));
+			gateway->notify_event(&janus_nanomsg_transport, admin_client.ts, info);
+		}
+	}
+
+	/* Start the Nanomsg service thread */
+	GError *error = NULL;
+	nanomsg_thread = g_thread_try_new("nanomsg thread", &janus_nanomsg_thread, NULL, &error);
+	if(!nanomsg_thread) {
+		g_atomic_int_set(&initialized, 0);
+		JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the Nanomsg thread...\n", error->code, error->message ? error->message : "??");
+		return -1;
+	}
+
+	/* Done */
+	g_atomic_int_set(&initialized, 1);
+	JANUS_LOG(LOG_INFO, "%s initialized!\n", JANUS_NANOMSG_NAME);
+	return 0;
+}
+
+void janus_nanomsg_destroy(void) {
+	if(!g_atomic_int_get(&initialized))
+		return;
+	g_atomic_int_set(&stopping, 1);
+
+	/* Stop the service thread */
+	(void)nn_send(write_nfd[1], "x", 1, 0);
+
+	if(nanomsg_thread != NULL) {
+		g_thread_join(nanomsg_thread);
+		nanomsg_thread = NULL;
+	}
+
+	g_atomic_int_set(&initialized, 0);
+	g_atomic_int_set(&stopping, 0);
+	JANUS_LOG(LOG_INFO, "%s destroyed!\n", JANUS_NANOMSG_NAME);
+}
+
+int janus_nanomsg_get_api_compatibility(void) {
+	/* Important! This is what your plugin MUST always return: don't lie here or bad things will happen */
+	return JANUS_TRANSPORT_API_VERSION;
+}
+
+int janus_nanomsg_get_version(void) {
+	return JANUS_NANOMSG_VERSION;
+}
+
+const char *janus_nanomsg_get_version_string(void) {
+	return JANUS_NANOMSG_VERSION_STRING;
+}
+
+const char *janus_nanomsg_get_description(void) {
+	return JANUS_NANOMSG_DESCRIPTION;
+}
+
+const char *janus_nanomsg_get_name(void) {
+	return JANUS_NANOMSG_NAME;
+}
+
+const char *janus_nanomsg_get_author(void) {
+	return JANUS_NANOMSG_AUTHOR;
+}
+
+const char *janus_nanomsg_get_package(void) {
+	return JANUS_NANOMSG_PACKAGE;
+}
+
+gboolean janus_nanomsg_is_janus_api_enabled(void) {
+	return nfd > -1;
+}
+
+gboolean janus_nanomsg_is_admin_api_enabled(void) {
+	return admin_nfd > -1;
+}
+
+int janus_nanomsg_send_message(janus_transport_session *transport, void *request_id, gboolean admin, json_t *message) {
+	if(message == NULL)
+		return -1;
+	/* Convert to string */
+	char *payload = json_dumps(message, json_format);
+	json_decref(message);
+	/* Enqueue the packet and have poll tell us when it's time to send it */
+	g_async_queue_push(admin ? admin_client.messages : client.messages, payload);
+	/* Notify the thread there's data to send */
+	(void)nn_send(write_nfd[1], "x", 1, 0);
+	return 0;
+}
+
+void janus_nanomsg_session_created(janus_transport_session *transport, guint64 session_id) {
+	/* We don't care */
+}
+
+void janus_nanomsg_session_over(janus_transport_session *transport, guint64 session_id, gboolean timeout, gboolean claimed) {
+	/* We don't care */
+}
+
+void janus_nanomsg_session_claimed(janus_transport_session *transport, guint64 session_id) {
+	/* We don't care about this. We should start receiving messages from the core about this session: no action necessary */
+	/* FIXME Is the above statement accurate? Should we care? Unlike the HTTP transport, there is no hashtable to update */
+}
+
+
+/* Thread */
+void *janus_nanomsg_thread(void *data) {
+	JANUS_LOG(LOG_INFO, "Nanomsg thread started\n");
+
+	int fds = 0;
+	struct nn_pollfd poll_nfds[3];	/* FIXME Should we allow for more clients? */
+	char buffer[BUFFER_SIZE];
+
+	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
+		/* Prepare poll list of file descriptors */
+		fds = 0;
+		/* Writeable monitor */
+		poll_nfds[fds].fd = write_nfd[0];
+		poll_nfds[fds].events = NN_POLLIN;
+		fds++;
+		if(nfd > -1) {
+			/* Janus API */
+			poll_nfds[fds].fd = nfd;
+			poll_nfds[fds].events = NN_POLLIN;
+			if(client.messages != NULL && g_async_queue_length(client.messages) > 0)
+				poll_nfds[fds].events |= NN_POLLOUT;
+			fds++;
+		}
+		if(admin_nfd > -1) {
+			/* Admin API */
+			poll_nfds[fds].fd = admin_nfd;
+			poll_nfds[fds].events = NN_POLLIN;
+			if(admin_client.messages != NULL && g_async_queue_length(admin_client.messages) > 0)
+				poll_nfds[fds].events |= NN_POLLOUT;
+			fds++;
+		}
+		/* Start polling */
+		int res = nn_poll(poll_nfds, fds, -1);
+		if(res == 0)
+			continue;
+		if(res < 0) {
+			if(errno == EINTR) {
+				JANUS_LOG(LOG_HUGE, "Got an EINTR (%s) polling the Nanomsg descriptors, ignoring...\n", nn_strerror(errno));
+				continue;
+			}
+			JANUS_LOG(LOG_ERR, "poll() failed: %d (%s)\n", errno, nn_strerror(errno));
+			break;
+		}
+		int i = 0;
+		for(i=0; i<fds; i++) {
+			/* FIXME Is there a Nanomsg equivalent of POLLERR? */
+			if(poll_nfds[i].revents & NN_POLLOUT) {
+				/* Find the client from its file descriptor */
+				if(poll_nfds[i].fd == nfd || poll_nfds[i].fd == admin_nfd) {
+					char *payload = NULL;
+					while((payload = g_async_queue_try_pop(poll_nfds[i].fd == nfd ? client.messages : admin_client.messages)) != NULL) {
+						int res = nn_send(poll_nfds[i].fd, payload, strlen(payload), 0);
+						/* FIXME Should we check if sent everything? */
+						JANUS_LOG(LOG_HUGE, "Written %d/%zu bytes on %d\n", res, strlen(payload), poll_nfds[i].fd);
+						g_free(payload);
+					}
+				}
+			}
+			if(poll_nfds[i].revents & NN_POLLIN) {
+				if(poll_nfds[i].fd == write_nfd[0]) {
+					/* Read and ignore: we use this to unlock the poll if there's data to write */
+					(void)nn_recv(poll_nfds[i].fd, buffer, BUFFER_SIZE, 0);
+				} else if(poll_nfds[i].fd == nfd || poll_nfds[i].fd == admin_nfd) {
+					/* Janus/Admin API: get the message from the client */
+					int res = nn_recv(poll_nfds[i].fd, buffer, BUFFER_SIZE, 0);
+					if(res < 0) {
+						JANUS_LOG(LOG_WARN, "Error receiving %s API message... %d (%s)\n",
+							poll_nfds[i].fd == nfd ? "Janus" : "Admin", errno, nn_strerror(errno));
+						continue;
+					}
+					/* If we got here, there's data to handle */
+					buffer[res] = '\0';
+					JANUS_LOG(LOG_VERB, "Got %s API message (%d bytes)\n",
+						poll_nfds[i].fd == nfd ? "Janus" : "Admin", res);
+					JANUS_LOG(LOG_HUGE, "%s\n", buffer);
+					/* Parse the JSON payload */
+					json_error_t error;
+					json_t *root = json_loads(buffer, 0, &error);
+					/* Notify the core, passing both the object and, since it may be needed, the error */
+					gateway->incoming_request(&janus_nanomsg_transport,
+						poll_nfds[i].fd == nfd ? client.ts : admin_client.ts,
+						NULL,
+						poll_nfds[i].fd == nfd ? FALSE : TRUE,
+						root, &error);
+				}
+			}
+		}
+	}
+
+	nn_close(write_nfd[0]);
+	nn_close(write_nfd[1]);
+	if(nfd > -1) {
+		nn_shutdown(nfd, nfd_addr);
+		nn_close(nfd);
+		janus_transport_session_destroy(client.ts);
+		client.ts = NULL;
+	}
+	if(admin_nfd > -1) {
+		nn_shutdown(admin_nfd, admin_nfd_addr);
+		nn_close(admin_nfd);
+		janus_transport_session_destroy(admin_client.ts);
+		admin_client.ts = NULL;
+	}
+
+	/* Done */
+	JANUS_LOG(LOG_INFO, "Nanomsg thread ended\n");
+	return NULL;
+}


### PR DESCRIPTION
Pretty self-explainatory: this is a new transport plugin that allows you to communicate with Janus using [Nanomsg](https://nanomsg.org/).

Notice that the only communication pattern this plugin implements is `PAIR`, that is the one-to-one scalability protocol: https://nanomsg.org/v1.1.4/nn_pair.html
This means that you can only have a single client talking to Janus at any given time. This was done because basically I found no way to identify "clients" using the other patterns instead. This is the same limitation the RabbitMQ plugin has, so not a big deal I think: in the future we might think of some kind of RSVP mechanism, where a Pub/Sub approach is used to create an ad-hoc pair for a new client.

The plugin is quite easy to configure. You choose an address, specify if you'll bind to this address (local address) or if you're connecting to it (remote address), and you're done. Tested briefly with a nodejs application using the `nanomsg` npm module and it seems to be working as expected.

As usual, I welcome your feedback, especially if you're quite familiar with Nanomsg and have suggestions to provide before we merge.