### PR TITLE
Improve Makefile.am and configure.ac to better support clang compiler.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,23 +1,8 @@
 ACLOCAL_AMFLAGS = -I m4
 
-# FIXME: These flags should be produced in configure.ac using AX_APPEND_COMPILE_FLAGS
-AM_CFLAGS = \
-	-Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations \
-	-Wunused -fstrict-aliasing -Wextra -Wformat=2 -Winit-self -Winline \
-	-Wpacked -Wpointer-arith -Wmissing-format-attribute -Wmissing-noreturn \
-	-Wnested-externs -Wstrict-prototypes -Wunsafe-loop-optimizations \
-	-Wwrite-strings -Wno-missing-field-initializers -Wno-unused-parameter \
-	-Wcast-align -Wformat-nonliteral -Wformat-security -Wswitch-default \
-	-Wmissing-include-dirs -Wno-aggregate-return -Wunused-but-set-variable \
-	-Warray-bounds -Wold-style-definition -Wsign-compare -Wlarger-than=65537
-AM_CFLAGS += -Wno-undef  # sofiasip is not -Wundef--safe
-AM_CFLAGS += -Wno-redundant-decls  # sofiasip also contains redundant declarations
-AM_CFLAGS += -Wno-override-init  # we need this for JANUS_PLUGIN_INIT and JANUS_TRANSPORT_INIT and JANUS_EVENTHANDLER_INIT
 # FIXME: These should be enabled once the code is safe for them. That requires
 # some fairly big refactoring though, which can wait.
 # AM_CFLAGS += -Wshadow -Wstrict-aliasing=2
-
-AM_CFLAGS += -fstack-protector-all -g -ggdb -fPIC -rdynamic -pthread
 
 # FIXME: make docs work with distcheck
 DISTCHECK_CONFIGURE_FLAGS = --disable-docs --enable-post-processing

--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AX_APPEND_COMPILE_FLAGS([ \
 	-Wpacked -Wpointer-arith -Wmissing-format-attribute -Wmissing-noreturn \
 	-Wnested-externs -Wstrict-prototypes  \
 	-Wwrite-strings -Wno-missing-field-initializers -Wno-unused-parameter \
-	-Wcast-align -Wformat-nonliteral -Wformat-security -Wswitch-default \
+	-Wformat-nonliteral -Wformat-security -Wswitch-default \
 	-Wmissing-include-dirs -Wno-aggregate-return  \
 	-Warray-bounds -Wold-style-definition -Wsign-compare -Wlarger-than=65537 \
 	-Wno-undef \
@@ -40,6 +40,7 @@ AM_COND_IF([USE_CLANG],
 	])],
 	# Specific gcc flags
 	[AX_APPEND_COMPILE_FLAGS([ \
+		-Wno-cast-align \
 		-Wno-override-init \
 		-Wunused-but-set-variable \
 		-Wunsafe-loop-optimizations \

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,6 @@ AX_APPEND_COMPILE_FLAGS([ \
 	-Wno-undef \
 	-Wno-redundant-decls \
 	-fstack-protector-all -ggdb3 -fPIC -pthread \
-	-Wl,--export-dynamic \
 ])
 
 AM_CONDITIONAL([USE_CLANG], [test "x$CC" = "xclang"])
@@ -44,6 +43,10 @@ AM_COND_IF([USE_CLANG],
 		-Wunused-but-set-variable \
 		-Wunsafe-loop-optimizations \
 	])
+])
+
+AX_APPEND_LINK_FLAGS([ \
+	-Wl,--export-dynamic \
 ])
 
 JANUS_VERSION=60

--- a/configure.ac
+++ b/configure.ac
@@ -923,7 +923,7 @@ AC_OUTPUT
 # Summary
 ##
 echo
-echo "using compiler:            $CC"
+echo "Compiler:                  $CC"
 AM_COND_IF([ENABLE_LIBSRTP_2],
 	[echo "libsrtp version:           2.x"],
 	[echo "libsrtp version:           1.5.x"])

