### PR TITLE
Allow use of HTTP urls without session/handle in the path

### DIFF
--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -1433,13 +1433,31 @@ int janus_http_handler(void *cls, struct MHD_Connection *connection, const char 
 	}
 
 parsingdone:
-	/* Check if we have session and handle identifiers */
-	session_id = session_path ? g_ascii_strtoull(session_path, NULL, 10) : 0;
-	handle_id = handle_path ? g_ascii_strtoull(handle_path, NULL, 10) : 0;
-	if(session_id > 0)
-		json_object_set_new(root, "session_id", json_integer(session_id));
-	if(handle_id > 0)
-		json_object_set_new(root, "handle_id", json_integer(handle_id));
+	/* Check if we have session and handle identifiers, and how they were provided */
+	session_id = json_integer_value(json_object_get(root, "session_id"));
+	if(session_id && session_path && g_ascii_strtoull(session_path, NULL, 10) != session_id) {
+		ret = janus_http_return_error(ts, 0, NULL, JANUS_ERROR_INVALID_REQUEST_PATH, "Conflicting session ID (payload and path)");
+		json_decref(root);
+		goto done;
+	}
+	if(!session_id) {
+		/* No session ID in the JSON object, maybe in the path? */
+		session_id = session_path ? g_ascii_strtoull(session_path, NULL, 10) : 0;
+		if(session_id > 0)
+			json_object_set_new(root, "session_id", json_integer(session_id));
+	}
+	handle_id = json_integer_value(json_object_get(root, "handle_id"));
+	if(handle_id && handle_path && g_ascii_strtoull(handle_path, NULL, 10) != handle_id) {
+		ret = janus_http_return_error(ts, 0, NULL, JANUS_ERROR_INVALID_REQUEST_PATH, "Conflicting handle ID (payload and path)");
+		json_decref(root);
+		goto done;
+	}
+	if(!handle_id) {
+		/* No session ID in the JSON object, maybe in the path? */
+		handle_id = handle_path ? g_ascii_strtoull(handle_path, NULL, 10) : 0;
+		if(handle_id > 0)
+			json_object_set_new(root, "handle_id", json_integer(handle_id));
+	}
 
 	/* Suspend the connection and pass the ball to the core */
 	JANUS_LOG(LOG_HUGE, "Forwarding request to the core (%p)\n", ts);
@@ -1657,13 +1675,31 @@ int janus_http_admin_handler(void *cls, struct MHD_Connection *connection, const
 	}
 
 parsingdone:
-	/* Check if we have session and handle identifiers */
-	session_id = session_path ? g_ascii_strtoull(session_path, NULL, 10) : 0;
-	handle_id = handle_path ? g_ascii_strtoull(handle_path, NULL, 10) : 0;
-	if(session_id > 0)
-		json_object_set_new(root, "session_id", json_integer(session_id));
-	if(handle_id > 0)
-		json_object_set_new(root, "handle_id", json_integer(handle_id));
+	/* Check if we have session and handle identifiers, and how they were provided */
+	session_id = json_integer_value(json_object_get(root, "session_id"));
+	if(session_id && session_path && g_ascii_strtoull(session_path, NULL, 10) != session_id) {
+		ret = janus_http_return_error(ts, 0, NULL, JANUS_ERROR_INVALID_REQUEST_PATH, "Conflicting session ID (payload and path)");
+		json_decref(root);
+		goto done;
+	}
+	if(!session_id) {
+		/* No session ID in the JSON object, maybe in the path? */
+		session_id = session_path ? g_ascii_strtoull(session_path, NULL, 10) : 0;
+		if(session_id > 0)
+			json_object_set_new(root, "session_id", json_integer(session_id));
+	}
+	handle_id = json_integer_value(json_object_get(root, "handle_id"));
+	if(handle_id && handle_path && g_ascii_strtoull(handle_path, NULL, 10) != handle_id) {
+		ret = janus_http_return_error(ts, 0, NULL, JANUS_ERROR_INVALID_REQUEST_PATH, "Conflicting handle ID (payload and path)");
+		json_decref(root);
+		goto done;
+	}
+	if(!handle_id) {
+		/* No session ID in the JSON object, maybe in the path? */
+		handle_id = handle_path ? g_ascii_strtoull(handle_path, NULL, 10) : 0;
+		if(handle_id > 0)
+			json_object_set_new(root, "handle_id", json_integer(handle_id));
+	}
 
 	/* Suspend the connection and pass the ball to the core */
 	JANUS_LOG(LOG_HUGE, "Forwarding admin request to the core (%p)\n", msg);


### PR DESCRIPTION
As you know, and as the [documentation](https://janus.conf.meetecho.com/docs/rest) explains, when you use HTTP to talk to Janus at the moment you have to send your requests to some properly constructed paths, e.g.:

* you send a `create` to `/janus` and get a session ID back;
* you send a GET To `/janus/<sessionID>` for long polls;
* you send an `attach` to `/janus/<sessionID>` and get a handle ID back;
* you send trickle, messages and other handle stuff to `/janus/<sessionID>/<handleID>`.

Other transport protocols don't work that way: they all expect the session and handle IDs to be put in the JSON request, as `session_id` and `handle_id`. As such, HTTP represents an exception and the different approach can be seen as an inconsistency in the API, which might make things more complicated for implementors.

This patch solves this by allowing you to use the same exact approach when doing HTTP as well. This means that you can always send your requests to `/janus` (or `/admin`, for the Admin API), if you make sure `session_id` and `handle_id` are part of the request payload as you'd do for WebSockets (of course, the same considerations apply if you configured a different base path in your deployment). The only exception, at the moment, is the long poll: since it has no JSON object you pass to the server, and we need the session ID, for long polls you still need to use `/janus/<sessionID>` as a path (although we might move the session ID to a query string parameter, for instance).

The change was quite trivial, and from a quick test this seemed to work nicely. This doesn't break anything, and the way the API worked before with HTTP will still work. It is just a different approach you can use as a client, as you want, and might make things easier for you.

lanning to merge soon, so feedback welcome!