### PR TITLE
Support for a couple of RTP extensions in the postprocessor

### DIFF
--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -17,15 +17,15 @@
  * G.711 (mu-law or a-law) frames. In case the recording contains text
  * frames as received via data channels, instead, a .srt file will be
  * generated with the text content and the related timing information.
- * 
+ *
  * Using the utility is quite simple. Just pass, as arguments to the tool,
  * the path to the .mjr source file you want to post-process, and the
  * path to the destination file, e.g.:
- * 
+ *
 \verbatim
 ./janus-pp-rec /path/to/source.mjr /path/to/destination.[opus|wav|webm|h264|srt]
-\endverbatim 
- * 
+\endverbatim
+ *
  * An attempt to specify an output format that is not compliant with the
  * recording content (e.g., a .webm for H.264 frames) will result in an
  * error since, again, no transcoding is involved.
@@ -45,7 +45,7 @@
  * the frames in a valid container. Any further post-processing (e.g.,
  * muxing audio and video belonging to the same media session in a single
  * .webm file) is up to third-party applications.
- * 
+ *
  * \ingroup postprocessing
  * \ref postprocessing
  */
@@ -94,6 +94,13 @@ static void janus_pp_handle_signal(int signum) {
 	working = 0;
 }
 
+/* Helper method to return an audio level from the related RTP extension, if any */
+static int audio_level_extmap_id = -1;
+static int janus_pp_rtp_header_extension_parse_audio_level(char *buf, int len, int id, int *level);
+/* Helper method to return the video rotation from the related RTP extension, if any */
+static int video_orient_extmap_id = -1;
+static int janus_pp_rtp_header_extension_parse_video_orientation(char *buf, int len, int id, int *rotation);
+
 
 /* Main Code */
 int main(int argc, char *argv[])
@@ -131,7 +138,19 @@ int main(int argc, char *argv[])
 			ignore_first_packets = val;
 		JANUS_LOG(LOG_INFO, "Ignoring first packets: %d\n", ignore_first_packets);
 	}
-	
+	if(g_getenv("JANUS_PPREC_AUDIOLEVELEXT") != NULL) {
+		int val = atoi(g_getenv("JANUS_PPREC_AUDIOLEVELEXT"));
+		if(val >= 0)
+			audio_level_extmap_id = val;
+		JANUS_LOG(LOG_INFO, "Audio level extension ID: %d\n", audio_level_extmap_id);
+	}
+	if(g_getenv("JANUS_PPREC_VIDEOORIENTEXT") != NULL) {
+		int val = atoi(g_getenv("JANUS_PPREC_VIDEOORIENTEXT"));
+		if(val >= 0)
+			video_orient_extmap_id = val;
+		JANUS_LOG(LOG_INFO, "Video orientation extension ID: %d\n", video_orient_extmap_id);
+	}
+
 	/* Evaluate arguments */
 	if(argc != 3) {
 		JANUS_LOG(LOG_INFO, "Usage: %s source.mjr destination.[opus|wav|webm|mp4|srt]\n", argv[0]);
@@ -405,6 +424,8 @@ int main(int argc, char *argv[])
 	int post_reset_pkts = 0;
 	int ignored = 0;
 	offset = 0;
+	/* Extensions, if any */
+	int audiolevel = 0, rotation = 0, last_rotation = -1, rotated = -1;
 	/* Timestamp reset related stuff */
 	last_ts = 0;
 	reset = 0;
@@ -463,6 +484,8 @@ int main(int argc, char *argv[])
 			p->drop = 0;
 			p->offset = offset;
 			p->skip = 0;
+			p->audiolevel = -1;
+			p->rotation = -1;
 			p->next = NULL;
 			p->prev = NULL;
 			if(list == NULL) {
@@ -476,7 +499,7 @@ int main(int argc, char *argv[])
 			continue;
 		}
 		/* Only read RTP header */
-		bytes = fread(prebuffer, sizeof(char), 16, file);
+		bytes = fread(prebuffer, sizeof(char), len > 24 ? 24: len, file);
 		janus_pp_rtp_header *rtp = (janus_pp_rtp_header *)prebuffer;
 		JANUS_LOG(LOG_VERB, "  -- RTP packet (ssrc=%"SCNu32", pt=%"SCNu16", ext=%"SCNu16", seq=%"SCNu16", ts=%"SCNu32")\n",
 				ntohl(rtp->ssrc), rtp->type, rtp->extension, ntohs(rtp->seq_number), ntohl(rtp->timestamp));
@@ -484,11 +507,22 @@ int main(int argc, char *argv[])
 			JANUS_LOG(LOG_VERB, "  -- -- Skipping CSRC list\n");
 			skip += rtp->csrccount*4;
 		}
