### PR TITLE
Typo update for videoroomtest reference link in svc test page

### DIFF
--- a/html/vp9svctest.html
+++ b/html/vp9svctest.html
@@ -47,7 +47,7 @@
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
-						<p>This is basically a clone of the plain <a href="videoroomtest.hmtl">Video Room</a>
+						<p>This is basically a clone of the plain <a href="videoroomtest.html">Video Room</a>
 						demo, but with a key difference: it forces VP9 on all publishers, and supports
 						the VP9 SVC layer selection (if you don't know what this means, check our
 						<a target="_blank" href="http://www.meetecho.com/blog/availability-of-chrome-interoperable-vp9-svc-in-janus-a-meetecho-cosmo-collaboration/">blog post</a>).


### PR DESCRIPTION
Just a small typo update for video room reference link. You can update it with your next commit to master, or accept to this tiny PR. 