### PR TITLE
Rtcp fixes

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -286,12 +286,14 @@ static gboolean janus_is_dtls(gchar *buf) {
 	return ((*buf >= 20) && (*buf <= 64));
 }
 
-static gboolean janus_is_rtp(gchar *buf) {
+static gboolean janus_is_rtp(gchar *buf, guint len) {
+	if (len < 2) return FALSE;
 	janus_rtp_header *header = (janus_rtp_header *)buf;
 	return ((header->type < 64) || (header->type >= 96));
 }
 
-static gboolean janus_is_rtcp(gchar *buf) {
+static gboolean janus_is_rtcp(gchar *buf, guint len) {
+	if (len < 2) return FALSE;
 	janus_rtp_header *header = (janus_rtp_header *)buf;
 	return ((header->type >= 64) && (header->type < 96));
 }
@@ -2114,7 +2116,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 		return;
 	}
 	/* What is this? */
-	if(janus_is_dtls(buf) || (!janus_is_rtp(buf) && !janus_is_rtcp(buf))) {
+	if(janus_is_dtls(buf) || (!janus_is_rtp(buf, len) && !janus_is_rtcp(buf, len))) {
 		/* This is DTLS: either handshake stuff, or data coming from SCTP DataChannels */
 		JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Looks like DTLS!\n", handle->handle_id);
 		janus_dtls_srtp_incoming_msg(component->dtls, buf, len);
@@ -2126,7 +2128,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 	/* Not DTLS... RTP or RTCP? (http://tools.ietf.org/html/rfc5761#section-4) */
 	if(len < 12)
 		return;	/* Definitely nothing useful */
-	if(janus_is_rtp(buf)) {
+	if(janus_is_rtp(buf, len)) {
 		/* This is RTP */
 		if(!component->dtls || !component->dtls->srtp_valid || !component->dtls->srtp_in) {
 			JANUS_LOG(LOG_WARN, "[%"SCNu64"]     Missing valid SRTP session (packet arrived too early?), skipping...\n", handle->handle_id);
@@ -2556,7 +2558,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 			}
 		}
 		return;
-	} else if(janus_is_rtcp(buf)) {
+	} else if(janus_is_rtcp(buf, len)) {
 		/* This is RTCP */
 		JANUS_LOG(LOG_HUGE, "[%"SCNu64"]  Got an RTCP packet\n", handle->handle_id);
 		if(!component->dtls || !component->dtls->srtp_valid || !component->dtls->srtp_in) {

--- a/rtcp.c
+++ b/rtcp.c
@@ -219,12 +219,12 @@ static void janus_rtcp_incoming_rr(janus_rtcp_context *ctx, janus_rtcp_rr *rr) {
 
 gboolean janus_rtcp_check_len(janus_rtcp_header *rtcp, int len) {
 	if (len < (int)(sizeof(janus_rtcp_header) + 1*sizeof(uint32_t))) {
-		JANUS_LOG(LOG_WARN, "Packet size is too small (%d bytes) to contain RTCP\n", len);
+		JANUS_LOG(LOG_VERB, "Packet size is too small (%d bytes) to contain RTCP\n", len);
 		return FALSE;
 	}
 	int header_def_len = 4*(int)ntohs(rtcp->length) + 4;
 	if (len < header_def_len) {
-		JANUS_LOG(LOG_WARN, "RTCP packet length is %d but actual size is %d\n", header_def_len, len);
+		JANUS_LOG(LOG_VERB, "RTCP packet length is %d but actual size is %d\n", header_def_len, len);
 		return FALSE;
 	}
 	return TRUE;
@@ -238,7 +238,7 @@ gboolean janus_rtcp_check_sr(janus_rtcp_header *rtcp, int len) {
 	int header_rb_len = (int)(rtcp->rc)*sizeof(report_block);
 	int actual_rb_len = len - sizeof(janus_rtcp_header) - 1*sizeof(uint32_t) - sizeof(sender_info);
 	if (actual_rb_len < header_rb_len) {
-		JANUS_LOG(LOG_WARN, "SR got %d RB count, expected %d bytes greater than actual %d bytes\n", (int)(rtcp->rc), header_rb_len, actual_rb_len);
+		JANUS_LOG(LOG_VERB, "SR got %d RB count, expected %d bytes greater than actual %d bytes\n", (int)(rtcp->rc), header_rb_len, actual_rb_len);
 		return FALSE;
 	}
 	return TRUE;
@@ -248,7 +248,7 @@ gboolean janus_rtcp_check_rr(janus_rtcp_header *rtcp, int len) {
 	int header_rb_len = (int)(rtcp->rc)*sizeof(report_block);
 	int actual_rb_len = len - sizeof(janus_rtcp_header) - 1*sizeof(uint32_t);
 	if (actual_rb_len < header_rb_len) {
-		JANUS_LOG(LOG_WARN, "RR got %d RB count, expected %d bytes greater than actual %d bytes\n", (int)(rtcp->rc), header_rb_len, actual_rb_len);
+		JANUS_LOG(LOG_VERB, "RR got %d RB count, expected %d bytes greater than actual %d bytes\n", (int)(rtcp->rc), header_rb_len, actual_rb_len);
 		return FALSE;
 	}
 	return TRUE;
@@ -256,7 +256,7 @@ gboolean janus_rtcp_check_rr(janus_rtcp_header *rtcp, int len) {
 
 gboolean janus_rtcp_check_len12(janus_rtcp_header *rtcp, int len) {
 	if (len < (int)(sizeof(janus_rtcp_header) + 2*sizeof(uint32_t))) {
-		JANUS_LOG(LOG_WARN, "Packet is smaller than 12 bytes (%d bytes)\n", len);
+		JANUS_LOG(LOG_VERB, "Packet is smaller than 12 bytes (%d bytes)\n", len);
 		return FALSE;
 	}
 	return TRUE;
@@ -272,7 +272,7 @@ gboolean janus_rtcp_check_nacks(janus_rtcp_header *rtcp, int len) {
 	int nacks = (int)ntohs(rtcp->length) - 2;
 	/* Every Generic NACK is 4 bytes */
 	if (fci_size < 4*nacks) {
-		JANUS_LOG(LOG_WARN, "Got %d NACKS count, expected %d bytes greater than actual %d bytes\n", nacks, 4*nacks, fci_size);
+		JANUS_LOG(LOG_VERB, "Got %d NACKS count, expected %d bytes greater than actual %d bytes\n", nacks, 4*nacks, fci_size);
 		return FALSE;
 	}
 	return TRUE;
@@ -288,7 +288,7 @@ gboolean janus_rtcp_check_fci8(janus_rtcp_header *rtcp, int len) {
 	int fcis = ((int)ntohs(rtcp->length) >> 1) - 1;
 	/* Every FCI is 8 bytes */
 	if (fci_size < 8*fcis) {
-		JANUS_LOG(LOG_WARN, "Got %d FCI count, expected %d bytes greater than actual %d bytes\n", fcis, 8*fcis, fci_size);
+		JANUS_LOG(LOG_VERB, "Got %d FCI count, expected %d bytes greater than actual %d bytes\n", fcis, 8*fcis, fci_size);
 		return FALSE;
 	}
 	return TRUE;
@@ -306,7 +306,7 @@ gboolean janus_rtcp_check_remb(janus_rtcp_header *rtcp, int len) {
 	int ssrc_size = len - sizeof(janus_rtcp_header) - 2*sizeof(uint32_t);
 	/* Every SSRC is 4 bytes */
 	if (ssrc_size < 4*numssrc) {
-		JANUS_LOG(LOG_WARN, "REMB got %d SSRC count, expected %d bytes greater than actual %d bytes\n", numssrc, 4*numssrc, ssrc_size);
+		JANUS_LOG(LOG_VERB, "REMB got %d SSRC count, expected %d bytes greater than actual %d bytes\n", numssrc, 4*numssrc, ssrc_size);
 		return FALSE;
 	}
 	return TRUE;

--- a/rtcp.c
+++ b/rtcp.c
@@ -232,7 +232,7 @@ gboolean janus_rtcp_check_len(janus_rtcp_header *rtcp, int len) {
 
 gboolean janus_rtcp_check_sr(janus_rtcp_header *rtcp, int len) {
 	if (len < (int)(sizeof(janus_rtcp_header) + 1*sizeof(uint32_t) + sizeof(sender_info))) {
-		JANUS_LOG(LOG_WARN, "Packet is too small (%d bytes) to contain SR\n", len);
+		JANUS_LOG(LOG_VERB, "Packet is too small (%d bytes) to contain SR\n", len);
 		return FALSE;
 	}
 	int header_rb_len = (int)(rtcp->rc)*sizeof(report_block);
@@ -297,7 +297,7 @@ gboolean janus_rtcp_check_fci8(janus_rtcp_header *rtcp, int len) {
 gboolean janus_rtcp_check_remb(janus_rtcp_header *rtcp, int len) {
 	/* At least 1 SSRC feedback */
 	if (len < (int)(sizeof(janus_rtcp_header) + 2*sizeof(uint32_t) + 3*sizeof(uint32_t))) {
-		JANUS_LOG(LOG_WARN, "Packet is too small (%d bytes) to contain REMB\n", len);
+		JANUS_LOG(LOG_VERB, "Packet is too small (%d bytes) to contain REMB\n", len);
 		return FALSE;
 	}
 	janus_rtcp_fb *rtcpfb = (janus_rtcp_fb *)rtcp;

--- a/rtcp.h
+++ b/rtcp.h
@@ -365,7 +365,7 @@ gboolean janus_rtcp_check_nacks(janus_rtcp_header *rtcp, int len);
  * @param[in] len The message data length in bytes
  * @returns TRUE if packet is OK, or FALSE in case of error */
 gboolean janus_rtcp_check_fci8(janus_rtcp_header *rtcp, int len);
-/*! \brief Method to check if a RTCP packet could contain a AFB REMB Message
+/*! \brief Method to check if a RTCP packet could contain an AFB REMB Message
  * @param[in] packet The message data
  * @param[in] len The message data length in bytes
  * @returns TRUE if packet is OK, or FALSE in case of error */

--- a/rtcp.h
+++ b/rtcp.h
@@ -347,24 +347,13 @@ gboolean janus_rtcp_check_rr(janus_rtcp_header *rtcp, int len);
  * @param[in] len The message data length in bytes
  * @returns TRUE if packet is OK, or FALSE in case of error */
 gboolean janus_rtcp_check_sr(janus_rtcp_header *rtcp, int len);
-/*! \brief Method to check that a RTCP packet size is at least 12 bytes
- *  This is useful because many RTCP packets must be at least that size.
- * @param[in] packet The message data
- * @param[in] len The message data length in bytes
- * @returns TRUE if packet is OK, or FALSE in case of error */
-gboolean janus_rtcp_check_len12(janus_rtcp_header *rtcp, int len);
-/*! \brief Method to check if a RTCP packet could contain a Transport Layer
- * Feedback Generic NACK Message.
- * @param[in] packet The message data
- * @param[in] len The message data length in bytes
- * @returns TRUE if packet is OK, or FALSE in case of error */
-gboolean janus_rtcp_check_nacks(janus_rtcp_header *rtcp, int len);
 /*! \brief Method to check if a RTCP packet could contain a Feedback Message
- * with an expected FCI size of 8 bytes (e.g. some FIRs or PLIs).
+ * with a defined FCI size.
  * @param[in] packet The message data
  * @param[in] len The message data length in bytes
+ * @param[in] sizeof_fci The size of a FCI entry
  * @returns TRUE if packet is OK, or FALSE in case of error */
-gboolean janus_rtcp_check_fci8(janus_rtcp_header *rtcp, int len);
+gboolean janus_rtcp_check_fci(janus_rtcp_header *rtcp, int len, int sizeof_fci);
 /*! \brief Method to check if a RTCP packet could contain an AFB REMB Message
  * @param[in] packet The message data
  * @param[in] len The message data length in bytes

--- a/rtcp.h
+++ b/rtcp.h
@@ -331,6 +331,46 @@ guint32 janus_rtcp_get_sender_ssrc(char *packet, int len);
  * @returns The receiver SSRC, or 0 in case of error */
 guint32 janus_rtcp_get_receiver_ssrc(char *packet, int len);
 
+/*! \brief Method to check that a RTCP packet size is at least the minimum necessary (8 bytes)
+ *  and to validate the length field against the actual size
+ * @param[in] packet The message data
+ * @param[in] len The message data length in bytes
+ * @returns TRUE if packet is OK, or FALSE in case of error */
+gboolean janus_rtcp_check_len(janus_rtcp_header *rtcp, int len);
+/*! \brief Method to check if a RTCP packet could contain a Receiver Report
+ * @param[in] packet The message data
+ * @param[in] len The message data length in bytes
+ * @returns TRUE if packet is OK, or FALSE in case of error */
+gboolean janus_rtcp_check_rr(janus_rtcp_header *rtcp, int len);
+/*! \brief Method to check if a RTCP packet could contain a Sender Report
+ * @param[in] packet The message data
+ * @param[in] len The message data length in bytes
+ * @returns TRUE if packet is OK, or FALSE in case of error */
+gboolean janus_rtcp_check_sr(janus_rtcp_header *rtcp, int len);
+/*! \brief Method to check that a RTCP packet size is at least 12 bytes
+ *  This is useful because many RTCP packets must be at least that size.
+ * @param[in] packet The message data
+ * @param[in] len The message data length in bytes
+ * @returns TRUE if packet is OK, or FALSE in case of error */
+gboolean janus_rtcp_check_len12(janus_rtcp_header *rtcp, int len);
+/*! \brief Method to check if a RTCP packet could contain a Transport Layer
+ * Feedback Generic NACK Message.
+ * @param[in] packet The message data
+ * @param[in] len The message data length in bytes
+ * @returns TRUE if packet is OK, or FALSE in case of error */
+gboolean janus_rtcp_check_nacks(janus_rtcp_header *rtcp, int len);
+/*! \brief Method to check if a RTCP packet could contain a Feedback Message
+ * with an expected FCI size of 8 bytes (e.g. some FIRs or PLIs).
+ * @param[in] packet The message data
+ * @param[in] len The message data length in bytes
+ * @returns TRUE if packet is OK, or FALSE in case of error */
+gboolean janus_rtcp_check_fci8(janus_rtcp_header *rtcp, int len);
+/*! \brief Method to check if a RTCP packet could contain a AFB REMB Message
+ * @param[in] packet The message data
+ * @param[in] len The message data length in bytes
+ * @returns TRUE if packet is OK, or FALSE in case of error */
+gboolean janus_rtcp_check_remb(janus_rtcp_header *rtcp, int len);
+
 /*! \brief Method to parse/validate an RTCP message
  * @param[in] ctx RTCP context to update, if needed (optional)
  * @param[in] packet The message data


### PR DESCRIPTION
This PR follows @fippo work on #1470 and fixes all the bugs found out while fuzzing the RTCP parsing methods in Janus. 
We added a bunch of new methods to check the RTCP packets before trying to access their fields, namely:
- `janus_rtcp_check_len` : validate minimum packet size and actual packet size against the header length field.
-  `janus_rtcp_check_rr`: validate the packet size against the report block count field.
-  `janus_rtcp_check_sr`:  validate minimum packet size for RTCP SR and validate the packet size against the report block count field.
-  `janus_rtcp_check_fci`: validate RTCP feedback messages containing a defined size FCI payload. E.g. Generic NACKs (4 bytes FCI), FIR (8 bytes FCI), PLI (0 bytes FCI). Also AFB is checked with a 0 bytes FCI because actual FCI has variable length in AFB.
- `janus_rtcp_check_remb`: check RTCP AFB REMB message minimum size and validate against the numssrc field.

Also we have extended the methods `janus_is_rtp` and `janus_is_rtcp` to check the packet length, because they were used before SRTP decrypting and so before the checks libsrtp does.