### PR TITLE
Fix infinite loop when an HTTP connection breaks

### DIFF
--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -1484,7 +1484,7 @@ parsingdone:
 	janus_mutex_lock(&msg->wait_mutex);
 	while(!msg->got_response) {
 		int res = janus_condition_wait_until(&msg->wait_cond, &msg->wait_mutex, wakeup);
-		if(msg->got_response || res == ETIMEDOUT)
+		if(msg->got_response || !res)
 			break;
 	}
 	janus_mutex_unlock(&msg->wait_mutex);
@@ -1737,7 +1737,7 @@ parsingdone:
 	janus_mutex_lock(&msg->wait_mutex);
 	while(!msg->got_response) {
 		int res = janus_condition_wait_until(&msg->wait_cond, &msg->wait_mutex, wakeup);
-		if(msg->got_response || res == ETIMEDOUT)
+		if(msg->got_response || !res)
 			break;
 	}
 	janus_mutex_unlock(&msg->wait_mutex);


### PR DESCRIPTION
The glib `g-cond-wait-until` method does not return ETIMEDOUT when a
timeout condition occurs. Instead, it returns FALSE. Expecting the
error code resulted in an infinite loop when the HTTP connection is
invalidated before a response is generated.

See https://developer.gnome.org/glib/stable/glib-Threads.html#g-cond-wait-until.

I don't believe this patch is complete yet. The wait condition is normally signaled in `janus_http_send_message`. "Invalid HTTP" errors are also handled in `janus_http_send_message`. However, in the case of an error, the wait condition is not signaled to complete. Should the condition also be signaled (with an empty response) to allow any waiters to cleanup before the timeout?