### PR TITLE
Added option to negotiate inband FEC for Opus in VideoRoom and EchoTest

### DIFF
--- a/conf/janus.plugin.videoroom.jcfg.sample
+++ b/conf/janus.plugin.videoroom.jcfg.sample
@@ -15,7 +15,8 @@
 #			can be a comma separated list in order of preference, e.g., opus,pcmu)
 # videocodec = vp8|vp9|h264 (video codec(s) to force on publishers, default=vp8
 #			can be a comma separated list in order of preference, e.g., vp9,vp8,h264)
-# video_svc = true|false (whether SVC support must be enabled# works only for VP9, default=false)
+# opus_fec = true|false (whether inband FEC must be negotiated; only works for Opus, default=false)
+# video_svc = true|false (whether SVC support must be enabled; only works for VP9, default=false)
 # audiolevel_ext = true|false (whether the ssrc-audio-level RTP extension must
 #		be negotiated/used or not for new publishers, default=true)
 # audiolevel_event = true|false (whether to emit event to other users or not, default=false)

--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -958,7 +958,7 @@ janus_sdp *janus_sdp_generate_offer(const char *name, const char *address, ...) 
 	gboolean do_audio = TRUE, do_video = TRUE, do_data = TRUE,
 		audio_dtmf = FALSE, video_rtcpfb = TRUE, h264_fmtp = TRUE,
 		data_legacy = TRUE;
-	const char *audio_codec = NULL, *video_codec = NULL, *audio_fmtp;
+	const char *audio_codec = NULL, *video_codec = NULL, *audio_fmtp = NULL;
 	int audio_pt = 111, video_pt = 96;
 	janus_sdp_mdirection audio_dir = JANUS_SDP_SENDRECV, video_dir = JANUS_SDP_SENDRECV;
 	int property = va_arg(args, int);