+		audiolevel = -1;
+		rotation = -1;
 		if(rtp->extension) {
 			janus_pp_rtp_header_extension *ext = (janus_pp_rtp_header_extension *)(prebuffer+12);
 			JANUS_LOG(LOG_VERB, "  -- -- RTP extension (type=%"SCNu16", length=%"SCNu16")\n",
 				ntohs(ext->type), ntohs(ext->length));
 			skip += 4 + ntohs(ext->length)*4;
+			if(audio_level_extmap_id > 0)
+				janus_pp_rtp_header_extension_parse_audio_level(prebuffer, len > 24 ? 24 : len, audio_level_extmap_id, &audiolevel);
+			if(video_orient_extmap_id > 0) {
+				janus_pp_rtp_header_extension_parse_video_orientation(prebuffer, len > 24 ? 24 : len, video_orient_extmap_id, &rotation);
+				if(rotation != -1 && rotation != last_rotation) {
+					last_rotation = rotation;
+					rotated++;
+				}
+			}
 		}
 		if(ssrc == 0) {
 			ssrc = ntohl(rtp->ssrc);
@@ -569,6 +603,8 @@ int main(int argc, char *argv[])
 		/* Fill in the rest of the details */
 		p->offset = offset;
 		p->skip = skip;
+		p->audiolevel = audiolevel;
+		p->rotation = rotation;
 		p->next = NULL;
 		p->prev = NULL;
 		if(list == NULL) {
@@ -650,7 +686,7 @@ int main(int argc, char *argv[])
 	}
 	if(!working)
 		exit(0);
-	
+
 	JANUS_LOG(LOG_INFO, "Counted %"SCNu32" RTP packets\n", count);
 	janus_pp_frame_packet *tmp = list;
 	count = 0;
@@ -663,6 +699,13 @@ int main(int argc, char *argv[])
 		tmp = tmp->next;
 	}
 	JANUS_LOG(LOG_INFO, "Counted %"SCNu32" frame packets\n", count);
+	if(rotated != -1) {
+		if(rotated == 0 && last_rotation != 0) {
+			JANUS_LOG(LOG_INFO, "The video is rotated\n");
+		} else if(rotated > 0) {
+			JANUS_LOG(LOG_INFO, "The video changed orientation %d times\n", rotated);
+		}
+	}
 
 	if(video) {
 		/* Look for maximum width and height, if possible, and for the average framerate */
@@ -720,7 +763,7 @@ int main(int argc, char *argv[])
 			}
 		}
 	}
-	
+
 	/* Loop */
 	if(!video && !data) {
 		if(opus) {
@@ -771,7 +814,7 @@ int main(int argc, char *argv[])
 		}
 	}
 	fclose(file);
-	
+
 	file = fopen(destination, "rb");
 	if(file == NULL) {
 		JANUS_LOG(LOG_INFO, "No destination file %s??\n", destination);
@@ -790,5 +833,83 @@ int main(int argc, char *argv[])
 	}
 
 	JANUS_LOG(LOG_INFO, "Bye!\n");
