### PR TITLE
Added sdpSemantics flag plan-b value until the Unified Plan SDP is used

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1604,6 +1604,9 @@ function Janus(gatewayCallbacks) {
 				// This is Edge, enable BUNDLE explicitly
 				pc_config.bundlePolicy = "max-bundle";
 			}
+			if(Janus.webRTCAdapter.browserDetails.browser === "chrome" && Janus.webRTCAdapter.browserDetails.version >= 65) {
+				pc_config.sdpSemantics = "plan-b";
+			}
 			Janus.log("Creating PeerConnection");
 			Janus.debug(pc_constraints);
 			config.pc = new RTCPeerConnection(pc_config, pc_constraints);


### PR DESCRIPTION
Yesterday **Unified Plan** SDP Phase 3 was relased:
[https://webrtc.org/web-apis/chrome/unified-plan/](https://webrtc.org/web-apis/chrome/unified-plan/)

Some demos stopped working in Janus with the latest stable version of Chrome, such as the videocall

With this PR we force M65+ browsers to  use **"plan-b"** semantics until the Unified Plan SDP is ready on Janus.