### PR TITLE
Evaluation step and tuning in skew compensation

### DIFF
--- a/rtp.c
+++ b/rtp.c
@@ -269,7 +269,7 @@ int janus_rtp_skew_compensate_audio(janus_rtp_header *header, janus_rtp_switchin
 	if (now-context->a_reference_time < SKEW_DETECTION_WAIT_TIME_SECS/2 * G_USEC_PER_SEC) {
 		return 0;
 	} else if (!context->a_start_time) {
-		JANUS_LOG(LOG_WARN, "audio skew SSRC=%"SCNu32" evaluation phase start\n", context->a_last_ssrc);
+		JANUS_LOG(LOG_VERB, "audio skew SSRC=%"SCNu32" evaluation phase start\n", context->a_last_ssrc);
 		context->a_start_time = now;
 		context->a_evaluating_start_time = now;
 		context->a_start_ts = context->a_last_ts;
@@ -307,13 +307,13 @@ int janus_rtp_skew_compensate_audio(janus_rtp_header *header, janus_rtp_switchin
 					if (abs(offset) <= skew_th/2) {
 						JANUS_LOG(LOG_HUGE, "audio skew SSRC=%"SCNu32" evaluation phase continue\n", context->a_last_ssrc);
 					} else {
-						JANUS_LOG(LOG_WARN, "audio skew SSRC=%"SCNu32" evaluation phase reset\n", context->a_last_ssrc);
+						JANUS_LOG(LOG_VERB, "audio skew SSRC=%"SCNu32" evaluation phase reset\n", context->a_last_ssrc);
 						context->a_start_time = now;
 						context->a_evaluating_start_time = now;
 						context->a_start_ts = context->a_last_ts;
 					}
 				} else {
-					JANUS_LOG(LOG_WARN, "audio skew SSRC=%"SCNu32" evaluation phase stop\n", context->a_last_ssrc);
+					JANUS_LOG(LOG_VERB, "audio skew SSRC=%"SCNu32" evaluation phase stop\n", context->a_last_ssrc);
 					context->a_evaluating_start_time = 0;
 				}
 				return 0;
@@ -383,7 +383,7 @@ int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switchin
 	if (now-context->v_reference_time < SKEW_DETECTION_WAIT_TIME_SECS*G_USEC_PER_SEC) {
 		return 0;
 	} else if (!context->v_start_time) {
-		JANUS_LOG(LOG_WARN, "video skew SSRC=%"SCNu32" evaluation phase start\n", context->v_last_ssrc);
+		JANUS_LOG(LOG_VERB, "video skew SSRC=%"SCNu32" evaluation phase start\n", context->v_last_ssrc);
 		context->v_start_time = now;
 		context->v_evaluating_start_time = now;
 		context->v_start_ts = context->v_last_ts;
@@ -420,13 +420,13 @@ int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switchin
 					if (abs(offset) <= skew_th/2) {
 						JANUS_LOG(LOG_HUGE, "video skew SSRC=%"SCNu32" evaluation phase continue\n", context->v_last_ssrc);
 					} else {
-						JANUS_LOG(LOG_WARN, "video skew SSRC=%"SCNu32" evaluation phase reset\n", context->v_last_ssrc);
+						JANUS_LOG(LOG_VERB, "video skew SSRC=%"SCNu32" evaluation phase reset\n", context->v_last_ssrc);
 						context->v_start_time = now;
 						context->v_evaluating_start_time = now;
 						context->v_start_ts = context->v_last_ts;
 					}
 				} else {
-					JANUS_LOG(LOG_WARN, "video skew SSRC=%"SCNu32" evaluation phase stop\n", context->v_last_ssrc);
+					JANUS_LOG(LOG_VERB, "video skew SSRC=%"SCNu32" evaluation phase stop\n", context->v_last_ssrc);
 					context->v_evaluating_start_time = 0;
 				}
 				return 0;

--- a/rtp.c
+++ b/rtp.c
@@ -413,7 +413,6 @@ int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switchin
 			/* Evaluate the distance between active delay and current delay estimate */
 			gint32 offset = context->v_active_delay - delay_estimate;
 			JANUS_LOG(LOG_HUGE, "video skew status SSRC=%"SCNu32" RECVD_TS=%"SCNu32" EXPTD_TS=%"SCNu32" OFFSET=%"SCNi32" TS_OFFSET=%"SCNi32" SEQ_OFFSET=%"SCNi16"\n", context->v_last_ssrc, context->v_last_ts, expected_ts, offset, context->v_ts_offset, context->v_seq_offset);
-			/* Check if the offset has surpassed the threshold */
 			gint32 skew_th = RTP_VIDEO_SKEW_TH_MS*vkhz;
 			/* Evaluation phase */
 			if (context->v_evaluating_start_time > 0) {
@@ -433,6 +432,7 @@ int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switchin
 				}
 				return 0;
 			}
+			/* Check if the offset has surpassed the threshold */
 			if (offset >= skew_th) {
 				/* The source is slowing down */
 				/* Update active delay */

--- a/rtp.c
+++ b/rtp.c
@@ -247,7 +247,7 @@ void janus_rtp_switching_context_reset(janus_rtp_switching_context *context) {
 int janus_rtp_skew_compensate_audio(janus_rtp_header *header, janus_rtp_switching_context *context, gint64 now) {
 	/* Reset values if a new ssrc has been detected */
 	if (context->a_new_ssrc) {
-		JANUS_LOG(LOG_WARN, "audio skew SSRC=%"SCNu32" resetting status\n", context->a_last_ssrc);
+		JANUS_LOG(LOG_VERB, "audio skew SSRC=%"SCNu32" resetting status\n", context->a_last_ssrc);
 		context->a_reference_time = now;
 		context->a_start_time = 0;
 		context->a_evaluating_start_time = 0;
@@ -363,9 +363,11 @@ int janus_rtp_skew_compensate_audio(janus_rtp_header *header, janus_rtp_switchin
 int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switching_context *context, gint64 now) {
 	/* Reset values if a new ssrc has been detected */
 	if (context->v_new_ssrc) {
+		JANUS_LOG(LOG_VERB, "video skew SSRC=%"SCNu32" resetting status\n", context->v_last_ssrc);
 		context->v_reference_time = now;
-		context->v_start_ts = 0;
 		context->v_start_time = 0;
+		context->v_evaluating_start_time = 0;
+		context->v_start_ts = 0;
 		context->v_active_delay = 0;
 		context->v_prev_delay = 0;
 		context->v_seq_offset = 0;
@@ -380,7 +382,7 @@ int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switchin
 	int exit_status = 0;
 
 	/* Do not execute skew analysis in the first seconds */
-	if (now-context->v_reference_time < SKEW_DETECTION_WAIT_TIME_SECS*G_USEC_PER_SEC) {
+	if (now-context->v_reference_time < SKEW_DETECTION_WAIT_TIME_SECS/2 *G_USEC_PER_SEC) {
 		return 0;
 	} else if (!context->v_start_time) {
 		JANUS_LOG(LOG_VERB, "video skew SSRC=%"SCNu32" evaluation phase start\n", context->v_last_ssrc);

--- a/rtp.c
+++ b/rtp.c
@@ -247,9 +247,11 @@ void janus_rtp_switching_context_reset(janus_rtp_switching_context *context) {
 int janus_rtp_skew_compensate_audio(janus_rtp_header *header, janus_rtp_switching_context *context, gint64 now) {
 	/* Reset values if a new ssrc has been detected */
 	if (context->a_new_ssrc) {
+		JANUS_LOG(LOG_WARN, "audio skew SSRC=%"SCNu32" resetting status\n", context->a_last_ssrc);
 		context->a_reference_time = now;
-		context->a_start_ts = 0;
 		context->a_start_time = 0;
+		context->a_evaluating_start_time = 0;
+		context->a_start_ts = 0;
 		context->a_active_delay = 0;
 		context->a_prev_delay = 0;
 		context->a_seq_offset = 0;
@@ -264,10 +266,12 @@ int janus_rtp_skew_compensate_audio(janus_rtp_header *header, janus_rtp_switchin
 	int exit_status = 0;
 
 	/* Do not execute skew analysis in the first seconds */
-	if (now-context->a_reference_time < SKEW_DETECTION_WAIT_TIME_SECS*G_USEC_PER_SEC) {
+	if (now-context->a_reference_time < SKEW_DETECTION_WAIT_TIME_SECS/2 * G_USEC_PER_SEC) {
 		return 0;
 	} else if (!context->a_start_time) {
+		JANUS_LOG(LOG_WARN, "audio skew SSRC=%"SCNu32" evaluation phase start\n", context->a_last_ssrc);
 		context->a_start_time = now;
+		context->a_evaluating_start_time = now;
 		context->a_start_ts = context->a_last_ts;
 	}
 
@@ -295,8 +299,26 @@ int janus_rtp_skew_compensate_audio(janus_rtp_header *header, janus_rtp_switchin
 			/* Evaluate the distance between active delay and current delay estimate */
 			gint32 offset = context->a_active_delay - delay_estimate;
 			JANUS_LOG(LOG_HUGE, "audio skew status SSRC=%"SCNu32" RECVD_TS=%"SCNu32" EXPTD_TS=%"SCNu32" OFFSET=%"SCNi32" TS_OFFSET=%"SCNi32" SEQ_OFFSET=%"SCNi16"\n", context->a_last_ssrc, context->a_last_ts, expected_ts, offset, context->a_ts_offset, context->a_seq_offset);
-			/* Check if the offset has surpassed the threshold */
 			gint32 skew_th = RTP_AUDIO_SKEW_TH_MS*akhz;
+			/* Evaluation phase */
+			if (context->a_evaluating_start_time > 0) {
+				/* Check if the offset has surpassed half the threshold during the evaluating phase */
+				if (now-context->a_evaluating_start_time <= SKEW_DETECTION_WAIT_TIME_SECS/2 * G_USEC_PER_SEC) {
+					if (abs(offset) <= skew_th/2) {
+						JANUS_LOG(LOG_HUGE, "audio skew SSRC=%"SCNu32" evaluation phase continue\n", context->a_last_ssrc);
+					} else {
+						JANUS_LOG(LOG_WARN, "audio skew SSRC=%"SCNu32" evaluation phase reset\n", context->a_last_ssrc);
+						context->a_start_time = now;
+						context->a_evaluating_start_time = now;
+						context->a_start_ts = context->a_last_ts;
+					}
+				} else {
+					JANUS_LOG(LOG_WARN, "audio skew SSRC=%"SCNu32" evaluation phase stop\n", context->a_last_ssrc);
+					context->a_evaluating_start_time = 0;
+				}
+				return 0;
+			}
+			/* Check if the offset has surpassed the threshold */
 			if (offset >= skew_th) {
 				/* The source is slowing down */
 				/* Update active delay */
@@ -361,7 +383,9 @@ int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switchin
 	if (now-context->v_reference_time < SKEW_DETECTION_WAIT_TIME_SECS*G_USEC_PER_SEC) {
 		return 0;
 	} else if (!context->v_start_time) {
+		JANUS_LOG(LOG_WARN, "video skew SSRC=%"SCNu32" evaluation phase start\n", context->v_last_ssrc);
 		context->v_start_time = now;
+		context->v_evaluating_start_time = now;
 		context->v_start_ts = context->v_last_ts;
 	}
 
@@ -381,7 +405,7 @@ int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switchin
 			/* Evaluate current delay */
 			gint32 delay_now = context->v_last_ts - expected_ts;
 			/* Exponentially weighted moving average estimation */
-			gint32 delay_estimate = (31*context->v_prev_delay + delay_now)/32;
+			gint32 delay_estimate = (63*context->v_prev_delay + delay_now)/64;
 			/* Save previous delay for the next iteration*/
 			context->v_prev_delay = delay_estimate;
 			/* Evaluate the distance between active delay and current delay estimate */
@@ -389,6 +413,24 @@ int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switchin
 			JANUS_LOG(LOG_HUGE, "video skew status SSRC=%"SCNu32" RECVD_TS=%"SCNu32" EXPTD_TS=%"SCNu32" OFFSET=%"SCNi32" TS_OFFSET=%"SCNi32" SEQ_OFFSET=%"SCNi16"\n", context->v_last_ssrc, context->v_last_ts, expected_ts, offset, context->v_ts_offset, context->v_seq_offset);
 			/* Check if the offset has surpassed the threshold */
 			gint32 skew_th = RTP_VIDEO_SKEW_TH_MS*vkhz;
+			/* Evaluation phase */
+			if (context->v_evaluating_start_time > 0) {
+				/* Check if the offset has surpassed half the threshold during the evaluating phase */
+				if (now-context->v_evaluating_start_time <= SKEW_DETECTION_WAIT_TIME_SECS/2 * G_USEC_PER_SEC) {
+					if (abs(offset) <= skew_th/2) {
+						JANUS_LOG(LOG_HUGE, "video skew SSRC=%"SCNu32" evaluation phase continue\n", context->v_last_ssrc);
+					} else {
+						JANUS_LOG(LOG_WARN, "video skew SSRC=%"SCNu32" evaluation phase reset\n", context->v_last_ssrc);
+						context->v_start_time = now;
+						context->v_evaluating_start_time = now;
+						context->v_start_ts = context->v_last_ts;
+					}
+				} else {
+					JANUS_LOG(LOG_WARN, "video skew SSRC=%"SCNu32" evaluation phase stop\n", context->v_last_ssrc);
+					context->v_evaluating_start_time = 0;
+				}
+				return 0;
+			}
 			if (offset >= skew_th) {
 				/* The source is slowing down */
 				/* Update active delay */

--- a/rtp.h
+++ b/rtp.h
@@ -178,8 +178,8 @@ void janus_rtp_switching_context_reset(janus_rtp_switching_context *context);
  * @param[in] step \b deprecated The expected timestamp step */
 void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_context *context, gboolean video, int step);
 
-#define RTP_AUDIO_SKEW_TH_MS 100
-#define RTP_VIDEO_SKEW_TH_MS 100
+#define RTP_AUDIO_SKEW_TH_MS 120
+#define RTP_VIDEO_SKEW_TH_MS 120
 #define SKEW_DETECTION_WAIT_TIME_SECS 10
 
 /*! \brief Use the context info to compensate for audio source skew, if needed

--- a/rtp.h
+++ b/rtp.h
@@ -163,8 +163,8 @@ typedef struct janus_rtp_switching_context {
 			v_seq_offset;
 	gint32 a_prev_delay, a_active_delay, a_ts_offset,
 			v_prev_delay, v_active_delay, v_ts_offset;
-	gint64 a_last_time, a_reference_time, a_start_time,
-			v_last_time, v_reference_time, v_start_time;
+	gint64 a_last_time, a_reference_time, a_start_time, a_evaluating_start_time,
+			v_last_time, v_reference_time, v_start_time, v_evaluating_start_time;
 } janus_rtp_switching_context;
 
 /*! \brief Set (or reset) the context fields to their default values
@@ -178,8 +178,8 @@ void janus_rtp_switching_context_reset(janus_rtp_switching_context *context);
  * @param[in] step \b deprecated The expected timestamp step */
 void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_context *context, gboolean video, int step);
 
-#define RTP_AUDIO_SKEW_TH_MS 160
-#define RTP_VIDEO_SKEW_TH_MS 160
+#define RTP_AUDIO_SKEW_TH_MS 100
+#define RTP_VIDEO_SKEW_TH_MS 100
 #define SKEW_DETECTION_WAIT_TIME_SECS 10
 
 /*! \brief Use the context info to compensate for audio source skew, if needed


### PR DESCRIPTION
This PR aims at optimizing and tuning the skew compensation code in cases when the reference timestamp and RTP timestamp used to calculate the offset is not accurate (e.g. have been affected by a network delay grater than RTT), thus leading to an incorrect estimation in the existing algorithm.

**HOW IT WORKS**
The skew estimation and compensation (SEC) does not execute any correction at all in a SKEW_DETECTION_WAIT_TIME_SECS time window.
This time window has been split in two: first half is a naive wait, to let the new media "stabilize" itself.
Then, after the first half, a time reference is taken (in terms of timestamp and RTP timestamp).
The second half of SKEW_DETECTION_WAIT_TIME_SECS is used to evaluate the stability of this time reference. Every incoming packet offset is checked against the estimation based on the time reference, and if the estimation is not too far from the actual packet TS for every packet in the analysis time window, the reference is considered valid and is used to compute the SEC.
In case the time reference proves to be not accurate, the second phase is restarted with a new time reference.
The threshold to define a stable estimation during the second phase is based on the same threshold used during the SEC. As of now, half of the SEC threshold is used.

**OTHER CHANGES**
The moving average parameters have been set to 63 and 64 for both audio and video SEC, the milliseconds threshold for SEC has been lowered to 120.
 