### PR TITLE
sdp-utils: avoid extra carriage return for extmap lines

### DIFF
--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -1374,7 +1374,7 @@ janus_sdp *janus_sdp_generate_answer(janus_sdp *offer, ...) {
 										break;
 								}
 								a = janus_sdp_attribute_create("extmap",
-									"%d%s %s\r\n", id, direction, extension);
+									"%d%s %s", id, direction, extension);
 								janus_sdp_attribute_add_to_mline(am, a);
 							}
 							temp = temp->next;


### PR DESCRIPTION
I'm currently seeing SDPs such as:
```
a=rtcp-fb:102 nack
a=rtcp-fb:102 nack pli
a=rtcp-fb:102 goog-remb
a=rtcp-fb:102 transport-cc
a=extmap:12 urn:3gpp:video-orientation

a=extmap:2 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01

a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
```
I imagine that these extra blank lines after extmap entries are unwanted, also no other calls to `janus_sdp_attribute_create` include carriage returns.