### PR TITLE
Fix SSRCs and RTP timestamps in incoming RTCP reports

### DIFF
--- a/rtcp.h
+++ b/rtcp.h
@@ -338,6 +338,17 @@ guint32 janus_rtcp_get_receiver_ssrc(char *packet, int len);
  * @returns 0 in case of success, -1 on errors */
 int janus_rtcp_parse(janus_rtcp_context *ctx, char *packet, int len);
 
+/*! \brief Method to fix incoming RTCP SR and RR data
+ * @param[in] packet The message data
+ * @param[in] len The message data length in bytes
+ * @param[in] rtp_ctx RTP context to get timestamp info from
+ * @param[in] ssrc_peer The remote SSRC in usage for this stream
+ * @param[in] ssrc_local The local SSRC in usage for this stream
+ * @param[in] ssrc_expected The expected SSRC for this RTCP packet
+ * @param[in] video Whether the RTCP packet contains report for video data
+ * @returns The number of fields updated, negative values on errors */
+int janus_rtcp_fix_report_data(char *packet, int len, janus_rtp_switching_context *rtp_ctx, uint32_t ssrc_peer, uint32_t ssrc_local, uint32_t ssrc_expected, gboolean video);
+
 /*! \brief Method to fix an RTCP message (http://tools.ietf.org/html/draft-ietf-straw-b2bua-rtcp-00)
  * @param[in] ctx RTCP context to update, if needed (optional)
  * @param[in] packet The message data


### PR DESCRIPTION
To have some more context refer to #1300.
This PR aims at fixing SSRC and RTP timestamp fields in the Sender Reports (SR) and Receiver Reports (RR) that the core is passing to a plugin, thus letting a renegotiation not disrupting the relationship between RTP and RTCP inside a plugin.
We have tried to accomplish something similar to what the Janus core already does for the RTP traffic. In order to keep coherent the flow of the RTCP traffic toward a plugin, the idea is to make use of the RTP context tied to that RTCP stream and to to re-use the local and remote SSRCs that Janus store for an active stream.
So for every incoming RTCP packet, we invoke `janus_rtcp_fix_report_data` just before passing the packet to a plugin. This function:
- parses the packet
- for every SR/RR it finds
- checks if the received SSRC is the one expected from the `janus_rtp_switching_context` (in negative case it drops the **entire** compound packet)
- updates the SSRCs according to the `janus_ice_stream` context
- updates the RTP timestamps according to the `janus_rtp_switching_context`

This seems to work quite well, however these changes do come with some caveats:
1) Some **dropping logic** has been added.
An entire RTCP packet will be dropped if the SSRC is not the one that either the Janus context or RTP context knows. This commonly means that while renegotiating, a compound packet containing a Goodbye RTCP message for the old SSRC and some packets containing a RTCP SR/RR message for the new SSRC are going to be dropped because in the former case the Janus context has already been updated (and so `old_ssrc != janus_context->current_ssrc`) while in the latter case we must wait some RTP traffic in order to update the RTP context (so `new_ssrc != rtp_context->current_ssrc`).
However I don't think this will be a big issue, because browsers tend to send RTCP feedback quite frequently, and I can't imagine a scenario where a lost RTCP will break something.
2) This patch **does not cover all RTCP messages** and **all SR/RR fields**.
We have tried to address to users that want to parse SR/RR in their custom plugins. So we restricted the focus to those report messages and even for those, some fields have still to be fixed (like cumulative lost packets, packet and octects count and things like these). However we don't think this is a priority as of now, because SSRC and timestamp should be enough for the majority of user cases.
3) The RTP timestamp in the SR/RR **may lose reliability** inside a plugin.
By using the RTP context, we are relying on the accuracy of the `time_diff` [estimate](https://github.com/meetecho/janus-gateway/blob/80f0e273a845d8ff2dcf2d586adc2d25c92d097f/rtp.c#L499). This means that every error occurring on this estimate will be reflected on the RTCP SR directed to a plugin after a renegotiation.
We're internally discussing on how this evaluation could be improved, but do not expect something too soon.