### PR TITLE
Simulcast support for RTP forwarder and recordings

### DIFF
--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -62,6 +62,8 @@ var recordingId = null;
 var selectedRecording = null;
 var selectedRecordingInfo = null;
 
+var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
+
 
 $(document).ready(function() {
 	// Initialize the library (all console debuggers enabled)
@@ -419,7 +421,11 @@ function startRecording() {
 		
 		recordplay.createOffer(
 			{
-				// By default, it's sendrecv for audio and video...
+				// By default, it's sendrecv for audio and video... no datachannels
+				// If you want to test simulcasting (Chrome and Firefox only), then
+				// pass a ?simulcast=true when opening this demo page: it will turn
+				// the following 'simulcast' property to pass to janus.js to true
+				simulcast: doSimulcast,
 				success: function(jsep) {
 					Janus.debug("Got SDP!");
 					Janus.debug(jsep);
@@ -460,4 +466,12 @@ function stop() {
 	var stop = { "request": "stop" };
 	recordplay.send({"message": stop});
 	recordplay.hangup();
+}
+
+// Helper to parse query string
+function getQueryStringValue(name) {
+	name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+	var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+		results = regex.exec(location.search);
+	return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
 }

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -770,6 +770,7 @@ static void janus_echotest_hangup_media_internal(janus_plugin_session *handle) {
 	session->peer_bitrate = 0;
 	janus_rtp_switching_context_reset(&session->context);
 	janus_rtp_simulcasting_context_reset(&session->sim_context);
+	janus_vp8_simulcast_context_reset(&session->vp8_context);
 	g_atomic_int_set(&session->hangingup, 0);
 }
 

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -202,14 +202,10 @@ typedef struct janus_echotest_session {
 	uint32_t bitrate, peer_bitrate;
 	janus_rtp_switching_context context;
 	uint32_t ssrc[3];		/* Only needed in case VP8 (or H.264) simulcasting is involved */
-	int rtpmapid_extmap_id;	/* Only needed in case Firefox's RID-based simulcasting is involved */
-	char *rid[3];			/* Only needed in case Firefox's RID-based simulcasting is involved */
-	int substream;			/* Which simulcast substream we should forward back */
-	int substream_target;	/* As above, but to handle transitions (e.g., wait for keyframe) */
-	int templayer;			/* Which simulcast temporal layer we should forward back */
-	int templayer_target;	/* As above, but to handle transitions (e.g., wait for keyframe) */
-	gint64 last_relayed;	/* When we relayed the last packet (used to detect when substreams become unavailable) */
-	janus_vp8_simulcast_context simulcast_context;
+	janus_rtp_simulcasting_context sim_context;
+	int rtpmapid_extmap_id;	/* Only needed for debugging in case Firefox's RID-based simulcasting is involved */
+	char *rid[3];			/* Only needed for debugging in case Firefox's RID-based simulcasting is involved */
+	janus_vp8_simulcast_context vp8_context;
 	janus_recorder *arc;	/* The Janus recorder instance for this user's audio, if enabled */
 	janus_recorder *vrc;	/* The Janus recorder instance for this user's video, if enabled */
 	janus_recorder *drc;	/* The Janus recorder instance for this user's data, if enabled */
@@ -388,15 +384,8 @@ void janus_echotest_create_session(janus_plugin_session *handle, int *error) {
 	session->bitrate = 0;	/* No limit */
 	session->peer_bitrate = 0;
 	janus_rtp_switching_context_reset(&session->context);
-	session->ssrc[0] = 0;
-	session->ssrc[1] = 0;
-	session->ssrc[2] = 0;
-	session->substream = -1;
-	session->substream_target = 0;
-	session->templayer = -1;
-	session->templayer_target = 0;
-	session->last_relayed = 0;
-	janus_vp8_simulcast_context_reset(&session->simulcast_context);
+	janus_rtp_simulcasting_context_reset(&session->sim_context);
+	janus_vp8_simulcast_context_reset(&session->vp8_context);
 	session->destroyed = 0;
 	g_atomic_int_set(&session->hangingup, 0);
 	g_atomic_int_set(&session->destroyed, 0);
@@ -454,10 +443,10 @@ json_t *janus_echotest_query_session(janus_plugin_session *handle) {
 	json_object_set_new(info, "peer-bitrate", json_integer(session->peer_bitrate));
 	if(session->ssrc[0] != 0) {
 		json_object_set_new(info, "simulcast", json_true());
-		json_object_set_new(info, "substream", json_integer(session->substream));
-		json_object_set_new(info, "substream-target", json_integer(session->substream_target));
-		json_object_set_new(info, "temporal-layer", json_integer(session->templayer));
-		json_object_set_new(info, "temporal-layer-target", json_integer(session->templayer_target));
+		json_object_set_new(info, "substream", json_integer(session->sim_context.substream));
+		json_object_set_new(info, "substream-target", json_integer(session->sim_context.substream_target));
+		json_object_set_new(info, "temporal-layer", json_integer(session->sim_context.templayer));
+		json_object_set_new(info, "temporal-layer-target", json_integer(session->sim_context.templayer_target));
 	}
 	if(session->arc || session->vrc || session->drc) {
 		json_t *recording = json_object();
@@ -544,118 +533,58 @@ void janus_echotest_incoming_rtp(janus_plugin_session *handle, int video, char *
 			}
 		}
 		if(video && session->video_active && session->ssrc[0] != 0) {
-			/* Handle simulcast: don't relay if it's not the SSRC we wanted to handle */
+			/* Handle simulcast: backup the header information first */
 			janus_rtp_header *header = (janus_rtp_header *)buf;
 			uint32_t seq_number = ntohs(header->seq_number);
 			uint32_t timestamp = ntohl(header->timestamp);
 			uint32_t ssrc = ntohl(header->ssrc);
-			/* Access the packet payload */
-			int plen = 0;
-			char *payload = janus_rtp_payload(buf, len, &plen);
-			if(payload == NULL)
-				return;
-			gboolean switched = FALSE;
-			if(session->substream != session->substream_target) {
-				/* There has been a change: let's wait for a keyframe on the target */
-				int step = (session->substream < 1 && session->substream_target == 2);
-				if((ssrc == session->ssrc[session->substream_target]) || (step && ssrc == session->ssrc[step])) {
-					//~ if(janus_vp8_is_keyframe(payload, plen)) {
-						uint32_t ssrc_old = 0;
-						if(session->substream != -1)
-							ssrc_old = session->ssrc[session->substream];
-						JANUS_LOG(LOG_VERB, "Received keyframe on SSRC %"SCNu32", switching (was %"SCNu32")\n", ssrc, ssrc_old);
-						session->substream = (ssrc == session->ssrc[session->substream_target] ? session->substream_target : step);
-						switched = TRUE;
-						/* Notify the user */
-						json_t *event = json_object();
-						json_object_set_new(event, "echotest", json_string("event"));
-						json_object_set_new(event, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
-						json_object_set_new(event, "substream", json_integer(session->substream));
-						gateway->push_event(handle, &janus_echotest_plugin, NULL, event, NULL);
-						json_decref(event);
-					//~ } else {
-						//~ JANUS_LOG(LOG_WARN, "Not a keyframe on SSRC %"SCNu32" yet, waiting before switching\n", ssrc);
-					//~ }
-				}
-			}
-			/* If we haven't received our desired substream yet, let's drop temporarily */
-			if(session->last_relayed == 0) {
-				/* Let's start slow */
-				session->last_relayed = janus_get_monotonic_time();
-			} else {
-				/* Check if 250ms went by with no packet relayed */
-				gint64 now = janus_get_monotonic_time();
-				if(now-session->last_relayed >= 250000) {
-					session->last_relayed = now;
-					int substream = session->substream-1;
-					if(substream < 0)
-						substream = 0;
-					if(session->substream != substream) {
-						JANUS_LOG(LOG_WARN, "No packet received on substream %d for a while, falling back to %d\n",
-							session->substream, substream);
-						session->substream = substream;
-						/* Send a PLI */
-						JANUS_LOG(LOG_VERB, "Just (re-)enabled video, sending a PLI to recover it\n");
-						char rtcpbuf[12];
-						memset(rtcpbuf, 0, 12);
-						janus_rtcp_pli((char *)&rtcpbuf, 12);
-						gateway->relay_rtcp(handle, 1, rtcpbuf, 12);
-						/* Notify the user */
-						json_t *event = json_object();
-						json_object_set_new(event, "echotest", json_string("event"));
-						json_object_set_new(event, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
-						json_object_set_new(event, "substream", json_integer(session->substream));
-						gateway->push_event(handle, &janus_echotest_plugin, NULL, event, NULL);
-						json_decref(event);
-					}
-				}
-			}
+			/* Process this packet: don't relay if it's not the SSRC/layer we wanted to handle */
+			gboolean relay = janus_rtp_simulcasting_context_process_rtp(&session->sim_context,
+				buf, len, session->ssrc, session->vcodec, &session->context);
 			/* Do we need to drop this? */
-			if(ssrc != session->ssrc[session->substream]) {
-				JANUS_LOG(LOG_HUGE, "Dropping packet (it's from SSRC %"SCNu32", but we're only relaying SSRC %"SCNu32" now\n",
-					ssrc, session->ssrc[session->substream]);
+			if(!relay)
 				return;
+			/* Any event we should notify? */
+			if(session->sim_context.changed_substream) {
+				/* Notify the user about the substream change */
+				json_t *event = json_object();
+				json_object_set_new(event, "echotest", json_string("event"));
+				json_object_set_new(event, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
+				json_object_set_new(event, "substream", json_integer(session->sim_context.substream));
+				gateway->push_event(handle, &janus_echotest_plugin, NULL, event, NULL);
+				json_decref(event);
 			}
-			session->last_relayed = janus_get_monotonic_time();
-			if(session->vcodec == JANUS_VIDEOCODEC_VP8) {
-				/* Check if there's any temporal scalability to take into account */
-				uint16_t picid = 0;
-				uint8_t tlzi = 0;
-				uint8_t tid = 0;
-				uint8_t ybit = 0;
-				uint8_t keyidx = 0;
-				if(janus_vp8_parse_descriptor(payload, plen, &picid, &tlzi, &tid, &ybit, &keyidx) == 0) {
-					//~ JANUS_LOG(LOG_WARN, "%"SCNu16", %u, %u, %u, %u\n", picid, tlzi, tid, ybit, keyidx);
-					if(session->templayer != session->templayer_target) {
-						/* FIXME We should be smarter in deciding when to switch */
-						session->templayer = session->templayer_target;
-						/* Notify the user */
-						json_t *event = json_object();
-						json_object_set_new(event, "echotest", json_string("event"));
-						json_object_set_new(event, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
-						json_object_set_new(event, "temporal", json_integer(session->templayer));
-						gateway->push_event(handle, &janus_echotest_plugin, NULL, event, NULL);
-						json_decref(event);
-					}
-					if(tid > session->templayer) {
-						JANUS_LOG(LOG_HUGE, "Dropping packet (it's temporal layer %d, but we're capping at %d)\n",
-							tid, session->templayer);
-						/* We increase the base sequence number, or there will be gaps when delivering later */
-						session->context.v_base_seq++;
-						return;
-					}
-				}
+			if(session->sim_context.need_pli) {
+				/* Send a PLI */
+				JANUS_LOG(LOG_VERB, "We need a PLI for the simulcast context\n");
+				char rtcpbuf[12];
+				memset(rtcpbuf, 0, 12);
+				janus_rtcp_pli((char *)&rtcpbuf, 12);
+				gateway->relay_rtcp(handle, 1, rtcpbuf, 12);
+			}
+			if(session->sim_context.changed_temporal) {
+				/* Notify the user about the temporal layer change */
+				json_t *event = json_object();
+				json_object_set_new(event, "echotest", json_string("event"));
+				json_object_set_new(event, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
+				json_object_set_new(event, "temporal", json_integer(session->sim_context.templayer));
+				gateway->push_event(handle, &janus_echotest_plugin, NULL, event, NULL);
+				json_decref(event);
 			}
 			/* If we got here, update the RTP header and send the packet */
 			janus_rtp_header_update(header, &session->context, TRUE, 0);
-			if(session->vcodec == JANUS_VIDEOCODEC_VP8)
-				janus_vp8_simulcast_descriptor_update(payload, plen, &session->simulcast_context, switched);
+			if(session->vcodec == JANUS_VIDEOCODEC_VP8) {
+				int plen = 0;
+				char *payload = janus_rtp_payload(buf, len, &plen);
+				janus_vp8_simulcast_descriptor_update(payload, plen, &session->vp8_context, session->sim_context.changed_substream);
+			}
 			/* Save the frame if we're recording (and make sure the SSRC never changes even if the substream does) */
 			header->ssrc = htonl(1);
 			janus_recorder_save_frame(session->vrc, buf, len);
 			/* Send the frame back */
 			gateway->relay_rtp(handle, video, buf, len);
 			/* Restore header or core statistics will be messed up */
+			header->ssrc = htonl(ssrc);
 			header->timestamp = htonl(timestamp);
 			header->seq_number = htons(seq_number);
 		} else {
@@ -839,14 +768,8 @@ static void janus_echotest_hangup_media_internal(janus_plugin_session *handle) {
 	session->vcodec = JANUS_VIDEOCODEC_NONE;
 	session->bitrate = 0;
 	session->peer_bitrate = 0;
-	session->ssrc[0] = 0;
-	session->ssrc[1] = 0;
-	session->ssrc[2] = 0;
-	session->substream = -1;
-	session->substream_target = 0;
-	session->templayer = -1;
-	session->templayer_target = 0;
-	session->last_relayed = 0;
+	janus_rtp_switching_context_reset(&session->context);
+	janus_rtp_simulcasting_context_reset(&session->sim_context);
 	g_atomic_int_set(&session->hangingup, 0);
 }
 
@@ -903,8 +826,8 @@ static void *janus_echotest_handler(void *data) {
 			session->ssrc[0] = json_integer_value(json_object_get(msg_simulcast, "ssrc-0"));
 			session->ssrc[1] = json_integer_value(json_object_get(msg_simulcast, "ssrc-1"));
 			session->ssrc[2] = json_integer_value(json_object_get(msg_simulcast, "ssrc-2"));
-			session->substream_target = 2;	/* Let's aim for the highest quality */
-			session->templayer_target = 2;	/* Let's aim for all temporal layers */
+			session->sim_context.substream_target = 2;	/* Let's aim for the highest quality */
+			session->sim_context.templayer_target = 2;	/* Let's aim for all temporal layers */
 		}
 		json_t *audio = json_object_get(root, "audio");
 		if(audio && !json_is_boolean(audio)) {
@@ -990,15 +913,15 @@ static void *janus_echotest_handler(void *data) {
 			}
 		}
 		if(substream) {
-			session->substream_target = json_integer_value(substream);
+			session->sim_context.substream_target = json_integer_value(substream);
 			JANUS_LOG(LOG_VERB, "Setting video SSRC to let through (simulcast): %"SCNu32" (index %d, was %d)\n",
-				session->ssrc[session->substream], session->substream_target, session->substream);
-			if(session->substream_target == session->substream) {
+				session->ssrc[session->sim_context.substream], session->sim_context.substream_target, session->sim_context.substream);
+			if(session->sim_context.substream_target == session->sim_context.substream) {
 				/* No need to do anything, we're already getting the right substream, so notify the user */
 				json_t *event = json_object();
 				json_object_set_new(event, "echotest", json_string("event"));
 				json_object_set_new(event, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
-				json_object_set_new(event, "substream", json_integer(session->substream));
+				json_object_set_new(event, "substream", json_integer(session->sim_context.substream));
 				gateway->push_event(session->handle, &janus_echotest_plugin, NULL, event, NULL);
 				json_decref(event);
 			} else {
@@ -1011,15 +934,15 @@ static void *janus_echotest_handler(void *data) {
 			}
 		}
 		if(temporal) {
-			session->templayer_target = json_integer_value(temporal);
+			session->sim_context.templayer_target = json_integer_value(temporal);
 			JANUS_LOG(LOG_VERB, "Setting video temporal layer to let through (simulcast): %d (was %d)\n",
-				session->templayer_target, session->templayer);
-			if(session->vcodec == JANUS_VIDEOCODEC_VP8 && session->templayer_target == session->templayer) {
+				session->sim_context.templayer_target, session->sim_context.templayer);
+			if(session->vcodec == JANUS_VIDEOCODEC_VP8 && session->sim_context.templayer_target == session->sim_context.templayer) {
 				/* No need to do anything, we're already getting the right temporal, so notify the user */
 				json_t *event = json_object();
 				json_object_set_new(event, "echotest", json_string("event"));
 				json_object_set_new(event, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
-				json_object_set_new(event, "temporal", json_integer(session->templayer));
+				json_object_set_new(event, "temporal", json_integer(session->sim_context.templayer));
 				gateway->push_event(session->handle, &janus_echotest_plugin, NULL, event, NULL);
 				json_decref(event);
 			} else {
@@ -1249,8 +1172,8 @@ static void *janus_echotest_handler(void *data) {
 				json_object_set_new(simulcast, "ssrc-0", json_integer(session->ssrc[0]));
 				json_object_set_new(simulcast, "ssrc-1", json_integer(session->ssrc[1]));
 				json_object_set_new(simulcast, "ssrc-2", json_integer(session->ssrc[2]));
-				json_object_set_new(simulcast, "substream", json_integer(session->substream));
-				json_object_set_new(simulcast, "temporal-layer", json_integer(session->templayer));
+				json_object_set_new(simulcast, "substream", json_integer(session->sim_context.substream));
+				json_object_set_new(simulcast, "temporal-layer", json_integer(session->sim_context.templayer));
 				json_object_set_new(info, "simulcast", simulcast);
 			}
 			if(session->arc || session->vrc || session->drc) {

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -955,6 +955,9 @@ void janus_videocall_hangup_media(janus_plugin_session *handle) {
 	session->acodec = JANUS_AUDIOCODEC_NONE;
 	session->vcodec = JANUS_VIDEOCODEC_NONE;
 	session->bitrate = 0;
+	janus_rtp_switching_context_reset(&session->context);
+	janus_rtp_simulcasting_context_reset(&session->sim_context);
+	janus_vp8_simulcast_context_reset(&session->vp8_context);
 	if(g_atomic_int_compare_and_exchange(&session->incall, 1, 0) && peer) {
 		janus_refcount_decrease(&peer->ref);
 	}

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -374,15 +374,10 @@ typedef struct janus_videocall_session {
 	guint16 slowlink_count;
 	struct janus_videocall_session *peer;
 	janus_rtp_switching_context context;
-	uint32_t ssrc[3];		/* Only needed in case VP8 simulcasting is involved */
-	int rtpmapid_extmap_id;	/* Only needed in case Firefox's RID-based simulcasting is involved */
-	char *rid[3];			/* Only needed in case Firefox's RID-based simulcasting is involved */
-	int substream;			/* Which simulcast substream we should forward back */
-	int substream_target;	/* As above, but to handle transitions (e.g., wait for keyframe) */
-	int templayer;			/* Which simulcast temporal layer we should forward back */
-	int templayer_target;	/* As above, but to handle transitions (e.g., wait for keyframe) */
-	gint64 last_relayed;	/* When we relayed the last packet (used to detect when substreams become unavailable) */
-	janus_vp8_simulcast_context simulcast_context;
+	uint32_t ssrc[3];		/* Only needed in case VP8 (or H.264) simulcasting is involved */
+	janus_rtp_simulcasting_context sim_context;
+	int rtpmapid_extmap_id;	/* Only needed for debugging in case Firefox's RID-based simulcasting is involved */
+	janus_vp8_simulcast_context vp8_context;
 	janus_recorder *arc;	/* The Janus recorder instance for this user's audio, if enabled */
 	janus_recorder *vrc;	/* The Janus recorder instance for this user's video, if enabled */
 	janus_recorder *drc;	/* The Janus recorder instance for this user's data, if enabled */
@@ -564,15 +559,8 @@ void janus_videocall_create_session(janus_plugin_session *handle, int *error) {
 	session->peer = NULL;
 	session->username = NULL;
 	janus_rtp_switching_context_reset(&session->context);
-	session->ssrc[0] = 0;
-	session->ssrc[1] = 0;
-	session->ssrc[2] = 0;
-	session->substream = -1;
-	session->substream_target = 0;
-	session->templayer = -1;
-	session->templayer_target = 0;
-	session->last_relayed = 0;
-	janus_vp8_simulcast_context_reset(&session->simulcast_context);
+	janus_rtp_simulcasting_context_reset(&session->sim_context);
+	janus_vp8_simulcast_context_reset(&session->vp8_context);
 	janus_mutex_init(&session->rec_mutex);
 	g_atomic_int_set(&session->incall, 0);
 	g_atomic_int_set(&session->hangingup, 0);
@@ -639,10 +627,10 @@ json_t *janus_videocall_query_session(janus_plugin_session *handle) {
 	}
 	if(peer && peer->ssrc[0] != 0) {
 		json_object_set_new(info, "simulcast-peer", json_true());
-		json_object_set_new(info, "substream", json_integer(session->substream));
-		json_object_set_new(info, "substream-target", json_integer(session->substream_target));
-		json_object_set_new(info, "temporal-layer", json_integer(session->templayer));
-		json_object_set_new(info, "temporal-layer-target", json_integer(session->templayer_target));
+		json_object_set_new(info, "substream", json_integer(session->sim_context.substream));
+		json_object_set_new(info, "substream-target", json_integer(session->sim_context.substream_target));
+		json_object_set_new(info, "temporal-layer", json_integer(session->sim_context.templayer));
+		json_object_set_new(info, "temporal-layer-target", json_integer(session->sim_context.templayer_target));
 	}
 	if(session->arc || session->vrc || session->drc) {
 		json_t *recording = json_object();
@@ -727,127 +715,65 @@ void janus_videocall_incoming_rtp(janus_plugin_session *handle, int video, char 
 			}
 		}
 		if(video && session->video_active && session->ssrc[0] != 0) {
-			/* Handle simulcast: don't relay if it's not the SSRC we wanted to handle */
+			/* Handle simulcast: backup the header information first */
 			janus_rtp_header *header = (janus_rtp_header *)buf;
 			uint32_t seq_number = ntohs(header->seq_number);
 			uint32_t timestamp = ntohl(header->timestamp);
 			uint32_t ssrc = ntohl(header->ssrc);
-			/* Access the packet payload */
-			int plen = 0;
-			char *payload = janus_rtp_payload(buf, len, &plen);
-			if(payload == NULL)
-				return;
-			gboolean switched = FALSE;
-			if(peer->substream != peer->substream_target) {
-				/* There has been a change: let's wait for a keyframe on the target */
-				int step = (peer->substream < 1 && peer->substream_target == 2);
-				if((ssrc == session->ssrc[peer->substream_target]) || (step && ssrc == session->ssrc[step])) {
-					//~ if(janus_vp8_is_keyframe(payload, plen)) {
-						uint32_t ssrc_old = 0;
-						if(peer->substream != -1)
-							ssrc_old = session->ssrc[peer->substream];
-						JANUS_LOG(LOG_VERB, "Received keyframe on SSRC %"SCNu32", switching (was %"SCNu32")\n", ssrc, ssrc_old);
-						peer->substream = (ssrc == session->ssrc[peer->substream_target] ? peer->substream_target : step);
-						switched = TRUE;
-						/* Notify the peer */
-						json_t *event = json_object();
-						json_object_set_new(event, "videocall", json_string("event"));
-						json_t *result = json_object();
-						json_object_set_new(result, "event", json_string("simulcast"));
-						json_object_set_new(result, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
-						json_object_set_new(result, "substream", json_integer(peer->substream));
-						json_object_set_new(event, "result", result);
-						gateway->push_event(peer->handle, &janus_videocall_plugin, NULL, event, NULL);
-						json_decref(event);
-					//~ } else {
-						//~ JANUS_LOG(LOG_WARN, "Not a keyframe on SSRC %"SCNu32" yet, waiting before switching\n", ssrc);
-					//~ }
-				}
-			}
-			/* If we haven't received our desired substream yet, let's drop temporarily */
-			if(session->last_relayed == 0) {
-				/* Let's start slow */
-				session->last_relayed = janus_get_monotonic_time();
-			} else {
-				/* Check if 250ms went by with no packet relayed */
-				gint64 now = janus_get_monotonic_time();
-				if(now-session->last_relayed >= 250000) {
-					session->last_relayed = now;
-					int substream = peer->substream-1;
-					if(substream < 0)
-						substream = 0;
-					if(peer->substream != substream) {
-						JANUS_LOG(LOG_WARN, "No packet received on substream %d for a while, falling back to %d\n",
-							peer->substream, substream);
-						peer->substream = substream;
-						/* Send a PLI to the user */
-						JANUS_LOG(LOG_VERB, "Just (re-)enabled video, sending a PLI to recover it\n");
-						char rtcpbuf[12];
-						memset(rtcpbuf, 0, 12);
-						janus_rtcp_pli((char *)&rtcpbuf, 12);
-						gateway->relay_rtcp(handle, 1, rtcpbuf, 12);
-						/* Notify the peer */
-						json_t *event = json_object();
-						json_object_set_new(event, "videocall", json_string("event"));
-						json_t *result = json_object();
-						json_object_set_new(result, "event", json_string("simulcast"));
-						json_object_set_new(result, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
-						json_object_set_new(result, "substream", json_integer(peer->substream));
-						json_object_set_new(event, "result", result);
-						gateway->push_event(peer->handle, &janus_videocall_plugin, NULL, event, NULL);
-						json_decref(event);
-					}
-				}
-			}
+			/* Process this packet: don't relay if it's not the SSRC/layer we wanted to handle
+			 * The caveat is that the targets in OUR simulcast context are the PEER's targets */
+			gboolean relay = janus_rtp_simulcasting_context_process_rtp(&peer->sim_context,
+				buf, len, session->ssrc, session->vcodec, &peer->context);
 			/* Do we need to drop this? */
-			if(ssrc != session->ssrc[peer->substream]) {
-				JANUS_LOG(LOG_HUGE, "Dropping packet (it's from SSRC %"SCNu32", but we're only relaying to the peer the SSRC %"SCNu32" now\n",
-					ssrc, session->ssrc[peer->substream]);
+			if(!relay)
 				return;
+			/* Any event we should notify? */
+			if(peer->sim_context.changed_substream) {
+				/* Notify the user about the substream change */
+				json_t *event = json_object();
+				json_object_set_new(event, "videocall", json_string("event"));
+				json_t *result = json_object();
+				json_object_set_new(result, "event", json_string("simulcast"));
+				json_object_set_new(result, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
+				json_object_set_new(result, "substream", json_integer(session->sim_context.substream));
+				json_object_set_new(event, "result", result);
+				gateway->push_event(peer->handle, &janus_videocall_plugin, NULL, event, NULL);
+				json_decref(event);
 			}
-			session->last_relayed = janus_get_monotonic_time();
-			if(session->vcodec == JANUS_VIDEOCODEC_VP8) {
-				/* Check if there's any temporal scalability to take into account */
-				uint16_t picid = 0;
-				uint8_t tlzi = 0;
-				uint8_t tid = 0;
-				uint8_t ybit = 0;
-				uint8_t keyidx = 0;
-				if(janus_vp8_parse_descriptor(payload, plen, &picid, &tlzi, &tid, &ybit, &keyidx) == 0) {
-					//~ JANUS_LOG(LOG_WARN, "%"SCNu16", %u, %u, %u, %u\n", picid, tlzi, tid, ybit, keyidx);
-					if(peer->templayer != peer->templayer_target) {
-						/* FIXME We should be smarter in deciding when to switch */
-						peer->templayer = peer->templayer_target;
-						/* Notify the peer */
-						json_t *event = json_object();
-							json_object_set_new(event, "videocall", json_string("event"));
-							json_t *result = json_object();
-							json_object_set_new(result, "event", json_string("simulcast"));
-							json_object_set_new(result, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
-							json_object_set_new(result, "temporal", json_integer(peer->templayer));
-							json_object_set_new(event, "result", result);
-						gateway->push_event(peer->handle, &janus_videocall_plugin, NULL, event, NULL);
-						json_decref(event);
-					}
-					if(tid > peer->templayer) {
-						JANUS_LOG(LOG_HUGE, "Dropping packet (it's temporal layer %d, but we're capping at %d)\n",
-							tid, peer->templayer);
-						/* We increase the base sequence number, or there will be gaps when delivering later */
-						peer->context.v_base_seq++;
-						return;
-					}
-				}
+			if(peer->sim_context.need_pli) {
+				/* Send a PLI */
+				JANUS_LOG(LOG_VERB, "We need a PLI for the simulcast context\n");
+				char rtcpbuf[12];
+				memset(rtcpbuf, 0, 12);
+				janus_rtcp_pli((char *)&rtcpbuf, 12);
+				gateway->relay_rtcp(session->handle, 1, rtcpbuf, 12);
+			}
+			if(peer->sim_context.changed_temporal) {
+				/* Notify the user about the temporal layer change */
+				json_t *event = json_object();
+				json_object_set_new(event, "videocall", json_string("event"));
+				json_t *result = json_object();
+				json_object_set_new(result, "event", json_string("simulcast"));
+				json_object_set_new(result, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
+				json_object_set_new(result, "temporal", json_integer(session->sim_context.templayer));
+				json_object_set_new(event, "result", result);
+				gateway->push_event(peer->handle, &janus_videocall_plugin, NULL, event, NULL);
+				json_decref(event);
 			}
 			/* If we got here, update the RTP header and send the packet */
 			janus_rtp_header_update(header, &peer->context, TRUE, 4500);
-			if(session->vcodec == JANUS_VIDEOCODEC_VP8)
-				janus_vp8_simulcast_descriptor_update(payload, plen, &peer->simulcast_context, switched);
+			if(session->vcodec == JANUS_VIDEOCODEC_VP8) {
+				int plen = 0;
+				char *payload = janus_rtp_payload(buf, len, &plen);
+				janus_vp8_simulcast_descriptor_update(payload, plen, &peer->vp8_context, peer->sim_context.changed_substream);
+			}
 			/* Save the frame if we're recording (and make sure the SSRC never changes even if the substream does) */
 			header->ssrc = htonl(1);
 			janus_recorder_save_frame(session->vrc, buf, len);
 			/* Send the frame back */
 			gateway->relay_rtp(peer->handle, video, buf, len);
 			/* Restore header or core statistics will be messed up */
+			header->ssrc = htonl(ssrc);
 			header->timestamp = htonl(timestamp);
 			header->seq_number = htons(seq_number);
 		} else {
@@ -1390,12 +1316,12 @@ static void *janus_videocall_handler(void *data) {
 			}
 			/* Is simulcasting involved on either side? */
 			if(session->ssrc[0] && session->ssrc[1]) {
-				peer->substream_target = 2;	/* Let's aim for the highest quality */
-				peer->templayer_target = 2;	/* Let's aim for all temporal layers */
+				peer->sim_context.substream_target = 2;	/* Let's aim for the highest quality */
+				peer->sim_context.templayer_target = 2;	/* Let's aim for all temporal layers */
 			}
 			if(peer->ssrc[0] && peer->ssrc[1]) {
-				session->substream_target = 2;	/* Let's aim for the highest quality */
-				session->templayer_target = 2;	/* Let's aim for all temporal layers */
+				session->sim_context.substream_target = 2;	/* Let's aim for the highest quality */
+				session->sim_context.templayer_target = 2;	/* Let's aim for all temporal layers */
 			}
 			/* We don't need this reference anymore, it was already increased by the peer calling us */
 			janus_refcount_decrease(&peer->ref);
@@ -1455,17 +1381,17 @@ static void *janus_videocall_handler(void *data) {
 			}
 			janus_videocall_session *peer = session->peer;
 			if(substream) {
-				session->substream_target = json_integer_value(substream);
+				session->sim_context.substream_target = json_integer_value(substream);
 				JANUS_LOG(LOG_VERB, "Setting video SSRC to let through (simulcast): %"SCNu32" (index %d, was %d)\n",
-					session->ssrc[session->substream], session->substream_target, session->substream);
-				if(session->substream_target == session->substream) {
+					session->ssrc[session->sim_context.substream], session->sim_context.substream_target, session->sim_context.substream);
+				if(session->sim_context.substream_target == session->sim_context.substream) {
 					/* No need to do anything, we're already getting the right substream, so notify the user */
 					json_t *event = json_object();
 					json_object_set_new(event, "videocall", json_string("event"));
 					json_t *result = json_object();
 					json_object_set_new(result, "event", json_string("simulcast"));
 					json_object_set_new(result, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
-					json_object_set_new(result, "substream", json_integer(session->substream));
+					json_object_set_new(result, "substream", json_integer(session->sim_context.substream));
 					json_object_set_new(event, "result", result);
 					gateway->push_event(session->handle, &janus_videocall_plugin, NULL, event, NULL);
 					json_decref(event);
@@ -1480,17 +1406,17 @@ static void *janus_videocall_handler(void *data) {
 				}
 			}
 			if(temporal) {
-				session->templayer_target = json_integer_value(temporal);
+				session->sim_context.templayer_target = json_integer_value(temporal);
 				JANUS_LOG(LOG_VERB, "Setting video temporal layer to let through (simulcast): %d (was %d)\n",
-					session->templayer_target, session->templayer);
-				if(session->vcodec == JANUS_VIDEOCODEC_VP8 && session->templayer_target == session->templayer) {
+					session->sim_context.templayer_target, session->sim_context.templayer);
+				if(session->vcodec == JANUS_VIDEOCODEC_VP8 && session->sim_context.templayer_target == session->sim_context.templayer) {
 					/* No need to do anything, we're already getting the right temporal, so notify the user */
 					json_t *event = json_object();
 					json_object_set_new(event, "videocall", json_string("event"));
 					json_t *result = json_object();
 					json_object_set_new(result, "event", json_string("simulcast"));
 					json_object_set_new(result, "videocodec", json_string(janus_videocodec_name(session->vcodec)));
-					json_object_set_new(result, "temporal", json_integer(session->templayer));
+					json_object_set_new(result, "temporal", json_integer(session->sim_context.templayer));
 					json_object_set_new(event, "result", result);
 					gateway->push_event(session->handle, &janus_videocall_plugin, NULL, event, NULL);
 					json_decref(event);

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1392,8 +1392,8 @@ typedef struct janus_videoroom_publisher {
 	guint32 audio_ssrc;		/* Audio SSRC of this publisher */
 	guint32 video_ssrc;		/* Video SSRC of this publisher */
 	uint32_t ssrc[3];		/* Only needed in case VP8 (or H.264) simulcasting is involved */
-	int rtpmapid_extmap_id;	/* Only needed in case Firefox's RID-based simulcasting is involved */
-	char *rid[3];			/* Only needed in case Firefox's RID-based simulcasting is involved */
+	int rtpmapid_extmap_id;	/* Only needed for debugging in case Firefox's RID-based simulcasting is involved */
+	char *rid[3];			/* Only needed for debugging in case Firefox's RID-based simulcasting is involved */
 	guint8 audio_level_extmap_id;		/* Audio level extmap ID */
 	guint8 video_orient_extmap_id;		/* Video orientation extmap ID */
 	guint8 playout_delay_extmap_id;		/* Playout delay extmap ID */
@@ -1416,6 +1416,7 @@ typedef struct janus_videoroom_publisher {
 	janus_recorder *arc;	/* The Janus recorder instance for this publisher's audio, if enabled */
 	janus_recorder *vrc;	/* The Janus recorder instance for this user's video, if enabled */
 	janus_recorder *drc;	/* The Janus recorder instance for this publisher's data, if enabled */
+	janus_rtp_simulcasting_context rec_simctx;
 	janus_mutex rec_mutex;	/* Mutex to protect the recorders from race conditions */
 	GSList *subscribers;	/* Subscriptions to this publisher (who's watching this publisher)  */
 	GSList *subscriptions;	/* Subscriptions this publisher has created (who this publisher is watching) */
@@ -1442,12 +1443,8 @@ typedef struct janus_videoroom_subscriber {
 	guint32 pvt_id;			/* Private ID of the participant that is subscribing (if available/provided) */
 	janus_sdp *sdp;			/* Offer we sent this listener (may be updated within renegotiations) */
 	janus_rtp_switching_context context;	/* Needed in case there are publisher switches on this subscriber */
-	int substream;			/* Which VP8 (or H.264) simulcast substream we should forward, in case the publisher is simulcasting */
-	int substream_target;	/* As above, but to handle transitions (e.g., wait for keyframe) */
-	int templayer;			/* Which VP8 (unavailable for H.264) simulcast temporal layer we should forward, in case the publisher is simulcasting */
-	int templayer_target;	/* As above, but to handle transitions (e.g., wait for keyframe) */
-	gint64 last_relayed;	/* When we relayed the last packet (used to detect when substreams become unavailable) */
-	janus_vp8_simulcast_context simulcast_context;
+	janus_rtp_simulcasting_context sim_context;
+	janus_vp8_simulcast_context vp8_context;
 	gboolean audio, video, data;		/* Whether audio, video and/or data must be sent to this subscriber */
 	/* As above, but can't change dynamically (says whether something was negotiated at all in SDP) */
 	gboolean audio_offered, video_offered, data_offered;
@@ -2432,10 +2429,10 @@ json_t *janus_videoroom_query_session(janus_plugin_session *handle) {
 				json_object_set_new(info, "media", media);
 				if(feed && feed->ssrc[0] != 0) {
 					json_t *simulcast = json_object();
-					json_object_set_new(simulcast, "substream", json_integer(participant->substream));
-					json_object_set_new(simulcast, "substream-target", json_integer(participant->substream_target));
-					json_object_set_new(simulcast, "temporal-layer", json_integer(participant->templayer));
-					json_object_set_new(simulcast, "temporal-layer-target", json_integer(participant->templayer_target));
+					json_object_set_new(simulcast, "substream", json_integer(participant->sim_context.substream));
+					json_object_set_new(simulcast, "substream-target", json_integer(participant->sim_context.substream_target));
+					json_object_set_new(simulcast, "temporal-layer", json_integer(participant->sim_context.templayer));
+					json_object_set_new(simulcast, "temporal-layer-target", json_integer(participant->sim_context.templayer_target));
 					json_object_set_new(info, "simulcast", simulcast);
 				}
 				if(participant->room && participant->room->do_svc) {
@@ -4822,12 +4819,10 @@ static void *janus_videoroom_handler(void *data) {
 					g_atomic_int_set(&subscriber->destroyed, 0);
 					janus_refcount_init(&subscriber->ref, janus_videoroom_subscriber_free);
 					janus_refcount_increase(&subscriber->ref);	/* The publisher references the new subscriber too */
-					subscriber->substream = -1;
-					subscriber->substream_target = 2;
-					subscriber->templayer = -1;
-					subscriber->templayer_target = 2;
-					subscriber->last_relayed = 0;
-					janus_vp8_simulcast_context_reset(&subscriber->simulcast_context);
+					janus_rtp_simulcasting_context_reset(&subscriber->sim_context);
+					subscriber->sim_context.substream_target = 2;
+					subscriber->sim_context.templayer_target = 2;
+					janus_vp8_simulcast_context_reset(&subscriber->vp8_context);
 					if(subscriber->room->do_svc) {
 						/* This subscriber belongs to a room where VP9 SVC has been enabled,
 						 * let's assume we're interested in all layers for the time being */
@@ -5262,15 +5257,17 @@ static void *janus_videoroom_handler(void *data) {
 						subscriber->data = json_is_true(data);
 					/* Check if a simulcasting-related request is involved */
 					if(sc_substream && publisher->ssrc[0] != 0) {
-						subscriber->substream_target = json_integer_value(sc_substream);
+						subscriber->sim_context.substream_target = json_integer_value(sc_substream);
 						JANUS_LOG(LOG_VERB, "Setting video SSRC to let through (simulcast): %"SCNu32" (index %d, was %d)\n",
-							publisher->ssrc[subscriber->substream], subscriber->substream_target, subscriber->substream);
-						if(subscriber->substream_target == subscriber->substream) {
+							publisher->ssrc[subscriber->sim_context.substream],
+							subscriber->sim_context.substream_target,
+							subscriber->sim_context.substream);
+						if(subscriber->sim_context.substream_target == subscriber->sim_context.substream) {
 							/* No need to do anything, we're already getting the right substream, so notify the user */
 							json_t *event = json_object();
 							json_object_set_new(event, "videoroom", json_string("event"));
 							json_object_set_new(event, "room", json_integer(subscriber->room_id));
-							json_object_set_new(event, "substream", json_integer(subscriber->substream));
+							json_object_set_new(event, "substream", json_integer(subscriber->sim_context.substream));
 							gateway->push_event(msg->handle, &janus_videoroom_plugin, NULL, event, NULL);
 							json_decref(event);
 						} else {
@@ -5280,15 +5277,15 @@ static void *janus_videoroom_handler(void *data) {
 					}
 					if(subscriber->feed && subscriber->feed->vcodec == JANUS_VIDEOCODEC_VP8 &&
 							sc_temporal && publisher->ssrc[0] != 0) {
-						subscriber->templayer_target = json_integer_value(sc_temporal);
+						subscriber->sim_context.templayer_target = json_integer_value(sc_temporal);
 						JANUS_LOG(LOG_VERB, "Setting video temporal layer to let through (simulcast): %d (was %d)\n",
-							subscriber->templayer_target, subscriber->templayer);
-						if(subscriber->templayer_target == subscriber->templayer) {
+							subscriber->sim_context.templayer_target, subscriber->sim_context.templayer);
+						if(subscriber->sim_context.templayer_target == subscriber->sim_context.templayer) {
 							/* No need to do anything, we're already getting the right temporal, so notify the user */
 							json_t *event = json_object();
 							json_object_set_new(event, "videoroom", json_string("event"));
 							json_object_set_new(event, "room", json_integer(subscriber->room_id));
-							json_object_set_new(event, "temporal", json_integer(subscriber->templayer));
+							json_object_set_new(event, "temporal", json_integer(subscriber->sim_context.templayer));
 							gateway->push_event(msg->handle, &janus_videoroom_plugin, NULL, event, NULL);
 							json_decref(event);
 						} else {
@@ -6119,106 +6116,44 @@ static void janus_videoroom_relay_rtp_packet(gpointer data, gpointer user_data) 
 			packet->data->timestamp = htonl(packet->timestamp);
 			packet->data->seq_number = htons(packet->seq_number);
 		} else if(packet->ssrc[0] != 0) {
-			/* Handle simulcast: don't relay if it's not the SSRC we wanted to handle */
-			uint32_t ssrc = ntohl(packet->data->ssrc);
+			/* Handle simulcast: make sure we have a payload to work with */
 			int plen = 0;
 			char *payload = janus_rtp_payload((char *)packet->data, packet->length, &plen);
 			if(payload == NULL)
 				return;
-			gboolean switched = FALSE;
-			if(subscriber->substream != subscriber->substream_target) {
-				/* There has been a change: let's wait for a keyframe on the target */
-				int step = (subscriber->substream < 1 && subscriber->substream_target == 2);
-				if(ssrc == packet->ssrc[subscriber->substream_target] || (step && ssrc == packet->ssrc[step])) {
-					//~ if(janus_vp8_is_keyframe(payload, plen)) {
-						uint32_t ssrc_old = 0;
-						if(subscriber->substream != -1)
-							ssrc_old = packet->ssrc[subscriber->substream];
-						JANUS_LOG(LOG_VERB, "Received keyframe on SSRC %"SCNu32", switching (was %"SCNu32")\n", ssrc, ssrc_old);
-						subscriber->substream = (ssrc == packet->ssrc[subscriber->substream_target] ? subscriber->substream_target : step);;
-						switched = TRUE;
-						/* Notify the viewer */
-						json_t *event = json_object();
-						json_object_set_new(event, "videoroom", json_string("event"));
-						json_object_set_new(event, "room", json_integer(subscriber->room_id));
-						json_object_set_new(event, "substream", json_integer(subscriber->substream));
-						gateway->push_event(subscriber->session->handle, &janus_videoroom_plugin, NULL, event, NULL);
-						json_decref(event);
-					//~ } else {
-						//~ JANUS_LOG(LOG_WARN, "Not a keyframe on SSRC %"SCNu32" yet, waiting before switching\n", ssrc);
-					//~ }
-				}
-			}
-			/* If we haven't received our desired substream yet, let's drop temporarily */
-			if(subscriber->last_relayed == 0) {
-				/* Let's start slow */
-				subscriber->last_relayed = janus_get_monotonic_time();
-			} else {
-				/* Check if 250ms went by with no packet relayed */
-				gint64 now = janus_get_monotonic_time();
-				if(now-subscriber->last_relayed >= 250000) {
-					subscriber->last_relayed = now;
-					int substream = subscriber->substream-1;
-					if(substream < 0)
-						substream = 0;
-					if(subscriber->substream != substream) {
-						JANUS_LOG(LOG_WARN, "No packet received on substream %d for a while, falling back to %d\n",
-							subscriber->substream, substream);
-						subscriber->substream = substream;
-						/* Send a PLI */
-						JANUS_LOG(LOG_VERB, "Just (re-)enabled video, sending a PLI to recover it\n");
-						char rtcpbuf[12];
-						memset(rtcpbuf, 0, 12);
-						janus_rtcp_pli((char *)&rtcpbuf, 12);
-						if(subscriber->feed && subscriber->feed->session && subscriber->feed->session->handle) {
-							gateway->relay_rtcp(subscriber->feed->session->handle, 1, rtcpbuf, 12);
-							/* Update the time of when we last sent a keyframe request */
-							subscriber->feed->fir_latest = janus_get_monotonic_time();
-						}
-						/* Notify the viewer */
-						json_t *event = json_object();
-						json_object_set_new(event, "videoroom", json_string("event"));
-						json_object_set_new(event, "room", json_integer(subscriber->room_id));
-						json_object_set_new(event, "substream", json_integer(subscriber->substream));
-						gateway->push_event(subscriber->session->handle, &janus_videoroom_plugin, NULL, event, NULL);
-						json_decref(event);
-					}
-				}
-			}
-			if(ssrc != packet->ssrc[subscriber->substream]) {
-				JANUS_LOG(LOG_HUGE, "Dropping packet (it's from SSRC %"SCNu32", but we're only relaying SSRC %"SCNu32" now\n",
-					ssrc, packet->ssrc[subscriber->substream]);
+			/* Process this packet: don't relay if it's not the SSRC/layer we wanted to handle */
+			gboolean relay = janus_rtp_simulcasting_context_process_rtp(&subscriber->sim_context,
+				(char *)packet->data, packet->length, packet->ssrc, subscriber->feed->vcodec, &subscriber->context);
+			/* Do we need to drop this? */
+			if(!relay)
 				return;
+			/* Any event we should notify? */
+			if(subscriber->sim_context.changed_substream) {
+				/* Notify the user about the substream change */
+				json_t *event = json_object();
+				json_object_set_new(event, "videoroom", json_string("event"));
+				json_object_set_new(event, "room", json_integer(subscriber->room_id));
+				json_object_set_new(event, "substream", json_integer(subscriber->sim_context.substream));
+				gateway->push_event(subscriber->session->handle, &janus_videoroom_plugin, NULL, event, NULL);
+				json_decref(event);
 			}
-			subscriber->last_relayed = janus_get_monotonic_time();
-			if(subscriber->feed && subscriber->feed->vcodec == JANUS_VIDEOCODEC_VP8) {
-				/* Check if there's any temporal scalability to take into account */
-				uint16_t picid = 0;
-				uint8_t tlzi = 0;
-				uint8_t tid = 0;
-				uint8_t ybit = 0;
-				uint8_t keyidx = 0;
-				if(janus_vp8_parse_descriptor(payload, plen, &picid, &tlzi, &tid, &ybit, &keyidx) == 0) {
-					//~ JANUS_LOG(LOG_WARN, "%"SCNu16", %u, %u, %u, %u\n", picid, tlzi, tid, ybit, keyidx);
-					if(subscriber->templayer != subscriber->templayer_target) {
-						/* FIXME We should be smarter in deciding when to switch */
-						subscriber->templayer = subscriber->templayer_target;
-						/* Notify the user */
-						json_t *event = json_object();
-						json_object_set_new(event, "videoroom", json_string("event"));
-						json_object_set_new(event, "room", json_integer(subscriber->room_id));
-						json_object_set_new(event, "temporal", json_integer(subscriber->templayer));
-						gateway->push_event(subscriber->session->handle, &janus_videoroom_plugin, NULL, event, NULL);
-						json_decref(event);
-					}
-					if(tid > subscriber->templayer) {
-						JANUS_LOG(LOG_HUGE, "Dropping packet (it's temporal layer %d, but we're capping at %d)\n",
-							tid, subscriber->templayer);
-						/* We increase the base sequence number, or there will be gaps when delivering later */
-						subscriber->context.v_base_seq++;
-						return;
-					}
-				}
+			if(subscriber->sim_context.need_pli && subscriber->feed && subscriber->feed->session &&
+					subscriber->feed->session->handle) {
+				/* Send a PLI */
+				JANUS_LOG(LOG_VERB, "We need a PLI for the simulcast context\n");
+				char rtcpbuf[12];
+				memset(rtcpbuf, 0, 12);
+				janus_rtcp_pli((char *)&rtcpbuf, 12);
+				gateway->relay_rtcp(subscriber->feed->session->handle, 1, rtcpbuf, 12);
+			}
+			if(subscriber->sim_context.changed_temporal) {
+				/* Notify the user about the temporal layer change */
+				json_t *event = json_object();
+				json_object_set_new(event, "videoroom", json_string("event"));
+				json_object_set_new(event, "room", json_integer(subscriber->room_id));
+				json_object_set_new(event, "temporal", json_integer(subscriber->sim_context.templayer));
+				gateway->push_event(subscriber->session->handle, &janus_videoroom_plugin, NULL, event, NULL);
+				json_decref(event);
 			}
 			/* If we got here, update the RTP header and send the packet */
 			janus_rtp_header_update(packet->data, &subscriber->context, TRUE, 4500);
@@ -6226,7 +6161,8 @@ static void janus_videoroom_relay_rtp_packet(gpointer data, gpointer user_data) 
 			if(subscriber->feed && subscriber->feed->vcodec == JANUS_VIDEOCODEC_VP8) {
 				/* For VP8, we save the original payload descriptor, to restore it after */
 				memcpy(vp8pd, payload, sizeof(vp8pd));
-				janus_vp8_simulcast_descriptor_update(payload, plen, &subscriber->simulcast_context, switched);
+				janus_vp8_simulcast_descriptor_update(payload, plen, &subscriber->vp8_context,
+					subscriber->sim_context.changed_substream);
 			}
 			/* Send the packet */
 			if(gateway != NULL)


### PR DESCRIPTION
While simulcast support has been around for a while, there were a couple of areas were it was still a bit sketchy. In particular, for instance, simulcast publishers in the VideoRoom could not be recorder properly, nor could you forward the "best" stream to a single endpoint either. The way we handled this so far was to always record the base substream when simulcast was available (thus meaning the recording would be quite low resolution, even if good video was available), and for RTP forwarding we had substream support, meaning that you could relay the individual substreams to three different ports.

For recordings the limitation was obvious, for RTP forwarding it isn't, as that part is already helpful as it is (being able to relay the individual substreams to separate ports merges well with the simulcast support in the Streaming plugin). Anyway, there are cases where you don't want the individual substreams to be relayed, but want the best current video stream to be forwarded to a separate endpoint, thus having a forwarder act pretty much as a regular viewer (assuming of course that the recipient can receive and handle varying resolutions).

This patch addresses exactly this limitation. More specifically, it moves the processing of simulcast RTP packets to a dedicated core function, adding a support structure that is similar to the already existing "RTP switching context" in concept. This allowed us to update the plugins that were using simulcasting before to use the dedicated function instead: first of all, this had the obvious advantage of cleaning up the code and avoiding redundances, but also meant it would ease the integration of simulcast functionality in other parts of the code as well. This is exactly what we did for recordings and RTP forwarders in the VideoRoom, which are now both aware of simulcast, and can handle it if needed.

Please notice that, while for recordings this support is automatic (if a publisher is simulcasting, recording his contribution will automatically try and get the best video available), for RTP forwarders it isn't, and on purpose. In fact, as I explained, we already had some kind of simulcast support there (forwarding the individual streams), which is a feature that we don't want to lose since it can be incredibly helpful in some scenarios. As such, that remains the default behaviour: if you want to RTP forward simulcast streams as a single stream to a remote endpoint, you'll have to add `simulcast: true` to your request, e.g.:

	sfutest.send({
		message: {
			request: "rtp_forward",
			room: 1234,
			publisher_id: myid,
			secret: "adminpwd",
			host: "127.0.0.1",
			simulcast: true,            <--- this parameter here
			video_port: 17004
		}, success: function(result) {
			console.log("Video forwarder:", result["rtp_stream"]["video_stream_id"]);
		}
	});

When it's there, the code will automatically try to forward the best stream available to the recipient, ensuring that RTP headers make it look like a consistent flow just as it happens for WebRTC viewers.

I've tested this while working on the feature and it seems to be working as expected. I'm not aware of any regression, but I didn't look hard. Since I'm planning to merge soon, feedback is welcome as usual!