### PR TITLE
audio/videoTransceiver direction property error in Safari

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2412,24 +2412,40 @@ function Janus(gatewayCallbacks) {
 			if(!audioSend && !audioRecv) {
 				// Audio disabled: have we removed it?
 				if(media.removeAudio && audioTransceiver) {
-					audioTransceiver.direction = "inactive";
+					if (audioTransceiver.setDirection) {
+						audioTransceiver.setDirection("inactive");
+					} else {
+						audioTransceiver.direction = "inactive";
+					}
 					Janus.log("Setting audio transceiver to inactive:", audioTransceiver);
 				}
 			} else {
 				// Take care of audio m-line
 				if(audioSend && audioRecv) {
 					if(audioTransceiver) {
-						audioTransceiver.direction = "sendrecv";
+						if (audioTransceiver.setDirection) {
+							audioTransceiver.setDirection("sendrecv");
+						} else {
+							audioTransceiver.direction = "sendrecv";
+						}
 						Janus.log("Setting audio transceiver to sendrecv:", audioTransceiver);
 					}
 				} else if(audioSend && !audioRecv) {
 					if(audioTransceiver) {
-						audioTransceiver.direction = "sendonly";
+						if (audioTransceiver.setDirection) {
+							audioTransceiver.setDirection("sendonly");
+						} else {
+							audioTransceiver.direction = "sendonly";
+						}
 						Janus.log("Setting audio transceiver to sendonly:", audioTransceiver);
 					}
 				} else if(!audioSend && audioRecv) {
 					if(audioTransceiver) {
-						audioTransceiver.direction = "recvonly";
+						if (audioTransceiver.setDirection) {
+							audioTransceiver.setDirection("recvonly");
+						} else {
+							audioTransceiver.direction = "recvonly";
+						}
 						Janus.log("Setting audio transceiver to recvonly:", audioTransceiver);
 					} else {
 						// In theory, this is the only case where we might not have a transceiver yet
@@ -2444,24 +2460,40 @@ function Janus(gatewayCallbacks) {
 			if(!videoSend && !videoRecv) {
 				// Video disabled: have we removed it?
 				if(media.removeVideo && videoTransceiver) {
-					videoTransceiver.direction = "inactive";
+					if (videoTransceiver.setDirection) {
+						videoTransceiver.setDirection("inactive");
+					} else {
+						videoTransceiver.direction = "inactive";
+					}
 					Janus.log("Setting video transceiver to inactive:", videoTransceiver);
 				}
 			} else {
 				// Take care of video m-line
 				if(videoSend && videoRecv) {
 					if(videoTransceiver) {
-						videoTransceiver.direction = "sendrecv";
+						if (videoTransceiver.setDirection) {
+							videoTransceiver.setDirection("sendrecv");
+						} else {
+							videoTransceiver.direction = "sendrecv";
+						}
 						Janus.log("Setting video transceiver to sendrecv:", videoTransceiver);
 					}
 				} else if(videoSend && !videoRecv) {
 					if(videoTransceiver) {
-						videoTransceiver.direction = "sendonly";
+						if (videoTransceiver.setDirection) {
+							videoTransceiver.setDirection("sendonly");
+						} else {
+							videoTransceiver.direction = "sendonly";
+						}
 						Janus.log("Setting video transceiver to sendonly:", videoTransceiver);
 					}
 				} else if(!videoSend && videoRecv) {
 					if(videoTransceiver) {
-						videoTransceiver.direction = "recvonly";
+						if (videoTransceiver.setDirection) {
+							videoTransceiver.setDirection("recvonly");
+						} else {
+							videoTransceiver.direction = "recvonly";
+						}
 						Janus.log("Setting video transceiver to recvonly:", videoTransceiver);
 					} else {
 						// In theory, this is the only case where we might not have a transceiver yet
@@ -2581,24 +2613,40 @@ function Janus(gatewayCallbacks) {
 			if(!audioSend && !audioRecv) {
 				// Audio disabled: have we removed it?
 				if(media.removeAudio && audioTransceiver) {
-					audioTransceiver.direction = "inactive";
+					if (audioTransceiver.setDirection) {
+						audioTransceiver.setDirection("inactive");
+					} else {
+						audioTransceiver.direction = "inactive";
+					}
 					Janus.log("Setting audio transceiver to inactive:", audioTransceiver);
 				}
 			} else {
 				// Take care of audio m-line
 				if(audioSend && audioRecv) {
 					if(audioTransceiver) {
-						audioTransceiver.direction = "sendrecv";
+						if (audioTransceiver.setDirection) {
+							audioTransceiver.setDirection("sendrecv");
+						} else {
+							audioTransceiver.direction = "sendrecv";
+						}
 						Janus.log("Setting audio transceiver to sendrecv:", audioTransceiver);
 					}
 				} else if(audioSend && !audioRecv) {
 					if(audioTransceiver) {
-						audioTransceiver.direction = "sendonly";
+						if (audioTransceiver.setDirection) {
+							audioTransceiver.setDirection("sendonly");
+						} else {
+							audioTransceiver.direction = "sendonly";
+						}
 						Janus.log("Setting audio transceiver to sendonly:", audioTransceiver);
 					}
 				} else if(!audioSend && audioRecv) {
 					if(audioTransceiver) {
-						audioTransceiver.direction = "recvonly";
+						if (audioTransceiver.setDirection) {
+							audioTransceiver.setDirection("recvonly");
+						} else {
+							audioTransceiver.direction = "recvonly";
+						}
 						Janus.log("Setting audio transceiver to recvonly:", audioTransceiver);
 					} else {
 						// In theory, this is the only case where we might not have a transceiver yet
@@ -2613,24 +2661,40 @@ function Janus(gatewayCallbacks) {
 			if(!videoSend && !videoRecv) {
 				// Video disabled: have we removed it?
 				if(media.removeVideo && videoTransceiver) {
-					videoTransceiver.direction = "inactive";
+					if (videoTransceiver.setDirection) {
+						videoTransceiver.setDirection("inactive");
+					} else {
+						videoTransceiver.direction = "inactive";
+					}
 					Janus.log("Setting video transceiver to inactive:", videoTransceiver);
 				}
 			} else {
 				// Take care of video m-line
 				if(videoSend && videoRecv) {
 					if(videoTransceiver) {
-						videoTransceiver.direction = "sendrecv";
+						if (videoTransceiver.setDirection) {
+							videoTransceiver.setDirection("sendrecv");
+						} else {
+							videoTransceiver.direction = "sendrecv";
+						}
 						Janus.log("Setting video transceiver to sendrecv:", videoTransceiver);
 					}
 				} else if(videoSend && !videoRecv) {
 					if(videoTransceiver) {
-						videoTransceiver.direction = "sendonly";
+						if (videoTransceiver.setDirection) {
+							videoTransceiver.setDirection("sendonly");
+						} else {
+							videoTransceiver.direction = "sendonly";
+						}
 						Janus.log("Setting video transceiver to sendonly:", videoTransceiver);
 					}
 				} else if(!videoSend && videoRecv) {
 					if(videoTransceiver) {
-						videoTransceiver.direction = "recvonly";
+						if (videoTransceiver.setDirection) {
+							videoTransceiver.setDirection("recvonly");
+						} else {
+							videoTransceiver.direction = "recvonly";
+						}
 						Janus.log("Setting video transceiver to recvonly:", videoTransceiver);
 					} else {
 						// In theory, this is the only case where we might not have a transceiver yet


### PR DESCRIPTION
I've got an error `Unhandled Promise Rejection: TypeError: Attempted to assign to readonly property.
` when **.direction** property was set in Safari (both mac and iOS). But I found that Safari has `.setDirection()` setter method, so I used it to set a direction if available