### PR TITLE
Added support for VP9 simulcasting

### DIFF
--- a/html/echotest.js
+++ b/html/echotest.js
@@ -59,6 +59,8 @@ var audioenabled = false;
 var videoenabled = false;
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
+var acodec = (getQueryStringValue("acodec") !== "" ? getQueryStringValue("acodec") : null);
+var vcodec = (getQueryStringValue("vcodec") !== "" ? getQueryStringValue("vcodec") : null);
 var simulcastStarted = false;
 
 $(document).ready(function() {
@@ -97,6 +99,12 @@ $(document).ready(function() {
 									Janus.log("Plugin attached! (" + echotest.getPlugin() + ", id=" + echotest.getId() + ")");
 									// Negotiate WebRTC
 									var body = { "audio": true, "video": true };
+									// We can try and force a specific codec, by telling the plugin what we'd prefer
+									// For simplicity, you can set it via a query string (e.g., ?vcodec=vp9)
+									if(acodec)
+										body["audiocodec"] = acodec;
+									if(vcodec)
+										body["videocodec"] = vcodec;
 									Janus.debug("Sending message (" + JSON.stringify(body) + ")");
 									echotest.send({"message": body});
 									Janus.debug("Trying a createOffer too (audio/video sendrecv)");
@@ -135,7 +143,7 @@ $(document).ready(function() {
 									Janus.debug("Consent dialog should be " + (on ? "on" : "off") + " now");
 									if(on) {
 										// Darken screen and show hint
-										$.blockUI({ 
+										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
 											css: {
 												border: 'none',
@@ -204,7 +212,7 @@ $(document).ready(function() {
 									if((substream !== null && substream !== undefined) || (temporal !== null && temporal !== undefined)) {
 										if(!simulcastStarted) {
 											simulcastStarted = true;
-											addSimulcastButtons(msg["videocodec"] === "vp8");
+											addSimulcastButtons(msg["videocodec"] !== "vp8" || msg["videocodec"] !== "vp9");
 										}
 										// We just received notice that there's been a switch, update the buttons
 										updateSimulcastButtons(substream, temporal);

--- a/html/videocalltest.js
+++ b/html/videocalltest.js
@@ -59,7 +59,7 @@ var audioenabled = false;
 var videoenabled = false;
 
 var myusername = null;
-var yourusername = null;	
+var yourusername = null;
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
 var simulcastStarted = false;
@@ -109,7 +109,7 @@ $(document).ready(function() {
 									Janus.debug("Consent dialog should be " + (on ? "on" : "off") + " now");
 									if(on) {
 										// Darken screen and show hint
-										$.blockUI({ 
+										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
 											css: {
 												border: 'none',
@@ -273,7 +273,7 @@ $(document).ready(function() {
 												if((substream !== null && substream !== undefined) || (temporal !== null && temporal !== undefined)) {
 													if(!simulcastStarted) {
 														simulcastStarted = true;
-														addSimulcastButtons(result["videocodec"] === "vp8");
+														addSimulcastButtons(result["videocodec"] === "vp8" || msg["videocodec"] !== "vp9");
 													}
 													// We just received notice that there's been a switch, update the buttons
 													updateSimulcastButtons(substream, temporal);
@@ -304,7 +304,7 @@ $(document).ready(function() {
 										$('#bitrate').attr('disabled', true);
 										$('#curbitrate').hide();
 										$('#curres').hide();
-										if(bitrateTimer !== null && bitrateTimer !== null) 
+										if(bitrateTimer !== null && bitrateTimer !== null)
 											clearInterval(bitrateTimer);
 										bitrateTimer = null;
 									}
@@ -468,7 +468,7 @@ $(document).ready(function() {
 									$('#bitrate').attr('disabled', true);
 									$('#curbitrate').hide();
 									$('#curres').hide();
-									if(bitrateTimer !== null && bitrateTimer !== null) 
+									if(bitrateTimer !== null && bitrateTimer !== null)
 										clearInterval(bitrateTimer);
 									bitrateTimer = null;
 									$('#waitingvideo').remove();

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -515,7 +515,8 @@ function newRemoteFeed(id, display, audio, video) {
 							if(!remoteFeed.simulcastStarted) {
 								remoteFeed.simulcastStarted = true;
 								// Add some new buttons
-								addSimulcastButtons(remoteFeed.rfindex, remoteFeed.videoCodec === "vp8");
+								addSimulcastButtons(remoteFeed.rfindex,
+									(remoteFeed.videoCodec === "vp8" || remoteFeed.videoCodec === "vp9"));
 							}
 							// We just received notice that there's been a switch, update the buttons
 							updateSimulcastButtons(remoteFeed.rfindex, substream, temporal);

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -424,7 +424,7 @@ typedef struct janus_recordplay_session {
 	guint64 video_keyframe_request_last;	/* Timestamp of last keyframe request sent */
 	gint video_fir_seq;
 	janus_rtp_switching_context context;
-	uint32_t ssrc[3];		/* Only needed in case VP8 (or H.264) simulcasting is involved */
+	uint32_t ssrc[3];		/* Only needed in case simulcasting is involved */
 	janus_rtp_simulcasting_context sim_context;
 	janus_vp8_simulcast_context vp8_context;
 	volatile gint hangingup;
@@ -1569,12 +1569,6 @@ recdone:
 				session->ssrc[2] = json_integer_value(json_object_get(msg_simulcast, "ssrc-2"));
 				session->sim_context.substream_target = 2;	/* Let's aim for the highest quality */
 				session->sim_context.templayer_target = 2;	/* Let's aim for all temporal layers */
-				if(rec->vcodec != JANUS_VIDEOCODEC_VP8 && rec->vcodec != JANUS_VIDEOCODEC_H264) {
-					/* VP8 r H.264 were not negotiated, if simulcasting was enabled then disable it here */
-					session->ssrc[0] = 0;
-					session->ssrc[1] = 0;
-					session->ssrc[2] = 0;
-				}
 			}
 			/* Done! */
 			result = json_object();

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -374,7 +374,7 @@ typedef struct janus_videocall_session {
 	guint16 slowlink_count;
 	struct janus_videocall_session *peer;
 	janus_rtp_switching_context context;
-	uint32_t ssrc[3];		/* Only needed in case VP8 (or H.264) simulcasting is involved */
+	uint32_t ssrc[3];		/* Only needed in case simulcasting is involved */
 	janus_rtp_simulcasting_context sim_context;
 	int rtpmapid_extmap_id;	/* Only needed for debugging in case Firefox's RID-based simulcasting is involved */
 	janus_vp8_simulcast_context vp8_context;
@@ -1419,7 +1419,8 @@ static void *janus_videocall_handler(void *data) {
 				session->sim_context.templayer_target = json_integer_value(temporal);
 				JANUS_LOG(LOG_VERB, "Setting video temporal layer to let through (simulcast): %d (was %d)\n",
 					session->sim_context.templayer_target, session->sim_context.templayer);
-				if(session->vcodec == JANUS_VIDEOCODEC_VP8 && session->sim_context.templayer_target == session->sim_context.templayer) {
+				if((session->vcodec == JANUS_VIDEOCODEC_VP8 || session->vcodec == JANUS_VIDEOCODEC_VP9) &&
+						session->sim_context.templayer_target == session->sim_context.templayer) {
 					/* No need to do anything, we're already getting the right temporal, so notify the user */
 					json_t *event = json_object();
 					json_object_set_new(event, "videocall", json_string("event"));

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1397,7 +1397,7 @@ typedef struct janus_videoroom_publisher {
 	guint32 video_pt;		/* Video payload type (depends on room configuration) */
 	guint32 audio_ssrc;		/* Audio SSRC of this publisher */
 	guint32 video_ssrc;		/* Video SSRC of this publisher */
-	uint32_t ssrc[3];		/* Only needed in case VP8 (or H.264) simulcasting is involved */
+	uint32_t ssrc[3];		/* Only needed in case simulcasting is involved */
 	int rtpmapid_extmap_id;	/* Only needed for debugging in case Firefox's RID-based simulcasting is involved */
 	char *rid[3];			/* Only needed for debugging in case Firefox's RID-based simulcasting is involved */
 	guint8 audio_level_extmap_id;		/* Audio level extmap ID */
@@ -5397,7 +5397,8 @@ static void *janus_videoroom_handler(void *data) {
 							janus_videoroom_reqfir(publisher, "Simulcasting substream change");
 						}
 					}
-					if(subscriber->feed && subscriber->feed->vcodec == JANUS_VIDEOCODEC_VP8 &&
+					if(subscriber->feed && (subscriber->feed->vcodec == JANUS_VIDEOCODEC_VP8 ||
+								subscriber->feed->vcodec == JANUS_VIDEOCODEC_VP9) &&
 							sc_temporal && publisher->ssrc[0] != 0) {
 						subscriber->sim_context.templayer_target = json_integer_value(sc_temporal);
 						JANUS_LOG(LOG_VERB, "Setting video temporal layer to let through (simulcast): %d (was %d)\n",
@@ -6014,8 +6015,7 @@ static void *janus_videoroom_handler(void *data) {
 				char *offer_sdp = janus_sdp_write(offer);
 				if(!sdp_update) {
 					/* Is simulcasting involved */
-					if(msg_simulcast && (participant->vcodec == JANUS_VIDEOCODEC_VP8 ||
-							participant->vcodec == JANUS_VIDEOCODEC_H264)) {
+					if(msg_simulcast) {
 						JANUS_LOG(LOG_VERB, "Publisher is going to do simulcasting\n");
 						participant->ssrc[0] = json_integer_value(json_object_get(msg_simulcast, "ssrc-0"));
 						participant->ssrc[1] = json_integer_value(json_object_get(msg_simulcast, "ssrc-1"));


### PR DESCRIPTION
Since it was announced that [Chrome Canary now supports simulcasting for VP9 too](https://twitter.com/juberti/status/1085764367113572353), I tweaked the Janus code to allow you to use it. Luckily enough, I didn't need to change much: in fact, we already had code to parse temporal scalability info in VP9 payload descriptors (for SVC), so I just had to hook that up to the simulcast code, and loosen up some checks we had in the plugins that do simulcasting.

From a quick check (I only tested with the EchoTest plugin, by passing the `?simulcast=true&vcodec=vp9` query string to the demo), it seems to be working, with a small caveat: I do see temporal layers, and I can select them, but I never see SSRC changes, which seems to suggest the other substreams are not being sent. The resolution in the only SSRC I get is quite high, so that seems to confirm it. I'll check if it is a bug in Chrome.

Planning to merge soon, so if you have objections please let me know.