### PR TITLE
Add VP9-SVC support to the Streaming plugin

### DIFF
--- a/conf/janus.plugin.streaming.cfg.sample.in
+++ b/conf/janus.plugin.streaming.cfg.sample.in
@@ -41,6 +41,7 @@
 ; videoport3 = third local port for receiving video frames (only for rtp, and simulcasting)
 ; videoskew = yes|no (whether the plugin should perform skew
 ;		analisys and compensation on incoming video RTP stream, EXPERIMENTAL)
+; videosvc = yes|no (whether the video will have SVC support; works only for VP9-SVC, default=no)
 ; collision = in case of collision (more than one SSRC hitting the same port), the plugin
 ;		will discard incoming RTP packets with a new SSRC unless this many milliseconds
 ;		passed, which would then change the current SSRC (0=disabled)

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -55,7 +55,7 @@ var opaqueId = "streamingtest-"+Janus.randomString(12);
 var bitrateTimer = null;
 var spinner = null;
 
-var simulcastStarted = false;
+var simulcastStarted = false, svcStarted = false;
 
 var selectedStream = null;
 
@@ -126,6 +126,17 @@ $(document).ready(function() {
 												}
 												// We just received notice that there's been a switch, update the buttons
 												updateSimulcastButtons(substream, temporal);
+											}
+											// Is VP9/SVC in place?
+											var spatial = result["spatial_layer"];
+											temporal = result["temporal_layer"];
+											if((spatial !== null && spatial !== undefined) || (temporal !== null && temporal !== undefined)) {
+												if(!svcStarted) {
+													svcStarted = true;
+													addSvcButtons();
+												}
+												// We just received notice that there's been a switch, update the buttons
+												updateSvcButtons(spatial, temporal);
 											}
 										}
 									} else if(msg["error"] !== undefined && msg["error"] !== null) {
@@ -441,6 +452,106 @@ function updateSimulcastButtons(substream, temporal) {
 		$('#tl-0').removeClass('btn-primary btn-success').addClass('btn-primary');
 	} else if(temporal === 2) {
 		toastr.success("Capped simulcast temporal layer! (highest FPS)", null, {timeOut: 2000});
+		$('#tl-2').removeClass('btn-primary btn-info btn-success').addClass('btn-success');
+		$('#tl-1').removeClass('btn-primary btn-success').addClass('btn-primary');
+		$('#tl-0').removeClass('btn-primary btn-success').addClass('btn-primary');
+	}
+}
+
+// Helpers to create SVC-related UI for a new viewer
+function addSvcButtons() {
+	if($('#svc').length > 0)
+		return;
+	$('#curres').parent().append(
+		'<div id="svc" class="btn-group-vertical btn-group-vertical-xs pull-right">' +
+		'	<div class"row">' +
+		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
+		'			<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal resolution" style="width: 50%">SL 1</button>' +
+		'			<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to low resolution" style="width: 50%">SL 0</button>' +
+		'		</div>' +
+		'	</div>' +
+		'	<div class"row">' +
+		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
+		'			<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2 (high FPS)" style="width: 34%">TL 2</button>' +
+		'			<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1 (medium FPS)" style="width: 33%">TL 1</button>' +
+		'			<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0 (low FPS)" style="width: 33%">TL 0</button>' +
+		'		</div>' +
+		'	</div>' +
+		'</div>'
+	);
+	// Enable the VP8 simulcast selection buttons
+	$('#sl-0').removeClass('btn-primary btn-success').addClass('btn-primary')
+		.unbind('click').click(function() {
+			toastr.info("Switching SVC spatial layer, wait for it... (low resolution)", null, {timeOut: 2000});
+			if(!$('#sl-1').hasClass('btn-success'))
+				$('#sl-1').removeClass('btn-primary btn-info').addClass('btn-primary');
+			$('#sl-0').removeClass('btn-primary btn-info btn-success').addClass('btn-info');
+			streaming.send({message: { request: "configure", spatial_layer: 0 }});
+		});
+	$('#sl-1').removeClass('btn-primary btn-success').addClass('btn-primary')
+		.unbind('click').click(function() {
+			toastr.info("Switching SVC spatial layer, wait for it... (normal resolution)", null, {timeOut: 2000});
+			$('#sl-1').removeClass('btn-primary btn-info btn-success').addClass('btn-info');
+			if(!$('#sl-0').hasClass('btn-success'))
+				$('#sl-0').removeClass('btn-primary btn-info').addClass('btn-primary');
+			streaming.send({message: { request: "configure", spatial_layer: 1 }});
+		});
+	$('#tl-0').removeClass('btn-primary btn-success').addClass('btn-primary')
+		.unbind('click').click(function() {
+			toastr.info("Capping SVC temporal layer, wait for it... (lowest FPS)", null, {timeOut: 2000});
+			if(!$('#tl-2').hasClass('btn-success'))
+				$('#tl-2').removeClass('btn-primary btn-info').addClass('btn-primary');
+			if(!$('#tl-1').hasClass('btn-success'))
+				$('#tl-1').removeClass('btn-primary btn-info').addClass('btn-primary');
+			$('#tl-0').removeClass('btn-primary btn-info btn-success').addClass('btn-info');
+			streaming.send({message: { request: "configure", temporal_layer: 0 }});
+		});
+	$('#tl-1').removeClass('btn-primary btn-success').addClass('btn-primary')
+		.unbind('click').click(function() {
+			toastr.info("Capping SVC temporal layer, wait for it... (medium FPS)", null, {timeOut: 2000});
+			if(!$('#tl-2').hasClass('btn-success'))
+				$('#tl-2').removeClass('btn-primary btn-info').addClass('btn-primary');
+			$('#tl-1').removeClass('btn-primary btn-info').addClass('btn-info');
+			if(!$('#tl-0').hasClass('btn-success'))
+				$('#tl-0').removeClass('btn-primary btn-info').addClass('btn-primary');
+			streaming.send({message: { request: "configure", temporal_layer: 1 }});
+		});
+	$('#tl-2').removeClass('btn-primary btn-success').addClass('btn-primary')
+		.unbind('click').click(function() {
+			toastr.info("Capping SVC temporal layer, wait for it... (highest FPS)", null, {timeOut: 2000});
+			$('#tl-2').removeClass('btn-primary btn-info btn-success').addClass('btn-info');
+			if(!$('#tl-1').hasClass('btn-success'))
+				$('#tl-1').removeClass('btn-primary btn-info').addClass('btn-primary');
+			if(!$('#tl-0').hasClass('btn-success'))
+				$('#tl-0').removeClass('btn-primary btn-info').addClass('btn-primary');
+			streaming.send({message: { request: "configure", temporal_layer: 2 }});
+		});
+}
+
+function updateSvcButtons(spatial, temporal) {
+	// Check the spatial layer
+	if(spatial === 0) {
+		toastr.success("Switched SVC spatial layer! (lower resolution)", null, {timeOut: 2000});
+		$('#sl-1').removeClass('btn-primary btn-success').addClass('btn-primary');
+		$('#sl-0').removeClass('btn-primary btn-info btn-success').addClass('btn-success');
+	} else if(spatial === 1) {
+		toastr.success("Switched SVC spatial layer! (normal resolution)", null, {timeOut: 2000});
+		$('#sl-1').removeClass('btn-primary btn-info btn-success').addClass('btn-success');
+		$('#sl-0').removeClass('btn-primary btn-success').addClass('btn-primary');
+	}
+	// Check the temporal layer
+	if(temporal === 0) {
+		toastr.success("Capped SVC temporal layer! (lowest FPS)", null, {timeOut: 2000});
+		$('#tl-2').removeClass('btn-primary btn-success').addClass('btn-primary');
+		$('#tl-1').removeClass('btn-primary btn-success').addClass('btn-primary');
+		$('#tl-0').removeClass('btn-primary btn-info btn-success').addClass('btn-success');
+	} else if(temporal === 1) {
+		toastr.success("Capped SVC temporal layer! (medium FPS)", null, {timeOut: 2000});
+		$('#tl-2').removeClass('btn-primary btn-success').addClass('btn-primary');
+		$('#tl-1').removeClass('btn-primary btn-info btn-success').addClass('btn-success');
+		$('#tl-0').removeClass('btn-primary btn-success').addClass('btn-primary');
+	} else if(temporal === 2) {
+		toastr.success("Capped SVC temporal layer! (highest FPS)", null, {timeOut: 2000});
 		$('#tl-2').removeClass('btn-primary btn-info btn-success').addClass('btn-success');
 		$('#tl-1').removeClass('btn-primary btn-success').addClass('btn-primary');
 		$('#tl-0').removeClass('btn-primary btn-success').addClass('btn-primary');

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -94,6 +94,7 @@ videoport2 = second local port for receiving video frames (only for rtp, and sim
 videoport3 = third local port for receiving video frames (only for rtp, and simulcasting)
 videoskew = yes|no (whether the plugin should perform skew
 	analisys and compensation on incoming video RTP stream, EXPERIMENTAL)
+videosvc = yes|no (whether the video will have SVC support; works only for VP9-SVC, default=no)
 collision = in case of collision (more than one SSRC hitting the same port), the plugin
 	will discard incoming RTP packets with a new SSRC unless this many milliseconds
 	passed, which would then change the current SSRC (0=disabled)
@@ -565,7 +566,9 @@ rtspiface = network interface IP address or device name to listen on when receiv
 	"video" : <true|false, depending on whether video should be relayed or not; optional>,
 	"data" : <true|false, depending on whether datachannel messages should be relayed or not; optional>,
 	"substream" : <substream to receive (0-2), in case simulcasting is enabled; optional>,
-	"temporal" : <temporal layers to receive (0-2), in case simulcasting is enabled; optional>
+	"temporal" : <temporal layers to receive (0-2), in case simulcasting is enabled; optional>,
+	"spatial_layer" : <spatial layer to receive (0-1), in case VP9-SVC is enabled; optional>,
+	"temporal_layer" : <temporal layers to receive (0-2), in case VP9-SVC is enabled; optional>
 }
 \endverbatim
  *
@@ -576,6 +579,9 @@ rtspiface = network interface IP address or device name to listen on when receiv
  * when the mountpoint is configured with video simulcasting support, and
  * as such the viewer is interested in receiving a specific substream
  * or temporal layer, rather than any other of the available ones.
+ * The \c spatial_layer and \c temporal_layer have exactly the same meaning,
+ * but within the context of VP9-SVC mountpoints, and will have no effect
+ * on mountpoints involving a different video codec.
  *
  * Another interesting feature in the Streaming plugin is the so-called
  * mountpoint "switching". Basically, when subscribed to a specific
@@ -814,7 +820,7 @@ static struct janus_json_parameter rtp_audio_parameters[] = {
 	{"audiortpmap", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
 	{"audiofmtp", JSON_STRING, 0},
 	{"audioiface", JSON_STRING, 0},
-	{"audioskew", JANUS_JSON_BOOL, 0},
+	{"audioskew", JANUS_JSON_BOOL, 0}
 };
 static struct janus_json_parameter rtp_video_parameters[] = {
 	{"videomcast", JSON_STRING, 0},
@@ -829,6 +835,7 @@ static struct janus_json_parameter rtp_video_parameters[] = {
 	{"videoport2", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"videoport3", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"videoskew", JANUS_JSON_BOOL, 0},
+	{"videosvc", JANUS_JSON_BOOL, 0}
 };
 static struct janus_json_parameter rtp_data_parameters[] = {
 	{"dataport", JSON_INTEGER, JANUS_JSON_PARAM_REQUIRED | JANUS_JSON_PARAM_POSITIVE},
@@ -857,6 +864,10 @@ static struct janus_json_parameter simulcast_parameters[] = {
 	{"substream", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"temporal", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE}
 };
+static struct janus_json_parameter svc_parameters[] = {
+	{"spatial_layer", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"temporal_layer", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE}
+};
 static struct janus_json_parameter configure_parameters[] = {
 	{"audio", JANUS_JSON_BOOL, 0},
 	{"video", JANUS_JSON_BOOL, 0},
@@ -864,6 +875,9 @@ static struct janus_json_parameter configure_parameters[] = {
 	/* For VP8 simulcast */
 	{"substream", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"temporal", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	/* For VP9 SVC */
+	{"spatial_layer", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"temporal_layer", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE}
 };
 
 /* Static configuration instance */
@@ -934,6 +948,7 @@ typedef struct janus_streaming_rtp_source {
 	int audio_rtcp_fd;
 	int video_rtcp_fd;
 	gboolean simulcast;
+	gboolean svc;
 	gboolean askew, vskew;
 	gint64 last_received_audio;
 	gint64 last_received_video;
@@ -1028,7 +1043,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 		int srtpsuite, char *srtpcrypto,
 		gboolean doaudio, char *amcast, const janus_network_address *aiface, uint16_t aport, uint16_t artcpport, uint8_t acodec, char *artpmap, char *afmtp, gboolean doaskew,
 		gboolean dovideo, char *vmcast, const janus_network_address *viface, uint16_t vport, uint16_t vrtcpport, uint8_t vcodec, char *vrtpmap, char *vfmtp, gboolean bufferkf,
-			gboolean simulcast, uint16_t vport2, uint16_t vport3, gboolean dovskew, int rtp_collision,
+			gboolean simulcast, uint16_t vport2, uint16_t vport3, gboolean svc, gboolean dovskew, int rtp_collision,
 		gboolean dodata, const janus_network_address *diface, uint16_t dport, gboolean buffermsg);
 /* Helper to create a file/ondemand live source */
 janus_streaming_mountpoint *janus_streaming_create_file_source(
@@ -1068,6 +1083,10 @@ typedef struct janus_streaming_session {
 	int templayer_target;	/* As above, but to handle transitions (e.g., wait for keyframe) */
 	gint64 last_relayed;	/* When we relayed the last packet (used to detect when substreams become unavailable) */
 	janus_vp8_simulcast_context simulcast_context;
+	/* The following are only relevant the mountpoint is VP9-SVC, and are not to be confused with VP8
+	 * simulcast, which has similar info (substream/templayer) but in a completely different context */
+	int spatial_layer, target_spatial_layer;
+	int temporal_layer, target_temporal_layer;
 	gboolean stopping;
 	volatile gint hangingup;
 	volatile gint destroyed;
@@ -1171,6 +1190,11 @@ typedef struct janus_streaming_rtp_relay_packet {
 	int codec, substream;
 	uint32_t timestamp;
 	uint16_t seq_number;
+	/* The following are only relevant for VP9 SVC*/
+	gboolean svc;
+	int spatial_layer;
+	int temporal_layer;
+	uint8_t pbit, dbit, ubit, bbit, ebit;
 } janus_streaming_rtp_relay_packet;
 
 
@@ -1318,6 +1342,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				janus_config_item *askew = janus_config_get_item(cat, "audioskew");
 				janus_config_item *video = janus_config_get_item(cat, "video");
 				janus_config_item *vskew = janus_config_get_item(cat, "videoskew");
+				janus_config_item *vsvc = janus_config_get_item(cat, "videosvc");
 				janus_config_item *data = janus_config_get_item(cat, "data");
 				janus_config_item *diface = janus_config_get_item(cat, "dataiface");
 				janus_config_item *amcast = janus_config_get_item(cat, "audiomcast");
@@ -1348,6 +1373,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				gboolean doaskew = audio && askew && askew->value && janus_is_true(askew->value);
 				gboolean dovideo = video && video->value && janus_is_true(video->value);
 				gboolean dovskew = video && vskew && vskew->value && janus_is_true(vskew->value);
+				gboolean dosvc = video && vsvc && vsvc->value && janus_is_true(vsvc->value);
 				gboolean dodata = data && data->value && janus_is_true(data->value);
 				gboolean bufferkf = video && vkf && vkf->value && janus_is_true(vkf->value);
 				gboolean simulcast = video && vsc && vsc->value && janus_is_true(vsc->value);
@@ -1476,6 +1502,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 						simulcast,
 						(vport2 && vport2->value) ? atoi(vport2->value) : 0,
 						(vport3 && vport3->value) ? atoi(vport3->value) : 0,
+						dosvc,
 						dovskew,
 						(rtpcollision && rtpcollision->value) ?  atoi(rtpcollision->value) : 0,
 						dodata,
@@ -1878,11 +1905,37 @@ json_t *janus_streaming_query_session(janus_plugin_session *handle) {
 	janus_streaming_mountpoint *mp = session->mountpoint;
 	json_object_set_new(info, "state", json_string(mp ? "watching" : "idle"));
 	if(mp) {
+		janus_refcount_increase(&mp->ref);
 		json_object_set_new(info, "mountpoint_id", json_integer(mp->id));
 		json_object_set_new(info, "mountpoint_name", mp->name ? json_string(mp->name) : NULL);
 		janus_mutex_lock(&mp->mutex);
 		json_object_set_new(info, "mountpoint_listeners", json_integer(mp->listeners ? g_list_length(mp->listeners) : 0));
 		janus_mutex_unlock(&mp->mutex);
+		json_t *media = json_object();
+		json_object_set_new(media, "audio", session->audio ? json_true() : json_false());
+		json_object_set_new(media, "video", session->video ? json_true() : json_false());
+		json_object_set_new(media, "data", session->data ? json_true() : json_false());
+		json_object_set_new(info, "media", media);
+		if(mp->streaming_source == janus_streaming_source_rtp) {
+			janus_streaming_rtp_source *source = mp->source;
+			if(source->simulcast) {
+				json_t *simulcast = json_object();
+				json_object_set_new(simulcast, "substream", json_integer(session->substream));
+				json_object_set_new(simulcast, "substream-target", json_integer(session->substream_target));
+				json_object_set_new(simulcast, "temporal-layer", json_integer(session->templayer));
+				json_object_set_new(simulcast, "temporal-layer-target", json_integer(session->templayer_target));
+				json_object_set_new(info, "simulcast", simulcast);
+			}
+			if(source->svc) {
+				json_t *svc = json_object();
+				json_object_set_new(svc, "spatial-layer", json_integer(session->spatial_layer));
+				json_object_set_new(svc, "target-spatial-layer", json_integer(session->target_spatial_layer));
+				json_object_set_new(svc, "temporal-layer", json_integer(session->temporal_layer));
+				json_object_set_new(svc, "target-temporal-layer", json_integer(session->target_temporal_layer));
+				json_object_set_new(info, "svc", svc);
+			}
+		}
+		janus_refcount_decrease(&mp->ref);
 	}
 	json_object_set_new(info, "hangingup", json_integer(g_atomic_int_get(&session->hangingup)));
 	json_object_set_new(info, "destroyed", json_integer(g_atomic_int_get(&session->destroyed)));
@@ -2069,6 +2122,9 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			if(source->simulcast) {
 				json_object_set_new(ml, "videosimulcast", json_true());
 			}
+			if(source->svc) {
+				json_object_set_new(ml, "videosvc", json_true());
+			}
 			if(source->askew)
 				json_object_set_new(ml, "audioskew", json_true());
 			if(source->vskew)
@@ -2177,7 +2233,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			gboolean doaudio = audio ? json_is_true(audio) : FALSE;
 			gboolean dovideo = video ? json_is_true(video) : FALSE;
 			gboolean dodata = data ? json_is_true(data) : FALSE;
-			gboolean doaskew = FALSE, dovskew = FALSE;
+			gboolean doaskew = FALSE, dovskew = FALSE, dosvc = FALSE;
 			if(!doaudio && !dovideo && !dodata) {
 				JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream, no audio, video or data have to be streamed...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
@@ -2279,6 +2335,8 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				}
 				json_t *vskew = json_object_get(root, "videoskew");
 				dovskew = vskew ? json_is_true(vskew) : FALSE;
+				json_t *vsvc = json_object_get(root, "videosvc");
+				dosvc = vsvc ? json_is_true(vsvc) : FALSE;
 			}
 			uint16_t dport = 0;
 			gboolean buffermsg = FALSE;
@@ -2335,7 +2393,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					scrypto ? (char *)json_string_value(scrypto) : NULL,
 					doaudio, amcast, &audio_iface, aport, artcpport, acodec, artpmap, afmtp, doaskew,
 					dovideo, vmcast, &video_iface, vport, vrtcpport, vcodec, vrtpmap, vfmtp, bufferkf,
-					simulcast, vport2, vport3, dovskew,
+					simulcast, vport2, vport3, dosvc, dovskew,
 					rtpcollision ? json_integer_value(rtpcollision) : 0,
 					dodata, &data_iface, dport, buffermsg);
 			if(mp == NULL) {
@@ -2625,11 +2683,13 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 							janus_config_add_item(config, mp->name, "videoport3", value);
 						}
 					}
+					if(source->svc)
+						janus_config_add_item(config, mp->name, "videosvc", "yes");
 					json_t *viface = json_object_get(root, "videoiface");
 					if(viface)
 						janus_config_add_item(config, mp->name, "videoiface", json_string_value(viface));
 					if(source->vskew)
-						janus_config_add_item(config, mp->name, "vskew", "yes");
+						janus_config_add_item(config, mp->name, "videoskew", "yes");
 				}
 				if(source->rtp_collision > 0) {
 					g_snprintf(value, BUFSIZ, "%d", source->rtp_collision);
@@ -2908,11 +2968,13 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 								janus_config_add_item(config, mp->name, "videoport3", value);
 							}
 						}
+						if(source->svc)
+							janus_config_add_item(config, mp->name, "videosvc", "yes");
 						json_t *viface = json_object_get(root, "videoiface");
 						if(viface)
 							janus_config_add_item(config, mp->name, "videoiface", json_string_value(viface));
 						if(source->vskew)
-							janus_config_add_item(config, mp->name, "vskew", "yes");
+							janus_config_add_item(config, mp->name, "videoskew", "yes");
 					}
 					if(source->rtp_collision > 0) {
 						g_snprintf(value, BUFSIZ, "%d", source->rtp_collision);
@@ -3514,6 +3576,10 @@ static void janus_streaming_hangup_media_internal(janus_plugin_session *handle) 
 	session->templayer_target = 2;
 	session->last_relayed = 0;
 	janus_vp8_simulcast_context_reset(&session->simulcast_context);
+	session->spatial_layer = -1;
+	session->target_spatial_layer = 1;	/* FIXME Chrome sends 0 and 1 */
+	session->temporal_layer = -1;
+	session->target_temporal_layer = 2;	/* FIXME Chrome sends 0, 1 and 2 */
 	session->stopping = TRUE;
 	session->started = FALSE;
 	session->paused = FALSE;
@@ -3704,13 +3770,13 @@ static void *janus_streaming_handler(void *data) {
 						janus_refcount_decrease(&mp->ref);
 						goto error;
 					}
-					/* This mountpoint is simulcasting, let's aim high by default */
+					/* In case this mountpoint is simulcasting, let's aim high by default */
 					session->substream = -1;
 					session->substream_target = 2;
 					session->templayer = -1;
 					session->templayer_target = 2;
 					janus_vp8_simulcast_context_reset(&session->simulcast_context);
-					/* Unless the request contains a target */
+					/* Unless the request contains a target for either layer */
 					json_t *substream = json_object_get(root, "substream");
 					if(substream) {
 						session->substream_target = json_integer_value(substream);
@@ -3722,6 +3788,34 @@ static void *janus_streaming_handler(void *data) {
 						session->templayer_target = json_integer_value(temporal);
 						JANUS_LOG(LOG_VERB, "Setting video temporal layer to let through (simulcast): %d (was %d)\n",
 							session->templayer_target, session->templayer);
+					}
+				} else if(source && source->svc) {
+					JANUS_VALIDATE_JSON_OBJECT(root, svc_parameters,
+						error_code, error_cause, TRUE,
+						JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
+					if(error_code != 0) {
+						session->mountpoint = NULL;
+						janus_mutex_unlock(&mp->mutex);
+						janus_refcount_decrease(&mp->ref);
+						goto error;
+					}
+					/* In case this mountpoint is doing VP9-SVC, let's aim high by default */
+					session->spatial_layer = -1;
+					session->target_spatial_layer = 1;	/* FIXME Chrome sends 0 and 1 */
+					session->temporal_layer = -1;
+					session->target_temporal_layer = 2;	/* FIXME Chrome sends 0, 1 and 2 */
+					/* Unless the request contains a target for either layer */
+					json_t *spatial = json_object_get(root, "spatial_layer");
+					if(spatial) {
+						session->target_spatial_layer = json_integer_value(spatial);
+						JANUS_LOG(LOG_VERB, "Setting video spatial layer to let through (SVC): %d (was %d)\n",
+							session->target_spatial_layer, session->spatial_layer);
+					}
+					json_t *temporal = json_object_get(root, "temporal_layer");
+					if(temporal) {
+						session->target_temporal_layer = json_integer_value(temporal);
+						JANUS_LOG(LOG_VERB, "Setting video temporal layer to let through (SVC): %d (was %d)\n",
+							session->target_temporal_layer, session->temporal_layer);
 					}
 				}
 			}
@@ -3874,7 +3968,7 @@ done:
 			if(mp->streaming_source == janus_streaming_source_rtp) {
 				janus_streaming_rtp_source *source = (janus_streaming_rtp_source *)mp->source;
 				if(source && source->simulcast) {
-					/* Unless the request contains a target */
+					/* Check if the viewer is requesting a different substream/temporal layer */
 					json_t *substream = json_object_get(root, "substream");
 					if(substream) {
 						session->substream_target = json_integer_value(substream);
@@ -3906,6 +4000,48 @@ done:
 							gateway->push_event(session->handle, &janus_streaming_plugin, NULL, event, NULL);
 							json_decref(event);
 						}
+					}
+				}
+				if(source && source->svc) {
+					/* Check if the viewer is requesting a different SVC spatial/temporal layer */
+					json_t *spatial = json_object_get(root, "spatial_layer");
+					if(spatial) {
+						int spatial_layer = json_integer_value(spatial);
+						if(spatial_layer > 1) {
+							JANUS_LOG(LOG_WARN, "Spatial layer higher than 1, will probably be ignored\n");
+						}
+						if(spatial_layer == session->spatial_layer) {
+							/* No need to do anything, we're already getting the right spatial layer, so notify the user */
+							json_t *event = json_object();
+							json_object_set_new(event, "streaming", json_string("event"));
+							json_t *result = json_object();
+							json_object_set_new(result, "spatial_layer", json_integer(session->spatial_layer));
+							json_object_set_new(event, "result", result);
+							gateway->push_event(msg->handle, &janus_streaming_plugin, NULL, event, NULL);
+							json_decref(event);
+						} else if(spatial_layer != session->target_spatial_layer) {
+							/* Send a FIR to the source, if RTCP is enabled */
+							g_atomic_int_set(&source->need_pli, 1);
+						}
+						session->target_spatial_layer = spatial_layer;
+					}
+					json_t *temporal = json_object_get(root, "temporal_layer");
+					if(temporal) {
+						int temporal_layer = json_integer_value(temporal);
+						if(temporal_layer > 2) {
+							JANUS_LOG(LOG_WARN, "Temporal layer higher than 2, will probably be ignored\n");
+						}
+						if(temporal_layer == session->temporal_layer) {
+							/* No need to do anything, we're already getting the right temporal layer, so notify the user */
+							json_t *event = json_object();
+							json_object_set_new(event, "streaming", json_string("event"));
+							json_t *result = json_object();
+							json_object_set_new(result, "temporal_layer", json_integer(session->temporal_layer));
+							json_object_set_new(event, "result", result);
+							gateway->push_event(msg->handle, &janus_streaming_plugin, NULL, event, NULL);
+							json_decref(event);
+						}
+						session->target_temporal_layer = temporal_layer;
 					}
 				}
 			}
@@ -4244,7 +4380,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 		int srtpsuite, char *srtpcrypto,
 		gboolean doaudio, char *amcast, const janus_network_address *aiface, uint16_t aport, uint16_t artcpport, uint8_t acodec, char *artpmap, char *afmtp, gboolean doaskew,
 		gboolean dovideo, char *vmcast, const janus_network_address *viface, uint16_t vport, uint16_t vrtcpport, uint8_t vcodec, char *vrtpmap, char *vfmtp, gboolean bufferkf,
-			gboolean simulcast, uint16_t vport2, uint16_t vport3, gboolean dovskew, int rtp_collision,
+			gboolean simulcast, uint16_t vport2, uint16_t vport3, gboolean svc, gboolean dovskew, int rtp_collision,
 		gboolean dodata, const janus_network_address *diface, uint16_t dport, gboolean buffermsg) {
 	janus_mutex_lock(&mountpoints_mutex);
 	if(id == 0) {
@@ -4554,6 +4690,13 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 			live_rtp->codecs.video_codec = JANUS_STREAMING_VP9;
 		else if(strstr(vrtpmap, "h264") || strstr(vrtpmap, "H264"))
 			live_rtp->codecs.video_codec = JANUS_STREAMING_H264;
+	}
+	if(svc) {
+		if(live_rtp->codecs.video_codec == JANUS_STREAMING_VP9) {
+			live_rtp_source->svc = TRUE;
+		} else {
+			JANUS_LOG(LOG_WARN, "SVC is only supported, in an experimental way, for VP9-SVC mountpoints: disabling it...\n");
+		}
 	}
 	live_rtp->codecs.video_pt = dovideo ? vcodec : -1;
 	live_rtp->codecs.video_rtpmap = dovideo ? g_strdup(vrtpmap) : NULL;
@@ -5926,6 +6069,28 @@ static void *janus_streaming_relay_thread(void *data) {
 					packet.simulcast = source->simulcast;
 					packet.substream = index;
 					packet.codec = mountpoint->codecs.video_codec;
+					packet.svc = FALSE;
+					if(source->svc) {
+						/* We're doing SVC: let's parse this packet to see which layers are there */
+						int plen = 0;
+						char *payload = janus_rtp_payload(buffer, bytes, &plen);
+						if(payload) {
+							uint8_t pbit = 0, dbit = 0, ubit = 0, bbit = 0, ebit = 0;
+							int found = 0, spatial_layer = 0, temporal_layer = 0;
+							if(janus_vp9_parse_svc(payload, plen, &found, &spatial_layer, &temporal_layer, &pbit, &dbit, &ubit, &bbit, &ebit) == 0) {
+								if(found) {
+									packet.svc = TRUE;
+									packet.spatial_layer = spatial_layer;
+									packet.temporal_layer = temporal_layer;
+									packet.pbit = pbit;
+									packet.dbit = dbit;
+									packet.ubit = ubit;
+									packet.bbit = bbit;
+									packet.ebit = ebit;
+								}
+							}
+						}
+					}
 					/* Do we have a new stream? */
 					if(ssrc != v_last_ssrc[index]) {
 						v_last_ssrc[index] = ssrc;
@@ -6094,11 +6259,119 @@ static void janus_streaming_relay_rtp_packet(gpointer data, gpointer user_data) 
 	}
 
 	if(packet->is_rtp) {
-		/* Make sure there hasn't been a publisher switch by checking the SSRC */
+		/* Make sure there hasn't been a video source switch by checking the SSRC */
 		if(packet->is_video) {
 			if(!session->video)
 				return;
-			if(packet->simulcast) {
+			/* Check if there's any SVC info to take into account */
+			if(packet->svc) {
+				/* There is: check if this is a layer that can be dropped for this viewer
+				 * Note: Following core inspired by the excellent job done by Sergio Garcia Murillo here:
+				 * https://github.com/medooze/media-server/blob/master/src/vp9/VP9LayerSelector.cpp */
+				gboolean override_mark_bit = FALSE, has_marker_bit = packet->data->markerbit;
+				int temporal_layer = session->temporal_layer;
+				if(session->target_temporal_layer > session->temporal_layer) {
+					/* We need to upscale */
+					JANUS_LOG(LOG_HUGE, "We need to upscale temporally:\n");
+					if(packet->ubit && packet->bbit && packet->temporal_layer <= session->target_temporal_layer) {
+						JANUS_LOG(LOG_HUGE, "  -- Upscaling temporal layer: %u --> %u\n",
+							packet->temporal_layer, session->target_temporal_layer);
+						session->temporal_layer = packet->temporal_layer;
+						temporal_layer = session->temporal_layer;
+						/* Notify the viewer */
+						json_t *event = json_object();
+						json_object_set_new(event, "streaming", json_string("event"));
+						json_t *result = json_object();
+						json_object_set_new(result, "temporal_layer", json_integer(session->temporal_layer));
+						json_object_set_new(event, "result", result);
+						gateway->push_event(session->handle, &janus_streaming_plugin, NULL, event, NULL);
+						json_decref(event);
+					}
+				} else if(session->target_temporal_layer < session->temporal_layer) {
+					/* We need to downscale */
+					JANUS_LOG(LOG_HUGE, "We need to downscale temporally:\n");
+					if(packet->ebit) {
+						JANUS_LOG(LOG_HUGE, "  -- Downscaling temporal layer: %u --> %u\n",
+							session->temporal_layer, session->target_temporal_layer);
+						session->temporal_layer = session->target_temporal_layer;
+						/* Notify the viewer */
+						json_t *event = json_object();
+						json_object_set_new(event, "streaming", json_string("event"));
+						json_t *result = json_object();
+						json_object_set_new(result, "temporal_layer", json_integer(session->temporal_layer));
+						json_object_set_new(event, "result", result);
+						gateway->push_event(session->handle, &janus_streaming_plugin, NULL, event, NULL);
+						json_decref(event);
+					}
+				}
+				if(temporal_layer < packet->temporal_layer) {
+					/* Drop the packet: update the context to make sure sequence number is increased normally later */
+					JANUS_LOG(LOG_HUGE, "Dropping packet (temporal layer %d < %d)\n", temporal_layer, packet->temporal_layer);
+					session->context.v_base_seq++;
+					return;
+				}
+				int spatial_layer = session->spatial_layer;
+				if(session->target_spatial_layer > session->spatial_layer) {
+					JANUS_LOG(LOG_HUGE, "We need to upscale spatially:\n");
+					/* We need to upscale */
+					if(packet->pbit == 0 && packet->bbit && packet->spatial_layer == session->spatial_layer+1) {
+						JANUS_LOG(LOG_HUGE, "  -- Upscaling spatial layer: %u --> %u\n",
+							packet->spatial_layer, session->target_spatial_layer);
+						session->spatial_layer = packet->spatial_layer;
+						spatial_layer = session->spatial_layer;
+						/* Notify the viewer */
+						json_t *event = json_object();
+						json_object_set_new(event, "streaming", json_string("event"));
+						json_t *result = json_object();
+						json_object_set_new(result, "spatial_layer", json_integer(session->spatial_layer));
+						json_object_set_new(event, "result", result);
+						gateway->push_event(session->handle, &janus_streaming_plugin, NULL, event, NULL);
+						json_decref(event);
+					}
+				} else if(session->target_spatial_layer < session->spatial_layer) {
+					/* We need to downscale */
+					JANUS_LOG(LOG_HUGE, "We need to downscale spatially:\n");
+					if(packet->ebit) {
+						JANUS_LOG(LOG_HUGE, "  -- Downscaling spatial layer: %u --> %u\n",
+							session->spatial_layer, session->target_spatial_layer);
+						session->spatial_layer = session->target_spatial_layer;
+						/* Notify the viewer */
+						json_t *event = json_object();
+						json_object_set_new(event, "streaming", json_string("event"));
+						json_t *result = json_object();
+						json_object_set_new(result, "spatial_layer", json_integer(session->spatial_layer));
+						json_object_set_new(event, "result", result);
+						gateway->push_event(session->handle, &janus_streaming_plugin, NULL, event, NULL);
+						json_decref(event);
+					}
+				}
+				if(spatial_layer < packet->spatial_layer) {
+					/* Drop the packet: update the context to make sure sequence number is increased normally later */
+					JANUS_LOG(LOG_HUGE, "Dropping packet (spatial layer %d < %d)\n", spatial_layer, packet->spatial_layer);
+					session->context.v_base_seq++;
+					return;
+				} else if(packet->ebit && spatial_layer == packet->spatial_layer) {
+					/* If we stop at layer 0, we need a marker bit now, as the one from layer 1 will not be received */
+					override_mark_bit = TRUE;
+				}
+				/* If we got here, we can send the frame: this doesn't necessarily mean it's
+				 * one of the layers the user wants, as there may be dependencies involved */
+				JANUS_LOG(LOG_HUGE, "Sending packet (spatial=%d, temporal=%d)\n",
+					packet->spatial_layer, packet->temporal_layer);
+				/* Fix sequence number and timestamp (video source switching may be involved) */
+				janus_rtp_header_update(packet->data, &session->context, TRUE, 4500);
+				if(override_mark_bit && !has_marker_bit) {
+					packet->data->markerbit = 1;
+				}
+				if(gateway != NULL)
+					gateway->relay_rtp(session->handle, packet->is_video, (char *)packet->data, packet->length);
+				if(override_mark_bit && !has_marker_bit) {
+					packet->data->markerbit = 0;
+				}
+				/* Restore the timestamp and sequence number to what the video source set them to */
+				packet->data->timestamp = htonl(packet->timestamp);
+				packet->data->seq_number = htons(packet->seq_number);
+			} else if(packet->simulcast) {
 				/* Handle simulcast: don't relay if it's not the substream we wanted to handle */
 				int plen = 0;
 				char *payload = janus_rtp_payload((char *)packet->data, packet->length, &plen);
@@ -6198,7 +6471,7 @@ static void janus_streaming_relay_rtp_packet(gpointer data, gpointer user_data) 
 				/* Send the packet */
 				if(gateway != NULL)
 					gateway->relay_rtp(session->handle, packet->is_video, (char *)packet->data, packet->length);
-				/* Restore the timestamp and sequence number to what the publisher set them to */
+				/* Restore the timestamp and sequence number to what the video source set them to */
 				packet->data->timestamp = htonl(packet->timestamp);
 				packet->data->seq_number = htons(packet->seq_number);
 				if(packet->codec == JANUS_STREAMING_VP8) {
@@ -6210,7 +6483,7 @@ static void janus_streaming_relay_rtp_packet(gpointer data, gpointer user_data) 
 				janus_rtp_header_update(packet->data, &session->context, TRUE, 0);
 				if(gateway != NULL)
 					gateway->relay_rtp(session->handle, packet->is_video, (char *)packet->data, packet->length);
-				/* Restore the timestamp and sequence number to what the publisher set them to */
+				/* Restore the timestamp and sequence number to what the video source set them to */
 				packet->data->timestamp = htonl(packet->timestamp);
 				packet->data->seq_number = htons(packet->seq_number);
 			}
@@ -6221,7 +6494,7 @@ static void janus_streaming_relay_rtp_packet(gpointer data, gpointer user_data) 
 			janus_rtp_header_update(packet->data, &session->context, FALSE, 0);
 			if(gateway != NULL)
 				gateway->relay_rtp(session->handle, packet->is_video, (char *)packet->data, packet->length);
-			/* Restore the timestamp and sequence number to what the publisher set them to */
+			/* Restore the timestamp and sequence number to what the video source set them to */
 			packet->data->timestamp = htonl(packet->timestamp);
 			packet->data->seq_number = htons(packet->seq_number);
 		}

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -648,12 +648,12 @@ notify_joining = true|false (optional, whether to notify all participants when a
 	"video_port" : <port to forward the video RTP packets to>,
 	"video_ssrc" : <video SSRC to use to use when streaming; optional>,
 	"video_ptype" : <video payload type to use when streaming; optional>,
-	"video_port_2" : <if simulcasting or doing VP9-SVC, port to forward the video RTP packets from the second substream/layer to>,
-	"video_ssrc_2" : <if simulcasting or doing VP9-SVC, video SSRC to use to use the second substream/layer; optional>,
-	"video_ptype_2" : <if simulcasting or doing VP9-SVC, video payload type to use the second substream/layer; optional>,
-	"video_port_3" : <if simulcasting or doing VP9-SVC, port to forward the video RTP packets from the third substream/layer to>,
-	"video_ssrc_3" : <if simulcasting or doing VP9-SVC, video SSRC to use to use the third substream/layer; optional>,
-	"video_ptype_3" : <if simulcasting or doing VP9-SVC, video payload type to use the third substream/layer; optional>,
+	"video_port_2" : <if simulcasting, port to forward the video RTP packets from the second substream/layer to>,
+	"video_ssrc_2" : <if simulcasting, video SSRC to use to use the second substream/layer; optional>,
+	"video_ptype_2" : <if simulcasting, video payload type to use the second substream/layer; optional>,
+	"video_port_3" : <if simulcasting, port to forward the video RTP packets from the third substream/layer to>,
+	"video_ssrc_3" : <if simulcasting, video SSRC to use to use the third substream/layer; optional>,
+	"video_ptype_3" : <if simulcasting, video payload type to use the third substream/layer; optional>,
 	"data_port" : <port to forward the datachannel messages to>,
 	"srtp_suite" : <length of authentication tag (32 or 80); optional>,
 	"srtp_crypto" : "<key to use as crypto (base64 encoded key as in SDES); optional>"
@@ -2289,14 +2289,15 @@ json_t *janus_videoroom_query_session(janus_plugin_session *handle) {
 				json_object_set_new(media, "video-offered", participant->video_offered ? json_true() : json_false());
 				json_object_set_new(media, "data", participant->data ? json_true() : json_false());
 				json_object_set_new(media, "data-offered", participant->data_offered ? json_true() : json_false());
-				if(feed && feed->ssrc[0] != 0) {
-					json_object_set_new(info, "simulcast", json_true());
-					json_object_set_new(info, "substream", json_integer(participant->substream));
-					json_object_set_new(info, "substream-target", json_integer(participant->substream_target));
-					json_object_set_new(info, "temporal-layer", json_integer(participant->templayer));
-					json_object_set_new(info, "temporal-layer-target", json_integer(participant->templayer_target));
-				}
 				json_object_set_new(info, "media", media);
+				if(feed && feed->ssrc[0] != 0) {
+					json_t *simulcast = json_object();
+					json_object_set_new(simulcast, "substream", json_integer(participant->substream));
+					json_object_set_new(simulcast, "substream-target", json_integer(participant->substream_target));
+					json_object_set_new(simulcast, "temporal-layer", json_integer(participant->templayer));
+					json_object_set_new(simulcast, "temporal-layer-target", json_integer(participant->templayer_target));
+					json_object_set_new(info, "simulcast", simulcast);
+				}
 				if(participant->room && participant->room->do_svc) {
 					json_t *svc = json_object();
 					json_object_set_new(svc, "spatial-layer", json_integer(participant->spatial_layer));


### PR DESCRIPTION
As the title explains, this patch adds support for VP9-SVC mountpoints to the Streaming plugin. This complements the same support we added to the VideoRoom in #925, as now you can RTP forward a publisher doing VP9-SVC to a Streaming mountpoint, for instance, and it will work as expected. Unlike for VideoRoom publishers, you don't need to enable any flag in Chrome to take advantage of this on the Streaming side: viewers are able to decode VP9 SVC by default.

Feedback welcome! And merging soon in case I don't see objections.