### PR TITLE
Add RTCP support to RTP forwarders

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -645,9 +645,11 @@ notify_joining = true|false (optional, whether to notify all participants when a
 	"audio_port" : <port to forward the audio RTP packets to>,
 	"audio_ssrc" : <audio SSRC to use to use when streaming; optional>,
 	"audio_ptype" : <audio payload type to use when streaming; optional>,
+	"audio_rtcp_port" : <port to contact to receive audio RTCP feedback from the recipient; optional, and currently unused for audio>,
 	"video_port" : <port to forward the video RTP packets to>,
 	"video_ssrc" : <video SSRC to use to use when streaming; optional>,
 	"video_ptype" : <video payload type to use when streaming; optional>,
+	"video_rtcp_port" : <port to contact to receive video RTCP feedback from the recipient; optional>,
 	"video_port_2" : <if simulcasting or doing VP9-SVC, port to forward the video RTP packets from the second substream/layer to>,
 	"video_ssrc_2" : <if simulcasting or doing VP9-SVC, video SSRC to use to use the second substream/layer; optional>,
 	"video_ptype_2" : <if simulcasting or doing VP9-SVC, video payload type to use the second substream/layer; optional>,
@@ -670,9 +672,11 @@ notify_joining = true|false (optional, whether to notify all participants when a
 	"publisher_id" : <unique numeric ID, same as request>,
 	"rtp_stream" : {
 		"host" : "<host this forwarder is streaming to, same as request>",
-		"audio" : <audio port, same as request if configured>,
+		"audio" : <audio RTP port, same as request if configured>,
+		"audio_rtcp" : <audio RTCP port, same as request if configured>,
 		"audio_stream_id" : <unique numeric ID assigned to the audio RTP forwarder, if any>,
-		"video" : <video port, same as request if configured>,
+		"video" : <video RTP port, same as request if configured>,
+		"video_rtcp" : <video RTCP port, same as request if configured>,
 		"video_stream_id" : <unique numeric ID assigned to the main video RTP forwarder, if any>,
 		"video_2" : <second video port, same as request if configured>,
 		"video_stream_id_2" : <unique numeric ID assigned to the second video RTP forwarder, if any>,
@@ -736,6 +740,7 @@ notify_joining = true|false (optional, whether to notify all participants when a
 					"data_stream_id" : <unique numeric ID assigned to this datachannel messages forwarder, if any>
 					"ip" : "<IP this forwarder is streaming to>",
 					"port" : <port this forwarder is streaming to>,
+					"rtcp_port" : <local port this forwarder is using to get RTCP feedback, if any>,
 					"ssrc" : <SSRC this forwarder is using, if any>,
 					"pt" : <payload type this forwarder is using, if any>,
 					"substream" : <video substream this video forwarder is relaying, if any>,
@@ -1172,6 +1177,7 @@ static struct janus_json_parameter rtp_forward_parameters[] = {
 	{"room", JSON_INTEGER, JANUS_JSON_PARAM_REQUIRED | JANUS_JSON_PARAM_POSITIVE},
 	{"publisher_id", JSON_INTEGER, JANUS_JSON_PARAM_REQUIRED | JANUS_JSON_PARAM_POSITIVE},
 	{"video_port", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"video_rtcp_port", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"video_ssrc", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"video_pt", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"video_port_2", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
@@ -1181,6 +1187,7 @@ static struct janus_json_parameter rtp_forward_parameters[] = {
 	{"video_ssrc_3", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"video_pt_3", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"audio_port", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"audio_rtcp_port", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"audio_ssrc", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"audio_pt", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"data_port", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
@@ -1308,16 +1315,26 @@ static janus_mutex sessions_mutex = JANUS_MUTEX_INITIALIZER;
 /* A host whose ports gets streamed RTP packets of the corresponding type */
 typedef struct janus_videoroom_srtp_context janus_videoroom_srtp_context;
 typedef struct janus_videoroom_rtp_forwarder {
+	GSource base;
+	void *source;
 	gboolean is_video;
 	gboolean is_data;
 	uint32_t ssrc;
 	int payload_type;
 	int substream;
 	struct sockaddr_in serv_addr;
+	/* Only needed for RTCP */
+	int rtcp_fd;
+	uint16_t local_rtcp_port, remote_rtcp_port;
 	/* Only needed for SRTP forwarders */
 	gboolean is_srtp;
 	janus_videoroom_srtp_context *srtp_ctx;
+	/* Reference */
+	volatile gint destroyed;
+	janus_refcount ref;
 } janus_videoroom_rtp_forwarder;
+static void janus_videoroom_rtp_forwarder_destroy(janus_videoroom_rtp_forwarder *forward);
+static void janus_videoroom_rtp_forwarder_free(const janus_refcount *f_ref);
 /* SRTP encryption may be needed, and potentially shared */
 struct janus_videoroom_srtp_context {
 	GHashTable *contexts;
@@ -1329,6 +1346,35 @@ struct janus_videoroom_srtp_context {
 	/* Keep track of how many forwarders are using this context */
 	uint8_t count;
 };
+static void janus_videoroom_srtp_context_free(gpointer data);
+/* RTCP support in RTP forwarders */
+static void janus_videoroom_rtp_forwarder_rtcp_receive(janus_videoroom_rtp_forwarder *forward);
+static gboolean janus_videoroom_rtp_forwarder_rtcp_prepare(GSource *source, gint *timeout) {
+	*timeout = -1;
+	return FALSE;
+}
+static gboolean janus_videoroom_rtp_forwarder_rtcp_dispatch(GSource *source, GSourceFunc callback, gpointer user_data) {
+	janus_videoroom_rtp_forwarder *f = (janus_videoroom_rtp_forwarder *)source;
+	/* Receive the packet */
+	janus_videoroom_rtp_forwarder_rtcp_receive(f);
+	return G_SOURCE_CONTINUE;
+}
+static void janus_videoroom_rtp_forwarder_rtcp_finalize(GSource *source) {
+	janus_videoroom_rtp_forwarder *f = (janus_videoroom_rtp_forwarder *)source;
+	/* Remove the reference to the forwarder */
+	janus_refcount_decrease(&f->ref);
+}
+static GSourceFuncs janus_videoroom_rtp_forwarder_rtcp_funcs = {
+	janus_videoroom_rtp_forwarder_rtcp_prepare,
+	NULL,
+	janus_videoroom_rtp_forwarder_rtcp_dispatch,
+	janus_videoroom_rtp_forwarder_rtcp_finalize,
+	NULL, NULL
+};
+static GMainContext *rtcpfwd_ctx = NULL;
+static GMainLoop *rtcpfwd_loop = NULL;
+static GThread *rtcpfwd_thread = NULL;
+static void *janus_videoroom_rtp_forwarder_rtcp_thread(void *data);
 
 typedef struct janus_videoroom_publisher {
 	janus_videoroom_session *session;
@@ -1382,10 +1428,8 @@ typedef struct janus_videoroom_publisher {
 	volatile gint destroyed;
 	janus_refcount ref;
 } janus_videoroom_publisher;
-static void janus_videoroom_rtp_forwarder_free_helper(gpointer data);
-static void janus_videoroom_srtp_context_free_helper(gpointer data);
 static guint32 janus_videoroom_rtp_forwarder_add_helper(janus_videoroom_publisher *p,
-	const gchar* host, int port, int pt, uint32_t ssrc,
+	const gchar *host, int port, int rtcp_port, int pt, uint32_t ssrc,
 	int srtp_suite, const char *srtp_crypto,
 	int substream, gboolean is_video, gboolean is_data);
 
@@ -1605,14 +1649,53 @@ static void janus_videoroom_reqfir(janus_videoroom_publisher *publisher, const c
 
 
 static guint32 janus_videoroom_rtp_forwarder_add_helper(janus_videoroom_publisher *p,
-		const gchar *host, int port, int pt, uint32_t ssrc,
+		const gchar *host, int port, int rtcp_port, int pt, uint32_t ssrc,
 		int srtp_suite, const char *srtp_crypto,
 		int substream, gboolean is_video, gboolean is_data) {
 	if(!p || !host) {
 		return 0;
 	}
 	janus_mutex_lock(&p->rtp_forwarders_mutex);
-	janus_videoroom_rtp_forwarder *forward = g_malloc0(sizeof(janus_videoroom_rtp_forwarder));
+	/* Do we need to bind to a port for RTCP? */
+	int fd = -1;
+	uint16_t local_rtcp_port = 0;
+	if(!is_data && rtcp_port > -1) {
+		fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+		if(fd < 0) {
+			JANUS_LOG(LOG_ERR, "Error creating RTCP socket for new RTP forwarder... %d (%s)\n",
+				errno, strerror(errno));
+			return 0;
+		}
+		struct sockaddr_in address;
+		socklen_t len = sizeof(address);
+		memset(&address, 0, sizeof(address));
+		address.sin_family = AF_INET;
+		address.sin_port = htons(0);	/* The RTCP port we received is the remote one */
+		address.sin_addr.s_addr = INADDR_ANY;
+		if(bind(fd, (struct sockaddr *)&address, sizeof(struct sockaddr)) < 0 ||
+				getsockname(fd, (struct sockaddr *)&address, &len) < 0) {
+			JANUS_LOG(LOG_ERR, "Error binding RTCP socket for new RTP forwarder... %d (%s)\n",
+				errno, strerror(errno));
+			close(fd);
+			return 0;
+		}
+		local_rtcp_port = ntohs(address.sin_port);
+		JANUS_LOG(LOG_VERB, "Bound local %s RTCP port: %"SCNu16"\n",
+			is_video ? "video" : "audio", local_rtcp_port);
+	}
+	janus_videoroom_rtp_forwarder *forward = NULL;
+	if(fd < 0) {
+		forward = g_malloc0(sizeof(janus_videoroom_rtp_forwarder));
+	} else {
+		GSource *source = g_source_new(&janus_videoroom_rtp_forwarder_rtcp_funcs, sizeof(janus_videoroom_rtp_forwarder));
+		g_source_set_priority(source, G_PRIORITY_DEFAULT);
+		g_source_add_unix_fd(source, fd, G_IO_IN | G_IO_ERR);
+		forward = (janus_videoroom_rtp_forwarder *)source;
+	}
+	forward->source = p;
+	forward->rtcp_fd = fd;
+	forward->local_rtcp_port = local_rtcp_port;
+	forward->remote_rtcp_port = rtcp_port;
 	/* First of all, let's check if we need to setup an SRTP forwarder */
 	if(!is_data && srtp_suite > 0 && srtp_crypto != NULL) {
 		/* First of all, let's check if there's already an RTP forwarder with
@@ -1642,6 +1725,8 @@ static guint32 janus_videoroom_rtp_forwarder_add_helper(janus_videoroom_publishe
 				JANUS_LOG(LOG_ERR, "Invalid SRTP crypto (%s)\n", srtp_crypto);
 				g_free(decoded);
 				g_free(srtp_ctx);
+				if(forward->rtcp_fd > -1)
+					close(forward->rtcp_fd);
 				g_free(forward);
 				return 0;
 			}
@@ -1665,6 +1750,8 @@ static guint32 janus_videoroom_rtp_forwarder_add_helper(janus_videoroom_publishe
 				g_free(decoded);
 				policy->key = NULL;
 				g_free(srtp_ctx);
+				if(forward->rtcp_fd > -1)
+					close(forward->rtcp_fd);
 				g_free(forward);
 				return 0;
 			}
@@ -1684,33 +1771,58 @@ static guint32 janus_videoroom_rtp_forwarder_add_helper(janus_videoroom_publishe
 	forward->serv_addr.sin_family = AF_INET;
 	inet_pton(AF_INET, host, &(forward->serv_addr.sin_addr));
 	forward->serv_addr.sin_port = htons(port);
+	janus_refcount_init(&forward->ref, janus_videoroom_rtp_forwarder_free);
 	guint32 stream_id = janus_random_uint32();
 	while(g_hash_table_lookup(p->rtp_forwarders, GUINT_TO_POINTER(stream_id)) != NULL) {
 		stream_id = janus_random_uint32();
 	}
 	g_hash_table_insert(p->rtp_forwarders, GUINT_TO_POINTER(stream_id), forward);
+	if(fd > -1) {
+		/* We need RTCP: track this file descriptor, and ref the forwarder */
+		janus_refcount_increase(&forward->ref);
+		g_source_attach((GSource *)forward, rtcpfwd_ctx);
+		/* Send a couple of empty RTP packets to the remote port to do latching */
+		struct sockaddr_in address;
+		socklen_t addrlen = sizeof(address);
+		memset(&address, 0, addrlen);
+		address.sin_family = AF_INET;
+		address.sin_addr.s_addr = forward->serv_addr.sin_addr.s_addr;
+		address.sin_port = htons(forward->remote_rtcp_port);
+		janus_rtp_header rtp;
+		memset(&rtp, 0, sizeof(rtp));
+		rtp.version = 2;
+		(void)sendto(fd, &rtp, 12, 0, (struct sockaddr *)&address, addrlen);
+		(void)sendto(fd, &rtp, 12, 0, (struct sockaddr *)&address, addrlen);
+	}
 	janus_mutex_unlock(&p->rtp_forwarders_mutex);
 	JANUS_LOG(LOG_VERB, "Added %s/%d rtp_forward to participant %"SCNu64" host: %s:%d stream_id: %"SCNu32"\n",
 		is_data ? "data" : (is_video ? "video" : "audio"), substream, p->user_id, host, port, stream_id);
 	return stream_id;
 }
 
-static void janus_videoroom_rtp_forwarder_free_helper(gpointer data) {
-	if(data) {
-		janus_videoroom_rtp_forwarder *forward = (janus_videoroom_rtp_forwarder *)data;
-		if(forward) {
-			if(forward->is_srtp && forward->srtp_ctx) {
-				forward->srtp_ctx->count--;
-				if(forward->srtp_ctx->count == 0 && forward->srtp_ctx->contexts != NULL)
-					g_hash_table_remove(forward->srtp_ctx->contexts, forward->srtp_ctx->id);
-			}
-			g_free(forward);
-			forward = NULL;
-		}
+static void janus_videoroom_rtp_forwarder_destroy(janus_videoroom_rtp_forwarder *forward) {
+	if(forward && g_atomic_int_compare_and_exchange(&forward->destroyed, 0, 1)) {
+		if(forward->rtcp_fd > -1)
+			g_source_destroy((GSource *)forward);
+		janus_refcount_decrease(&forward->ref);
 	}
 }
+static void janus_videoroom_rtp_forwarder_free(const janus_refcount *f_ref) {
+	janus_videoroom_rtp_forwarder *forward = janus_refcount_containerof(f_ref, janus_videoroom_rtp_forwarder, ref);
+	if(!forward)
+		return;
+	if(forward->rtcp_fd > -1)
+		close(forward->rtcp_fd);
+	if(forward->is_srtp && forward->srtp_ctx) {
+		forward->srtp_ctx->count--;
+		if(forward->srtp_ctx->count == 0 && forward->srtp_ctx->contexts != NULL)
+			g_hash_table_remove(forward->srtp_ctx->contexts, forward->srtp_ctx->id);
+	}
+	g_free(forward);
+	forward = NULL;
+}
 
-static void janus_videoroom_srtp_context_free_helper(gpointer data) {
+static void janus_videoroom_srtp_context_free(gpointer data) {
 	if(data) {
 		janus_videoroom_srtp_context *srtp_ctx = (janus_videoroom_srtp_context *)data;
 		if(srtp_ctx) {
@@ -1970,14 +2082,26 @@ int janus_videoroom_init(janus_callbacks *callback, const char *config_path) {
 	}
 	janus_mutex_unlock(&rooms_mutex);
 
+	/* Thread for handling incoming RTCP packets from RTP forwarders, if any */
+	rtcpfwd_ctx = g_main_context_new();
+	rtcpfwd_loop = g_main_loop_new(rtcpfwd_ctx, FALSE);
+	GError *error = NULL;
+	rtcpfwd_thread = g_thread_try_new("videoroom rtcpfwd", janus_videoroom_rtp_forwarder_rtcp_thread, NULL, &error);
+	if(error != NULL) {
+		/* We show the error but it's not fatal */
+		JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the VideoRoom RTCP thread for RTP forwarders...\n",
+			error->code, error->message ? error->message : "??");
+	}
+
 	g_atomic_int_set(&initialized, 1);
 
 	/* Launch the thread that will handle incoming messages */
-	GError *error = NULL;
+	error = NULL;
 	handler_thread = g_thread_try_new("videoroom handler", janus_videoroom_handler, NULL, &error);
 	if(error != NULL) {
 		g_atomic_int_set(&initialized, 0);
-		JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the VideoRoom handler thread...\n", error->code, error->message ? error->message : "??");
+		JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the VideoRoom handler thread...\n",
+			error->code, error->message ? error->message : "??");
 		janus_config_destroy(config);
 		return -1;
 	}
@@ -1994,6 +2118,14 @@ void janus_videoroom_destroy(void) {
 	if(handler_thread != NULL) {
 		g_thread_join(handler_thread);
 		handler_thread = NULL;
+	}
+	if(rtcpfwd_thread != NULL) {
+		if(g_main_loop_is_running(rtcpfwd_loop)) {
+			g_main_loop_quit(rtcpfwd_loop);
+			g_main_context_wakeup(rtcpfwd_ctx);
+		}
+		g_thread_join(rtcpfwd_thread);
+		rtcpfwd_thread = NULL;
 	}
 
 	/* FIXME We should destroy the sessions cleanly */
@@ -3058,9 +3190,9 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 			goto plugin_response;
 		json_t *room = json_object_get(root, "room");
 		json_t *pub_id = json_object_get(root, "publisher_id");
-		int video_port[3] = {-1, -1, -1}, video_pt[3] = {0, 0, 0};
+		int video_port[3] = {-1, -1, -1}, video_rtcp_port = -1, video_pt[3] = {0, 0, 0};
 		uint32_t video_ssrc[3] = {0, 0, 0};
-		int audio_port = -1, audio_pt = 0;
+		int audio_port = -1, audio_rtcp_port = -1, audio_pt = 0;
 		uint32_t audio_ssrc = 0;
 		int data_port = -1;
 		int srtp_suite = 0;
@@ -3096,6 +3228,9 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 			if(ssrc)
 				video_ssrc[2] = json_integer_value(ssrc);
 		}
+		json_t *vid_rtcp_port = json_object_get(root, "video_rtcp_port");
+		if(vid_rtcp_port)
+			video_rtcp_port = json_integer_value(vid_rtcp_port);
 		/* Audio target */
 		json_t *au_port = json_object_get(root, "audio_port");
 		if(au_port) {
@@ -3107,6 +3242,9 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 			if(ssrc)
 				audio_ssrc = json_integer_value(ssrc);
 		}
+		json_t *au_rtcp_port = json_object_get(root, "audio_rtcp_port");
+		if(au_rtcp_port)
+			audio_rtcp_port = json_integer_value(au_rtcp_port);
 		/* Data target */
 		json_t *d_port = json_object_get(root, "data_port");
 		if(d_port) {
@@ -3163,23 +3301,23 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 		guint32 video_handle[3] = {0, 0, 0};
 		guint32 data_handle = 0;
 		if(audio_port > 0) {
-			audio_handle = janus_videoroom_rtp_forwarder_add_helper(publisher, host, audio_port, audio_pt, audio_ssrc,
+			audio_handle = janus_videoroom_rtp_forwarder_add_helper(publisher, host, audio_port, audio_rtcp_port, audio_pt, audio_ssrc,
 				srtp_suite, srtp_crypto, 0, FALSE, FALSE);
 		}
 		if(video_port[0] > 0) {
-			video_handle[0] = janus_videoroom_rtp_forwarder_add_helper(publisher, host, video_port[0], video_pt[0], video_ssrc[0],
+			video_handle[0] = janus_videoroom_rtp_forwarder_add_helper(publisher, host, video_port[0], video_rtcp_port, video_pt[0], video_ssrc[0],
 				srtp_suite, srtp_crypto, 0, TRUE, FALSE);
 		}
 		if(video_port[1] > 0) {
-			video_handle[1] = janus_videoroom_rtp_forwarder_add_helper(publisher, host, video_port[1], video_pt[1], video_ssrc[1],
+			video_handle[1] = janus_videoroom_rtp_forwarder_add_helper(publisher, host, video_port[1], 0, video_pt[1], video_ssrc[1],
 				srtp_suite, srtp_crypto, 1, TRUE, FALSE);
 		}
 		if(video_port[2] > 0) {
-			video_handle[2] = janus_videoroom_rtp_forwarder_add_helper(publisher, host, video_port[2], video_pt[2], video_ssrc[2],
+			video_handle[2] = janus_videoroom_rtp_forwarder_add_helper(publisher, host, video_port[2], 0, video_pt[2], video_ssrc[2],
 				srtp_suite, srtp_crypto, 2, TRUE, FALSE);
 		}
 		if(data_port > 0) {
-			data_handle = janus_videoroom_rtp_forwarder_add_helper(publisher, host, data_port, 0, 0, 0, NULL, 0, FALSE, TRUE);
+			data_handle = janus_videoroom_rtp_forwarder_add_helper(publisher, host, data_port, 0, 0, 0, 0, NULL, 0, FALSE, TRUE);
 		}
 		janus_mutex_unlock(&videoroom->mutex);
 		response = json_object();
@@ -3590,6 +3728,10 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 				} else if(rpv->is_video) {
 					json_object_set_new(fl, "video_stream_id", json_integer(rpk));
 					json_object_set_new(fl, "port", json_integer(ntohs(rpv->serv_addr.sin_port)));
+					if(rpv->local_rtcp_port > 0)
+						json_object_set_new(fl, "local_rtcp_port", json_integer(rpv->local_rtcp_port));
+					if(rpv->remote_rtcp_port > 0)
+						json_object_set_new(fl, "remote_rtcp_port", json_integer(rpv->remote_rtcp_port));
 					if(rpv->payload_type)
 						json_object_set_new(fl, "pt", json_integer(rpv->payload_type));
 					if(rpv->ssrc)
@@ -3599,6 +3741,10 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 				} else {
 					json_object_set_new(fl, "audio_stream_id", json_integer(rpk));
 					json_object_set_new(fl, "port", json_integer(ntohs(rpv->serv_addr.sin_port)));
+					if(rpv->local_rtcp_port > 0)
+						json_object_set_new(fl, "local_rtcp_port", json_integer(rpv->local_rtcp_port));
+					if(rpv->remote_rtcp_port > 0)
+						json_object_set_new(fl, "remote_rtcp_port", json_integer(rpv->remote_rtcp_port));
 					if(rpv->payload_type)
 						json_object_set_new(fl, "pt", json_integer(rpv->payload_type));
 					if(rpv->ssrc)
@@ -4505,8 +4651,8 @@ static void *janus_videoroom_handler(void *data) {
 				publisher->fir_latest = 0;
 				publisher->fir_seq = 0;
 				janus_mutex_init(&publisher->rtp_forwarders_mutex);
-				publisher->rtp_forwarders = g_hash_table_new_full(NULL, NULL, NULL, (GDestroyNotify)janus_videoroom_rtp_forwarder_free_helper);
-				publisher->srtp_contexts = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, (GDestroyNotify)janus_videoroom_srtp_context_free_helper);
+				publisher->rtp_forwarders = g_hash_table_new_full(NULL, NULL, NULL, (GDestroyNotify)janus_videoroom_rtp_forwarder_destroy);
+				publisher->srtp_contexts = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, (GDestroyNotify)janus_videoroom_srtp_context_free);
 				publisher->udp_sock = -1;
 				/* Finally, generate a private ID: this is only needed in case the participant
 				 * wants to allow the plugin to know which subscriptions belong to them */
@@ -6138,4 +6284,28 @@ static void janus_videoroom_relay_data_packet(gpointer data, gpointer user_data)
 		gateway->relay_data(session->handle, text, strlen(text));
 	}
 	return;
+}
+
+/* The following methods are only relevant if RTCP is used for RTP forwarders */
+static void janus_videoroom_rtp_forwarder_rtcp_receive(janus_videoroom_rtp_forwarder *forward) {
+	char buffer[1500];
+	struct sockaddr_storage remote_addr;
+	socklen_t addrlen = sizeof(remote_addr);
+	int len = recvfrom(forward->rtcp_fd, buffer, sizeof(buffer), 0, (struct sockaddr *)&remote_addr, &addrlen);
+	if(len > 0) {
+		JANUS_LOG(LOG_HUGE, "Got %s RTCP packet: %d bytes\n", forward->is_video ? "video" : "audio", len);
+		/* We only handle incoming video PLIs or FIR at the moment */
+		if(!janus_rtcp_has_fir(buffer, len) && !janus_rtcp_has_pli(buffer, len))
+			return;
+		janus_videoroom_reqfir((janus_videoroom_publisher *)forward->source, "RTCP from forwarder");
+	}
+}
+
+static void *janus_videoroom_rtp_forwarder_rtcp_thread(void *data) {
+	JANUS_LOG(LOG_VERB, "Joining RTCP thread for RTP forwarders...\n");
+	/* Run the main loop */
+	g_main_loop_run(rtcpfwd_loop);
+	/* When the loop ends, we're done */
+	JANUS_LOG(LOG_VERB, "Leaving RTCP thread for RTP forwarders...\n");
+	return NULL;
 }


### PR DESCRIPTION
This patch complements the RTCP support added to the Streaming plugin in #1279, and can actually be used whenever there's need for RTCP feedback for RTP forwarders (even though their usage with the Streaming plugin is the main use case that motivated us here).

It's quite easy to use. Whenever you create an RTP forward, you can specify `audio_rtcp_port` and `video_rtcp_port` as well, e.g.:

```
sfutest.send({
	message: {
		request: "rtp_forward",
		room: 1234,
		publisher_id: myid,
		secret: "adminpwd",
		host: "192.168.1.80",
		audio_port: 5002,
		audio_rtcp_port: 5003,
		video_port: 5004,
		video_rtcp_port: 5005
	}, success: function(result) {
		console.log("Audio forwarder:", result["rtp_stream"]["audio_stream_id"]);
		console.log("Video forwarder:", result["rtp_stream"]["video_stream_id"]);
	}
});
```

This configures the _remote_ RTCP ports, just as you configure the remote RTP ports with `audio_port` and `video_port`. This results in the plugin creating a new socket, binding to a random port, and latching to the remote specified port(s) in order to be able to receive RTCP feedback. This means that, after the forwarder did its latching, it's up to the recipient to figure out the port the forwarder will wait RTCP feedback on, exactly as the Streaming plugin currently does.

At the moment, we ignore everything that isn't a PLI/FIR, which means configuring an audio RTCP port is pretty useless. In future commits we can extend this for other RTCP packets: anyway, this already allows me to configure an RTCP port for a Streaming mountpoint, configure a new RTP forwarder to send RTP there and latch to the RTCP port, and make sure that any time a new Streaming plugin viewer opens the mountpoint their keyframe requests are properly relayed to the original source (the VideoRoom publisher).

Tested briefly and it seems to work, so I plan to merge soon. Feedback welcome!