### PR TITLE
codec detection during videocall accept

### DIFF
--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -1351,14 +1351,14 @@ static void *janus_videocall_handler(void *data) {
 			janus_sdp_find_first_codecs(answer, &acodec, &vcodec);
 			session->acodec = janus_audiocodec_from_name(acodec);
 			session->vcodec = janus_videocodec_from_name(vcodec);
-			if(session->acodec != JANUS_AUDIOCODEC_NONE) {
+			if(session->acodec == JANUS_AUDIOCODEC_NONE) {
 				session->has_audio = FALSE;
 				if(peer)
 					peer->has_audio = FALSE;
 			} else if(peer) {
 				peer->acodec = session->acodec;
 			}
-			if(session->vcodec != JANUS_VIDEOCODEC_NONE) {
+			if(session->vcodec == JANUS_VIDEOCODEC_NONE) {
 				session->has_video = FALSE;
 				if(peer)
 					peer->has_video = FALSE;


### PR DESCRIPTION
I'm a bit afraid that I don't fully understand everything that is happening, but I believe that #1286 may have inadvertently changed the logic for detecting codecs during call acceptance.

Maybe it's just how I am using Janus (wrapped on a server) but without this change, I am unable to use the `set` API to start recording. Video calls start as expected, but since `has_audio` and `has_video` are both `FALSE`, the `set` handler does not create a recorder. With this change, recording starts as expected upon receipt of a `set` message containing `record: true`.

Thanks for your time. Cheers :tada: 