+	return 0;
+}
+
+/* Static helper to quickly find the extension data */
+static int janus_pp_rtp_header_extension_find(char *buf, int len, int id,
+		uint8_t *byte, uint32_t *word, char **ref) {
+	if(!buf || len < 12)
+		return -1;
+	janus_pp_rtp_header *rtp = (janus_pp_rtp_header *)buf;
+	int hlen = 12;
+	if(rtp->csrccount)	/* Skip CSRC if needed */
+		hlen += rtp->csrccount*4;
+	if(rtp->extension) {
+		janus_pp_rtp_header_extension *ext = (janus_pp_rtp_header_extension *)(buf+hlen);
+		int extlen = ntohs(ext->length)*4;
+		hlen += 4;
+		if(len > (hlen + extlen)) {
+			/* 1-Byte extension */
+			if(ntohs(ext->type) == 0xBEDE) {
+				const uint8_t padding = 0x00, reserved = 0xF;
+				uint8_t extid = 0, idlen;
+				int i = 0;
+				while(i < extlen) {
+					extid = buf[hlen+i] >> 4;
+					if(extid == reserved) {
+						break;
+					} else if(extid == padding) {
+						i++;
+						continue;
+					}
+					idlen = (buf[hlen+i] & 0xF)+1;
+					if(extid == id) {
+						/* Found! */
+						if(byte)
+							*byte = buf[hlen+i+1];
+						if(word)
+							*word = ntohl(*(uint32_t *)(buf+hlen+i));
+						if(ref)
+							*ref = &buf[hlen+i];
+						return 0;
+					}
+					i += 1 + idlen;
+				}
+			}
+			hlen += extlen;
+		}
+	}
+	return -1;
+}
+
+static int janus_pp_rtp_header_extension_parse_audio_level(char *buf, int len, int id, int *level) {
+	uint8_t byte = 0;
+	if(janus_pp_rtp_header_extension_find(buf, len, id, &byte, NULL, NULL) < 0)
+		return -1;
+	/* a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level */
+	int value = byte & 0x7F;
+	if(level)
+		*level = value;
+	return 0;
+}
+
+static int janus_pp_rtp_header_extension_parse_video_orientation(char *buf, int len, int id, int *rotation) {
+	uint8_t byte = 0;
+	if(janus_pp_rtp_header_extension_find(buf, len, id, &byte, NULL, NULL) < 0)
+		return -1;
+	/* a=extmap:4 urn:3gpp:video-orientation */
+	gboolean r1bit = (byte & 0x02) >> 1;
+	gboolean r0bit = byte & 0x01;
+	if(rotation) {
+		if(!r0bit && !r1bit)
+			*rotation = 0;
+		else if(r0bit && !r1bit)
+			*rotation = 90;
+		else if(!r0bit && r1bit)
+			*rotation = 180;
+		else if(r0bit && r1bit)
+			*rotation = 270;
+	}
 	return 0;
 }

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -510,7 +510,7 @@ int main(int argc, char *argv[])
 		audiolevel = -1;
 		rotation = -1;
 		if(rtp->extension) {
-			janus_pp_rtp_header_extension *ext = (janus_pp_rtp_header_extension *)(prebuffer+12);
+			janus_pp_rtp_header_extension *ext = (janus_pp_rtp_header_extension *)(prebuffer+12+skip);
 			JANUS_LOG(LOG_VERB, "  -- -- RTP extension (type=%"SCNu16", length=%"SCNu16")\n",
 				ntohs(ext->type), ntohs(ext->length));
 			skip += 4 + ntohs(ext->length)*4;

--- a/postprocessing/pp-g711.c
+++ b/postprocessing/pp-g711.c
@@ -4,7 +4,7 @@
  * \brief    Post-processing to generate .wav files (headers)
  * \details  Implementation of the post-processing code needed to
  * generate raw .wav files out of G.711 (mu-law or a-law) RTP frames.
- * 
+ *
  * \ingroup postprocessing
  * \ref postprocessing
  */
@@ -184,6 +184,9 @@ int janus_pp_g711_process(FILE *file, janus_pp_frame_packet *list, int *working)
 			JANUS_LOG(LOG_WARN, "Dropping previously marked audio packet (time ~%"SCNu64"s)\n", (tmp->ts-list->ts)/48000);
 			tmp = tmp->next;
 			continue;
+		}
+		if(tmp->audiolevel != -1) {
+			JANUS_LOG(LOG_VERB, "Audio level: %d dB\n", tmp->audiolevel);
 		}
 		guint16 diff = tmp->prev == NULL ? 1 : (tmp->seq - tmp->prev->seq);
 		len = 0;

