### PR TITLE
add padding for sdes cname

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -3259,7 +3259,7 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 	if(stream && stream->component && stream->component->out_stats.audio.packets > 0) {
 		/* Create a SR/SDES compound */
 		int srlen = 28;
-		int sdeslen = 20;
+		int sdeslen = 24;
 		char rtcpbuf[srlen+sdeslen];
 		memset(rtcpbuf, 0, sizeof(rtcpbuf));
 		rtcp_sr *sr = (rtcp_sr *)&rtcpbuf;
@@ -3312,7 +3312,7 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 	if(stream && stream->component && stream->component->out_stats.video[0].packets > 0) {
 		/* Create a SR/SDES compound */
 		int srlen = 28;
-		int sdeslen = 20;
+		int sdeslen = 24;
 		char rtcpbuf[srlen+sdeslen];
 		memset(rtcpbuf, 0, sizeof(rtcpbuf));
 		rtcp_sr *sr = (rtcp_sr *)&rtcpbuf;

--- a/rtcp.c
+++ b/rtcp.c
@@ -993,7 +993,7 @@ int janus_rtcp_sdes_cname(char *packet, int len, const char *cname, int cnamelen
 	rtcp->rc = 1;
 	int plen = 8;	/* Header + chunk + item header */
 	plen += cnamelen+2;
-	if((cnamelen+2)%4)	/* Account for padding */
+	if((cnamelen+3)%4)	/* Account for padding */
 		plen += 4;
 	if(len < plen) {
 		JANUS_LOG(LOG_ERR, "Buffer too small for SDES message: %d < %d\n", len, plen);


### PR DESCRIPTION
sdes chunk should end with null terminator

see: https://tools.ietf.org/html/rfc1889
6.4 SDES: Source description RTCP packet
 Items are contiguous, i.e., items are not individually padded to a
32-bit boundary. Text is not null terminated because some multi-octet
encodings include null octets. The list of items in each chunk is
terminated by one or more null octets, the first of which is
interpreted as an item type of zero to denote the end of the list,
and the remainder as needed to pad until the next 32-bit boundary. A
chunk with zero items (four null octets) is valid but useless.