### PR TITLE
Generate last chunk of transport wide cc fb msg correctly

### DIFF
--- a/rtcp.c
+++ b/rtcp.c
@@ -1413,14 +1413,13 @@ int janus_rtcp_transport_wide_cc_feedback(char *packet, size_t size, guint32 ssr
 			/* Write chunk */
 			word = janus_push_bits(word, 1, 1);
 			word = janus_push_bits(word, 1, 1);
-			/* Get fist status */
-			janus_rtp_packet_status status = (janus_rtp_packet_status) GPOINTER_TO_UINT(g_queue_pop_head (statuses));
-			/* Write rest */
-			while(!g_queue_is_empty(statuses)) {
+			/* Write rest statuses  */
+			unsigned int i = 0;
+			for (i=0;i<statuses_len;i++) {
+				/* Get each status */
+				janus_rtp_packet_status status = (janus_rtp_packet_status) GPOINTER_TO_UINT(g_queue_pop_head (statuses));
 				/* Write */
 				word = janus_push_bits(word, 2, (guint8)status);
-				/* Next */
-				status = (janus_rtp_packet_status) GPOINTER_TO_UINT(g_queue_pop_head (statuses));
 			}
 			/* Write pending */
 			word = janus_push_bits(word, 14-statuses_len*2, 0);
@@ -1432,14 +1431,13 @@ int janus_rtcp_transport_wide_cc_feedback(char *packet, size_t size, guint32 ssr
 			/* Write chunck */
 			word = janus_push_bits(word, 1, 1);
 			word = janus_push_bits(word, 1, 0);
-			/* Get fist status */
-			janus_rtp_packet_status status = (janus_rtp_packet_status) GPOINTER_TO_UINT(g_queue_pop_head (statuses));
-			/* Write rest */
-			while(!g_queue_is_empty(statuses)) {
+			/* Write rest statuses  */
+			unsigned int i = 0;
+			for (i=0;i<statuses_len;i++) {
+				/* Get each status */
+			        janus_rtp_packet_status status = (janus_rtp_packet_status) GPOINTER_TO_UINT(g_queue_pop_head (statuses));
 				/* Write */
 				word = janus_push_bits(word, 1, (guint8)status);
-				/* Next */
-				status = (janus_rtp_packet_status) GPOINTER_TO_UINT(g_queue_pop_head (statuses));
 			}
 			/* Write pending */
 			word = janus_push_bits(word, 14-statuses_len, 0);


### PR DESCRIPTION
* The current implementation generates malformed last packet chunk
* While statements check whether each queue is empty after the last status is popped, resulting in 1 less byte chunk generated.