### PR TITLE
url-encoding token and apisecret parameters

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -467,9 +467,9 @@ function Janus(gatewayCallbacks) {
 		if(maxev !== undefined && maxev !== null)
 			longpoll = longpoll + "&maxev=" + maxev;
 		if(token !== null && token !== undefined)
-			longpoll = longpoll + "&token=" + token;
+			longpoll = longpoll + "&token=" + encodeURIComponent(token);
 		if(apisecret !== null && apisecret !== undefined)
-			longpoll = longpoll + "&apisecret=" + apisecret;
+			longpoll = longpoll + "&apisecret=" + encodeURIComponent(apisecret);
 		Janus.httpAPICall(longpoll, {
 			verb: 'GET',
 			withCredentials: withCredentials,


### PR DESCRIPTION
url-encoding token and apisecret parameters in long-poll request since both parameters can contain special characters (e.g., = at the end of an hmac signature) which, if left unencoded, will cause the token verification to fail and the session to expire if there is no other activity occurring