### PR TITLE
Don't call getUserMedia when audio and video are false 

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2242,14 +2242,18 @@ function Janus(gatewayCallbacks) {
 						video: (videoExist && !media.keepVideo) ? videoSupport : false
 					};
 					Janus.debug("getUserMedia constraints", gumConstraints);
-					navigator.mediaDevices.getUserMedia(gumConstraints)
-						.then(function(stream) {
-							pluginHandle.consentDialog(false);
-							streamsDone(handleId, jsep, media, callbacks, stream);
-						}).catch(function(error) {
-							pluginHandle.consentDialog(false);
-							callbacks.error({code: error.code, name: error.name, message: error.message});
-						});
+					if (!gumConstraints.audio && !gumConstraints.video) {
+						streamsDone(handleId, jsep, media, callbacks, stream);
+					} else {
+						navigator.mediaDevices.getUserMedia(gumConstraints)
+							.then(function(stream) {
+								pluginHandle.consentDialog(false);
+								streamsDone(handleId, jsep, media, callbacks, stream);
+							}).catch(function(error) {
+								pluginHandle.consentDialog(false);
+								callbacks.error({code: error.code, name: error.name, message: error.message});
+							});
+					}
 				})
 				.catch(function(error) {
 					pluginHandle.consentDialog(false);


### PR DESCRIPTION
(e.g. when using removeVideo)

See discussion: https://github.com/meetecho/janus-gateway/issues/1558