@@ -1102,7 +1102,7 @@ janus_sdp *janus_sdp_generate_answer(janus_sdp *offer, ...) {
 	/* Let's see what we should do with the media */
 	gboolean do_audio = TRUE, do_video = TRUE, do_data = TRUE,
 		audio_dtmf = FALSE, video_rtcpfb = TRUE, h264_fmtp = TRUE;
-	const char *audio_codec = NULL, *video_codec = NULL, *audio_fmtp;
+	const char *audio_codec = NULL, *video_codec = NULL, *audio_fmtp = NULL;
 	janus_sdp_mdirection audio_dir = JANUS_SDP_SENDRECV, video_dir = JANUS_SDP_SENDRECV;
 	int property = va_arg(args, int);
 	while(property != JANUS_SDP_OA_DONE) {

--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -958,7 +958,7 @@ janus_sdp *janus_sdp_generate_offer(const char *name, const char *address, ...) 
 	gboolean do_audio = TRUE, do_video = TRUE, do_data = TRUE,
 		audio_dtmf = FALSE, video_rtcpfb = TRUE, h264_fmtp = TRUE,
 		data_legacy = TRUE;
-	const char *audio_codec = NULL, *video_codec = NULL;
+	const char *audio_codec = NULL, *video_codec = NULL, *audio_fmtp;
 	int audio_pt = 111, video_pt = 96;
 	janus_sdp_mdirection audio_dir = JANUS_SDP_SENDRECV, video_dir = JANUS_SDP_SENDRECV;
 	int property = va_arg(args, int);
@@ -983,6 +983,8 @@ janus_sdp *janus_sdp_generate_offer(const char *name, const char *address, ...) 
 			video_pt = va_arg(args, int);
 		} else if(property == JANUS_SDP_OA_AUDIO_DTMF) {
 			audio_dtmf = va_arg(args, gboolean);
+		} else if(property == JANUS_SDP_OA_AUDIO_FMTP) {
+			audio_fmtp = va_arg(args, char *);
 		} else if(property == JANUS_SDP_OA_VIDEO_RTCPFB_DEFAULTS) {
 			video_rtcpfb = va_arg(args, gboolean);
 		} else if(property == JANUS_SDP_OA_VIDEO_H264_FMTP) {
@@ -1031,6 +1033,11 @@ janus_sdp *janus_sdp_generate_offer(const char *name, const char *address, ...) 
 			int dtmf_pt = 126;
 			m->ptypes = g_list_append(m->ptypes, GINT_TO_POINTER(dtmf_pt));
 			janus_sdp_attribute *a = janus_sdp_attribute_create("rtpmap", "%d %s", dtmf_pt, janus_sdp_get_codec_rtpmap("dtmf"));
+			m->attributes = g_list_append(m->attributes, a);
+		}
+		/* Check if there's a custom fmtp line to add for audio */
+		if(audio_fmtp) {
+			janus_sdp_attribute *a = janus_sdp_attribute_create("fmtp", "%d %s", audio_pt, audio_fmtp);
 			m->attributes = g_list_append(m->attributes, a);
 		}
 		offer->m_lines = g_list_append(offer->m_lines, m);
@@ -1095,7 +1102,7 @@ janus_sdp *janus_sdp_generate_answer(janus_sdp *offer, ...) {
 	/* Let's see what we should do with the media */
 	gboolean do_audio = TRUE, do_video = TRUE, do_data = TRUE,
 		audio_dtmf = FALSE, video_rtcpfb = TRUE, h264_fmtp = TRUE;
-	const char *audio_codec = NULL, *video_codec = NULL;
+	const char *audio_codec = NULL, *video_codec = NULL, *audio_fmtp;
 	janus_sdp_mdirection audio_dir = JANUS_SDP_SENDRECV, video_dir = JANUS_SDP_SENDRECV;
 	int property = va_arg(args, int);
 	while(property != JANUS_SDP_OA_DONE) {
@@ -1115,6 +1122,8 @@ janus_sdp *janus_sdp_generate_answer(janus_sdp *offer, ...) {
 			video_codec = va_arg(args, char *);
 		} else if(property == JANUS_SDP_OA_AUDIO_DTMF) {
 			audio_dtmf = va_arg(args, gboolean);
+		} else if(property == JANUS_SDP_OA_AUDIO_FMTP) {
+			audio_fmtp = va_arg(args, char *);
 		} else if(property == JANUS_SDP_OA_VIDEO_RTCPFB_DEFAULTS) {
 			video_rtcpfb = va_arg(args, gboolean);
 		} else if(property == JANUS_SDP_OA_VIDEO_H264_FMTP) {
@@ -1301,6 +1310,12 @@ janus_sdp *janus_sdp_generate_answer(janus_sdp *offer, ...) {
 						janus_sdp_attribute *a = janus_sdp_attribute_create("rtpmap", "%d %s", dtmf_pt, janus_sdp_get_codec_rtpmap("dtmf"));
 						am->attributes = g_list_append(am->attributes, a);
 					}
+				}
+				/* Check if there's a custom fmtp line to add for audio
+				 * FIXME We should actually check if it matches the offer */
+				if(audio_fmtp) {
+					janus_sdp_attribute *a = janus_sdp_attribute_create("fmtp", "%d %s", pt, audio_fmtp);
+					am->attributes = g_list_append(am->attributes, a);
 				}
 			} else {
 				/* Add rtpmap attribute */

--- a/sdp-utils.h
+++ b/sdp-utils.h
@@ -7,11 +7,11 @@
  * of such object by playing with its properties, and a serialization
  * to an SDP string that can be passed around. Since they don't have any
  * core dependencies, these utilities can be used by plugins as well.
- * 
+ *
  * \ingroup core
  * \ref core
  */
- 
+
 #ifndef _JANUS_SDP_UTILS_H
 #define _JANUS_SDP_UTILS_H
 
@@ -266,6 +266,8 @@ JANUS_SDP_OA_AUDIO_PT,
 JANUS_SDP_OA_VIDEO_PT,
 /*! \brief When generating an offer or answer automatically, do or do not negotiate telephone events (FIXME telephone-event/8000 only) */
 JANUS_SDP_OA_AUDIO_DTMF,
+/*! \brief When generating an offer or answer automatically, add this custom fmtp string for audio */
+JANUS_SDP_OA_AUDIO_FMTP,
 /*! \brief When generating an offer or answer automatically, do or do not add the rtcpfb attributes we typically negotiate (fir, nack, pli, remb) */
 JANUS_SDP_OA_VIDEO_RTCPFB_DEFAULTS,
 /*! \brief When generating an offer or answer automatically, do or do not add the default fmtp attribute for H.264 (profile-level-id=42e01f;packetization-mode=1) */


### PR DESCRIPTION
As the title suggests, very simple change to the SDP utils to allow providing custom fmtp attributes in negotiation. This is used in this patch to negotiate `useinbandfec=1` in both EchoTest and VideoRoom.

For the VideoRoom, this is tied to a new `opus_fec=true` property when creating rooms (default is still FALSE, for backwards compatibility). When set to TRUE, if publishers are negotiating inband FEC for Opus, we set it in the answer as well, and in all the offers we send to their subscribers. Anyway, notice that in principle the amount of redundancy to add to Opus packets is derived from the lost packets that are notified back: in the current implementation, this would be the lost packets on the publisher "leg", but in a one-to-many scenario it makes more sense to convey the lost packets on the subscribers' side instead. This is not envisaged in this pull request, and would need to be done in a later stage.

Planning to merge soon, so please stop me before that if you have questions or doubts.