### PR TITLE
Update janus.js to use navigator.mediaDevices.getDisplayMedia

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -26,7 +26,7 @@
 Janus.sessions = {};
 
 Janus.isExtensionEnabled = function() {
-	if(navigator.getDisplayMedia) {
+	if(navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
 		// No need for the extension, getDisplayMedia is supported
 		return true;
 	}
@@ -2060,11 +2060,11 @@ function Janus(gatewayCallbacks) {
 					if(!media.screenshareFrameRate) {
 						media.screenshareFrameRate = 3;
 					}
-					if(navigator.getDisplayMedia) {
+					if(navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
 						// The new experimental getDisplayMedia API is available, let's use that
 						// https://groups.google.com/forum/#!topic/discuss-webrtc/Uf0SrR4uxzk
 						// https://webrtchacks.com/chrome-screensharing-getdisplaymedia/
-						navigator.getDisplayMedia({ video: true })
+						navigator.mediaDevices.getDisplayMedia({ video: true })
 							.then(function(stream) {
 								pluginHandle.consentDialog(false);
 								if(isAudioSendEnabled(media) && !media.keepAudio) {


### PR DESCRIPTION
Chrome 72+ now supports screen sharing by default without any plugins or flag tweaks by using `navigator.mediaDevices.getDisplayMedia`.

It seems as if there was some support for this, but it used the now deprecated path of `navigator.getDisplayMedia`. This simple pull request updates the path to match the new spec.

adapter.js does have support for `getDisplayMedia` - if you'd prefer, I can update the code to use it instead. I'm not sure if there are any browsers that ship `navigator.getDisplayMedia` exposed without any flags, but not `navigator.mediaDevices.getDisplayMedia`. 