### PR TITLE
Limit packet counts per single transport wide cc FB message

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -3404,13 +3404,40 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 		/* Free and reset stats list */
 		g_slist_free(stream->transport_wide_received_seq_nums);
 		stream->transport_wide_received_seq_nums = NULL;
-		/* Get feedback packet count and increase it for next one */
-		guint8 feedback_packet_count = stream->transport_wide_cc_feedback_count++;
-		/* Create rtcp packet */
-		int len = janus_rtcp_transport_wide_cc_feedback(rtcpbuf, size,
-			stream->video_ssrc, stream->video_ssrc_peer[0], feedback_packet_count, packets);
-		/* Enqueue it, we'll send it later */
-		janus_ice_relay_rtcp_internal(handle, 1, rtcpbuf, len, FALSE);
+
+		guint packets_len = 0;
+		while ((packets_len = g_queue_get_length(packets)) > 0) {
+			GQueue *packets_to_process;
+			// if packets_len > 400, transport_wide_cc packet could be overflow the buffer
+			if (packets_len > 400) {
+				// split the queue into two
+				GList *new_head = g_queue_peek_nth_link(packets, 400);
+				GList *new_tail = new_head->prev;
+				new_head->prev = NULL;
+				new_tail->next = NULL;
+				packets_to_process = g_queue_new();
+				packets_to_process->head = packets->head;
+				packets_to_process->tail = new_tail;
+				packets_to_process->length = 400;
+				packets->head = new_head;
+				// packets->tail is unchanged
+				packets->length = packets_len - 400;
+			} else {
+				packets_to_process = packets;
+			}
+
+			/* Get feedback packet count and increase it for next one */
+			guint8 feedback_packet_count = stream->transport_wide_cc_feedback_count++;
+			/* Create rtcp packet */
+			int len = janus_rtcp_transport_wide_cc_feedback(rtcpbuf, size,
+					stream->video_ssrc, stream->video_ssrc_peer[0], feedback_packet_count, packets_to_process);
+			/* Enqueue it, we'll send it later */
+			janus_ice_relay_rtcp_internal(handle, 1, rtcpbuf, len, FALSE);
+
+			if (packets_to_process != packets) {
+				g_queue_free(packets_to_process);
+			}
+		}
 		/* Free mem */
 		g_queue_free(packets);
 	}


### PR DESCRIPTION
* This prevents potential stack corruption made by janus_rtcp_transport_wide_cc_feedback()
(janus_rtcp_transport_wide_cc_feedback() doesn't handle packet buffer overflow)
* A packet can take up to 2.125 byte(16+1 bit) in the transport wide cc FB message
* Considering buffer size and the MTU, 400 seems to be good limit for packet counts per single FB  message