--- a/postprocessing/pp-g722.c
+++ b/postprocessing/pp-g722.c
@@ -4,7 +4,7 @@
  * \brief    Post-processing to generate .wav files out of G.722 (headers)
  * \details  Implementation of the post-processing code needed to
  * generate raw .wav files out of G.722 RTP frames.
- * 
+ *
  * \ingroup postprocessing
  * \ref postprocessing
  */
@@ -160,6 +160,9 @@ int janus_pp_g722_process(FILE *file, janus_pp_frame_packet *list, int *working)
 			JANUS_LOG(LOG_WARN, "Dropping previously marked audio packet (time ~%"SCNu64"s)\n", (tmp->ts-list->ts)/48000);
 			tmp = tmp->next;
 			continue;
+		}
+		if(tmp->audiolevel != -1) {
+			JANUS_LOG(LOG_VERB, "Audio level: %d dB\n", tmp->audiolevel);
 		}
 		guint16 diff = tmp->prev == NULL ? 1 : (tmp->seq - tmp->prev->seq);
 		len = 0;

--- a/postprocessing/pp-h264.c
+++ b/postprocessing/pp-h264.c
@@ -4,7 +4,7 @@
  * \brief    Post-processing to generate .mp4 files
  * \details  Implementation of the post-processing code (based on FFmpeg)
  * needed to generate .mp4 files out of H.264 RTP frames.
- * 
+ *
  * \ingroup postprocessing
  * \ref postprocessing
  */
@@ -242,6 +242,7 @@ int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list) {
 		return -1;
 	janus_pp_frame_packet *tmp = list;
 	int bytes = 0, min_ts_diff = 0, max_ts_diff = 0;
+	int rotation = -1;
 	char prebuffer[1500];
 	memset(prebuffer, 0, 1500);
 	while(tmp) {
@@ -255,7 +256,7 @@ int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list) {
 			}
 			if(tmp->seq - tmp->prev->seq > 1) {
 				JANUS_LOG(LOG_WARN, "Lost a packet here? (got seq %"SCNu16" after %"SCNu16", time ~%"SCNu64"s)\n",
-					tmp->seq, tmp->prev->seq, (tmp->ts-list->ts)/90000); 
+					tmp->seq, tmp->prev->seq, (tmp->ts-list->ts)/90000);
 			}
 		}
 		/* Parse H264 header now */
@@ -312,6 +313,10 @@ int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list) {
 			JANUS_LOG(LOG_WARN, "Dropping previously marked video packet (time ~%"SCNu64"s)\n", (tmp->ts-list->ts)/90000);
 			tmp = tmp->next;
 			continue;
+		}
+		if(tmp->rotation != -1 && tmp->rotation != rotation) {
+			rotation = tmp->rotation;
+			JANUS_LOG(LOG_INFO, "Video rotation: %d degrees\n", rotation);
 		}
 		tmp = tmp->next;
 	}

--- a/postprocessing/pp-opus.c
+++ b/postprocessing/pp-opus.c
@@ -4,7 +4,7 @@
  * \brief    Post-processing to generate .opus files
  * \details  Implementation of the post-processing code (based on libogg)
  * needed to generate .opus files out of Opus RTP frames.
- * 
+ *
  * \ingroup postprocessing
  * \ref postprocessing
  */
@@ -96,6 +96,9 @@ int janus_pp_opus_process(FILE *file, janus_pp_frame_packet *list, int *working)
 			JANUS_LOG(LOG_WARN, "Dropping previously marked audio packet (time ~%"SCNu64"s)\n", (tmp->ts-list->ts)/48000);
 			tmp = tmp->next;
 			continue;
