### PR TITLE
[FEEDBACK] Redefine mutexes to use GMutex instead of pthread_mutex_t

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,12 @@ AC_ARG_ENABLE([dtls-settimeout],
               [],
               [enable_dtls_settimeout=no])
 
+AC_ARG_ENABLE([pthread-mutex],
+              [AS_HELP_STRING([--enable-pthread-mutex],
+                              [Use pthread_mutex instead of GMutex (see #1397)])],
+              [],
+              [enable_pthread_mutex=no])
+
 AC_ARG_ENABLE([turn-rest-api],
               [AS_HELP_STRING([--disable-turn-rest-api],
                               [Disable TURN REST API client (via libcurl)])],
@@ -258,6 +264,13 @@ AS_IF([test "x$enable_dtls_settimeout" = "xyes"],
       AC_MSG_NOTICE([Assuming DTLSv1_set_initial_timeout_duration is available])
       ])
 AM_CONDITIONAL([ENABLE_DTLS_SETTIMEOUT], [test "x$enable_dtls_settimeout" = "xyes"])
+
+AS_IF([test "x$enable_pthread_mutex" = "xyes"],
+      [
+      AC_DEFINE(USE_PTHREAD_MUTEX)
+      AC_MSG_NOTICE([Will use pthread_mutex instead of GMutex])
+      ])
+AM_CONDITIONAL([ENABLE_PTHREAD_MUTEX], [test "x$enable_pthread_mutex" = "xyes"])
 
 AC_SEARCH_LIBS([tls_config_set_ca_mem],[tls],
              [AM_CONDITIONAL([LIBRESSL_DETECTED], true)],
@@ -865,6 +878,9 @@ AM_COND_IF([ENABLE_BORINGSSL],
 		[echo "SSL/crypto library:        LibreSSL"],
 		[echo "SSL/crypto library:        OpenSSL"])
 	 echo "DTLS set-timeout:          not available"])
+AM_COND_IF([ENABLE_PTHREAD_MUTEX],
+	[echo "Mutex implementation:      pthread mutex"],
+	[echo "Mutex implementation:      GMutex (native futex on Linux)"])
 AM_COND_IF([ENABLE_SCTP],
 	[echo "DataChannels support:      yes"],
 	[echo "DataChannels support:      no"])

--- a/mutex.h
+++ b/mutex.h
@@ -1,7 +1,7 @@
 /*! \file    mutex.h
  * \author   Lorenzo Miniero <lorenzo@meetecho.com>
  * \brief    Semaphors, Mutexes and Conditions
- * \details  Implementation (based on pthread) of a locking mechanism based on mutexes and conditions.
+ * \details  Implementation (based on GMutex) of a locking mechanism based on mutexes and conditions.
  * 
  * \ingroup core
  * \ref core
@@ -18,39 +18,39 @@
 extern int lock_debug;
 
 /*! \brief Janus mutex implementation */
-typedef pthread_mutex_t janus_mutex;
+typedef GMutex janus_mutex;
 /*! \brief Janus mutex initialization */
-#define janus_mutex_init(a) pthread_mutex_init(a,NULL)
+#define janus_mutex_init(a) g_mutex_init(a)
 /*! \brief Janus static mutex initializer */
-#define JANUS_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+#define JANUS_MUTEX_INITIALIZER {0}
 /*! \brief Janus mutex destruction */
-#define janus_mutex_destroy(a) pthread_mutex_destroy(a)
+#define janus_mutex_destroy(a) g_mutex_clear(a)
 /*! \brief Janus mutex lock without debug */
-#define janus_mutex_lock_nodebug(a) pthread_mutex_lock(a);
+#define janus_mutex_lock_nodebug(a) g_mutex_lock(a);
 /*! \brief Janus mutex lock with debug (prints the line that locked a mutex) */
-#define janus_mutex_lock_debug(a) { JANUS_PRINT("[%s:%s:%d:lock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); pthread_mutex_lock(a); };
+#define janus_mutex_lock_debug(a) { JANUS_PRINT("[%s:%s:%d:lock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); g_mutex_lock(a); };
 /*! \brief Janus mutex lock wrapper (selective locking debug) */
 #define janus_mutex_lock(a) { if(!lock_debug) { janus_mutex_lock_nodebug(a); } else { janus_mutex_lock_debug(a); } };
 /*! \brief Janus mutex unlock without debug */
-#define janus_mutex_unlock_nodebug(a) pthread_mutex_unlock(a);
+#define janus_mutex_unlock_nodebug(a) g_mutex_unlock(a);
 /*! \brief Janus mutex unlock with debug (prints the line that unlocked a mutex) */
-#define janus_mutex_unlock_debug(a) { JANUS_PRINT("[%s:%s:%d:unlock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); pthread_mutex_unlock(a); };
+#define janus_mutex_unlock_debug(a) { JANUS_PRINT("[%s:%s:%d:unlock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); g_mutex_unlock(a); };
 /*! \brief Janus mutex unlock wrapper (selective locking debug) */
 #define janus_mutex_unlock(a) { if(!lock_debug) { janus_mutex_unlock_nodebug(a); } else { janus_mutex_unlock_debug(a); } };
 
 /*! \brief Janus condition implementation */
-typedef pthread_cond_t janus_condition;
+typedef GCond janus_condition;
 /*! \brief Janus condition initialization */
-#define janus_condition_init(a) pthread_cond_init(a,NULL)
+#define janus_condition_init(a) g_cond_init(a)
 /*! \brief Janus condition destruction */
-#define janus_condition_destroy(a) pthread_cond_destroy(a)
+#define janus_condition_destroy(a) g_cond_clear(a)
 /*! \brief Janus condition wait */
-#define janus_condition_wait(a, b) pthread_cond_wait(a, b);
-/*! \brief Janus condition timed wait */
-#define janus_condition_timedwait(a, b, c) pthread_cond_timedwait(a, b, c);
+#define janus_condition_wait(a, b) g_cond_wait(a, b);
+/*! \brief Janus condition wait until */
+#define janus_condition_wait_until(a, b, c) g_cond_wait_until(a, b, c);
 /*! \brief Janus condition signal */
-#define janus_condition_signal(a) pthread_cond_signal(a);
+#define janus_condition_signal(a) g_cond_signal(a);
 /*! \brief Janus condition broadcast */
-#define janus_condition_broadcast(a) pthread_cond_broadcast(a);
+#define janus_condition_broadcast(a) g_cond_broadcast(a);
 
 #endif

--- a/mutex.h
+++ b/mutex.h
@@ -1,7 +1,7 @@
 /*! \file    mutex.h
  * \author   Lorenzo Miniero <lorenzo@meetecho.com>
  * \brief    Semaphors, Mutexes and Conditions
- * \details  Implementation (based on GMutex) of a locking mechanism based on mutexes and conditions.
+ * \details  Implementation (based on GMutex or pthread_mutex) of a locking mechanism based on mutexes and conditions.
  * 
  * \ingroup core
  * \ref core
@@ -16,6 +16,46 @@
 #include "debug.h"
 
 extern int lock_debug;
+
+#ifdef USE_PTHREAD_MUTEX
+
+/*! \brief Janus mutex implementation */
+typedef pthread_mutex_t janus_mutex;
+/*! \brief Janus mutex initialization */
+#define janus_mutex_init(a) pthread_mutex_init(a,NULL)
+/*! \brief Janus static mutex initializer */
+#define JANUS_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+/*! \brief Janus mutex destruction */
+#define janus_mutex_destroy(a) pthread_mutex_destroy(a)
+/*! \brief Janus mutex lock without debug */
+#define janus_mutex_lock_nodebug(a) pthread_mutex_lock(a);
+/*! \brief Janus mutex lock with debug (prints the line that locked a mutex) */
+#define janus_mutex_lock_debug(a) { JANUS_PRINT("[%s:%s:%d:lock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); pthread_mutex_lock(a); };
+/*! \brief Janus mutex lock wrapper (selective locking debug) */
+#define janus_mutex_lock(a) { if(!lock_debug) { janus_mutex_lock_nodebug(a); } else { janus_mutex_lock_debug(a); } };
+/*! \brief Janus mutex unlock without debug */
+#define janus_mutex_unlock_nodebug(a) pthread_mutex_unlock(a);
+/*! \brief Janus mutex unlock with debug (prints the line that unlocked a mutex) */
+#define janus_mutex_unlock_debug(a) { JANUS_PRINT("[%s:%s:%d:unlock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); pthread_mutex_unlock(a); };
+/*! \brief Janus mutex unlock wrapper (selective locking debug) */
+#define janus_mutex_unlock(a) { if(!lock_debug) { janus_mutex_unlock_nodebug(a); } else { janus_mutex_unlock_debug(a); } };
+
+/*! \brief Janus condition implementation */
+typedef pthread_cond_t janus_condition;
+/*! \brief Janus condition initialization */
+#define janus_condition_init(a) pthread_cond_init(a,NULL)
+/*! \brief Janus condition destruction */
+#define janus_condition_destroy(a) pthread_cond_destroy(a)
+/*! \brief Janus condition wait */
+#define janus_condition_wait(a, b) pthread_cond_wait(a, b);
+/*! \brief Janus condition timed wait */
+#define janus_condition_timedwait(a, b, c) pthread_cond_timedwait(a, b, c);
+/*! \brief Janus condition signal */
+#define janus_condition_signal(a) pthread_cond_signal(a);
+/*! \brief Janus condition broadcast */
+#define janus_condition_broadcast(a) pthread_cond_broadcast(a);
+
+#else
 
 /*! \brief Janus mutex implementation */
 typedef GMutex janus_mutex;
@@ -52,5 +92,7 @@ typedef GCond janus_condition;
 #define janus_condition_signal(a) g_cond_signal(a);
 /*! \brief Janus condition broadcast */
 #define janus_condition_broadcast(a) g_cond_broadcast(a);
+
+#endif
 
 #endif

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -1463,18 +1463,14 @@ parsingdone:
 	JANUS_LOG(LOG_HUGE, "Forwarding request to the core (%p)\n", ts);
 	gateway->incoming_request(&janus_http_transport, ts, ts, FALSE, root, &error);
 	/* Wait for a response (but not forever) */
-	struct timeval now;
-	gettimeofday(&now, NULL);
-	struct timespec wakeup;
-	wakeup.tv_sec = now.tv_sec+10;	/* Wait at max 10 seconds for a response */
-	wakeup.tv_nsec = now.tv_usec*1000UL;
-	pthread_mutex_lock(&msg->wait_mutex);
+	gint64 wakeup = janus_get_monotonic_time() + 10*G_TIME_SPAN_SECOND;
+	janus_mutex_lock(&msg->wait_mutex);
 	while(!msg->got_response) {
-		int res = pthread_cond_timedwait(&msg->wait_cond, &msg->wait_mutex, &wakeup);
+		int res = janus_condition_wait_until(&msg->wait_cond, &msg->wait_mutex, wakeup);
 		if(msg->got_response || res == ETIMEDOUT)
 			break;
 	}
-	pthread_mutex_unlock(&msg->wait_mutex);
+	janus_mutex_unlock(&msg->wait_mutex);
 	if(!msg->response) {
 		ret = MHD_NO;
 	} else {
@@ -1705,18 +1701,14 @@ parsingdone:
 	JANUS_LOG(LOG_HUGE, "Forwarding admin request to the core (%p)\n", msg);
 	gateway->incoming_request(&janus_http_transport, ts, ts, TRUE, root, &error);
 	/* Wait for a response (but not forever) */
-	struct timeval now;
-	gettimeofday(&now, NULL);
-	struct timespec wakeup;
-	wakeup.tv_sec = now.tv_sec+10;	/* Wait at max 10 seconds for a response */
-	wakeup.tv_nsec = now.tv_usec*1000UL;
-	pthread_mutex_lock(&msg->wait_mutex);
+	gint64 wakeup = janus_get_monotonic_time() + 10*G_TIME_SPAN_SECOND;
+	janus_mutex_lock(&msg->wait_mutex);
 	while(!msg->got_response) {
-		int res = pthread_cond_timedwait(&msg->wait_cond, &msg->wait_mutex, &wakeup);
+		int res = janus_condition_wait_until(&msg->wait_cond, &msg->wait_mutex, wakeup);
 		if(msg->got_response || res == ETIMEDOUT)
 			break;
 	}
-	pthread_mutex_unlock(&msg->wait_mutex);
+	janus_mutex_unlock(&msg->wait_mutex);
 	if(!msg->response) {
 		ret = MHD_NO;
 	} else {


### PR DESCRIPTION
This is more of a request for feedback than an actual pull request, as the code change is really marginal: actual question towards the end, after a brief technical explanation of what I changed.

I've been wondering if there was anything we could do to make locks in principle more efficient, e.g., toying with the idea of doing our own thing based on atomic operations rather than using mutexes directly. While I've discarded that idea (apparently busy waits are useful in some cases and quite harmful in others), I still wanted to better understand if there were options, and found out that, on Linux, [futexes](https://en.wikipedia.org/wiki/Futex) are supposed to be much more efficient as a native solution.

Rather than rewriting the mutex code myself to use those (especially considering we'd need to still support other systems Janus can be built on which might not support those), I checked how Glib implements mutexes, and found out that [they do use futex](https://bugzilla.gnome.org/show_bug.cgi?id=731986), if available on the system, and fallback to pthread mutexes otherwise. As such, I simply redefined our `janus_mutex` and `janus_condition` to use the [GMutex](developer.gnome.org/glib/stable/glib-Threads.html) methods instead. They were pretty much a 1-1 replacement, apart for a missing `PTHREAD_MUTEX_INITIALIZER` static initialization, that I set to `{ 0 }`, which should be fine as according to the docs:

    Its placement in static storage ensures that it will be initialised to all-zeros, which is appropriate.

My request for feedback comes from a couple of major doubts. From [what I've read](https://stackoverflow.com/questions/6364314/why-is-a-pthread-mutex-considered-slower-than-a-futex), on Linux the pthread mutex implementation also makes use of futex where available, only involving system calls when there are contentions (which should be pretty much what GMutex does in its "native" implementation): as such, is it really worth to switch just for the apparent overhead pthread has? I've personally not done any comparative testing of the two different approaches yet: is there any info or personal experience you can share on whether or not you think there are actual benefits on Linux, or if it's all just theoretical?

Thanks!