### PR TITLE
Fix and enhance RTCP stats and link quality metrics.

### DIFF
--- a/rtcp.h
+++ b/rtcp.h
@@ -227,6 +227,8 @@ typedef struct rtcp_context
 {
 	/* Whether we received any RTP packet at all (don't send RR otherwise) */
 	uint8_t rtp_recvd:1;
+	uint32_t rtp_last_inorder_ts;
+	int64_t rtp_last_inorder_time;
 
 	uint16_t max_seq_nr;
 	uint16_t seq_cycle;
@@ -268,9 +270,6 @@ typedef struct rtcp_context
 	uint32_t rr_last_nack_count;
 	gint sent_packets_since_last_rr;
 	gint nack_count;
-
-	/* Outbound RR process */
-	int64_t out_rr_last_ts;
 
 	/* Link quality estimations */
 	double in_link_quality;
@@ -406,9 +405,11 @@ char *janus_rtcp_filter(char *packet, int len, int *newlen);
  * @param[in] ctx RTCP context to update, if needed (optional)
  * @param[in] packet The RTP packet
  * @param[in] len The packet data length in bytes
- * @param[in] count_lost Whether we should try and compute a count of the lost packets
+ * @param[in] rfc4588_pkt True if this is a RTX packet
+ * @param[in] rfc4588_enabled True if this packet comes from a RTX enabled stream
+ * @param[in] retransmissions_disabled True if retransmissions are not supported at all for this stream
  * @returns 0 in case of success, -1 on errors */
-int janus_rtcp_process_incoming_rtp(janus_rtcp_context *ctx, char *packet, int len, gboolean count_lost);
+int janus_rtcp_process_incoming_rtp(janus_rtcp_context *ctx, char *packet, int len, gboolean rfc4588_pkt, gboolean rfc4588_enabled, gboolean retransmissions_disabled);
 
 /*! \brief Method to fill in a Report Block in a Receiver Report
  * @param[in] ctx The RTCP context to use for the report


### PR DESCRIPTION
This PR heavily refactors the way Janus calculates some RTCP stats, estimate link metrics and generate receiver reports.

- Before this PR the lost count was basically incremented before sending the first NACK for a packet.
Now the calculation happens whenever a RTCP Receiver Report is being sent, that is once in a second.
The cumulative loss is now obtained as the accumulation of the _packets lost_ in every 1 second time window.
That is, for every RR being sent:
```
lost_interval = expected_interval - received_interval
cumulative_loss += lost_interval
```

- The `expected` packets semantics has not been changed and is calculated from the highest sequence number in the stream.

- The `received` packet counter is now incremented upon the reception of one of the followings:

1. in-order RTP media packet
2. out-of-order RTP media packet for RFC4588 enabled RTP streams
3. out-of-order, not too late (*), RTP media packet for non-RFC4588-enabled and NACKs-enabled RTP streams

- The `retransmitted` packet counter  is now incremented upon the reception of one of the followings:

1. RTP RFC4588 packet
2. out-of-order, too late (*), RTP media packet for non-RFC4588-enabled and NACKs-enabled RTP streams

(*) The late evaluation is done with a heuristic based on the difference between the last in-order RTP timestamp and the out-of-order packet RTP timestamp

- Jitter is now calculated only for in-order packet.

- In link quality estimation has been fixed in order to consider only the difference between `expected` and `received`

- In media link quality has been fixed in order to consider also the `retransmitted` packet.