### PR TITLE
Initialize Last Will and Testament properties for mqttevh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -341,8 +341,8 @@ events_libjanus_mqttevh_la_SOURCES = events/janus_mqttevh.c
 events_libjanus_mqttevh_la_CFLAGS = $(events_cflags)
 events_libjanus_mqttevh_la_LDFLAGS = $(events_ldflags) -lpaho-mqtt3as
 events_libjanus_mqttevh_la_LIBADD = $(events_libadd)
-conf_DATA += conf/janus.eventhandler.mqttevh.cfg.sample
-EXTRA_DIST += conf/janus.eventhandler.mqttevh.cfg.sample
+conf_DATA += conf/janus.eventhandler.mqttevh.jcfg.sample
+EXTRA_DIST += conf/janus.eventhandler.mqttevh.jcfg.sample
 endif
 
 ##

--- a/conf/janus.eventhandler.mqttevh.jcfg.sample
+++ b/conf/janus.eventhandler.mqttevh.jcfg.sample
@@ -28,10 +28,11 @@ general: {
 	#addevent = true				# Whether we should add the event type to the base topic
 
 	# Initial message sent to status topic
-	#initial_status = "{\"event\": \"connected\", \"eventhandler\": \"janus.eventhandler.mqttevh\"}"
+	#connect_status = "{\"event\": \"connected\", \"eventhandler\": \"janus.eventhandler.mqttevh\"}"
+	# Message sent after disconnect or as LWT
+	#disconnect_status = "{\"event\": \"disconnected\"}"
 
 	#will_enabled = false							# Whether to enable LWT (default: false)
-	#will_content = "{\"event\": \"disconnected\"}"	# LWT content
 	#will_retain = 1								# Whether LWT should be retained (default: 1)
 	#will_qos = 0									# QoS for LWT (default: 0)
 

--- a/conf/janus.eventhandler.mqttevh.jcfg.sample
+++ b/conf/janus.eventhandler.mqttevh.jcfg.sample
@@ -27,9 +27,9 @@ general: {
 	#topic = "/janus/events"		# Base topic (default: /janus/events)
 	#addevent = true				# Whether we should add the event type to the base topic
 
-	#will_enabled = no								# Whether to enable LWT (default: no)
+	#will_enabled = false							# Whether to enable LWT (default: false)
 	#will_content = "{\"event\": \"disconnect\"}"	# LWT content
-	#will_retain = yes								# Whether LWT should be retained (default: yes)
+	#will_retain = 1								# Whether LWT should be retained (default: 1)
 	#will_qos = 0									# QoS for LWT (default: 0)
 
 	# Additional parameters if "mqtts://" schema is used

--- a/conf/janus.eventhandler.mqttevh.jcfg.sample
+++ b/conf/janus.eventhandler.mqttevh.jcfg.sample
@@ -16,15 +16,16 @@ general: {
 							# plain (no indentation) or compact (no indentation and no spaces)
 
 	url = "tcp://localhost:1883"	# The URL of the MQTT server. Only tcp supported at this time.
-	client_id = "janus.example.com"	# Janus client id. You have to configure a unique ID.
+	client_id = "janus.example.com"	# Janus client id. You have to configure a unique ID (default: guest).
 	#keep_alive_interval = 20		# Keep connection for N seconds (default: 30)
 	#cleansession = 0				# Clean session flag (default: off)
-	#mqtt_qos = 1					# Default MQTT QoS for published events
+	#retain = 0						# Default MQTT retain flag for published events
+	#qos = 1						# Default MQTT QoS for published events
 	#disconnect_timeout = 100		# Seconds to wait before destroying client
 	#username = "guest"				# Username for authentication (default: no authentication)
 	#password = "guest"				# Password for authentication (default: no authentication)
 	#topic = "/janus/events"		# Base topic (default: /janus/events)
-	#addtype = true					# Whether we should add the event type to the base topic
+	#addevent = true				# Whether we should add the event type to the base topic
 
 	#will_enabled = no								# Whether to enable LWT (default: no)
 	#will_content = "{\"event\": \"disconnect\"}"	# LWT content

--- a/conf/janus.eventhandler.mqttevh.jcfg.sample
+++ b/conf/janus.eventhandler.mqttevh.jcfg.sample
@@ -27,8 +27,11 @@ general: {
 	#topic = "/janus/events"		# Base topic (default: /janus/events)
 	#addevent = true				# Whether we should add the event type to the base topic
 
+	# Initial message sent to status topic
+	#initial_status = "{\"event\": \"connected\", \"eventhandler\": \"janus.eventhandler.mqttevh\"}"
+
 	#will_enabled = false							# Whether to enable LWT (default: false)
-	#will_content = "{\"event\": \"disconnect\"}"	# LWT content
+	#will_content = "{\"event\": \"disconnected\"}"	# LWT content
 	#will_retain = 1								# Whether LWT should be retained (default: 1)
 	#will_qos = 0									# QoS for LWT (default: 0)
 

--- a/conf/janus.eventhandler.mqttevh.jcfg.sample
+++ b/conf/janus.eventhandler.mqttevh.jcfg.sample
@@ -26,11 +26,10 @@ general: {
 	#topic = "/janus/events"		# Base topic (default: /janus/events)
 	#addtype = true					# Whether we should add the event type to the base topic
 
-
+	#will_enabled = no								# Whether to enable LWT (default: no)
 	#will_content = "{\"event\": \"disconnect\"}"	# LWT content
 	#will_retain = yes								# Whether LWT should be retained (default: yes)
 	#will_qos = 0									# QoS for LWT (default: 0)
-
 
 	# Additional parameters if "mqtts://" schema is used
 	#tls_verify_peer = true			# Whether peer verification must be enabled

--- a/conf/janus.eventhandler.mqttevh.jcfg.sample
+++ b/conf/janus.eventhandler.mqttevh.jcfg.sample
@@ -27,6 +27,11 @@ general: {
 	#addtype = true					# Whether we should add the event type to the base topic
 
 
+	#will_content = "{\"event\": \"disconnect\"}"	# LWT content
+	#will_retain = yes								# Whether LWT should be retained (default: yes)
+	#will_qos = 0									# QoS for LWT (default: 0)
+
+
 	# Additional parameters if "mqtts://" schema is used
 	#tls_verify_peer = true			# Whether peer verification must be enabled
 	#tls_verify_hostname = true		# Whether hostname verification must be enabled


### PR DESCRIPTION
Hi!

Added initialization for MQTT's Last Will and Testament options. There was some default
values but they weren't used anywhere. I tested it manually and it works.

But it comes that LWT is enabled by default now. Should I add some flag to enable/disable it?