### PR TITLE
Add support for dumping to .pcap directly

### DIFF
--- a/html/admin.html
+++ b/html/admin.html
@@ -135,11 +135,15 @@
 						<div id="info" class="col-md-8">
 							<h4>Handle Info <i id="update-handle" class="fa fa-refresh" title="Refresh handle info" style="cursor: pointer;"></i></h4>
 							<div id="options" class="hide">
-								<label class="checkbox-inline">
-									<input id="autorefresh"type="checkbox" value="">Autorefresh
+								<label class="checkbox-inline" title="Autorefresh this info every 5s">
+									<input id="autorefresh" type="checkbox" value="" title="Autorefresh this info every 5s">Autorefresh
 								</label>
-								<label class="checkbox-inline">
-									<input id="prettify"type="checkbox" value="">Prettify
+								<label class="checkbox-inline" title="Show information as HTML">
+									<input id="prettify" type="checkbox" value="" title="Show information as HTML">Prettify
+								</label>
+								<label class="checkbox-inline" title="Start of stop capturing traffic to .pcap">
+									<input id="capture" type="checkbox" value="" title="Start of stop capturing traffic to .pcap">
+									<span id="capturetext">Start capture</span>
 								</label>
 							</div>
 							<div id="handle-info">

--- a/html/admin.js
+++ b/html/admin.js
@@ -168,6 +168,17 @@ function updateServerInfo() {
 					rawHandleInfo();
 				}
 			});
