### PR TITLE
Missing sendDtmf success callback call (JS)

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1421,6 +1421,7 @@ function Janus(gatewayCallbacks) {
 			gap = 50;	// We choose 50ms as the default gap between tones
 		Janus.debug("Sending DTMF string " + tones + " (duration " + duration + "ms, gap " + gap + "ms)");
 		config.dtmfSender.insertDTMF(tones, duration, gap);
+		callbacks.success();
 	}
 
 	// Private method to destroy a plugin handle


### PR DESCRIPTION
The `sendDtmf` receives a `callbacks` object but `callbacks.success` is never called.

Given that `insertDTMF` doesn't return a `Promise`, the fix just calls the success callback in the last line.