### PR TITLE
Nanomsg transport libconfig migration

### DIFF
--- a/transports/janus_nanomsg.c
+++ b/transports/janus_nanomsg.c
@@ -131,9 +131,15 @@ int janus_nanomsg_init(janus_transport_callbacks *callback, const char *config_p
 
 	/* Read configuration */
 	char filename[255];
-	g_snprintf(filename, 255, "%s/%s.cfg", config_path, JANUS_NANOMSG_PACKAGE);
+	g_snprintf(filename, 255, "%s/%s.jcfg", config_path, JANUS_NANOMSG_PACKAGE);
 	JANUS_LOG(LOG_VERB, "Configuration file: %s\n", filename);
 	janus_config *config = janus_config_parse(filename);
+	if(config == NULL) {
+		JANUS_LOG(LOG_WARN, "Couldn't find .jcfg configuration file (%s), trying .cfg\n", JANUS_NANOMSG_PACKAGE);
+		g_snprintf(filename, 255, "%s/%s.cfg", config_path, JANUS_NANOMSG_PACKAGE);
+		JANUS_LOG(LOG_VERB, "Configuration file: %s\n", filename);
+		config = janus_config_parse(filename);
+	}
 	if(config != NULL) {
 		/* Handle configuration */
 		janus_config_print(config);


### PR DESCRIPTION
Nanomsg transport seems to have been missed in the conversion to libconfig. The .jcfg configuration file is never tried.