### PR TITLE
add endian define/include to pp-rtp.h

### DIFF
--- a/postprocessing/pp-rtp.h
+++ b/postprocessing/pp-rtp.h
@@ -13,6 +13,14 @@
 #ifndef _JANUS_PP_RTP
 #define _JANUS_PP_RTP
 
+#ifdef __MACH__
+#include <machine/endian.h>
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#else
+#include <endian.h>
+#endif
 
 typedef struct janus_pp_rtp_header
 {


### PR DESCRIPTION
without that definition, janus-pp-rec will use big endian in macOS, which will fail to convert h264 video into mp4.