+		}
+		if(tmp->audiolevel != -1) {
+			JANUS_LOG(LOG_VERB, "Audio level: %d dB\n", tmp->audiolevel);
 		}
 		guint16 diff = tmp->prev == NULL ? 1 : (tmp->seq - tmp->prev->seq);
 		len = 0;

--- a/postprocessing/pp-rtp.h
+++ b/postprocessing/pp-rtp.h
@@ -5,7 +5,7 @@
  * \details  A few structures to ease the post-processing of RTP frames:
  * the RTP header, its extensions (that we just skip), and a linked list
  * we use to re-order them for post-processing audio/video later on.
- * 
+ *
  * \ingroup postprocessing
  * \ref postprocessing
  */
@@ -58,9 +58,10 @@ typedef struct janus_pp_frame_packet {
 	long offset;	/* Offset of the data in the file */
 	int skip;		/* Bytes to skip, besides the RTP header */
 	uint8_t drop;	/* Whether this packet can be dropped (e.g., padding)*/
+	int audiolevel;	/* Value of audio level in RTP extension, if parsed */
+	int rotation;	/* Value of rotation in RTP extension, if parsed */
 	struct janus_pp_frame_packet *next;
 	struct janus_pp_frame_packet *prev;
 } janus_pp_frame_packet;
-
 
 #endif

--- a/postprocessing/pp-webm.c
+++ b/postprocessing/pp-webm.c
@@ -174,6 +174,7 @@ int janus_pp_webm_preprocess(FILE *file, janus_pp_frame_packet *list, int vp8) {
 		return -1;
 	janus_pp_frame_packet *tmp = list;
 	int bytes = 0, min_ts_diff = 0, max_ts_diff = 0;
+	int rotation = -1;
 	char prebuffer[1500];
 	memset(prebuffer, 0, 1500);
 	while(tmp) {
@@ -195,6 +196,10 @@ int janus_pp_webm_preprocess(FILE *file, janus_pp_frame_packet *list, int vp8) {
 			JANUS_LOG(LOG_WARN, "Dropping previously marked video packet (time ~%"SCNu64"s)\n", (tmp->ts-list->ts)/90000);
 			tmp = tmp->next;
 			continue;
+		}
+		if(tmp->rotation != -1 && tmp->rotation != rotation) {
+			rotation = tmp->rotation;
+			JANUS_LOG(LOG_INFO, "Video rotation: %d degrees\n", rotation);
 		}
 		if(vp8) {
 			/* https://tools.ietf.org/html/draft-ietf-payload-vp8 */


### PR DESCRIPTION
This patch is actually a revisitation of the original effort started in #1400, and so most of the credits should go to @Piasy.

It adds two new environment variables that can be passed when launching the post-processor:

1. `JANUS_PPREC_AUDIOLEVELEXT`: ID of the audio level RTP extension;
2. `JANUS_PPREC_VIDEOORIENTEXT`: ID of the video orientation RTP extension.

Manually passing these identifiers is needed as they're advertised via SDP, and so this info is lost when we save recordings to the .mjr format.

When an RTP extension ID is specified, the postprocessor also looks for their values in the RTP packets it goes through, and stores them in the structure it uses for each of the packets. This way, the info is available to the individual processors (e.g., webm, h264, opus, etc.) in case later on we find a way to use them properly for more than just printed information.

The audio level extension values are only printed when debugging is at least 5. The video orientation extension values, instead, are interpreted by the postprocessor to give a summary, that can be especially useful when just parsing recordings with `--parse`. Specifically, if the video is not "straight" (orientation=0), the postprocessor will tell you if the video is rotated, and if the video rotated more than once, the postprocessor will tell you that as well. The information is not used in any way by the postprocessor: it's just printed so that you're aware of that.

Again, the original idea came to @Piasy, and so most of the credits go to him. I'm just publishing this as a separate effort due to some differences in the way I wanted the code to look like: since I had already asked him for multiple revisions, it didn't seem fair to keep on asking for changes, and it seemed easier to do the changes myself. I tried to reuse the same code we use for parsing extensions in Janus, which should make it feel more consistent.