### PR TITLE
prometheus plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -323,6 +323,17 @@ conf_DATA += conf/janus.eventhandler.mqttevh.cfg.sample
 EXTRA_DIST += conf/janus.eventhandler.mqttevh.cfg.sample
 endif
 
+if ENABLE_PROMETHEUSEVH
+event_LTLIBRARIES += events/libjanus_prometheusevh.la
+events_libjanus_prometheusevh_la_SOURCES = events/janus_prometheusevh.cc
+events_libjanus_prometheusevh_la_CXXFLAGS = $(events_cflags) $(ZLIB_CFLAGS)
+events_libjanus_prometheusevh_la_LDFLAGS = $(ZLIB_LIBS)
+events_libjanus_prometheusevh_la_LIBADD = -lprometheus-cpp-pull -lprometheus-cpp-core
+conf_DATA += conf/janus.eventhandler.prometheusevh.cfg.sample
+EXTRA_DIST += conf/janus.eventhandler.prometheusevh.cfg.sample
+janus_prometheusevh.o: CPPFLAGS += -std=c++11
+endif
+
 ##
 # Plugins
 ##

--- a/conf/janus.eventhandler.prometheusevh.cfg.sample
+++ b/conf/janus.eventhandler.prometheusevh.cfg.sample
@@ -1,0 +1,10 @@
+; This configures the Prometheus event handler.
+
+[general]
+enabled = no				; By default the module is not enabled
+events = all				; Comma separated list of the events mask you're interested
+							; in. Valid values are none, sessions, handles, jsep, webrtc,
+							; media, plugins, transports, core, external and all. By
+							; default we subscribe to everything (all)
+host = 0.0.0.0				; The address of the Prometheus server
+;port = 9091				; The listening port of the Prometheus server (9091 by default)

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ AM_SILENT_RULES([yes])
 AC_GNU_SOURCE
 
 AC_PROG_CC
+AC_PROG_CXX
 
 LT_PREREQ([2.2])
 LT_INIT
@@ -150,6 +151,8 @@ AC_ARG_ENABLE([all-handlers],
                      [enable_rabbitmq_event_handler=no])
                AS_IF([test "x$enable_mqtt_event_handler" != "xyes"],
                      [enable_mqtt_event_handler=no])
+               AS_IF([test "x$enable_prometheus_event_handler" != "xyes"],
+                     [x$enable_prometheus_event_handler=no])
               ],
               [])
 
@@ -226,6 +229,13 @@ AC_ARG_ENABLE([mqtt-event-handler],
               [AS_IF([test "x$enable_mqtt_event_handler" != "xyes"],
                      [enable_mqtt_event_handler=no])],
               [enable_mqtt_event_handler=maybe])
