### PR TITLE
Videocall: decline incoming call fix

### DIFF
--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -1004,7 +1004,7 @@ void janus_videocall_hangup_media(janus_plugin_session *handle) {
 	}
 	if(g_atomic_int_get(&session->destroyed))
 		return;
-	if(g_atomic_int_add(&session->hangingup, 1))
+	if(g_atomic_int_and(&session->hangingup, 1))
 		return;
 	/* Get rid of the recorders, if available */
 	janus_mutex_lock(&session->rec_mutex);


### PR DESCRIPTION
This fixes the critical issue with declining the incoming call.
With add we quickly get the 'hangingup' property of the handle being set to 1 and then 2, so we can only decline a call once, after that we continue having a 'peer', so, we continue recieving a call