--- a/configure.ac
+++ b/configure.ac
@@ -29,18 +29,17 @@ AX_APPEND_COMPILE_FLAGS([ \
 	-Wno-undef \
 	-Wno-redundant-decls \
 	-fstack-protector-all -ggdb3 -fPIC -pthread \
+	-Wl,--export-dynamic \
 ])
 
 AM_CONDITIONAL([USE_CLANG], [test "x$CC" = "xclang"])
 AM_COND_IF([USE_CLANG],
 	# Specific clang flags
 	[AX_APPEND_COMPILE_FLAGS([ \
-		-Wl,--export-dynamic \
 		-Wno-initializer-overrides \
 	])],
 	# Specific gcc flags
 	[AX_APPEND_COMPILE_FLAGS([ \
-		-rdynamic \
 		-Wno-override-init \
 		-Wunused-but-set-variable \
 		-Wunsafe-loop-optimizations \
@@ -897,9 +896,7 @@ AC_OUTPUT
 # Summary
 ##
 echo
-AM_COND_IF([USE_CLANG],
-	[echo "using clang compiler:      yes"],
-	[echo "using clang compiler:      no"])
+echo "using compiler:            $CC"
 AM_COND_IF([ENABLE_LIBSRTP_2],
 	[echo "libsrtp version:           2.x"],
 	[echo "libsrtp version:           1.5.x"])

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,5 @@
 AC_INIT([Janus WebRTC Server],[0.6.0],[https://github.com/meetecho/janus-gateway],[janus-gateway],[https://janus.conf.meetecho.com])
+AC_LANG(C)
 AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/configure.ac
+++ b/configure.ac
@@ -18,38 +18,60 @@ LT_PREREQ([2.2])
 LT_INIT
 
 # Common CFLAGS
-AX_APPEND_COMPILE_FLAGS([ \
-	-Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations \
-	-Wunused -fstrict-aliasing -Wextra -Wformat=2 -Winit-self -Winline \
-	-Wpacked -Wpointer-arith -Wmissing-format-attribute -Wmissing-noreturn \
-	-Wnested-externs -Wstrict-prototypes  \
-	-Wwrite-strings -Wno-missing-field-initializers -Wno-unused-parameter \
-	-Wformat-nonliteral -Wformat-security -Wswitch-default \
-	-Wmissing-include-dirs -Wno-aggregate-return  \
-	-Warray-bounds -Wold-style-definition -Wsign-compare -Wlarger-than=65537 \
-	-Wno-undef \
+CFLAGS="$CFLAGS \
+	-fPIC \
+	-fstack-protector-all \
+	-fstrict-aliasing \
+	-ggdb3 \
+	-pthread \
+	-Wall \
+	-Warray-bounds \
+	-Wextra \
+	-Wformat-nonliteral \
+	-Wformat-security \
+	-Wformat=2 \
+	-Winit-self \
+	-Winline \
+	-Wlarger-than=65537 \
+	-Wmissing-declarations \
+	-Wmissing-format-attribute \
+	-Wmissing-include-dirs \
+	-Wmissing-noreturn \
+	-Wmissing-prototypes \
+	-Wnested-externs \
+	-Wno-aggregate-return \
+	-Wno-missing-field-initializers \
 	-Wno-redundant-decls \
-	-fstack-protector-all -ggdb3 -fPIC -pthread \
-])
+	-Wno-undef \
+	-Wno-unused-parameter \
+	-Wold-style-definition \
+	-Wpacked \
+	-Wpointer-arith \
+	-Wsign-compare \
+	-Wstrict-prototypes \
+	-Wswitch-default \
+	-Wunused \
+	-Wwrite-strings"
 
 AM_CONDITIONAL([USE_CLANG], [test "x$CC" = "xclang"])
 AM_COND_IF([USE_CLANG],
 	# Specific clang flags
-	[AX_APPEND_COMPILE_FLAGS([ \
-		-Wno-initializer-overrides \
-	])],
-	# Specific gcc flags
-	[AX_APPEND_COMPILE_FLAGS([ \
+	[CFLAGS="$CFLAGS \
 		-Wno-cast-align \
+		-Wno-initializer-overrides"
+	],
+	# Specific gcc flags
+	[CFLAGS="$CFLAGS \
+		-Wcast-align \
 		-Wno-override-init \
-		-Wunused-but-set-variable \
 		-Wunsafe-loop-optimizations \
-	])
-])
+		-Wunused-but-set-variable"	
+	]
+)
 
-AX_APPEND_LINK_FLAGS([ \
-	-Wl,--export-dynamic \
-])
+# add rdynamic to LDFLAGS
+LDFLAGS="$LDFLAGS \
+	-Wl,--export-dynamic"
 
 JANUS_VERSION=60
 AC_SUBST(JANUS_VERSION)

--- a/configure.ac
+++ b/configure.ac
@@ -8,12 +8,44 @@ AC_ENABLE_STATIC(no)
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_SILENT_RULES([yes])
 
-AC_GNU_SOURCE
+#AC_GNU_SOURCE has been deprecated (https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html)
+AC_USE_SYSTEM_EXTENSIONS
 
 AC_PROG_CC
 
 LT_PREREQ([2.2])
 LT_INIT
+
+# Common CFLAGS
+AX_APPEND_COMPILE_FLAGS([ \
+	-Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations \
+	-Wunused -fstrict-aliasing -Wextra -Wformat=2 -Winit-self -Winline \
+	-Wpacked -Wpointer-arith -Wmissing-format-attribute -Wmissing-noreturn \
+	-Wnested-externs -Wstrict-prototypes  \
+	-Wwrite-strings -Wno-missing-field-initializers -Wno-unused-parameter \
+	-Wcast-align -Wformat-nonliteral -Wformat-security -Wswitch-default \
+	-Wmissing-include-dirs -Wno-aggregate-return  \
+	-Warray-bounds -Wold-style-definition -Wsign-compare -Wlarger-than=65537 \
+	-Wno-undef \
+	-Wno-redundant-decls \
+	-fstack-protector-all -ggdb3 -fPIC -pthread \
+])
+
+AM_CONDITIONAL([USE_CLANG], [test "x$CC" = "xclang"])
+AM_COND_IF([USE_CLANG],
+	# Specific clang flags
+	[AX_APPEND_COMPILE_FLAGS([ \
+		-Wl,--export-dynamic \
+		-Wno-initializer-overrides \
+	])],
+	# Specific gcc flags
+	[AX_APPEND_COMPILE_FLAGS([ \
+		-rdynamic \
+		-Wno-override-init \
+		-Wunused-but-set-variable \
+		-Wunsafe-loop-optimizations \
+	])
+])
 
 JANUS_VERSION=60
 AC_SUBST(JANUS_VERSION)
@@ -865,7 +897,9 @@ AC_OUTPUT
 # Summary
 ##
 echo
-
+AM_COND_IF([USE_CLANG],
+	[echo "using clang compiler:      yes"],
+	[echo "using clang compiler:      no"])
 AM_COND_IF([ENABLE_LIBSRTP_2],
 	[echo "libsrtp version:           2.x"],
 	[echo "libsrtp version:           1.5.x"])


### PR DESCRIPTION
This PR aims at enhancing Janus build-chain in order to better support the `clang` compiler.

**What has been added**
When in use, the `clang` compiler is detected  while issuing `configure`. This distinction is necessary because some specific `CFLAGS` that are used for `gcc` have a different name in `clang`.
<del>e.g. `-rdynamic` in `gcc`  becomes `-Wl,--export-dynamic` in `clang`.</del>
(Now `-Wl,--export-dynamic` is used as a common flag)
e.g. `-Wno-override-init` becomes `-Wno-initializer-overrides` in `clang`.

**What has been improved in general**
The `CFLAGS` are not appended in Makefile anymore but in the `configure.ac`<del>but the Macro `AX_APPEND_COMPILE_FLAGS` has been added to `configure.ac`. The macro checks for every flag availability and then appends it to `CFLAGS`.</del>
<del>**IMPORTANT**: To use this new macro I had to install the package `autoconf-archive`.</del>
The obsolete Macro `AC_GNU_SOURCE` has been replaced by `AC_USE_SYSTEM_EXTENSIONS`.

**How to compile Janus with `clang`**
First install `clang`. In Ubuntu this means `apt install clang`. 
Just set `clang` as your compiler while issuing the usual commands.
```
./autogen.sh
./configure CC=clang
sudo make clean
make -j$(nproc)
sudo make install
```
I have added a <del>"`using clang compiler`"</del> "`using compiler`" print in the configuration summary to double-check if the script has recognized the compiler.

**Why so many warnings?**
When compiling Janus with `clang` expect A LOT of warnings about memory alignment. This compiler seems to be more sensible to pointer casting respect to `gcc`. However many of those warns (especially the ones coming from the ICE stack `char*` buffers castings) should be bogus warnings, because the compiler ignores that those pointers contains very large `char[]` arrays and those arrays, at least on my x86_64 machine, are  16-bytes aligned.
The other warnings about the printf format can also be ignored.
**EDIT:** the cast alignment warnings have now been suppressed (really too much noise).