### PR TITLE
Configurable TWCC feedback period

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ or on the command line:
                                   notifies you about this
 	-r, --rtp-port-range=min-max  Port range to use for RTP/RTCP (only available
 								  if the installed libnice supports it)
+	-B, --twcc-period=number      How often (in ms) to send TWCC feedback back to
+                                  senders, if negotiated (default=1s)
 	-n, --server-name=name        Public name of this Janus instance
                                   (default=MyJanusInstance)
 	-s, --session-timeout=number  Session timeout value, in seconds (default=60)

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -109,14 +109,16 @@ certificates: {
 }
 
 # Media-related stuff: you can configure whether if you want
-# to enable IPv6 support (still WIP, so handle with care), if RFC4588
-# support should be negotiated or not (off by default), the maximum size
+# to enable IPv6 support, if RFC4588 support for retransmissions
+# should be negotiated or not (off by default), the maximum size
 # of the NACK queue (in milliseconds, defaults to 500ms) for retransmissions, the
 # range of ports to use for RTP and RTCP (by default, no range is envisaged), the
-# starting MTU for DTLS (1200 by default, it adapts automatically), and
-# finally how much time, in seconds, should pass with no media (audio or
+# starting MTU for DTLS (1200 by default, it adapts automatically),
+# how much time, in seconds, should pass with no media (audio or
 # video) being received before Janus notifies you about this (default=1s,
-# 0 disables these events entirely). Finally, if you're using BoringSSL
+# 0 disables these events entirely), and how often, in milliseconds,
+# to send the Transport Wide Congestion Control feedback information back
+# to senders, if negotiated (default=1s). Finally, if you're using BoringSSL
 # you can customize the frequency of retransmissions: OpenSSL has a fixed
 # value of 1 second (the default), while BoringSSL can override that. Notice
 # that lower values (e.g., 100ms) will typically get you faster connection
@@ -129,6 +131,7 @@ media: {
 	#rtp_port_range = "20000-40000"
 	#dtls_mtu = 1200
 	#no_media_timer = 1
+	#twcc_period = 200
 	#dtls_timeout = 500
 }
 

--- a/ice.c
+++ b/ice.c
@@ -395,6 +395,22 @@ uint janus_get_no_media_timer(void) {
 	return no_media_timer;
 }
 
+/* Period, in milliseconds, to refer to for sending TWCC feedback */
+#define DEFAULT_TWCC_PERIOD		1000
+static uint twcc_period = DEFAULT_TWCC_PERIOD;
+void janus_set_twcc_period(uint period) {
+	twcc_period = period;
+	if(twcc_period == 0) {
+		JANUS_LOG(LOG_WARN, "Invalid TWCC period, falling back to default\n");
+		twcc_period = DEFAULT_TWCC_PERIOD;
+	} else {
+		JANUS_LOG(LOG_VERB, "Setting TWCC period to %ds\n", twcc_period);
+	}
+}
+uint janus_get_twcc_period(void) {
+	return twcc_period;
+}
+
 
 /* RFC4588 support */
 static gboolean rfc4588_enabled = FALSE;
