### PR TITLE
Support for multiple datachannel streams in the same PeerConnection

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -955,10 +955,10 @@ int janus_dtls_verify_callback(int preverify_ok, X509_STORE_CTX *ctx) {
 }
 
 #ifdef HAVE_SCTP
-void janus_dtls_wrap_sctp_data(janus_dtls_srtp *dtls, char *buf, int len) {
+void janus_dtls_wrap_sctp_data(janus_dtls_srtp *dtls, char *label, char *buf, int len) {
 	if(dtls == NULL || !dtls->ready || dtls->sctp == NULL || buf == NULL || len < 1)
 		return;
-	janus_sctp_send_data(dtls->sctp, buf, len);
+	janus_sctp_send_data(dtls->sctp, label, buf, len);
 }
 
 int janus_dtls_send_sctp_data(janus_dtls_srtp *dtls, char *buf, int len) {
@@ -972,7 +972,7 @@ int janus_dtls_send_sctp_data(janus_dtls_srtp *dtls, char *buf, int len) {
 	return res;
 }
 
-void janus_dtls_notify_data(janus_dtls_srtp *dtls, char *buf, int len) {
+void janus_dtls_notify_data(janus_dtls_srtp *dtls, char *label, char *buf, int len) {
 	if(dtls == NULL || buf == NULL || len < 1)
 		return;
 	janus_ice_component *component = (janus_ice_component *)dtls->component;
@@ -990,7 +990,7 @@ void janus_dtls_notify_data(janus_dtls_srtp *dtls, char *buf, int len) {
 		JANUS_LOG(LOG_ERR, "No handle...\n");
 		return;
 	}
-	janus_ice_incoming_data(handle, buf, len);
+	janus_ice_incoming_data(handle, label, buf, len);
 }
 #endif
 

--- a/dtls.h
+++ b/dtls.h
@@ -139,9 +139,10 @@ int janus_dtls_verify_callback(int preverify_ok, X509_STORE_CTX *ctx);
 #ifdef HAVE_SCTP
 /*! \brief Callback (called from the ICE handle) to encapsulate in DTLS outgoing SCTP data (DataChannel)
  * @param[in] dtls The janus_dtls_srtp instance to use
+ * @param[in] label The label of the data channel to use
  * @param[in] buf The data buffer to encapsulate
  * @param[in] len The data length */
-void janus_dtls_wrap_sctp_data(janus_dtls_srtp *dtls, char *buf, int len);
+void janus_dtls_wrap_sctp_data(janus_dtls_srtp *dtls, char *label, char *buf, int len);
 
 /*! \brief Callback (called from the SCTP stack) to encapsulate in DTLS outgoing SCTP data (DataChannel)
  * @param[in] dtls The janus_dtls_srtp instance to use
@@ -152,9 +153,10 @@ int janus_dtls_send_sctp_data(janus_dtls_srtp *dtls, char *buf, int len);
 
 /*! \brief Callback to be notified about incoming SCTP data (DataChannel) to forward to the handle
  * @param[in] dtls The janus_dtls_srtp instance to use
+ * @param[in] label The label of the data channel the message is from
  * @param[in] buf The data buffer
  * @param[in] len The data length */
-void janus_dtls_notify_data(janus_dtls_srtp *dtls, char *buf, int len);
+void janus_dtls_notify_data(janus_dtls_srtp *dtls, char *label, char *buf, int len);
 #endif
 
 /*! \brief DTLS retransmission timer

--- a/ice.h
+++ b/ice.h
@@ -579,14 +579,16 @@ void janus_ice_relay_rtp(janus_ice_handle *handle, int video, char *buf, int len
 void janus_ice_relay_rtcp(janus_ice_handle *handle, int video, char *buf, int len);
 /*! \brief Core SCTP/DataChannel callback, called when a plugin has data to send to a peer
  * @param[in] handle The Janus ICE handle associated with the peer
+ * @param[in] label The label of the data channel to use
  * @param[in] buf The message data (buffer)
  * @param[in] len The buffer lenght */
-void janus_ice_relay_data(janus_ice_handle *handle, char *buf, int len);
+void janus_ice_relay_data(janus_ice_handle *handle, char *label, char *buf, int len);
 /*! \brief Plugin SCTP/DataChannel callback, called by the SCTP stack when when there's data for a plugin
  * @param[in] handle The Janus ICE handle associated with the peer
+ * @param[in] label The label of the data channel the message is from
  * @param[in] buffer The message data (buffer)
  * @param[in] length The buffer lenght */
-void janus_ice_incoming_data(janus_ice_handle *handle, char *buffer, int length);
+void janus_ice_incoming_data(janus_ice_handle *handle, char *label, char *buffer, int length);
 /*! \brief Core SCTP/DataChannel callback, called by the SCTP stack when when there's data to send.
  * @param[in] handle The Janus ICE handle associated with the peer
  * @param[in] buffer The message data (buffer)

--- a/janus.c
+++ b/janus.c
@@ -431,7 +431,7 @@ int janus_plugin_push_event(janus_plugin_session *plugin_session, janus_plugin *
 json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plugin *plugin, const char *sdp_type, const char *sdp, gboolean restart);
 void janus_plugin_relay_rtp(janus_plugin_session *plugin_session, int video, char *buf, int len);
 void janus_plugin_relay_rtcp(janus_plugin_session *plugin_session, int video, char *buf, int len);
-void janus_plugin_relay_data(janus_plugin_session *plugin_session, char *buf, int len);
+void janus_plugin_relay_data(janus_plugin_session *plugin_session, char *label, char *buf, int len);
 void janus_plugin_close_pc(janus_plugin_session *plugin_session);
 void janus_plugin_end_session(janus_plugin_session *plugin_session);
 void janus_plugin_notify_event(janus_plugin *plugin, janus_plugin_session *plugin_session, json_t *event);
@@ -3162,7 +3162,7 @@ void janus_plugin_relay_rtcp(janus_plugin_session *plugin_session, int video, ch
 	janus_ice_relay_rtcp(handle, video, buf, len);
 }
 
-void janus_plugin_relay_data(janus_plugin_session *plugin_session, char *buf, int len) {
+void janus_plugin_relay_data(janus_plugin_session *plugin_session, char *label, char *buf, int len) {
 	if((plugin_session < (janus_plugin_session *)0x1000) || g_atomic_int_get(&plugin_session->stopped) || buf == NULL || len < 1)
 		return;
 	janus_ice_handle *handle = (janus_ice_handle *)plugin_session->gateway_handle;
@@ -3170,7 +3170,7 @@ void janus_plugin_relay_data(janus_plugin_session *plugin_session, char *buf, in
 			|| janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT))
 		return;
 #ifdef HAVE_SCTP
-	janus_ice_relay_data(handle, buf, len);
+	janus_ice_relay_data(handle, label, buf, len);
 #else
 	JANUS_LOG(LOG_WARN, "Asked to relay data, but Data Channels support has not been compiled...\n");
 #endif

--- a/plugins/janus_duktape.c
+++ b/plugins/janus_duktape.c
@@ -214,7 +214,7 @@ struct janus_plugin_result *janus_duktape_handle_message(janus_plugin_session *h
 void janus_duktape_setup_media(janus_plugin_session *handle);
 void janus_duktape_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_duktape_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_duktape_incoming_data(janus_plugin_session *handle, char *buf, int len);
+void janus_duktape_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
 void janus_duktape_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_duktape_hangup_media(janus_plugin_session *handle);
 void janus_duktape_destroy_session(janus_plugin_session *handle, int *error);
@@ -1051,7 +1051,7 @@ static duk_ret_t janus_duktape_method_relaydata(duk_context *ctx) {
 	janus_refcount_increase(&session->ref);
 	janus_mutex_unlock(&duktape_sessions_mutex);
 	/* Send the RTP packet */
-	janus_core->relay_data(session->handle, (char *)payload, len);
+	janus_core->relay_data(session->handle, NULL, (char *)payload, len);
 	janus_refcount_decrease(&session->ref);
 	duk_push_int(ctx, 0);
 	return 1;
@@ -2113,7 +2113,7 @@ void janus_duktape_incoming_rtcp(janus_plugin_session *handle, int video, char *
 	}
 }
 
-void janus_duktape_incoming_data(janus_plugin_session *handle, char *buf, int len) {
+void janus_duktape_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len) {
 	if(handle == NULL || handle->stopped || g_atomic_int_get(&duktape_stopping) || !g_atomic_int_get(&duktape_initialized))
 		return;
 	janus_duktape_session *session = (janus_duktape_session *)handle->plugin_handle;
@@ -2301,7 +2301,7 @@ static void janus_duktape_relay_data_packet(gpointer data, gpointer user_data) {
 	if(janus_core != NULL && text != NULL) {
 		JANUS_LOG(LOG_VERB, "Forwarding DataChannel message (%zu bytes) to session %"SCNu32": %s\n",
 			strlen(text), session->id, text);
-		janus_core->relay_data(session->handle, text, strlen(text));
+		janus_core->relay_data(session->handle, NULL, text, strlen(text));
 	}
 	return;
 }

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -143,7 +143,7 @@ struct janus_plugin_result *janus_echotest_handle_message(janus_plugin_session *
 void janus_echotest_setup_media(janus_plugin_session *handle);
 void janus_echotest_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_echotest_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_echotest_incoming_data(janus_plugin_session *handle, char *buf, int len);
+void janus_echotest_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
 void janus_echotest_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_echotest_hangup_media(janus_plugin_session *handle);
 void janus_echotest_destroy_session(janus_plugin_session *handle, int *error);
@@ -626,7 +626,7 @@ void janus_echotest_incoming_rtcp(janus_plugin_session *handle, int video, char 
 	}
 }
 
-void janus_echotest_incoming_data(janus_plugin_session *handle, char *buf, int len) {
+void janus_echotest_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	/* Simple echo test */
@@ -643,7 +643,7 @@ void janus_echotest_incoming_data(janus_plugin_session *handle, char *buf, int l
 		char *text = g_malloc(len+1);
 		memcpy(text, buf, len);
 		*(text+len) = '\0';
-		JANUS_LOG(LOG_VERB, "Got a DataChannel message (%zu bytes) to bounce back: %s\n", strlen(text), text);
+		JANUS_LOG(LOG_VERB, "Got a DataChannel message (label=%s, %zu bytes) to bounce back: %s\n", label, strlen(text), text);
 		/* Save the frame if we're recording */
 		janus_recorder_save_frame(session->drc, text, strlen(text));
 		/* We send back the same text with a custom prefix */
@@ -651,7 +651,7 @@ void janus_echotest_incoming_data(janus_plugin_session *handle, char *buf, int l
 		char *reply = g_malloc(strlen(prefix)+len+1);
 		g_snprintf(reply, strlen(prefix)+len+1, "%s%s", prefix, text);
 		g_free(text);
-		gateway->relay_data(handle, reply, strlen(reply));
+		gateway->relay_data(handle, label, reply, strlen(reply));
 		g_free(reply);
 	}
 }

--- a/plugins/janus_lua.c
+++ b/plugins/janus_lua.c
@@ -30,7 +30,7 @@
  *
  * Every Lua script that wants to implement a Janus plugin must provide
  * the following functions as callbacks:
- * 
+ *
  * - \c init(): called when janus_lua.c is initialized;
  * - \c destroy(): called when janus_lua.c is deinitialized (Janus shutting down);
  * - \c createSession(): called when a new user attaches to the Janus Lua plugin;
@@ -215,7 +215,7 @@ struct janus_plugin_result *janus_lua_handle_message(janus_plugin_session *handl
 void janus_lua_setup_media(janus_plugin_session *handle);
 void janus_lua_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_lua_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_lua_incoming_data(janus_plugin_session *handle, char *buf, int len);
+void janus_lua_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
 void janus_lua_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_lua_hangup_media(janus_plugin_session *handle);
 void janus_lua_destroy_session(janus_plugin_session *handle, int *error);
@@ -234,7 +234,7 @@ static janus_plugin janus_lua_plugin =
 		.get_name = janus_lua_get_name,
 		.get_author = janus_lua_get_author,
 		.get_package = janus_lua_get_package,
-		
+
 		.create_session = janus_lua_create_session,
 		.handle_message = janus_lua_handle_message,
 		.setup_media = janus_lua_setup_media,
@@ -918,7 +918,7 @@ static int janus_lua_method_relaydata(lua_State *s) {
 	janus_refcount_increase(&session->ref);
 	janus_mutex_unlock(&lua_sessions_mutex);
 	/* Send the RTP packet */
-	janus_core->relay_data(session->handle, (char *)payload, len);
+	janus_core->relay_data(session->handle, NULL, (char *)payload, len);
 	janus_refcount_decrease(&session->ref);
 	lua_pushnumber(s, 0);
 	return 1;
@@ -1479,7 +1479,7 @@ void janus_lua_create_session(janus_plugin_session *handle, int *error) {
 	if(g_atomic_int_get(&lua_stopping) || !g_atomic_int_get(&lua_initialized)) {
 		*error = -1;
 		return;
-	}	
+	}
 	janus_mutex_lock(&lua_sessions_mutex);
 	guint32 id = 0;
 	while(id == 0) {
@@ -1518,7 +1518,7 @@ void janus_lua_destroy_session(janus_plugin_session *handle, int *error) {
 	if(g_atomic_int_get(&lua_stopping) || !g_atomic_int_get(&lua_initialized)) {
 		*error = -1;
 		return;
-	}	
+	}
 	janus_mutex_lock(&lua_sessions_mutex);
 	janus_lua_session *session = janus_lua_lookup_session(handle);
 	if(!session) {
@@ -1566,7 +1566,7 @@ void janus_lua_destroy_session(janus_plugin_session *handle, int *error) {
 json_t *janus_lua_query_session(janus_plugin_session *handle) {
 	if(g_atomic_int_get(&lua_stopping) || !g_atomic_int_get(&lua_initialized)) {
 		return NULL;
-	}	
+	}
 	janus_mutex_lock(&lua_sessions_mutex);
 	janus_lua_session *session = janus_lua_lookup_session(handle);
 	if(!session) {
@@ -1703,7 +1703,7 @@ void janus_lua_setup_media(janus_plugin_session *handle) {
 void janus_lua_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len) {
 	if(handle == NULL || handle->stopped || g_atomic_int_get(&lua_stopping) || !g_atomic_int_get(&lua_initialized))
 		return;
-	janus_lua_session *session = (janus_lua_session *)handle->plugin_handle;	
+	janus_lua_session *session = (janus_lua_session *)handle->plugin_handle;
 	if(!session) {
 		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
 		return;
@@ -1809,7 +1809,7 @@ void janus_lua_incoming_rtcp(janus_plugin_session *handle, int video, char *buf,
 	}
 }
 
-void janus_lua_incoming_data(janus_plugin_session *handle, char *buf, int len) {
+void janus_lua_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len) {
 	if(handle == NULL || handle->stopped || g_atomic_int_get(&lua_stopping) || !g_atomic_int_get(&lua_initialized))
 		return;
 	janus_lua_session *session = (janus_lua_session *)handle->plugin_handle;
@@ -1952,7 +1952,7 @@ static void janus_lua_relay_rtp_packet(gpointer data, gpointer user_data) {
 	if(!session || !session->handle || !g_atomic_int_get(&session->started)) {
 		return;
 	}
-	
+
 	/* Check if this recipient is willing/allowed to receive this medium */
 	if((packet->is_video && !session->accept_video) || (!packet->is_video && !session->accept_audio)) {
 		/* Nope, don't relay */
@@ -1979,7 +1979,7 @@ static void janus_lua_relay_data_packet(gpointer data, gpointer user_data) {
 	if(janus_core != NULL && text != NULL) {
 		JANUS_LOG(LOG_VERB, "Forwarding DataChannel message (%zu bytes) to session %"SCNu32": %s\n",
 			strlen(text), session->id, text);
-		janus_core->relay_data(session->handle, text, strlen(text));
+		janus_core->relay_data(session->handle, NULL, text, strlen(text));
 	}
 	return;
 }

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -295,7 +295,6 @@ struct janus_plugin_result *janus_recordplay_handle_message(janus_plugin_session
 void janus_recordplay_setup_media(janus_plugin_session *handle);
 void janus_recordplay_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_recordplay_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_recordplay_incoming_data(janus_plugin_session *handle, char *buf, int len);
 void janus_recordplay_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_recordplay_hangup_media(janus_plugin_session *handle);
 void janus_recordplay_destroy_session(janus_plugin_session *handle, int *error);
@@ -320,7 +319,6 @@ static janus_plugin janus_recordplay_plugin =
 		.setup_media = janus_recordplay_setup_media,
 		.incoming_rtp = janus_recordplay_incoming_rtp,
 		.incoming_rtcp = janus_recordplay_incoming_rtcp,
-		.incoming_data = janus_recordplay_incoming_data,
 		.slow_link = janus_recordplay_slow_link,
 		.hangup_media = janus_recordplay_hangup_media,
 		.destroy_session = janus_recordplay_destroy_session,
@@ -1190,12 +1188,6 @@ void janus_recordplay_incoming_rtp(janus_plugin_session *handle, int video, char
 void janus_recordplay_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
-}
-
-void janus_recordplay_incoming_data(janus_plugin_session *handle, char *buf, int len) {
-	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
-		return;
-	/* FIXME We don't care */
 }
 
 void janus_recordplay_slow_link(janus_plugin_session *handle, int uplink, int video) {

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -6715,7 +6715,7 @@ static void janus_streaming_relay_rtp_packet(gpointer data, gpointer user_data) 
 			return;
 		char *text = (char *)packet->data;
 		if(gateway != NULL && text != NULL)
-			gateway->relay_data(session->handle, text, strlen(text));
+			gateway->relay_data(session->handle, NULL, text, strlen(text));
 	}
 
 	return;

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -290,7 +290,7 @@ struct janus_plugin_result *janus_videocall_handle_message(janus_plugin_session 
 void janus_videocall_setup_media(janus_plugin_session *handle);
 void janus_videocall_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_videocall_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_videocall_incoming_data(janus_plugin_session *handle, char *buf, int len);
+void janus_videocall_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
 void janus_videocall_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_videocall_hangup_media(janus_plugin_session *handle);
 void janus_videocall_destroy_session(janus_plugin_session *handle, int *error);
@@ -810,7 +810,7 @@ void janus_videocall_incoming_rtcp(janus_plugin_session *handle, int video, char
 	}
 }
 
-void janus_videocall_incoming_data(janus_plugin_session *handle, char *buf, int len) {
+void janus_videocall_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	if(gateway) {
@@ -835,7 +835,7 @@ void janus_videocall_incoming_data(janus_plugin_session *handle, char *buf, int 
 		/* Save the frame if we're recording */
 		janus_recorder_save_frame(session->drc, buf, len);
 		/* Forward the packet to the peer */
-		gateway->relay_data(peer->handle, text, strlen(text));
+		gateway->relay_data(peer->handle, label, text, strlen(text));
 		g_free(text);
 	}
 }

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1057,7 +1057,7 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 void janus_videoroom_setup_media(janus_plugin_session *handle);
 void janus_videoroom_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_videoroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_videoroom_incoming_data(janus_plugin_session *handle, char *buf, int len);
+void janus_videoroom_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
 void janus_videoroom_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_videoroom_hangup_media(janus_plugin_session *handle);
 void janus_videoroom_destroy_session(janus_plugin_session *handle, int *error);
@@ -4325,7 +4325,7 @@ void janus_videoroom_incoming_rtcp(janus_plugin_session *handle, int video, char
 	}
 }
 
-void janus_videoroom_incoming_data(janus_plugin_session *handle, char *buf, int len) {
+void janus_videoroom_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized) || !gateway)
 		return;
 	if(buf == NULL || len <= 0)
@@ -6371,7 +6371,7 @@ static void janus_videoroom_relay_data_packet(gpointer data, gpointer user_data)
 	}
 	if(gateway != NULL && text != NULL) {
 		JANUS_LOG(LOG_VERB, "Forwarding DataChannel message (%zu bytes) to viewer: %s\n", strlen(text), text);
-		gateway->relay_data(session->handle, text, strlen(text));
+		gateway->relay_data(session->handle, NULL, text, strlen(text));
 	}
 	return;
 }

--- a/plugins/plugin.h
+++ b/plugins/plugin.h
@@ -169,7 +169,7 @@ janus_plugin *create(void) {
  * Janus instance or it will crash.
  *
  */
-#define JANUS_PLUGIN_API_VERSION	11
+#define JANUS_PLUGIN_API_VERSION	12
 
 /*! \brief Initialization of all plugin properties to NULL
  *
@@ -297,9 +297,10 @@ struct janus_plugin {
 	 * DataChannels send unterminated strings, so you'll have to terminate them with a \0 yourself to
 	 * use them.
 	 * @param[in] handle The plugin/gateway session used for this peer
+	 * @param[in] label The label of the data channel to use
 	 * @param[in] buf The message data (buffer)
 	 * @param[in] len The buffer lenght */
-	void (* const incoming_data)(janus_plugin_session *handle, char *buf, int len);
+	void (* const incoming_data)(janus_plugin_session *handle, char *label, char *buf, int len);
 	/*! \brief Method to be notified by the core when too many NACKs have
 	 * been received or sent by Janus, and so a slow or potentially
 	 * unreliable network is to be expected for this peer
@@ -360,9 +361,10 @@ struct janus_callbacks {
 	void (* const relay_rtcp)(janus_plugin_session *handle, int video, char *buf, int len);
 	/*! \brief Callback to relay SCTP/DataChannel messages to a peer
 	 * @param[in] handle The plugin/gateway session that will be used for this peer
+	 * @param[in] label The label of the data channel to use
 	 * @param[in] buf The message data (buffer)
 	 * @param[in] len The buffer lenght */
-	void (* const relay_data)(janus_plugin_session *handle, char *buf, int len);
+	void (* const relay_data)(janus_plugin_session *handle, char *label, char *buf, int len);
 
 	/*! \brief Callback to ask the core to close a WebRTC PeerConnection
 	 * \note A call to this method will result in the core invoking the hangup_media

--- a/sctp.c
+++ b/sctp.c
@@ -6,12 +6,12 @@
  * The code takes care of the SCTP association between peers and the server,
  * and allows for sending and receiving text messages (binary stuff yet to
  * be implemented) after that.
- * 
+ *
  * \note Right now, the code is heavily based on the rtcweb.c sample code
  * provided in the \c usrsctp library code, and as such the copyright notice
  * that appears at the beginning of that code is ideally present here as
- * well: http://code.google.com/p/sctp-refimpl/source/browse/trunk/KERN/usrsctp/programs/rtcweb.c 
- * 
+ * well: http://code.google.com/p/sctp-refimpl/source/browse/trunk/KERN/usrsctp/programs/rtcweb.c
+ *
  * \note If you want/need to debug SCTP messages for any reason, you can
  * do so by uncommenting the definition of \c DEBUG_SCTP in sctp.h. This
  * will force this code to save all the SCTP messages being exchanged to
@@ -19,19 +19,19 @@
  * these files in by modifying the \c debug_folder variable. Once a file
  * has been saved, you need to process it using the \c text2pcap tool
  * that is usually shipped with Wireshark, e.g.:
- * 
+ *
 \verbatim
 cd /path/to/sctp
 /usr/sbin/text2pcap -n -l 248 -D -t '%H:%M:%S.' sctp-debug-XYZ.txt sctp-debug-XYZ.pcapng
 /usr/sbin/wireshark sctp-debug-XYZ.pcapng
 \endverbatim
- * 
+ *
  * \ingroup protocols
  * \ref protocols
  */
 
 #ifdef HAVE_SCTP
- 
+
 #include "sctp.h"
 #include "dtls.h"
 #include "janus.h"
@@ -42,6 +42,8 @@ cd /path/to/sctp
 /* If we're debugging the SCTP messaging, save the files here (edit path) */
 const char *debug_folder = "/path/to/sctp";
 #endif
+
+static const char *default_label = "JanusDataChannel";
 
 
 #define SCTP_MAX_PACKET_SIZE (1<<16)
@@ -63,11 +65,11 @@ janus_sctp_channel *janus_sctp_find_channel_by_stream(janus_sctp_association *sc
 janus_sctp_channel *janus_sctp_find_free_channel(janus_sctp_association *sctp);
 uint16_t janus_sctp_find_free_stream(janus_sctp_association *sctp);
 void janus_sctp_request_more_streams(janus_sctp_association *sctp);
-int janus_sctp_send_open_request_message(struct socket *sock, uint16_t stream, uint8_t unordered, uint16_t pr_policy, uint32_t pr_value);
+int janus_sctp_send_open_request_message(struct socket *sock, uint16_t stream, char *label, uint8_t unordered, uint16_t pr_policy, uint32_t pr_value);
 int janus_sctp_send_open_response_message(struct socket *sock, uint16_t stream);
 int janus_sctp_send_open_ack_message(struct socket *sock, uint16_t stream);
 void janus_sctp_send_deferred_messages(janus_sctp_association *sctp);
-int janus_sctp_open_channel(janus_sctp_association *sctp, uint8_t unordered, uint16_t pr_policy, uint32_t pr_value);
+int janus_sctp_open_channel(janus_sctp_association *sctp, char *label, uint8_t unordered, uint16_t pr_policy, uint32_t pr_value);
 int janus_sctp_send_text(janus_sctp_association *sctp, uint16_t id, char *text, size_t length);
 void janus_sctp_reset_outgoing_stream(janus_sctp_association *sctp, uint16_t stream);
 void janus_sctp_send_outgoing_stream_reset(janus_sctp_association *sctp);
@@ -125,7 +127,7 @@ static void janus_sctp_association_free(const janus_refcount *sctp_ref) {
 janus_sctp_association *janus_sctp_association_create(janus_dtls_srtp *dtls, janus_ice_handle *handle, uint16_t udp_port) {
 	if(dtls == NULL || handle == NULL || udp_port == 0)
 		return NULL;
-	
+
 	/* usrsctp provides UDP encapsulation of SCTP, but we need these messages to
 	 * be encapsulated in DTLS and actually sent/received by libnice, and not by
 	 * usrsctp itself... as such, we make use of the AF_CONN approach */
@@ -157,6 +159,7 @@ janus_sctp_association *janus_sctp_association_create(janus_dtls_srtp *dtls, jan
 	for(i = 0; i < NUMBER_OF_CHANNELS; i++) {
 		channel = &(sctp->channels[i]);
 		channel->id = i;
+		channel->label[0] = '\0';
 		channel->state = DATA_CHANNEL_CLOSED;
 		channel->pr_policy = SCTP_PR_SCTP_NONE;
 		channel->pr_value = 0;
@@ -209,7 +212,7 @@ janus_sctp_association *janus_sctp_association_create(janus_dtls_srtp *dtls, jan
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] setsockopt error: SCTP_NODELAY (%d)\n", sctp->handle_id, errno);
 		janus_refcount_decrease(&sctp->ref);
 		return NULL;
-	}	
+	}
 	/* Enable the events of interest */
 	struct sctp_event event;
 	memset(&event, 0, sizeof(event));
@@ -334,41 +337,42 @@ static int janus_sctp_incoming_data(struct socket *sock, union sctp_sockstore ad
 	return 1;
 }
 
-void janus_sctp_send_data(janus_sctp_association *sctp, char *buf, int len) {
+void janus_sctp_send_data(janus_sctp_association *sctp, char *label, char *buf, int len) {
 	if(sctp == NULL || buf == NULL || len <= 0)
 		return;
-	JANUS_LOG(LOG_VERB, "[%"SCNu64"] SCTP data to send (%d bytes) coming from a plugin.\n",
-		  sctp->handle_id, len);
+	if(label == NULL)
+		label = (char *)default_label;
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"] SCTP data to send (label=%s, %d bytes) coming from a plugin.\n",
+		  sctp->handle_id, label, len);
 	JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Outgoing SCTP contents: %.*s\n",
 		  sctp->handle_id, len, buf);
 	/* FIXME Is there any open channel we can use? */
 	int i = 0, found = 0;
 	for(i = 0; i < NUMBER_OF_CHANNELS; i++) {
-		if(sctp->channels[i].state != DATA_CHANNEL_CLOSED) {
+		if(sctp->channels[i].state != DATA_CHANNEL_CLOSED && !strcmp(sctp->channels[i].label, label)) {
 			found = 1;
 			JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Using open channel %i\n", sctp->handle_id, i);
 			break;
 		}
 	}
 	if(!found) {
-		JANUS_LOG(LOG_WARN, "[%"SCNu64"] Couldn't send data, channel %i is not open yet\n", sctp->handle_id, i);
-		return;
-		//~ /* FIXME There's no open channel (shouldn't happen, we always create it in janus.js), try opening one now */
-		//~ if(janus_sctp_open_channel(sctp, 0, 0, 0) < 0) {
-			//~ JANUS_LOG(LOG_ERR, "[%"SCNu64"] Couldn't open channel...\n", sctp->handle_id);
-			//~ return;
-		//~ }
-		//~ for(i = 0; i < NUMBER_OF_CHANNELS; i++) {
-			//~ if(sctp->channels[i].state != DATA_CHANNEL_CLOSED) {
-				//~ found = 1;
-				//~ JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Using open channel %i\n", sctp->handle_id, i);
-				//~ break;
-			//~ }
-		//~ }
-		//~ if(!found) {
-			//~ JANUS_LOG(LOG_ERR, "[%"SCNu64"] Channel opened but not found?? giving up...\n", sctp->handle_id);
-			//~ return;
-		//~ }
+		/* There's no open channel, try opening one now */
+		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Creating channel '%s'...\n", sctp->handle_id, label);
+		if(janus_sctp_open_channel(sctp, label, 0, 0, 0) < 0) {
+			JANUS_LOG(LOG_ERR, "[%"SCNu64"] Couldn't open channel...\n", sctp->handle_id);
+			return;
+		}
+		for(i = 0; i < NUMBER_OF_CHANNELS; i++) {
+			if(sctp->channels[i].state != DATA_CHANNEL_CLOSED && !strcmp(sctp->channels[i].label, label)) {
+				found = 1;
+				JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- Using open channel %i\n", sctp->handle_id, i);
+				break;
+			}
+		}
+		if(!found) {
+			JANUS_LOG(LOG_ERR, "[%"SCNu64"] Channel opened but not found?? giving up...\n", sctp->handle_id);
+			return;
+		}
 	}
 	/* FIXME We're assuming this is a string (we don't support binary data yet) */
 	janus_sctp_send_text(sctp, i, buf, len);
@@ -462,15 +466,16 @@ void janus_sctp_request_more_streams(janus_sctp_association *sctp) {
 	return;
 }
 
-int janus_sctp_send_open_request_message(struct socket *sock, uint16_t stream, uint8_t unordered, uint16_t pr_policy, uint32_t pr_value) {
+int janus_sctp_send_open_request_message(struct socket *sock, uint16_t stream, char *label, uint8_t unordered, uint16_t pr_policy, uint32_t pr_value) {
 	/* XXX: This should be encoded in a better way */
 	janus_datachannel_open_request *req = NULL;
 	struct sctp_sndinfo sndinfo;
 
-	/* FIXME For open requests we send, we always use this label */
-	const char *label = "JanusDataChannel";
+	/* Use the default label, if none was provided */
+	if(label == NULL)
+		label = (char *)default_label;
 	guint label_size = (strlen(label)+3) & ~3;
-	JANUS_LOG(LOG_VERB, "Using label '%s' (%zu, %u with padding)\n", label, strlen(label), label_size);
+	JANUS_LOG(LOG_VERB, "Opening channel with label '%s' (%zu, %u with padding)\n", label, strlen(label), label_size);
 
 	req = g_malloc0(sizeof(janus_datachannel_open_request) + label_size);
 	req->msg_type = DATA_CHANNEL_OPEN_REQUEST;
@@ -571,7 +576,8 @@ void janus_sctp_send_deferred_messages(janus_sctp_association *sctp) {
 	for(i = 0; i < NUMBER_OF_CHANNELS; i++) {
 		channel = &(sctp->channels[i]);
 		if(channel->flags & DATA_CHANNEL_FLAGS_SEND_REQ) {
-			if(janus_sctp_send_open_request_message(sctp->sock, channel->stream, channel->unordered, channel->pr_policy, channel->pr_value)) {
+			if(janus_sctp_send_open_request_message(sctp->sock, channel->stream,
+					channel->label, channel->unordered, channel->pr_policy, channel->pr_value)) {
 				channel->flags &= ~DATA_CHANNEL_FLAGS_SEND_REQ;
 			} else {
 				if(errno != EAGAIN) {
@@ -601,7 +607,7 @@ void janus_sctp_send_deferred_messages(janus_sctp_association *sctp) {
 	return;
 }
 
-int janus_sctp_open_channel(janus_sctp_association *sctp, uint8_t unordered, uint16_t pr_policy, uint32_t pr_value) {
+int janus_sctp_open_channel(janus_sctp_association *sctp, char *label, uint8_t unordered, uint16_t pr_policy, uint32_t pr_value) {
 	if(sctp == NULL)
 		return -1;
 	janus_sctp_channel *channel;
@@ -628,16 +634,18 @@ int janus_sctp_open_channel(janus_sctp_association *sctp, uint8_t unordered, uin
 	channel->pr_value = pr_value;
 	channel->stream = stream;
 	channel->flags = 0;
+	g_snprintf(channel->label, sizeof(channel->label), "%s", (label ? label : default_label));
 	if(stream == 0) {
 		janus_sctp_request_more_streams(sctp);
 	} else {
-		if(janus_sctp_send_open_request_message(sctp->sock, stream, unordered, pr_policy, pr_value)) {
+		if(janus_sctp_send_open_request_message(sctp->sock, stream, channel->label, unordered, pr_policy, pr_value)) {
 			sctp->stream_channel[stream] = channel;
 		} else {
 			if(errno == EAGAIN) {
 				sctp->stream_channel[stream] = channel;
 				channel->flags |= DATA_CHANNEL_FLAGS_SEND_REQ;
 			} else {
+				channel->label[0] = '\0';
 				channel->state = DATA_CHANNEL_CLOSED;
 				channel->unordered = 0;
 				channel->pr_policy = 0;
@@ -686,7 +694,7 @@ int janus_sctp_send_text(janus_sctp_association *sctp, uint16_t id, char *text, 
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] sctp_sendv error (%d)\n", sctp->handle_id, errno);
 		return -1;
 	}
-	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Message sent on channel %"SCNu16"\n", sctp->handle_id, id); 
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Message sent on channel %"SCNu16"\n", sctp->handle_id, id);
 	return 0;
 }
 
@@ -811,6 +819,7 @@ void janus_sctp_handle_open_request_message(janus_sctp_association *sctp, janus_
 			} else {
 				/* XXX: Signal error to the other end */
 				sctp->stream_channel[stream] = NULL;
+				channel->label[0] = '\0';
 				channel->state = DATA_CHANNEL_CLOSED;
 				channel->unordered = 0;
 				channel->pr_policy = 0;
@@ -826,10 +835,11 @@ void janus_sctp_handle_open_request_message(janus_sctp_association *sctp, janus_
 	if(len > 0 && len < length) {
 		label = g_malloc(len+1);
 		memcpy(label, req->label, len);
-		label[len] = '\0'; 
+		label[len] = '\0';
+		g_snprintf(channel->label, sizeof(channel->label), "%s", label);
 	}
-	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Opened channel '%s' (id=%"SCNu16") (%d/%d/%d)\n", sctp->handle_id,
-		label ? label : "??",
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Opened channel '%s' (id=%"SCNu16") (%d/%d/%d)\n",
+		sctp->handle_id, label ? label : "??",
 		channel->stream, channel->unordered, channel->pr_policy, channel->pr_value);
 	g_free(label);
 }
@@ -915,7 +925,8 @@ void janus_sctp_handle_data_message(janus_sctp_association *sctp, char *buffer, 
 		JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Incoming SCTP contents: %.*s\n",
 		       sctp->handle_id, (int)length, buffer);
 		/* FIXME: notify this to the core */
-		janus_dtls_notify_data(sctp->dtls, buffer, (int)length);
+			/* TODO: Use label */
+		janus_dtls_notify_data(sctp->dtls, channel->label, buffer, (int)length);
 	}
 	return;
 }
@@ -1145,7 +1156,7 @@ void janus_sctp_handle_stream_reset_event(janus_sctp_association *sctp, struct s
 		}
 		JANUS_LOG(LOG_VERB, "%d", strrst->strreset_stream_list[i]);
 	}
-	JANUS_LOG(LOG_VERB, ".\n");	
+	JANUS_LOG(LOG_VERB, ".\n");
 	if(!(strrst->strreset_flags & SCTP_STREAM_RESET_DENIED) &&
 	    !(strrst->strreset_flags & SCTP_STREAM_RESET_FAILED)) {
 		for(i = 0; i < n; i++) {
@@ -1160,6 +1171,7 @@ void janus_sctp_handle_stream_reset_event(janus_sctp_association *sctp, struct s
 						channel->unordered = 0;
 						channel->flags = 0;
 						channel->state = DATA_CHANNEL_CLOSED;
+						channel->label[0] = '\0';
 					} else {
 						if(channel->state == DATA_CHANNEL_OPEN) {
 							janus_sctp_reset_outgoing_stream(sctp, channel->stream);

--- a/sctp.h
+++ b/sctp.h
@@ -6,16 +6,16 @@
  * The code takes care of the SCTP association between peers and the server,
  * and allows for sending and receiving text messages (binary stuff yet to
  * be implemented) after that.
- * 
+ *
  * \note Right now, the code is heavily based on the rtcweb.c sample code
  * provided in the \c usrsctp library code, and as such the copyright notice
  * that appears at the beginning of that code is ideally present here as
- * well: http://code.google.com/p/sctp-refimpl/source/browse/trunk/KERN/usrsctp/programs/rtcweb.c 
- * 
+ * well: http://code.google.com/p/sctp-refimpl/source/browse/trunk/KERN/usrsctp/programs/rtcweb.c
+ *
  * \ingroup protocols
  * \ref protocols
  */
- 
+
 #ifndef _JANUS_SCTP_H
 #define _JANUS_SCTP_H
 
@@ -80,6 +80,8 @@ struct janus_ice_handle;
 typedef struct janus_sctp_channel {
 	/*! \brief SCTP channel ID */
 	uint32_t id;
+	/*! \brief SCTP channel label */
+	char label[64];
 	/*! \brief Value of the PR-SCTP policy (http://tools.ietf.org/html/rfc6458) */
 	uint32_t pr_value;
 	/*! \brief PR-SCTP policy to use (http://tools.ietf.org/html/rfc6458) */
@@ -200,9 +202,10 @@ void janus_sctp_data_from_dtls(janus_sctp_association *sctp, char *buf, int len)
 
 /*! \brief Method to send data via SCTP to the peer
  * \param[in] sctp The SCTP association this data is from
+ * @param[in] label The label of the data channel to use
  * \param[in] buf The data buffer
  * \param[in] len The buffer length */
-void janus_sctp_send_data(janus_sctp_association *sctp, char *buf, int len);
+void janus_sctp_send_data(janus_sctp_association *sctp, char *label, char *buf, int len);
 
 #endif
 


### PR DESCRIPTION
Historically, in Janus we've always supported a single stream in a PeerConnection datachannel: this stream was called "JanusDataChannel" and had to be created by the client, with Janus simply reacting to this; then, each message exchanged by Janus and client would be sent over this stream.

Of course, while simple and effective in most scenarios, this could be limiting in others, e.g., in custom plugins where a more sophisticated approach might be needed. This is definitely the case for the unified-plan version of the VideoRoom plugin, where a single PeerConnection can stream multiple publishers at the same time, and so being limited to a single stream would basically break datachannel broadcasting (when I receive a datachannel message, is it coming from Bob or Alice?).

This PR aims at fixing this, and adds multichannel support to our datachannel implementation. The feature is quite simple, and based on labels: in JavaScript we extended the existing API in a backwards compatible way (more on that below), while plugins are now notified from which label a new message originated in `incoming_data`, and at the same time plugins can specify a custom label that should be used for sending messages via `relay_data`. In case the label doesn't exist, a new stream is created automatically. Plugins are free to pass `NULL` as the label in `relay_data`: this will use the default stream that we've been used since the beginning, and so should ensure backwards compatibility.

As I was saying, we slightly changed the JavaScript API to support this new feature. Specifically, the two existing callbacks simply have a new `label` property in the signature:

    ondataopen() ---> ondataopen(label)
    ondata(text) ---> ondata(text, label)

This way, you know which label a new available stream is using, and you also know which label originated an incoming message. You're free to ignore those if you won't use the feature. To send a message using a custom label, instead, just add a `label` property to a `data` request, e.g.:

	echotest.data({
		text: "hello",
		label: "mylabel", <--- custom stream
		error: function(reason) { bootbox.alert(reason); },
		success: function() { $('#datasend').val(''); },
	});

In case a stream with that label doesn't exist yet, it will be created for you.

Tested briefly and it seems to be working as expected. Unless I find breaking bugs or relevant regressions, I plan to merge soon, so please let me know if think there's anything I should fix.