### PR TITLE
Fix parallel build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -172,6 +172,8 @@ man1_MANS = janus.1
 
 BUILT_SOURCES = cmdline.c cmdline.h version.c
 
+cmdline.h: cmdline.c
+
 cmdline.c: janus.c
 	gengetopt --set-package="janus" --set-version="$(VERSION)" < janus.ggo
 


### PR DESCRIPTION
Fix ``make: *** No rule to make target `cmdline.h', needed by `install'.  Stop.`` when you `make` janus with parallel build such as `-j4`.