@@ -3352,7 +3368,90 @@ void janus_ice_resend_trickles(janus_ice_handle *handle) {
 static gint rtcp_transport_wide_cc_stats_comparator(gconstpointer item1, gconstpointer item2) {
 	return ((rtcp_transport_wide_cc_stats*)item1)->transport_seq_num - ((rtcp_transport_wide_cc_stats*)item2)->transport_seq_num;
 }
-
+static gboolean janus_ice_outgoing_transport_wide_cc_feedback(gpointer user_data) {
+	janus_ice_handle *handle = (janus_ice_handle *)user_data;
+	janus_ice_stream *stream = handle->stream;
+	if(stream && stream->do_transport_wide_cc) {
+		/* Create a transport wide feedback message */
+		size_t size = 1300;
+		char rtcpbuf[1300];
+		/* Order packet list */
+		stream->transport_wide_received_seq_nums = g_slist_sort(stream->transport_wide_received_seq_nums,
+			rtcp_transport_wide_cc_stats_comparator);
+		/* Create full stats queue */
+		GQueue *packets = g_queue_new();
+		/* For all packets */
+		GSList *it = NULL;
+		for(it = stream->transport_wide_received_seq_nums; it; it = it->next) {
+			/* Get stat */
+			janus_rtcp_transport_wide_cc_stats *stats = (janus_rtcp_transport_wide_cc_stats *)it->data;
+			/* Get transport seq */
+			guint32 transport_seq_num = stats->transport_seq_num;
+			/* Check if it is an out of order  */
+			if(transport_seq_num < stream->transport_wide_cc_last_feedback_seq_num) {
+				/* Skip, it was already reported as lost */
+				g_free(stats);
+				continue;
+			}
+			/* If not first */
+			if(stream->transport_wide_cc_last_feedback_seq_num) {
+				/* For each lost */
+				guint32 i = 0;
+				for(i = stream->transport_wide_cc_last_feedback_seq_num+1; i<transport_seq_num; ++i) {
+					/* Create new stat */
+					janus_rtcp_transport_wide_cc_stats *missing = g_malloc(sizeof(janus_rtcp_transport_wide_cc_stats));
+					/* Add missing packet */
+					missing->transport_seq_num = i;
+					missing->timestamp = 0;
+					/* Add it */
+					g_queue_push_tail(packets, missing);
+				}
+			}
+			/* Store last */
+			stream->transport_wide_cc_last_feedback_seq_num = transport_seq_num;
+			/* Add this one */
+			g_queue_push_tail(packets, stats);
+		}
+		/* Free and reset stats list */
+		g_slist_free(stream->transport_wide_received_seq_nums);
+		stream->transport_wide_received_seq_nums = NULL;
+		/* Create and enqueue RTCP packets */
+		guint packets_len = 0;
+		while((packets_len = g_queue_get_length(packets)) > 0) {
+			GQueue *packets_to_process;
+			/* If we have more than 400 packets to acknowledge, let's send more than one message */
+			if(packets_len > 400) {
+				/* Split the queue into two */
+				GList *new_head = g_queue_peek_nth_link(packets, 400);
+				GList *new_tail = new_head->prev;
+				new_head->prev = NULL;
+				new_tail->next = NULL;
+				packets_to_process = g_queue_new();
+				packets_to_process->head = packets->head;
+				packets_to_process->tail = new_tail;
+				packets_to_process->length = 400;
+				packets->head = new_head;
+				/* packets->tail is unchanged */
+				packets->length = packets_len - 400;
+			} else {
+				packets_to_process = packets;
+			}
+			/* Get feedback packet count and increase it for next one */
+			guint8 feedback_packet_count = stream->transport_wide_cc_feedback_count++;
+			/* Create RTCP packet */
+			int len = janus_rtcp_transport_wide_cc_feedback(rtcpbuf, size,
+				stream->video_ssrc, stream->video_ssrc_peer[0], feedback_packet_count, packets_to_process);
+			/* Enqueue it, we'll send it later */
+			janus_ice_relay_rtcp_internal(handle, 1, rtcpbuf, len, FALSE);
+			if(packets_to_process != packets) {
+				g_queue_free(packets_to_process);
+			}
+		}
+		/* Free mem */
+		g_queue_free(packets);
+	}
+	return G_SOURCE_CONTINUE;
+}
 
 static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 	janus_ice_handle *handle = (janus_ice_handle *)user_data;
@@ -3469,84 +3568,9 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 			}
 		}
 	}
-	if(stream && stream->do_transport_wide_cc) {
-		/* Create a transport wide feedback message */
-		size_t size = 1300;
-		char rtcpbuf[1300];
-		/* Order packet list */
-		stream->transport_wide_received_seq_nums = g_slist_sort(stream->transport_wide_received_seq_nums,
-			rtcp_transport_wide_cc_stats_comparator);
-		/* Create full stats queue */
-		GQueue *packets = g_queue_new();
-		/* For all packets */
-		GSList *it = NULL;
-		for(it = stream->transport_wide_received_seq_nums; it; it = it->next) {
-			/* Get stat */
-			janus_rtcp_transport_wide_cc_stats *stats = (janus_rtcp_transport_wide_cc_stats *)it->data;
-			/* Get transport seq */
-			guint32 transport_seq_num = stats->transport_seq_num;
-			/* Check if it is an out of order  */
-			if(transport_seq_num < stream->transport_wide_cc_last_feedback_seq_num) {
-				/* Skip, it was already reported as lost */
-				g_free(stats);
-				continue;
-			}
-			/* If not first */
-			if(stream->transport_wide_cc_last_feedback_seq_num) {
-				/* For each lost */
-				guint32 i = 0;
-				for(i = stream->transport_wide_cc_last_feedback_seq_num+1; i<transport_seq_num; ++i) {
-					/* Create new stat */
-					janus_rtcp_transport_wide_cc_stats *missing = g_malloc(sizeof(janus_rtcp_transport_wide_cc_stats));
-					/* Add missing packet */
-					missing->transport_seq_num = i;
-					missing->timestamp = 0;
-					/* Add it */
-					g_queue_push_tail(packets, missing);
-				}
-			}
-			/* Store last */
-			stream->transport_wide_cc_last_feedback_seq_num = transport_seq_num;
-			/* Add this one */
-			g_queue_push_tail(packets, stats);
-		}
-		/* Free and reset stats list */
-		g_slist_free(stream->transport_wide_received_seq_nums);
-		stream->transport_wide_received_seq_nums = NULL;
-		/* Create and enqueue RTCP packets */
-		guint packets_len = 0;
-		while((packets_len = g_queue_get_length(packets)) > 0) {
-			GQueue *packets_to_process;
-			/* If we have more than 400 packets to acknowledge, let's send more than one message */
-			if(packets_len > 400) {
-				/* Split the queue into two */
-				GList *new_head = g_queue_peek_nth_link(packets, 400);
-				GList *new_tail = new_head->prev;
-				new_head->prev = NULL;
-				new_tail->next = NULL;
-				packets_to_process = g_queue_new();
-				packets_to_process->head = packets->head;
-				packets_to_process->tail = new_tail;
-				packets_to_process->length = 400;
-				packets->head = new_head;
-				/* packets->tail is unchanged */
-				packets->length = packets_len - 400;
-			} else {
-				packets_to_process = packets;
-			}
-			/* Get feedback packet count and increase it for next one */
-			guint8 feedback_packet_count = stream->transport_wide_cc_feedback_count++;
-			/* Create RTCP packet */
-			int len = janus_rtcp_transport_wide_cc_feedback(rtcpbuf, size,
-				stream->video_ssrc, stream->video_ssrc_peer[0], feedback_packet_count, packets_to_process);
-			/* Enqueue it, we'll send it later */
-			janus_ice_relay_rtcp_internal(handle, 1, rtcpbuf, len, FALSE);
-			if(packets_to_process != packets) {
-				g_queue_free(packets_to_process);
-			}
-		}
-		/* Free mem */
-		g_queue_free(packets);
+	if(twcc_period == 1000) {
+		/* The Transport Wide CC feedback period is 1s as well, send it here */
+		janus_ice_outgoing_transport_wide_cc_feedback(handle);
 	}
 	return G_SOURCE_CONTINUE;
 }
