### PR TITLE
Disconnect websocket on timeout gateway message (JS)

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -701,10 +701,12 @@ function Janus(gatewayCallbacks) {
 				Janus.debug("No provided notification callback");
 			}
 		} else if(json["janus"] === "timeout") {
-		    Janus.error("Timeout on session " + sessionId);
-		    Janus.debug(json);
-		    ws.close(3504, "Gateway timeout");
-		    return;
+			Janus.error("Timeout on session " + sessionId);
+			Janus.debug(json);
+			if (websockets) {
+				ws.close(3504, "Gateway timeout");
+			}
+			return;
 		} else {
 			Janus.warn("Unknown message/event  '" + json["janus"] + "' on session " + sessionId);
 			Janus.debug(json);

--- a/html/janus.js
+++ b/html/janus.js
@@ -700,6 +700,11 @@ function Janus(gatewayCallbacks) {
 				// Send to generic callback (?)
 				Janus.debug("No provided notification callback");
 			}
+		} else if(json["janus"] === "timeout") {
+		    Janus.error("Timeout on session " + sessionId);
+		    Janus.debug(json);
+		    ws.close(3504, "Gateway timeout");
+		    return;
 		} else {
 			Janus.warn("Unknown message/event  '" + json["janus"] + "' on session " + sessionId);
 			Janus.debug(json);


### PR DESCRIPTION
Janus Gateway sometimes sends a timeout message which is not properly handled by the existing Javascript Janus code (v0.4.5):

```
{
   "janus": "timeout",
   "session_id": 112005209173740
}
```

When this timeout message comes:
1. A warn is shown - `Unknown message/event timeout on session 112005209173740`
2. The connection keeps open and the Janus instance/session becomes unusable (returns server errors every time informing that the session no longer exists).

This PR code handles the timeout message, closing the websocket connection with the following code/message - `3504 / Gateway timeout`