### PR TITLE
Use createOffer with no constraints if browser is safari.

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2529,8 +2529,13 @@ function Janus(gatewayCallbacks) {
 				sender.setParameters(parameters);
 			}
 		}
-		config.pc.createOffer(mediaConstraints)
-			.then(function(offer) {
+		var offer;
+		if(Janus.webRTCAdapter.browserDetails.browser !== "safari"){
+			offer = config.pc.createOffer(mediaConstraints)
+		}else{
+			offer = config.pc.createOffer()
+		}
+		offer.then(function(offer) {
 				Janus.debug(offer);
 				Janus.log("Setting local description");
 				if(sendVideo && simulcast) {


### PR DESCRIPTION
Use createOffer with no constraints if browser is safari. This is due to Safari not being able to handle media constraints.