@@ -3725,6 +3749,11 @@ static gboolean janus_ice_outgoing_traffic_handle(janus_ice_handle *handle, janu
 			g_source_destroy(handle->rtcp_source);
 			g_source_unref(handle->rtcp_source);
 			handle->rtcp_source = NULL;
+		}
+		if(handle->twcc_source) {
+			g_source_destroy(handle->twcc_source);
+			g_source_unref(handle->twcc_source);
+			handle->twcc_source = NULL;
 		}
 		if(handle->stats_source) {
 			g_source_destroy(handle->stats_source);
@@ -4267,6 +4296,13 @@ void janus_ice_dtls_handshake_done(janus_ice_handle *handle, janus_ice_component
 	g_source_set_priority(handle->rtcp_source, G_PRIORITY_DEFAULT);
 	g_source_set_callback(handle->rtcp_source, janus_ice_outgoing_rtcp_handle, handle, NULL);
 	g_source_attach(handle->rtcp_source, handle->mainctx);
+	if(twcc_period != 1000) {
+		/* The Transport Wide CC feedback period is different, create another source */
+		handle->twcc_source = g_timeout_source_new(twcc_period);
+		g_source_set_priority(handle->twcc_source, G_PRIORITY_DEFAULT);
+		g_source_set_callback(handle->twcc_source, janus_ice_outgoing_transport_wide_cc_feedback, handle, NULL);
+		g_source_attach(handle->twcc_source, handle->mainctx);
+	}
 	handle->last_event_stats = 0;
 	handle->last_srtp_summary = -1;
 	handle->stats_source = g_timeout_source_new_seconds(1);

--- a/ice.h
+++ b/ice.h
@@ -125,6 +125,12 @@ void janus_set_no_media_timer(uint timer);
 /*! \brief Method to get the current no-media event timer (see above)
  * @returns The current no-media event timer */
 uint janus_get_no_media_timer(void);
+/*! \brief Method to modify the TWCC feedback period (i.e., how often TWCC feedback is sent back to media senders)
+ * @param[in] timer The new period value, in milliseconds */
+void janus_set_twcc_period(uint period);
+/*! \brief Method to get the current TWCC period (see above)
+ * @returns The current TWCC period */
+uint janus_get_twcc_period(void);
 /*! \brief Method to enable or disable the RFC4588 support negotiation
  * @param[in] enabled The new timer value, in seconds */
 void janus_set_rfc4588_enabled(gboolean enabled);
@@ -269,8 +275,8 @@ struct janus_ice_handle {
 	GMainLoop *mainloop;
 	/*! \brief GLib thread for the handle and libnice */
 	GThread *thread;
-	/*! \brief GLib sources for outgoing traffic, recurring RTCP, and stats */
-	GSource *rtp_source, *rtcp_source, *stats_source;
+	/*! \brief GLib sources for outgoing traffic, recurring RTCP, and stats (and optionally TWCC) */
+	GSource *rtp_source, *rtcp_source, *stats_source, *twcc_source;
 	/*! \brief libnice ICE agent */
 	NiceAgent *agent;
 	/*! \brief Monotonic time of when the ICE agent has been created */

--- a/janus.1
+++ b/janus.1
@@ -89,6 +89,9 @@ Time (in s) that should pass with no media (audio or video) being received befor
 .BR \-r ", " \-\-rtp-port-range=\fImin\-max\fR
 Port range to use for RTP/RTCP
 .TP
+.BR \-B ", " \-\-twcc-period=\fInumber\fR
+How often (in ms) to send TWCC feedback back to senders, if negotiated (default=1s)
+.TP
 .BR \-n ", " \-\-server-name=\fIname\fR
 Public name of this Janus instance (default=MyJanusInstance)
 .TP

--- a/janus.c
+++ b/janus.c
@@ -255,6 +255,7 @@ static json_t *janus_info(const char *transaction) {
 	json_object_set_new(info, "ice-tcp", janus_ice_is_ice_tcp_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "full-trickle", janus_ice_is_full_trickle_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "rfc-4588", janus_is_rfc4588_enabled() ? json_true() : json_false());
+	json_object_set_new(info, "twcc-period", json_integer(janus_get_twcc_period()));
 	if(janus_ice_get_stun_server() != NULL) {
 		char server[255];
 		g_snprintf(server, 255, "%s:%"SCNu16, janus_ice_get_stun_server(), janus_ice_get_stun_port());
@@ -3532,6 +3533,11 @@ gint main(int argc, char *argv[])
 		g_snprintf(nmt, 20, "%d", args_info.no_media_timer_arg);
 		janus_config_add(config, config_media, janus_config_item_create("no_media_timer", nmt));
 	}
+	if(args_info.twcc_period_given) {
+		char tp[20];
+		g_snprintf(tp, 20, "%d", args_info.twcc_period_arg);
+		janus_config_add(config, config_media, janus_config_item_create("twcc_period", tp));
+	}
 	if(args_info.rfc_4588_given) {
 		janus_config_add(config, config_media, janus_config_item_create("rfc_4588", "yes"));
 	}
@@ -3871,6 +3877,16 @@ gint main(int argc, char *argv[])
 			JANUS_LOG(LOG_WARN, "Ignoring no_media_timer value as it's not a positive integer\n");
 		} else {
 			janus_set_no_media_timer(nmt);
+		}
+	}
+	/* TWCC period */
+	item = janus_config_get(config, config_media, janus_config_type_item, "twcc_period");
+	if(item && item->value) {
+		int tp = atoi(item->value);
+		if(tp <= 0) {
+			JANUS_LOG(LOG_WARN, "Ignoring twcc_period value as it's not a positive integer\n");
+		} else {
+			janus_set_twcc_period(tp);
 		}
 	}
 	/* RFC4588 support */

--- a/janus.ggo
+++ b/janus.ggo
@@ -23,6 +23,7 @@ option "rfc-4588" R "Whether to enable RFC4588 retransmissions support or not" f
 option "max-nack-queue" q "Maximum size of the NACK queue (in ms) per user for retransmissions" int typestr="number" optional
 option "no-media-timer" t "Time (in s) that should pass with no media (audio or video) being received before Janus notifies you about this" int typestr="number" optional
 option "rtp-port-range" r "Port range to use for RTP/RTCP" string typestr="min-max" optional
+option "twcc-period" B "How often (in ms) to send TWCC feedback back to senders, if negotiated (default=1s)" int typestr="number" optional
 option "server-name" n "Public name of this Janus instance (default=MyJanusInstance)" string typestr="name" optional
 option "session-timeout" s "Session timeout value, in seconds (default=60)" int typestr="number" optional
 option "reclaim-session-timeout" m "Reclaim session timeout value, in seconds (default=0)" int typestr="number" optional


### PR DESCRIPTION
As the title says, this patch makes the Transport Wide Congestion Control RTCP feedback period configurable. By default, we send this feedback once per second, as we do for other RTCP packets like SR and RR. Since it might make sense for the TWCC feedback to be more frequent though (or less so, depending on the requirements), this adds an option both in `janus.jcfg` and the command line to do that.

Specifically, there's a new property called `twcc_period` in the `media` container of `janus.jcfg` to override it. For instance:

	media: {
		[..]
		twcc_period = 200
		[..]
	}

will set the period to 200ms (5 feedback messages per second). The same result can be achieved using the `-B` command line option, e.g.:

	/opt/janus/bin/janus -B 200

It is backwards compatible, meaning that if you don't set anything (the default) we'll keep on sending once per second exactly as before (it's pretty much the same code).

I'm planning to merge soon, so please let me know if you notice any regression.