+
+AC_ARG_ENABLE([prometheus-event-handler],
+              [AS_HELP_STRING([--enable-prometheus-event-handler],
+                              [Enable Prometheus metrics server])],
+              [AS_IF([test "x$enable_prometheus_event_handler" != "xyes"],
+                     [enable_prometheus_event_handler=no])],
+              [enable_prometheus_event_handler=no])
 
 AC_ARG_ENABLE([systemd-sockets],
               [AS_HELP_STRING([--enable-systemd-sockets],
@@ -512,11 +522,63 @@ AC_CHECK_LIB([nanomsg],
                AS_IF([test "x$enable_nanomsg" = "xyes"],
                      [AC_MSG_ERROR([nanomsg not found. See README.md for installation instructions or use --disable-nanomsg])])
              ])
+
+AS_IF([test "x$enable_prometheus_event_handler" = "xyes"],
+[
+	AC_LANG_PUSH([C++])
+	CXXFLAGS="$CXXFLAGS -std=c++11"
+
+	SAVED_CPPFLAGS=$CPPFLAGS
+	CPPFLAGS="$CPPFLAGS -std=c++11"
+	AC_CHECK_HEADERS(	[prometheus/exposer.h prometheus/counter.h],
+						[AC_MSG_NOTICE([Promethus headers found])],
+						[AC_MSG_ERROR([Promethus headers not found])]
+                       )
+	CPPFLAGS=$SAVED_CPPFLAGS
+
+	PKG_CHECK_MODULES([ZLIB],[zlib],[:],[AC_MSG_ERROR([zlib not found])])
+	AC_SUBST([ZLIB_CFLAGS])
+	AC_SUBST([ZLIB_LIBS])
+
+	AC_MSG_CHECKING([prometheus static libraries])
+	saved_CXXLAGS="$CXXFLAGS"
+	saved_LDFLAGS="$LDFLAGS"
+	saved_LIBS="$LIBS"
+	CXXFLAGS="$CXXFLAGS $ZLIB_CFLAGS"
+	LDFLAGS="$LDFLAGS -lpthread $ZLIB_LIBS"
+	LIBS="$LIBS -lprometheus-cpp-pull -lprometheus-cpp-core"
+	AC_LINK_IFELSE(
+		[AC_LANG_PROGRAM(
+			[[
+				#include <prometheus/exposer.h>
+				#include <prometheus/registry.h>
+			]], 
+			[[
+				auto registry = std::make_shared<prometheus::Registry>();
+				auto& counter_family = prometheus::BuildCounter().Register(*registry);
+		    	prometheus::Exposer exposer{"0.0.0.0:9091"};
+			]]
+		)],
+		[
+			AC_DEFINE(HAVE_PROMETHEUSEVH)
+			AC_MSG_NOTICE([libprometheus-cpp-core and libprometheus-cpp-pull found.])
+		], 
+  		[
+			AC_MSG_ERROR([libprometheus-cpp-core or libprometheus-cpp-pull not found. Prometheus server not supported.])
+		]
+	)
+	CXXFLAGS="$saved_CXXLAGS"
+	LDFLAGS="$saved_LDFLAGS"
+	LIBS="$saved_LIBS"
+	AC_LANG_POP([C++])
+])
+
 AM_CONDITIONAL([ENABLE_RABBITMQ], [test "x$enable_rabbitmq" = "xyes"])
 AM_CONDITIONAL([ENABLE_RABBITMQEVH], [test "x$enable_rabbitmq_event_handler" = "xyes"])
 AM_CONDITIONAL([ENABLE_MQTT], [test "x$enable_mqtt" = "xyes"])
 AM_CONDITIONAL([ENABLE_MQTTEVH], [test "x$enable_mqtt_event_handler" = "xyes"])
 AM_CONDITIONAL([ENABLE_NANOMSG], [test "x$enable_nanomsg" = "xyes"])
+AM_CONDITIONAL([ENABLE_PROMETHEUSEVH], [test "x$enable_prometheus_event_handler" = "xyes"])
 
 AC_TRY_COMPILE([
                #include <stdlib.h>
@@ -549,7 +611,6 @@ AS_IF([test "x$enable_systemd_sockets" = "xyes"],
                           ],
                           [AC_MSG_ERROR([libsystemd not found. systemd unix domain socket service not supported])])
       ])
-
 
 ##
 # Plugins
@@ -764,7 +825,6 @@ AM_CONDITIONAL([ENABLE_PLUGIN_TEXTROOM], [test "x$enable_plugin_textroom" = "xye
 ##
 # Event handlers
 ##
-
 PKG_CHECK_MODULES([EVENTS],
                   [
                     glib-2.0 >= $glib_version
@@ -962,6 +1022,9 @@ AM_COND_IF([ENABLE_RABBITMQEVH],
 AM_COND_IF([ENABLE_MQTTEVH],
 	[echo "    MQTT event handler:    yes"],
 	[echo "    MQTT event handler:    no"])
+AM_COND_IF([ENABLE_PROMETHEUSEVH],
+	[echo "    Prometheus event handler: yes"],
+	[echo "    Prometheus event handler: no"])
 AM_COND_IF([ENABLE_JAVASCRIPT_MODULES], [
 	echo "JavaScript modules:        yes"
 	echo "    Using npm:             $NPM"

--- a/events/janus_prometheusevh.cc
+++ b/events/janus_prometheusevh.cc
@@ -1,0 +1,365 @@
+/*! \file   janus_prometheusevh.cc 
+ * \author Dmitry Yudin <yudind@gmail.com>
+ * \copyright GNU General Public License v3
+ * \brief  Janus PrometheusEventHandler plugin
+ * \details  This is a Prometheus client-side server implemented as event handler plugin for Janus
+ *
+ * \ingroup eventhandlers
+ * \ref eventhandlers
+ */
+
+extern "C" {
+#include "eventhandler.h"
+#include "../debug.h"
+#include "../config.h"
+#include "../mutex.h"
+#include "../utils.h"
+#include "../events.h"
+}
+
+#include <math.h>
+
+/* Plugin information */
+#define JANUS_PROMETHEUS_VERSION		1
+#define JANUS_PROMETHEUS_VERSION_STRING	"0.0.1"
+#define JANUS_PROMETHEUS_DESCRIPTION	"This is a Prometheus client-side server implemented as event handler plugin for Janus."
+#define JANUS_PROMETHEUS_NAME			"JANUS PrometheusEventHandler plugin"
+#define JANUS_PROMETHEUS_AUTHOR			"Meetecho s.r.l."
+#define JANUS_PROMETHEUS_PACKAGE		"janus.eventhandler.prometheusevh"
+
+/* Plugin methods */
+extern "C" {
+janus_eventhandler *create(void);
+int janus_promevh_init(const char *config_path);
+void janus_promevh_destroy(void);
+int janus_promevh_get_api_compatibility(void);
+int janus_promevh_get_version(void);
+const char *janus_promevh_get_version_string(void);
+const char *janus_promevh_get_description(void);
+const char *janus_promevh_get_name(void);
+const char *janus_promevh_get_author(void);
+const char *janus_promevh_get_package(void);
+void janus_promevh_incoming_event(json_t *event);
+json_t *janus_promevh_handle_request(json_t *request);
+}
+
+/* Event handler setup */
+static janus_eventhandler janus_promevh = {
+
+// Can't prefill with JANUS_EVENTHANDLER_INIT macro due to g++:
+// error: too many initializers for 'janus_eventhandler'
+//	JANUS_EVENTHANDLER_INIT (
+	.init = janus_promevh_init,
+	.destroy = janus_promevh_destroy,
+	.get_api_compatibility = janus_promevh_get_api_compatibility,
+	.get_version = janus_promevh_get_version,
+	.get_version_string = janus_promevh_get_version_string,
+	.get_description = janus_promevh_get_description,
+	.get_name = janus_promevh_get_name,
+	.get_author = janus_promevh_get_author,
+	.get_package = janus_promevh_get_package,
+	.incoming_event = janus_promevh_incoming_event,
+	.handle_request = janus_promevh_handle_request,
+	.events_mask = JANUS_EVENT_TYPE_NONE,
+};
+
+/* Plugin creator */
+janus_eventhandler *create(void) {
+	JANUS_LOG(LOG_VERB, "%s created!\n", JANUS_PROMETHEUS_NAME);
+	return &janus_promevh;
+}
+
+
+/* Useful stuff */
+static volatile gint initialized = 0, stopping = 0;
+static GThread *handler_thread;
+static void *janus_promevh_handler(void *data);
+
+/* Queue of events to handle */
+static GAsyncQueue *events = NULL;
+static json_t exit_event;
+static void janus_promevh_event_free(json_t *event) {
+	if(!event || event == &exit_event)
+		return;
+	json_decref(event);
+}
+
+/* Parameter validation (for tweaking via Admin API) */
+static struct janus_json_parameter request_parameters[] = {
+	{"request", JSON_STRING, JANUS_JSON_PARAM_REQUIRED}
+};
+#if 0
+static struct janus_json_parameter tweak_parameters[] = {
+	{"events", JSON_STRING, 0},
+	{"grouping", JANUS_JSON_BOOL, 0}
+};
+#endif
+/* Error codes (for the tweaking via Admin API */
+//#define JANUS_PROMETHEUS_ERROR_INVALID_REQUEST		411
+#define JANUS_PROMETHEUS_ERROR_MISSING_ELEMENT		412
+#define JANUS_PROMETHEUS_ERROR_INVALID_ELEMENT		413
+//#define JANUS_PROMETHEUS_ERROR_UNKNOWN_ERROR		499
+
+
+/* Plugin implementation */
+int janus_promevh_init(const char *config_path) {
+	gboolean success = TRUE;
+	char *host = NULL;
+	int port = 9091;
+
+	if(g_atomic_int_get(&stopping)) {
+		/* Still stopping from before */
+		return -1;
+	}
+	if(config_path == NULL) {
+		/* Invalid arguments */
+		return -1;
+	}
+	/* Read configuration */
+	char filename[255];
+	g_snprintf(filename, 255, "%s/%s.cfg", config_path, JANUS_PROMETHEUS_PACKAGE);
+	JANUS_LOG(LOG_VERB, "Configuration file: %s\n", filename);
+	janus_config *config = janus_config_parse(filename);
+	if(config != NULL)
+		janus_config_print(config);
+
+	/* Setup the event handler, if required */
+	janus_config_item *item = janus_config_get_item_drilldown(config, "general", "enabled");
+	if(!item || !item->value || !janus_is_true(item->value)) {
+		JANUS_LOG(LOG_WARN, "Prometheus event handler disabled\n");
+		goto error;
+	}
+
+	/* Which events should we subscribe to? */
+	item = janus_config_get_item_drilldown(config, "general", "events");
+	if(item && item->value)
+		janus_events_edit_events_mask(item->value, &janus_promevh.events_mask);
+
+	/* Handle configuration, starting from the server details */
+	item = janus_config_get_item_drilldown(config, "general", "host");
+	if(item && item->value)
+		host = g_strdup(item->value);
+	else
+		host = g_strdup("localhost");
+
+	item = janus_config_get_item_drilldown(config, "general", "port");
+	if(item && item->value)
+		port = atoi(item->value);
+
+	/* Connect */
+	JANUS_LOG(LOG_VERB, "PrometheusEventHandler: Creating Prometheus http server at %s:%u...\n", host, port);
+
+	/* Initialize the events queue */
+	events = g_async_queue_new_full((GDestroyNotify) janus_promevh_event_free);
+	g_atomic_int_set(&initialized, 1);
+
+	GError *error;
+	handler_thread = g_thread_try_new("janus promevh handler", janus_promevh_handler, NULL, &error);
+	if(!handler_thread) {
+		g_atomic_int_set(&initialized, 0);
+		JANUS_LOG(LOG_FATAL, "Got error %d (%s) trying to launch the PrometheusEventHandler handler thread...\n", error->code, error->message ? error->message : "??");
+		goto error;
+	}
+
+	/* Done */
+	JANUS_LOG(LOG_INFO, "Setup of Prometheus event handler completed\n");
+	goto done;
+
+error:
+	/* If we got here, something went wrong */
+	success = FALSE;
+
+	/* Fall through */
+done:
+	if(host)
+		g_free((char *)host);
+	if(config)
+		janus_config_destroy(config);
+	if(!success) {
+		return -1;
+	}
+	JANUS_LOG(LOG_INFO, "%s initialized!\n", JANUS_PROMETHEUS_NAME);
+	return 0;
+}
+
+void janus_promevh_destroy(void) {
+	if(!g_atomic_int_get(&initialized))
+		return;
+	g_atomic_int_set(&stopping, 1);
+
+	g_async_queue_push(events, &exit_event);
+	if(handler_thread != NULL) {
+		g_thread_join(handler_thread);
+		handler_thread = NULL;
+	}
+
+	g_async_queue_unref(events);
+	events = NULL;
+
+	// destroy here
+
+	g_atomic_int_set(&initialized, 0);
+	g_atomic_int_set(&stopping, 0);
+	JANUS_LOG(LOG_INFO, "%s destroyed!\n", JANUS_PROMETHEUS_NAME);
+}
+
+int janus_promevh_get_api_compatibility(void) {
+	/* Important! This is what your plugin MUST always return: don't lie here or bad things will happen */
+	return JANUS_EVENTHANDLER_API_VERSION;
+}
+
+int janus_promevh_get_version(void) {
+	return JANUS_PROMETHEUS_VERSION;
+}
+
+const char *janus_promevh_get_version_string(void) {
+	return JANUS_PROMETHEUS_VERSION_STRING;
+}
+
+const char *janus_promevh_get_description(void) {
+	return JANUS_PROMETHEUS_DESCRIPTION;
+}
+
+const char *janus_promevh_get_name(void) {
+	return JANUS_PROMETHEUS_NAME;
+}
+
+const char *janus_promevh_get_author(void) {
+	return JANUS_PROMETHEUS_AUTHOR;
+}
+
+const char *janus_promevh_get_package(void) {
+	return JANUS_PROMETHEUS_PACKAGE;
+}
+
+void janus_promevh_incoming_event(json_t *event) {
+	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized)) {
+		/* Janus is closing or the plugin is */
+		return;
+	}
+
+	/* Do NOT handle the event here in this callback! Since Janus notifies you right
+	 * away when something happens, these events are triggered from working threads and
+	 * not some sort of message bus. As such, performing I/O or network operations in
+	 * here could dangerously slow Janus down. Let's just reference and enqueue the event,
+	 * and handle it in our own thread: the event contains a monotonic time indicator of
+	 * when the event actually happened on this machine, so that, if relevant, we can compute
+	 * any delay in the actual event processing ourselves. */
+	json_incref(event);
+	g_async_queue_push(events, event);
+}
+
+json_t *janus_promevh_handle_request(json_t *request) {
+	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized)) {
+		return NULL;
+	}
+	/* We can use this requests to apply tweaks to the logic */
+	int error_code = 0;
+	char error_cause[512];
+	const char *request_text;
+	JANUS_VALIDATE_JSON_OBJECT(request, request_parameters,
+		error_code, error_cause, TRUE,
+		JANUS_PROMETHEUS_ERROR_MISSING_ELEMENT, JANUS_PROMETHEUS_ERROR_INVALID_ELEMENT);
+	if(error_code != 0)
+		goto plugin_response;
+	/* Get the request */
+	request_text = json_string_value(json_object_get(request, "request"));
+#if 0
+	if(!strcasecmp(request_text, "tweak")) {
+		/* We only support a request to tweak the current settings */
+		JANUS_VALIDATE_JSON_OBJECT(request, tweak_parameters,
+			error_code, error_cause, TRUE,
+			JANUS_PROMETHEUS_ERROR_MISSING_ELEMENT, JANUS_PROMETHEUS_ERROR_INVALID_ELEMENT);
+		if(error_code != 0)
+			goto plugin_response;
+		/* Events */
+		if(json_object_get(request, "events"))
+			janus_events_edit_events_mask(json_string_value(json_object_get(request, "events")), &janus_promevh.events_mask);
+	} else {
+		JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
+		error_code = JANUS_PROMETHEUS_ERROR_INVALID_REQUEST;
+		g_snprintf(error_cause, 512, "Unknown request '%s'", request_text);
+	}
+#endif
+plugin_response:
+	{
+		json_t *response = json_object();
+		if(error_code == 0) {
+			/* Return a success */
+			json_object_set_new(response, "result", json_integer(200));
+		} else {
+			/* Prepare JSON error event */
+			json_object_set_new(response, "error_code", json_integer(error_code));
+			json_object_set_new(response, "error", json_string(error_cause));
+		}
+		return response;
+	}
+}
+
+/* Thread to handle incoming events */
+static void *janus_promevh_handler(void *data) {
+	JANUS_LOG(LOG_VERB, "Joining PrometheusEventHandler handler thread\n");
+	json_t *event = NULL;
+
+	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
+		event = (json_t *)g_async_queue_pop(events);
+		if(event == NULL)
+			continue;
+		if(event == &exit_event)
+			break;
+
+		if(!g_atomic_int_get(&stopping)) {
+			// process event here
+		}
+
+		/* Done, let's unref the event */
+		json_decref(event);
+	}
+	JANUS_LOG(LOG_VERB, "Leaving PrometheusEventHandler handler thread\n");
+	return NULL;
+}
+
+
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+#include <thread>
+#include <stdio.h>
+
+#include <prometheus/exposer.h>
+#include <prometheus/registry.h>
+
+// reference test to check library load
+int test_prometheus() {
+  	// create an http server running on port 8080
+  	prometheus::Exposer exposer{"0.0.0.0:9091"};
+  	printf("Start listent at 0.0.0.0:9091\n");
+
+  	// create a metrics registry with component=main labels applied to all its metrics
+  	auto registry = std::make_shared<prometheus::Registry>();
+
+  	// add a new counter family to the registry (families combine values with the same name, but distinct label dimensions)
+	prometheus::Family<prometheus::Counter>& 
+	counter_family = prometheus::BuildCounter()
+                             .Name("time_running_seconds")
+                             .Help("How many seconds is this server running?")
+                             .Labels({{"label", "value"}})
+                             .Register(*registry);
+
+  	// add a counter to the metric family
+	prometheus::Counter&
+	second_counter = counter_family.Add(
+      {{"another_label", "value"}, {"yet_another_label", "value"}});
+
+  	// ask the exposer to scrape the registry on incoming scrapes
+  	exposer.RegisterCollectable(registry);
+
+  	for (;;) {
+    	std::this_thread::sleep_for(std::chrono::seconds(2));
+    	// increment the counter by one (second)
+		second_counter.Increment();
+		printf ("increment!!!\n");
+  	}
+  	return 0;
+}


### PR DESCRIPTION
There is initial version which only expose events counter to http://$host:$port/metrics.

The plugin depends on prometheus-cpp static library which can be built as:
```
git clone --depth 1 -b v0.6.0 --recurse-submodules https://github.com/jupp0r/prometheus-cpp && cd $(basename "$_") && \
mkdir -p .build && cd "$_" && cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DENABLE_PUSH=OFF -DENABLE_TESTING=OFF .. && \
make -j8 && \
make install
```

Hope, you'll find it useful)
