### PR TITLE
ES6 -> ES5 replace

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -3113,7 +3113,7 @@ function Janus(gatewayCallbacks) {
 			return false;
 		if (typeof media.video !== 'object' || typeof media.video.mandatory !== 'object')
 			return false;
-		const constraints = media.video.mandatory;
+		var constraints = media.video.mandatory;
 		if (constraints.chromeMediaSource)
 			return constraints.chromeMediaSource === 'desktop' || constraints.chromeMediaSource === 'screen';
 		else if (constraints.mozMediaSource)


### PR DESCRIPTION
replaced **const** to **var**. my IDE complains on it because it configured to ES5 support only