+			$("#capture").change(function() {
+				if(this.checked) {
+					// We're trying to start a new capture, show a dialog
+					$('#capturetext').html('Stop capture');
+					captureTrafficPrompt();
+				} else {
+					// We're trying to stop a capture
+					$('#capturetext').html('Start capture');
+					captureTrafficRequest(false, handleInfo["dump-to-text2pcap"] === true);
+				}
+			});
 			// Only check tokens if the mechanism is enabled
 			if(!json["auth_token"]) {
 				$('a[href=#tokens]').parent().addClass('disabled');
@@ -695,6 +706,8 @@ function updateHandleInfo(refresh) {
 	$('#update-sessions').unbind('click');
 	$('#update-handles').unbind('click');
 	$('#update-handle').unbind('click').addClass('fa-spin');
+	$('#capture').removeAttr('checked');
+	$('#capturetext').html('Start capture');
 	var request = { "janus": "handle_info", "transaction": randomString(12), "admin_secret": secret };
 	$.ajax({
 		type: 'POST',
@@ -732,6 +745,10 @@ function updateHandleInfo(refresh) {
 				prettyHandleInfo();
 			} else {
 				rawHandleInfo();
+			}
+			if(handleInfo["dump-to-pcap"] || handleInfo["dump-to-text2pcap"]) {
+				$('#capture').attr('checked', true);
+				$('#capturetext').html('Stop capture');
 			}
 			setTimeout(function() {
 				$('#update-sessions').click(updateSessions);
@@ -1093,6 +1110,100 @@ function sendTokenRequest(request) {
 				return;
 			}
 			updateTokens();
+		},
+		error: function(XMLHttpRequest, textStatus, errorThrown) {
+			console.log(textStatus + ": " + errorThrown);	// FIXME
+			if(!prompting && !alerted) {
+				alerted = true;
+				bootbox.alert("Couldn't contact the backend: is Janus down, or is the Admin/Monitor interface disabled?", function() {
+					promptAccessDetails();
+					alerted = false;
+				});
+			}
+		},
+		dataType: "json"
+	});
+}
+
+// text2pcap and pcap requests
+function captureTrafficPrompt() {
+	bootbox.dialog({
+		title: "Start capturing traffic",
+		message:
+			'<div class="form-content">' +
+			'	<form class="form" role="form">' +
+			'		<div class="form-group">' +
+			'			<label for="type">Capture Type</label>' +
+			'			<select class="form-control" id="type" name="type" value="pcal">' +
+			'				<option value="pcap">pcap</option>' +
+			'				<option value="text2pcap">text2pcap</option>' +
+			'			</select>' +
+			'		</div>' +
+			'		<div class="form-group">' +
+			'			<label for="extra">Folder to save in</label>' +
+			'			<input type="text" class="form-control" id="folder" name="folder" placeholder="Insert a path to the target folder" value=""></input>' +
+			'		</div>' +
+			'		<div class="form-group">' +
+			'			<label for="extra">Filename</label>' +
+			'			<input type="text" class="form-control" id="filename" name="filename" placeholder="Insert the target filename" value=""></input>' +
+			'		</div>' +
+			'		<div class="form-group">' +
+			'			<label for="extra">Truncate</label>' +
+			'			<input type="text" class="form-control" id="truncate" name="truncate" placeholder="Bytes to truncate at (0 or omit to save the whole packet)" value=""></input>' +
+			'		</div>' +
+			'	</form>' +
+			'</div>',
+		buttons: [
+			{
+				label: "Start",
+				className: "btn btn-primary pull-left",
+				callback: function() {
+					var text = $('#type').val() === "text2pcap";
+					var folder = $('#folder').val() !== '' ? $('#folder').val() : undefined;
+					var filename = $('#filename').val() !== '' ? $('#filename').val() : undefined;
+					var truncate = parseInt($('#truncate').val());
+					if(!truncate || isNaN(truncate))
+						truncate = 0;
+					captureTrafficRequest(true, text, folder, filename, truncate);
+				}
+			},
+			{
+				label: "Close",
+				className: "btn btn-default pull-left",
+				callback: function() {
+					$('#capture').removeAttr('checked');
+					$('#capturetext').html('Start capture');
+				}
+			}
+		]
+	});
+}
+
+function captureTrafficRequest(start, text, folder, filename, truncate) {
+	var req = start ? ( text ? "start_text2pcap" : "start_pcap" ) :
+		( text ? "stop_text2pcap" : "stop_pcap" )
+	var request = { "janus": req, "transaction": randomString(12), "admin_secret": secret };
+	if(start) {
+		request["folder"] = folder;
+		request["filename"] = filename;
+		request["truncate"] = truncate;
+	}
+	$.ajax({
+		type: 'POST',
+		url: server + "/" + session + "/" + handle,
+		cache: false,
+		contentType: "application/json",
+		data: JSON.stringify(request),
+		success: function(json) {
+			if(json["janus"] !== "success") {
+				console.log("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+				bootbox.alert(json["error"].reason);
+				if(start && json["error"].reason.indexOf('already') === -1) {
+					$('#capture').removeAttr('checked');
+					$('#capturetext').html('Start capture');
+				}
+				return;
+			}
 		},
 		error: function(XMLHttpRequest, textStatus, errorThrown) {
 			console.log(textStatus + ": " + errorThrown);	// FIXME

--- a/janus.c
+++ b/janus.c
@@ -2203,10 +2203,14 @@ int janus_process_incoming_admin_request(janus_request *request) {
 			json_object_set_new(info, "pending-trickles", json_integer(g_list_length(handle->pending_trickles)));
 		if(handle->queued_packets)
 			json_object_set_new(info, "queued-packets", json_integer(g_async_queue_length(handle->queued_packets)));
-		if(g_atomic_int_get(&handle->dump_packets)) {
-			json_object_set_new(info, "dump-to-text2pcap", json_true());
-			if(handle->text2pcap && handle->text2pcap->filename)
-			json_object_set_new(info, "text2pcap-file", json_string(handle->text2pcap->filename));
+		if(g_atomic_int_get(&handle->dump_packets) && handle->text2pcap) {
+			if(handle->text2pcap->text) {
+				json_object_set_new(info, "dump-to-text2pcap", json_true());
+				json_object_set_new(info, "text2pcap-file", json_string(handle->text2pcap->filename));
+			} else {
+				json_object_set_new(info, "dump-to-pcap", json_true());
+				json_object_set_new(info, "pcap-file", json_string(handle->text2pcap->filename));
+			}
 		}
 		json_t *streams = json_array();
 		if(handle->stream) {

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -141,8 +141,8 @@
  * -# connect to the server and create a session;
  * -# create one or more handles to attach to a plugin (e.g., echo test and/or streaming);
  * -# interact with the plugin (sending/receiving messages, negotiating a PeerConnection);
- * -# eventually, close all the handles and shutdown the related PeerConnections;  
- * -# destroy the session.  
+ * -# eventually, close all the handles and shutdown the related PeerConnections;
+ * -# destroy the session.
  *
  * The above steps will be presented in order, describing how you can use
  * the low level API to accomplish them. Consider that in the future we might
@@ -393,7 +393,7 @@ janus.attach(
 	});
  \endverbatim
  *
- * So the \c attach() method allows you to attach to a plugin, and specify 
+ * So the \c attach() method allows you to attach to a plugin, and specify
  * the callbacks to invoke when anything relevant happens in this interaction.
  * To actively interact with the plugin, you can use the \c Handle object
  * that is returned by the \c success callback (pluginHandle in the example).
@@ -444,7 +444,7 @@ janus.attach(
  * to mute your stream, or to be notified about someone joining a virtual room),
  * while the \c ondata callback is triggered whenever data is received
  * on the Data Channel, if available (and the \c ondataopen callback
- * will tell you when a Data Channel is actually available). 
+ * will tell you when a Data Channel is actually available).
  *
  * The following paragraphs will delve a bit deeper in the negotiation
  * mechanism provided by the \c Handle API, in particular describing
@@ -489,7 +489,7 @@ janus.attach(
  * request, and that you want the library to use instead of having it get one by itself (makes
  * the \c media property useless, as it won't be read for accessing any device);
  *   - a set of callbacks to be notified about the result, namely:
- *     - \c success: the session description was created (attached as a parameter) and is ready to be sent to the plugin; 
+ *     - \c success: the session description was created (attached as a parameter) and is ready to be sent to the plugin;
  *     - \c error: the session description was NOT successfully created;
  * - \c createAnswer takes the same options as createOffer, but requires
  * an additional one as part of the single parameter argument:
@@ -598,7 +598,7 @@ janus.attach(
  * would involve both, allowing you to either send offers to a plugin,
  * or receive some from them. Handling this is just a matter of checking
  * the \c type of the \c jsep object and reacting accordingly.
- *  
+ *
  * \section renegotiation Updating an existing PeerConnection (renegotiations)
  * While the JavaScript APIs described above will suffice for most of the
  * common scenarios, there are cases when updates on a PeerConnection may
@@ -1047,7 +1047,7 @@ export const initialiseJanusLibrary = () => Janus.init({dependencies: setupDeps(
  * The API exposes an \c info endpoint you can query to get information
  * about the Janus instance you're talking to. Specifically, it returns
  * information about the version of the Janus server, whether some of the
- * optional features (e.g., Data Channels or IPv6) are supported or not, 
+ * optional features (e.g., Data Channels or IPv6) are supported or not,
  * and which transports and plugins are available.
  *
  * To get this information, just send an HTTP \b GET message to the \c info
@@ -1138,7 +1138,7 @@ export const initialiseJanusLibrary = () => Janus.init({dependencies: setupDeps(
  * concatenating the server root and the session identifier you've been
  * returned (\c e.g., \c /janus/12345678).
  *
- * This endpoint can be used in two different ways: 
+ * This endpoint can be used in two different ways:
  *
  * -# using a parameter-less \b GET request to the endpoint, you'll
  * issue a long-poll request to be notified about events and incoming
@@ -1243,7 +1243,7 @@ GET http://host:port/janus/<sessionid>?maxev=5
  * To attach to a plugin in order to exploit its features, you need to
  * \b POST a \c janus "attach" JSON message to the server; you'll need
  * of course to provide information on the plugin you want to attach to,
- * which can be done using the \c plugin field: 
+ * which can be done using the \c plugin field:
  *
 \verbatim
 {
@@ -1286,10 +1286,10 @@ GET http://host:port/janus/<sessionid>?maxev=5
 \endverbatim
  *
  * This will also destroy the endpoint created for this session.
- * If your session is currently managing one or more plugin handles, 
+ * If your session is currently managing one or more plugin handles,
  * make sure you destroy them first (as explained in the next section).
  * The server tries to do this automatically when receiving a session
- * destroy request, but a cleaner approach on the client side would help 
+ * destroy request, but a cleaner approach on the client side would help
  * nonetheless avoid potential issues.
  *
  * \section handles The plugin handle endpoint
@@ -1307,7 +1307,7 @@ GET http://host:port/janus/<sessionid>?maxev=5
  * endpoint a \c janus "message" JSON payload. The \c body field will
  * have to contain a plugin-specific JSON payload. In case the message
  * also needs to convey WebRTC-related negotiation information, a \c jsep
- * field containing the JSON-ified version of the JSEP object can be 
+ * field containing the JSON-ified version of the JSEP object can be
  * attached as well.
  *
  * \note If you attach a \c jsep object, whether it's an offer or an answer,
@@ -1390,7 +1390,7 @@ GET http://host:port/janus/<sessionid>?maxev=5
 {
 	"janus" : "trickle",
 	"transaction" : "hehe83hd8dw12e",
-	"candidates" : [ 
+	"candidates" : [
 		{
 			"sdpMid" : "video",
 			"sdpMLineIndex" : 1,
@@ -1632,7 +1632,7 @@ var websocket = new WebSocket('ws://1.2.3.4:8188', 'janus-protocol');
  * fields to the requests when necessary.
  *
  * So, when you want to create a session using the REST API, you send a
- * POST to the server base path: 
+ * POST to the server base path:
  *
 \verbatim
 {
@@ -2155,8 +2155,11 @@ const token = getJanusToken('janus', ['janus.plugin.videoroom']),
  * - \c list_handles: list all the ICE handles currently active in a Janus
  * session (returns an array of handle identifiers);
  * - \c handle_info: list all the available info on a specific ICE handle;
- * - \c start_text2pcap: start dumping incoming and outgoing RTP/RTCP packets
- * of a handle to a text2pcap file (e.g., for ex-post analysis via Wireshark);
+ * - \c start_pcap: start dumping incoming and outgoing RTP/RTCP packets
+ * of a handle to a pcap file (e.g., for ex-post analysis via Wireshark);
+ * - \c stop_pcap: stop the pcap dump;
+ * - \c start_text2pcap: same as above, but saves to a text file instead,
+ * to be fed to \c text2pcap in order to generate a \c .pcap or \c .pcapng file;
  * - \c stop_text2pcap: stop the text2pcap dump;
  * - \c set_session_timeout: change the session timeout value in Janus on the fly;
  * - \c set_log_level: change the log level in Janus on the fly;
@@ -2294,7 +2297,7 @@ POST /admin/12345678/98765432
  * etc.) or the SDP/ICE/DTLS states.
  *
  * As anticipated, you can also enable/disable the dumping of the RTP/RTCP
- * packets a handle is sending and receiving to a text2pcap file. This is
+ * packets a handle is sending and receiving to a pcap or text2pcap file. This is
  * especially useful for debugging reasons, e.g., to check whether or not
  * there are issues in a specific packet Janus is sending or receiving
  * with tools like Wireshark. Notice that this is not supposed to be used
@@ -2302,7 +2305,8 @@ POST /admin/12345678/98765432
  * janus_recorder utility is much more suited for the task, and is what
  * all plugins make use of when they're interested in recordings.
  *
- * The syntax for the \c start_text2pcap command is trivial, as all you
+ * The syntax for the \c start_pcap and \c start_text2pcap commands is
+ * trivial, and apart from the command name pretty much the same: all you
  * need to specify are information on the handle to dump, information
  * on the target file (target folder and filename), and whether to truncate
  * packets or not before dumping them:
@@ -2310,23 +2314,23 @@ POST /admin/12345678/98765432
 \verbatim
 POST /admin/12345678/98765432
 {
-	"janus" : "start_text2pcap",
+	"janus" : "start_pcap",		// Use start_text2pcap for a text file instead
 	"folder" : "<folder to save the dump to; optional, current folder if missing>",
 	"filename" : "<filename of the dump; optional, random filename if missing>",
-	"truncate" : "<number of bytes to truncate at; optional, truncate=0 (don't truncate) if missing>",
+	"truncate" : "<number of bytes to truncate packet at; optional, truncate=0 (don't truncate) if missing>",
 	"transaction" : "<random alphanumeric string>",
 	"admin_secret" : "<password specified in janus.cfg, if any>"
 }
 \endverbatim
  *
  * If successful, the full path of the dump file can be obtained by doing
- * a \c handle_info request. A \c start_text2pcap command is even easier
- * to generate, as it doesn't need any parameter:
+ * a \c handle_info request. A \c stop_pcap or \c start_text2pcap command
+ * is even easier to generate, as it doesn't need any parameter:
  *
 \verbatim
 POST /admin/12345678/98765432
 {
-	"janus" : "stop_text2pcap",
+	"janus" : "stop_pcap",		// Use stop_text2pcap if you started a text-based capture
 	"transaction" : "<random alphanumeric string>",
 	"admin_secret" : "<password specified in janus.cfg, if any>"
 }
@@ -2386,7 +2390,7 @@ POST /admin
  *
  * Let's assume, for the sake of simplicity, that your webserver is serving
  * files on port \c 80. By default, Janus binds on the \c 8088 port for HTTP.
- * So, if Janus and the webserver hosting the are co-located, all you need to get your 
+ * So, if Janus and the webserver hosting the are co-located, all you need to get your
  * application working is configure the web application to point to the right
  * address for the server. In the demos provided with these packages, this
  * is done by means of the \c server variable:
@@ -2396,8 +2400,8 @@ var server = "http://" + window.location.hostname + ":8088/janus";
  \endverbatim
  *
  * which basically tells the JavaScript application that the Janus API can be
- * contacted at the same host as the website but at a different port (8088) and path (/janus). 
- * In case you configured the server differently, e.g., 7000 as the port 
+ * contacted at the same host as the website but at a different port (8088) and path (/janus).
+ * In case you configured the server differently, e.g., 7000 as the port
  * for HTTP and /my/custom/path as the API endpoint, the \c server variable
  * could be built this way:
  *
@@ -2448,7 +2452,7 @@ else
  * To avoid most of the issues explained above, an easy approach can be
  * deploying Janus behind a frontend (e.g., Apache HTTPD, nginx, lighttpd
  * or others) that would act as a reverse proxy for incoming requests.
- * This would allow you to make the Janus API available as a relative path 
+ * This would allow you to make the Janus API available as a relative path
  * of your web application, rather than a service reachable at a different
  * port and/or domain.
  *
@@ -2515,7 +2519,7 @@ python -m SimpleHTTPServer 8000
  \endverbatim
  *
  * This will setup a webserver on port \c 8000 for you to use, meaning you'll
- * just need to have your browser open a local connection to that port to 
+ * just need to have your browser open a local connection to that port to
  * try the demos:
  *
  *\verbatim
@@ -2536,7 +2540,7 @@ php -S 0.0.0.0:9000
 python -m SimpleHTTPServer 9000
  \endverbatim
  *
- * \section deplyws Using Janus with WebSockets 
+ * \section deplyws Using Janus with WebSockets
  *
  * Configuring the usae of WebSockets rather than the REST API in the JavaScript
  * library is quite trivial, as it's a matter of passing a \c ws:// address
@@ -2588,7 +2592,7 @@ var server = "ws://www.example.com:8188/";
  * so in case this is something you're interested in, we recommend you
  * follow the best practices related to that made available by the web server developers.
  *
- * \section both Using fallback addresses 
+ * \section both Using fallback addresses
  * As anticipated in the \ref JS section, you can also pass an array of servers
  * to the Janus library initialization. This allows you, for instance, to
  * pass a link to both the WebSockets and REST interfaces, and have the
@@ -2638,7 +2642,7 @@ var servers = [ws_server, http_server];
  * \c & character to the command line. Anyway, this will still "flood" the console
  * with output from Janus. While there are ways to handle it (e.g., as
  * explained <a href="http://www.thegeekstuff.com/2010/05/unix-background-job/">here</a>),
- * a nice and easy way to handle this is redirecting the output to a 
+ * a nice and easy way to handle this is redirecting the output to a
  * separate file, e.g., a dedicated log:
  *
  \verbatim
@@ -2669,7 +2673,7 @@ screen -r janus -X stuff $'/opt/janus/bin/janus -d 5 -6\n'
  * a few command line options (in this case, just the option to enable
  * IPv6 support and set the debug to verbose). Janus will then be running
  * in the background: accessing the console is just a matter of attaching
- * to the "janus" screen: 
+ * to the "janus" screen:
  *
  \verbatim
 screen -r janus
@@ -2710,7 +2714,7 @@ WantedBy=multi-user.target
  * <code>/etc/systemd/journald.conf</code> is usually enough.
  *
  * \note systemd example provided by
- * <a href="https://github.com/meetecho/janus-gateway/pull/306">\@saghul</a> 
+ * <a href="https://github.com/meetecho/janus-gateway/pull/306">\@saghul</a>
  *
  * \section upstart upstart
  * This section shows how you can add Janus as a daemon to
@@ -2732,7 +2736,7 @@ exec /opt/janus/bin/janus
  \endverbatim
  *
  * \note upstart example provided by
- * <a href="https://github.com/meetecho/janus-gateway/pull/306">\@ploxiln</a> 
+ * <a href="https://github.com/meetecho/janus-gateway/pull/306">\@ploxiln</a>
  *
  * \warning In case starting Janus depends on some external conditions, you
  * may need to modify the \c start and \c stop lines accordingly. Here you can
@@ -2808,7 +2812,7 @@ exit 0
  \endverbatim
  *
  * \note sysvinit example provided by
- * <a href="https://github.com/saghul">\@saghul</a> 
+ * <a href="https://github.com/saghul">\@saghul</a>
  *
  * \section supervisor supervisor
  * This section shows how you can add Janus to
@@ -2838,7 +2842,7 @@ sudo supervisorctl update
  * TODO.
  *
  */
- 
+
 /*! \page debug Debugging Janus
  *
  * In the magical world of fairies and unicorns, the sun always shines
@@ -2968,7 +2972,7 @@ ldd janus | grep asan
  * context of the \c janus.js JavaScript library we provide. It is not
  * a complete list, but just a summary of the material that has been
  * shared so far on the <a href="https://groups.google.com/forum/#!forum/meetecho-janus">meetecho-janus</a>
- * Google group. 
+ * Google group.
  *
  * If you've developed anything related to Janus (client stacks, plugins,
  * transports, etc.) and you're willing to share them with the community,
@@ -3232,7 +3236,7 @@ ldd janus | grep asan
  * - \b npm: https://docs.npmjs.com/ (\c optional, used during build for generating JavaScript modules)
  *
  */
-  
+
 /*! \page COPYING License
  * This program is free software, distributed under the terms of the GNU
  * General Public License Version 3.
@@ -3248,7 +3252,7 @@ ldd janus | grep asan
 /*! \page FAQ Frequently Asked Questions
  * This page contains a list of FAQ as gathered on the
  * <a href="https://groups.google.com/forum/?pli=1#!forum/meetecho-janus">meetecho-janus</a>
- * Google group and the 
+ * Google group and the
  * <a href="https://github.com/meetecho/janus-gateway/issues">Issues</a>
  * page on GitHub. It obviously also includes things we're being asked all the
  * time in general! If your question is not listed here or not available
@@ -3364,7 +3368,7 @@ ldd janus | grep asan
  *    at the future (WebRTC) and the other at the past (whatever the modules
  *    allows you to do, be it legacy stuff or not), Janus looked like the
  *    perfect name for it! And besides, we're Italian, Ancient Rome was
- *    awesome and mythology rules... ;-)  
+ *    awesome and mythology rules... ;-)
  *    \n\n
  *    .
  * \anchor januslicense
@@ -3763,7 +3767,7 @@ ldd janus | grep asan
  * \brief Implementations of the WebRTC protocols
  * \details The WebRTC specification (WEBRTC/RTCWEB) currently mandates
  * the usage of a few protocols and techniques. The code in this group
- * takes care of them all (SDP, ICE, DTLS-SRTP, RTP/RTCP). 
+ * takes care of them all (SDP, ICE, DTLS-SRTP, RTP/RTCP).
  * \ingroup core
  */
 
@@ -3779,7 +3783,7 @@ ldd janus | grep asan
  * \brief Plugin API (aka, how to write your own plugin)
  * \details The plugin.h header specifies the API a plugin needs to
  * implement and make available in order to be used by the server and
- * exposed to browsers. 
+ * exposed to browsers.
  * \ingroup plugins
  */
 
@@ -3837,13 +3841,13 @@ ldd janus | grep asan
 /*! \defgroup tools Tools and utilities
  * \brief Tools and utilities
  * \details Set of simple tools and utilities that may be of help when
- * used in conjunction with Janus. 
+ * used in conjunction with Janus.
  */
 
 /*! \defgroup postprocessing Recordings post-processing utility
  * \brief Recordings post-processing utility
  * \details This simple utility (janus-pp-rec.c) allows you to
  * post-process recordings generated by the janus_recorder helper (e.g.,
- * in the Video MCU plugin). 
+ * in the Video MCU plugin).
  * \ingroup tools
  */

--- a/text2pcap.c
+++ b/text2pcap.c
@@ -1,12 +1,14 @@
 /*! \file    text2pcap.c
  * \author   Lorenzo Miniero <lorenzo@meetecho.com>
  * \copyright GNU General Public License v3
- * \brief    Dumping of RTP/RTCP packets to text2pcap format
+ * \brief    Dumping of RTP/RTCP packets to text2pcap or pcap format
  * \details  Implementation of a simple helper utility that can be used
- * to dump incoming and outgoing RTP/RTCP packets to text2pcap format.
- * The resulting file can then be passed to the \c text2pcap application
- * in order to get a \c .pcap or \c .pcapng file that can be analyzed
- * via Wireshark or similar applications, e.g.:
+ * to dump incoming and outgoing RTP/RTCP packets to pcap or text2pcap format.
+ * Saving to pcap natively can be more efficient but will lack some features,
+ * as the target will be a legacy (v2.4) \c .pcap file and not a \c .pcapng one.
+ * When saving to a text file, instead, the resulting file can be passed to
+ * the \c text2pcap application in order to get a \c .pcap or \c .pcapng file
+ * that can be analyzed via Wireshark or similar applications, e.g.:
  *
 \verbatim
 /usr/sbin/text2pcap -D -n -l 1 -i 17 -u 1000,2000 -t '%H:%M:%S.' dump.txt dump.pcapng
@@ -33,7 +35,16 @@
 
 #include <errno.h>
 #include <sys/time.h>
- 
+#include <arpa/inet.h>
+#ifdef __MACH__
+#include <machine/endian.h>
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#else
+#include <endian.h>
+#endif
+
 #include "text2pcap.h"
 #include "debug.h"
 #include "utils.h"
@@ -50,7 +61,93 @@ const char *janus_text2pcap_packet_string(janus_text2pcap_packet type) {
 	return NULL;
 }
 
-janus_text2pcap *janus_text2pcap_create(const char *dir, const char *filename, int truncate) {
+/* Helper struct to define a libpcap global header
+ * https://wiki.wireshark.org/Development/LibpcapFileFormat */
+typedef struct janus_text2pcap_global_header {
+	guint32 magic_number;	/* Magic number */
+	guint16 version_major;	/* Major version number */
+	guint16 version_minor;	/* Minor version number */
+	gint32  thiszone;		/* GMT to local correction */
+	guint32 sigfigs;		/* Accuracy of timestamps */
+	guint32 snaplen;		/* Max length of captured packets, in octets */
+	guint32 network;		/* Data link type */
+} janus_text2pcap_global_header;
+
+/* Helper struct to define a libpcap packet header
+ * https://wiki.wireshark.org/Development/LibpcapFileFormat */
+typedef struct janus_text2pcap_packet_header {
+	guint32 ts_sec;			/* Timestamp seconds */
+	guint32 ts_usec;		/* Timestamp microseconds */
+	guint32 incl_len;		/* Number of octets of packet saved in file */
+	guint32 orig_len;		/* Actual length of packet */
+} janus_text2pcap_packet_header;
+
+/* Ethernet header */
+typedef struct janus_text2pcap_ethernet_header {
+	uint8_t dst[6];
+	uint8_t src[6];
+	uint16_t type;
+} janus_text2pcap_ethernet_header;
+static void janus_text2pcap_ethernet_header_init(janus_text2pcap_ethernet_header *eth) {
+	memset(eth, 0, sizeof(*eth));
+	eth->type = htons(0x0800);
+}
+
+/* IP header */
+typedef struct janus_text2pcap_ip_header {
+#if __BYTE_ORDER == __BIG_ENDIAN
+	uint8_t version:4;
+	uint8_t hlen:4;
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+	uint8_t hlen:4;
+	uint8_t version:4;
+#endif
+	uint8_t tos;
+	uint16_t tlen;
+	uint16_t id;
+	uint16_t flags;
+	uint8_t ttl;
+	uint8_t protocol;
+	uint16_t csum;
+	uint8_t src[4];
+	uint8_t dst[4];
+} janus_text2pcap_ip_header;
+static void janus_text2pcap_ip_header_init(janus_text2pcap_ip_header *ip, gboolean incoming, int psize) {
+	ip->version = 4;
+	ip->hlen = 5;
+	ip->tos = 0;
+	ip->tlen = htons(28+psize);
+	ip->id = htons(0);
+	ip->flags = htons(0x4000);
+	ip->ttl = 64;
+	ip->protocol = 17;
+	ip->csum = 0;
+	ip->src[0] = 10;
+	ip->src[1] = incoming ? 1 : 2;
+	ip->src[2] = incoming ? 1 : 2;
+	ip->src[3] = incoming ? 1 : 2;
+	ip->dst[0] = 10;
+	ip->dst[1] = incoming ? 2 : 1;
+	ip->dst[2] = incoming ? 2 : 1;
+	ip->dst[3] = incoming ? 2 : 1;
+}
+
+/* UDP header */
+typedef struct janus_text2pcap_udp_header {
+	uint16_t srcport;
+	uint16_t dstport;
+	uint16_t len;
+	uint16_t csum;
+} janus_text2pcap_udp_header;
+static void janus_text2pcap_udp_header_init(janus_text2pcap_udp_header *udp, gboolean incoming, int psize) {
+	udp->srcport = htons(incoming ? 1000 : 2000);
+	udp->dstport = htons(incoming ? 2000 : 1000);
+	udp->len = htons(8+psize);
+	udp->csum = 0;
+}
+
+
+janus_text2pcap *janus_text2pcap_create(const char *dir, const char *filename, int truncate, gboolean text) {
 	janus_text2pcap *tp;
 	char newname[1024];
 	char *fname;
@@ -60,11 +157,12 @@ janus_text2pcap *janus_text2pcap_create(const char *dir, const char *filename, i
 		return NULL;
 
 	/* Copy given filename or generate a random one */
-	if (filename == NULL)
+	if (filename == NULL) {
 		g_snprintf(newname, sizeof(newname),
-		    "janus-text2pcap-%"SCNu32".txt", janus_random_uint32());
-	else
+		    "janus-text2pcap-%"SCNu32".%s", janus_random_uint32(), text ? "txt" : "pcap");
+	} else {
 		g_strlcpy(newname, filename, sizeof(newname));
+	}
 
 	if(dir != NULL) {
 		/* Create the directory, if needed */
@@ -72,7 +170,6 @@ janus_text2pcap *janus_text2pcap_create(const char *dir, const char *filename, i
 			JANUS_LOG(LOG_ERR, "mkdir error: %d\n", errno);
 			return NULL;
 		}
-
 		fname = g_strdup_printf("%s/%s", dir, newname);
 	} else {
 		fname = g_strdup(newname);
@@ -91,8 +188,17 @@ janus_text2pcap *janus_text2pcap_create(const char *dir, const char *filename, i
 	tp->filename = fname;
 	tp->file = f;
 	tp->truncate = truncate;
+	tp->text = text;
 	g_atomic_int_set(&tp->writable, 1);
 	janus_mutex_init(&tp->mutex);
+
+	/* If we're saving to .pcap directly, generate a global header */
+	if(!text) {
+		janus_text2pcap_global_header header = {
+			0xa1b2c3d4, 2, 4, 0, 0, 65535, 1
+		};
+		fwrite(&header, sizeof(char), sizeof(header), f);
+	}
 
 	return tp;
 }
@@ -106,7 +212,47 @@ int janus_text2pcap_dump(janus_text2pcap *instance,
 		janus_mutex_unlock_nodebug(&instance->mutex);
 		return -1;
 	}
-	/* Prepare text representation of the packet */
+	/* If we're saving to .pcap directly, generate a packet header and save the payload */
+	if(!instance->text) {
+		/* Are we truncating? */
+		int size = instance->truncate ? (len > instance->truncate ? instance->truncate : len) : len;
+		int hsize = sizeof(janus_text2pcap_ethernet_header) + sizeof(janus_text2pcap_ip_header) +
+			sizeof(janus_text2pcap_udp_header);
+		int hsize_cut = hsize + size;
+		int hsize_tot = hsize + len;
+		/* We need a fake Ethernet/IP/UDP encapsulation for this packet */
+		janus_text2pcap_ethernet_header eth;
+		janus_text2pcap_ethernet_header_init(&eth);
+		janus_text2pcap_ip_header ip;
+		janus_text2pcap_ip_header_init(&ip, incoming, len);
+		janus_text2pcap_udp_header udp;
+		janus_text2pcap_udp_header_init(&udp, incoming, len);
+		/* Now prepare the packet header */
+		struct timeval tv;
+		gettimeofday(&tv, NULL);
+		janus_text2pcap_packet_header header = {
+			tv.tv_sec, tv.tv_usec, hsize_cut, hsize_tot
+		};
+		fwrite(&header, sizeof(char), sizeof(header), instance->file);
+		fwrite(&eth, sizeof(char), sizeof(eth), instance->file);
+		fwrite(&ip, sizeof(char), sizeof(ip), instance->file);
+		fwrite(&udp, sizeof(char), sizeof(udp), instance->file);
+		/* The write the packet itself (or part of it) */
+		int temp = 0, tot = size;
+		while(tot > 0) {
+			temp = fwrite(buf+size-tot, sizeof(char), tot, instance->file);
+			if(temp <= 0) {
+				JANUS_LOG(LOG_ERR, "Error dumping packet...\n");
+				janus_mutex_unlock_nodebug(&instance->mutex);
+				return -2;
+			}
+			tot -= temp;
+		}
+		/* Done */
+		janus_mutex_unlock_nodebug(&instance->mutex);
+		return 0;
+	}
+	/* If we got here, we need to prepare a text representation of the packet */
 	char buffer[5000], timestamp[20], usec[10], byte[10];
 	memset(timestamp, 0, sizeof(timestamp));
 	memset(usec, 0, sizeof(usec));

--- a/text2pcap.h
+++ b/text2pcap.h
@@ -1,12 +1,14 @@
 /*! \file    text2pcap.h
  * \author   Lorenzo Miniero <lorenzo@meetecho.com>
  * \copyright GNU General Public License v3
- * \brief    Dumping of RTP/RTCP packets to text2pcap format (headers)
+ * \brief    Dumping of RTP/RTCP packets to text2pcap or pcap format (headers)
  * \details  Implementation of a simple helper utility that can be used
- * to dump incoming and outgoing RTP/RTCP packets to text2pcap format.
- * The resulting file can then be passed to the \c text2pcap application
- * in order to get a \c .pcap or \c .pcapng file that can be analyzed
- * via Wireshark or similar applications, e.g.:
+ * to dump incoming and outgoing RTP/RTCP packets to pcap or text2pcap format.
+ * Saving to pcap natively can be more efficient but will lack some features,
+ * as the target will be a legacy (v2.4) \c .pcap file and not a \c .pcapng one.
+ * When saving to a text file, instead, the resulting file can be passed to
+ * the \c text2pcap application in order to get a \c .pcap or \c .pcapng file
+ * that can be analyzed via Wireshark or similar applications, e.g.:
  *
 \verbatim
 /usr/sbin/text2pcap -D -n -l 1 -i 17 -u 1000,2000 -t '%H:%M:%S.' dump.txt dump.pcapng
@@ -30,7 +32,7 @@
  * \ingroup core
  * \ref core
  */
- 
+
 #ifndef _JANUS_TEXT2PCAP_H
 #define _JANUS_TEXT2PCAP_H
 
@@ -45,15 +47,17 @@
 
 /*! \brief Instance of a text2pcap recorder */
 typedef struct janus_text2pcap {
-	/*! \brief Absolute path to where the text2pcap file is stored */ 
+	/*! \brief Absolute path to where the text2pcap file is stored */
 	char *filename;
 	/*! \brief Pointer to the file handle */
 	FILE *file;
 	/*! \brief Number of bytes to truncate at */
 	int truncate;
+	/*! \brief Whether we'll save as text, or directly to pcap */
+	gboolean text;
 	/*! \brief Whether we can write to this file or not */
 	volatile int writable;
-	/*! \brief Mutex to lock/unlock this recorder instance */ 
+	/*! \brief Mutex to lock/unlock this recorder instance */
 	janus_mutex mutex;
 } janus_text2pcap;
 
@@ -71,8 +75,9 @@ const char *janus_text2pcap_packet_string(janus_text2pcap_packet type);
  * @param[in] dir Path of the directory to save the recording into (will try to create it if it doesn't exist)
  * @param[in] filename Filename to use for the recording
  * @param[in] truncate Number of bytes to truncate each packet at (0 to not truncate at all)
+ * @param[in] text Whether we'll save as text, or directly to pcap
  * @returns A valid janus_text2pcap instance in case of success, NULL otherwise */
-janus_text2pcap *janus_text2pcap_create(const char *dir, const char *filename, int truncate);
+janus_text2pcap *janus_text2pcap_create(const char *dir, const char *filename, int truncate, gboolean text);
 
 /*! \brief Dump an RTP or RTCP packet
  * @param[in] instance Instance of the janus_text2pcap recorder to dump the packet to


### PR DESCRIPTION
This patch extends the support we first added in #993.

As you may already know, in Janus you can currently dump the unencrypted traffic for a handle (RTP/RTCP) via a `start_text2pcap` request sent via Admin API: this results in each incoming or outgoing packet to be serialized to a text string with some metadata, and saved to a text file, which needs to subsequently be passed to `text2pcap` in order to get a `.pcap` or `.pcapng` file you can look at, e.g., via Wireshark. While this works and has been useful to me in several cases, it is also a resource hungry process: the text serialization in particular means that it takes quite a toll on the process, and CPU usage is not low.

As such, I started looking into ways to save to a `.pcap` file directly and natively, rather than going through the text file and the `text2pcap` translation, which is what this patch provides. I didn't want to add any additional dependency (in this case to libpcap), so this process is done manually in the core: the pcap headers are created accordingly, and each time we save a packet we create the ethernet/ip/udp layers we need to encapsulate the payload to dump. This seems to work nicely, from the few tests I made, and more importantly it's incredibly more lightweight: my guess is that it has pretty much the same impact as our .mjr recordings, so quite neglectible.

This doesn't replace the text2pcap support, it's an alternative, as there may be more things we might add to that in the future (e.g., comments to packets and other stuff that pcapng supports and basic pcap doesn't): as such, I partly reused the Admin API commands. If you use `start_text2pcap` as a command, you'll use the old approach, while if you use the `start_pcap` command, you'll use the new approach instead: all the other properties (e.g., the `folder`, `filename` and `truncate` attributes) are exactly the same; of course, use a different extension for the filename part depending on which approach you'll use (typically `.txt` for text2pcap and `.pcap` for pcap).

As an example, you can use this snippet on the JavaScript console when running the EchoTest demo and it should save all traffic:

```
Janus.httpAPICall("http://localhost:7088/admin/" + janus.getSessionId() + "/" + echotest.getId(), {
	verb: 'POST',
	withCredentials: false,
	body: {
		janus: "start_pcap",
		folder: "/tmp",
		filename: "my-test2pcap-dump.pcap",
		transaction: "123",
		admin_secret: "janusoverlord"
	},
	success: function(json) {
		Janus.vdebug(json);
	},
	error: function(textStatus, errorThrown) {
		Janus.error(textStatus + ": " + errorThrown);
	}
});
```

I'm planning to merge really soon, so feedback is welcome!