### PR TITLE
Replace enable with enabled

### DIFF
--- a/conf/janus.transport.mqtt.jcfg.sample
+++ b/conf/janus.transport.mqtt.jcfg.sample
@@ -1,6 +1,6 @@
 # Configuration of the MQTT additional transport for the Janus API.
 general: {
-	enable = false						# Whether the support must be enabled
+	enabled = false						# Whether the support must be enabled
 	json = "indented"						# Whether the JSON messages should be indented (default),
 										# plain (no indentation) or compact (no indentation and no spaces)
 
@@ -12,14 +12,14 @@ general: {
 	#password = "guest"					# Password to use to authenticate, if needed
 	#keep_alive_interval = 20			# Keep connection for N seconds
 	#cleansession = 0					# Clean session flag
-	#disconnect_timeout = 100			# Seconds to wait before destroying client
+	#disconnect_timeout = 100			# Milliseconds to wait before destroying client
 	subscribe_topic = "to-janus"		# Topic for incoming messages
 	#subscribe_qos = 1					# QoS for incoming messages
 	publish_topic = "from-janus"		# Topic for outgoing messages
 	#publish_qos = 1					# QoS for outgoing messages
 
-	#ssl_enable = yes					# Whether ssl support must be enabled
-	#verify_peer = yes					# Whether peer verification must be enabled
+	#ssl_enabled = true					# Whether ssl support must be enabled
+	#verify_peer = true					# Whether peer verification must be enabled
 
 	# Certificates to use when SSL support is enabled, if needed
 	#cacertfile = /path/to/cacert.pem
@@ -29,7 +29,7 @@ general: {
 }
 
 admin: {
-	#admin_enable = false				# Whether the support must be enabled
+	#admin_enabled = false				# Whether the support must be enabled
 	subscribe_topic = "to-janus-admin"	# Topic for incoming admin messages
 	#subscribe_qos = 1					# QoS for incoming admin messages
 	publish_topic = "from-janus-admin"	# Topic for outgoing admin messages

--- a/conf/janus.transport.rabbitmq.jcfg.sample
+++ b/conf/janus.transport.rabbitmq.jcfg.sample
@@ -13,9 +13,9 @@
 # different queues for each of them (e.g., from-janus-1/to-janus-1 and
 # from-janus-2/to-janus-2), or otherwise both the instances will make
 # use of the same queues and messages will get lost. The integration
-# is disabled by default, so set enable=yes if you want to use it.
+# is disabled by default, so set enabled=true if you want to use it.
 general: {
-	enable = false						# Whether the support must be enabled
+	enabled = false						# Whether the support must be enabled
 	json = "indented"					# Whether the JSON messages should be indented (default),
 										# plain (no indentation) or compact (no indentation and no spaces)
 	host = "localhost"					# The address of the RabbitMQ server
@@ -26,7 +26,7 @@ general: {
 	to_janus = "to-janus"				# Name of the queue for incoming messages
 	from_janus = "from-janus"			# Name of the queue for outgoing messages
 	#janus_exchange = "janus-exchange"	# Exchange for outgoing messages, using default if not provided
-	#ssl_enable = false					# Whether ssl support must be enabled
+	#ssl_enabled = false					# Whether ssl support must be enabled
 	#ssl_verify_peer = true				# Whether peer verification must be enabled
 	#ssl_verify_hostname = true			# Whether hostname verification must be enabled
 
@@ -41,7 +41,7 @@ general: {
 # Admin API messaging. The same RabbitMQ server is supposed to be used.
 # Notice that by default the Admin API support via RabbitMQ is disabled.
 admin: {
-	#admin_enable = false					# Whether the support must be enabled
+	#admin_enabled = false					# Whether the support must be enabled
 	#to_janus_admin = "to-janus-admin"		# Name of the queue for incoming messages
 	#from_janus_admin = "from-janus-admin"	# Name of the queue for outgoing messages
 }

--- a/transports/janus_rabbitmq.c
+++ b/transports/janus_rabbitmq.c
@@ -242,14 +242,21 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 		password = g_strdup("guest");
 
 	/* SSL config*/
-	gboolean ssl_enable = FALSE;
+	gboolean ssl_enabled = FALSE;
 	gboolean ssl_verify_peer = FALSE;
 	gboolean ssl_verify_hostname = FALSE;
-	item = janus_config_get(config, config_general, janus_config_type_item, "ssl_enable");
+	item = janus_config_get(config, config_general, janus_config_type_item, "ssl_enabled");
+	if(item == NULL) {
+		/* Try legacy property */
+		item = janus_config_get(config, config_general, janus_config_type_item, "ssl_enable");
+		if (item && item->value) {
+			JANUS_LOG(LOG_WARN, "Found deprecated 'ssl_enable' property, please update it to 'ssl_enabled' instead\n");
+		}
+	}
 	if(!item || !item->value || !janus_is_true(item->value)) {
 		JANUS_LOG(LOG_INFO, "RabbitMQ SSL support disabled\n");
 	} else {
-		ssl_enable = TRUE;
+		ssl_enabled = TRUE;
 		item = janus_config_get(config, config_general, janus_config_type_item, "ssl_cacert");
 		if(item && item->value)
 			ssl_cacert_file = g_strdup(item->value);
@@ -268,7 +275,14 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 	}
 
 	/* Now check if the Janus API must be supported */
-	item = janus_config_get(config, config_general, janus_config_type_item, "enable");
+	item = janus_config_get(config, config_general, janus_config_type_item, "enabled");
+	if(item == NULL) {
+		/* Try legacy property */
+		item = janus_config_get(config, config_general, janus_config_type_item, "enable");
+		if (item && item->value) {
+			JANUS_LOG(LOG_WARN, "Found deprecated 'enable' property, please update it to 'enabled' instead\n");
+		}
+	}
 	if(!item || !item->value || !janus_is_true(item->value)) {
 		JANUS_LOG(LOG_WARN, "RabbitMQ support disabled (Janus API)\n");
 	} else {
@@ -299,7 +313,14 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 		rmq_janus_api_enabled = TRUE;
 	}
 	/* Do the same for the admin API */
-	item = janus_config_get(config, config_admin, janus_config_type_item, "admin_enable");
+	item = janus_config_get(config, config_admin, janus_config_type_item, "admin_enabled");
+	if(item == NULL) {
+		/* Try legacy property */
+		item = janus_config_get(config, config_general, janus_config_type_item, "admin_enable");
+		if (item && item->value) {
+			JANUS_LOG(LOG_WARN, "Found deprecated 'admin_enable' property, please update it to 'admin_enabled' instead\n");
+		}
+	}
 	if(!item || !item->value || !janus_is_true(item->value)) {
 		JANUS_LOG(LOG_WARN, "RabbitMQ support disabled (Admin API)\n");
 	} else {
@@ -330,7 +351,7 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 		amqp_socket_t *socket = NULL;
 		int status;
 		JANUS_LOG(LOG_VERB, "Creating RabbitMQ socket...\n");
-		if (ssl_enable) {
+		if (ssl_enabled) {
 			socket = amqp_ssl_socket_new(rmq_client->rmq_conn);
 			if(socket == NULL) {
 				JANUS_LOG(LOG_FATAL, "Can't connect to RabbitMQ server: error creating socket...\n");


### PR DESCRIPTION
MQTT and RabbitMQ transport plugins mistakenly have `enable` property in their configuration while other plugins have `enabled`. It seems as a good time to change those properties' names during migration to `jcfg`.