### PR TITLE
Added proper management of incoming re-INVITEs to SIP plugin (see #1591)

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1954,6 +1954,7 @@ function Janus(gatewayCallbacks) {
 			// If we're updating and keeping all tracks, let's skip the getUserMedia part
 			if((isAudioSendEnabled(media) && media.keepAudio) &&
 					(isVideoSendEnabled(media) && media.keepVideo)) {
+				pluginHandle.consentDialog(false);
 				streamsDone(handleId, jsep, media, callbacks, config.myStream);
 				return;
 			}
@@ -2041,6 +2042,7 @@ function Janus(gatewayCallbacks) {
 			}
 			// Skip the getUserMedia part
 			config.streamExternal = true;
+			pluginHandle.consentDialog(false);
 			streamsDone(handleId, jsep, media, callbacks, stream);
 			return;
 		}
@@ -2296,6 +2298,7 @@ function Janus(gatewayCallbacks) {
 					};
 					Janus.debug("getUserMedia constraints", gumConstraints);
 					if (!gumConstraints.audio && !gumConstraints.video) {
+						pluginHandle.consentDialog(false);
 						streamsDone(handleId, jsep, media, callbacks, stream);
 					} else {
 						navigator.mediaDevices.getUserMedia(gumConstraints)

--- a/html/siptest.js
+++ b/html/siptest.js
@@ -127,7 +127,7 @@ $(document).ready(function() {
 									Janus.debug("Consent dialog should be " + (on ? "on" : "off") + " now");
 									if(on) {
 										// Darken screen and show hint
-										$.blockUI({ 
+										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
 											css: {
 												border: 'none',
@@ -268,6 +268,12 @@ $(document).ready(function() {
 																		// also specify the SRTP profile to negotiate by setting the
 																		// "srtp_profile" property accordingly (the default if not
 																		// set in the request is "AES_CM_128_HMAC_SHA1_80")
+																		// Note 2: by default, the SIP plugin auto-answers incoming
+																		// re-INVITEs, without involving the browser/client: this is
+																		// for backwards compatibility with older Janus clients that
+																		// may not be able to handle them. If you want to receive
+																		// re-INVITES to handle them yourself, specify it here, e.g.:
+																		//		body["autoaccept_reinvites"] = false;
 																		sipcall.send({"message": body, "jsep": jsep});
 																		$('#call').removeAttr('disabled').html('Hangup')
 																			.removeClass("btn-success").addClass("btn-danger")
@@ -293,7 +299,7 @@ $(document).ready(function() {
 														}
 													}
 												}
-											});											
+											});
 										} else if(event === 'accepting') {
 											// Response to an offerless INVITE, let's wait for an 'accepted'
 										} else if(event === 'progress') {
@@ -312,6 +318,28 @@ $(document).ready(function() {
 												sipcall.handleRemoteJsep({jsep: jsep, error: doHangup });
 											}
 											toastr.success("Call accepted!");
+										} else if(event === 'updatingcall') {
+											// We got a re-INVITE: while we may prompt the user (e.g.,
+											// to notify about media changes), to keep things simple
+											// we just accept the update and send an answer right away
+											Janus.log("Got re-INVITE");
+											var doAudio = (jsep.sdp.indexOf("m=audio ") > -1),
+												doVideo = (jsep.sdp.indexOf("m=video ") > -1);
+											sipcall.createAnswer(
+												{
+													jsep: jsep,
+													media: { audio: doAudio, video: doVideo },
+													success: function(jsep) {
+														Janus.debug("Got SDP " + jsep.type + "! audio=" + doAudio + ", video=" + doVideo);
+														Janus.debug(jsep);
+														var body = { request: "update" };
+														sipcall.send({"message": body, "jsep": jsep});
+													},
+													error: function(error) {
+														Janus.error("WebRTC error:", error);
+														bootbox.alert("WebRTC error... " + JSON.stringify(error));
+													}
+												});
 										} else if(event === 'hangup') {
 											if(incoming != null) {
 												incoming.modal('hide');
@@ -445,7 +473,7 @@ $(document).ready(function() {
 		});
 	}});
 });
-	
+
 function checkEnter(field, event) {
 	var theCode = event.keyCode ? event.keyCode : event.which ? event.which : event.charCode;
 	if(theCode == 13) {
@@ -531,7 +559,7 @@ function registerUsername() {
 						$('#register').removeAttr('disabled').click(registerUsername);
 						$('#registerset').removeAttr('disabled');
 					}
-				}); 
+				});
 		} else {
 			sipcall.send({"message": register});
 		}
@@ -598,7 +626,7 @@ function registerUsername() {
 					$('#register').removeAttr('disabled').click(registerUsername);
 					$('#registerset').removeAttr('disabled');
 				}
-			}); 
+			});
 	} else {
 		register["proxy"] = sipserver;
 		// Uncomment this if you want to see an outbound proxy too
@@ -629,7 +657,7 @@ function doCall() {
 	}
 	// Call this URI
 	doVideo = $('#dovideo').is(':checked');
-	Janus.log("This is a SIP " + (doVideo ? "video" : "audio") + " call (dovideo=" + doVideo + ")"); 
+	Janus.log("This is a SIP " + (doVideo ? "video" : "audio") + " call (dovideo=" + doVideo + ")");
 	sipcall.createOffer(
 		{
 			media: {
@@ -660,6 +688,12 @@ function doCall() {
 				// Just beware that some endpoints will NOT accept an INVITE
 				// with a crypto line in it if the protocol is not RTP/SAVP,
 				// so if you want SDES use "sdes_optional" with care.
+				// Note 2: by default, the SIP plugin auto-answers incoming
+				// re-INVITEs, without involving the browser/client: this is
+				// for backwards compatibility with older Janus clients that
+				// may not be able to handle them. If you want to receive
+				// re-INVITES to handle them yourself, specify it here, e.g.:
+				//		body["autoaccept_reinvites"] = false;
 				sipcall.send({"message": body, "jsep": jsep});
 			},
 			error: function(error) {

--- a/ice.c
+++ b/ice.c
@@ -1293,6 +1293,11 @@ void janus_ice_webrtc_hangup(janus_ice_handle *handle, const char *reason) {
 		return;
 	janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT);
 	janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_CLEANING);
+	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_GOT_OFFER);
+	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_GOT_ANSWER);
+	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_NEGOTIATED);
+	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AUDIO);
+	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO);
 	/* User will be notified only after the actual hangup */
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Hanging up PeerConnection because of a %s\n",
 		handle->handle_id, reason);
@@ -3116,6 +3121,7 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Setting ICE locally: got %s (%d audios, %d videos)\n", handle->handle_id, offer ? "OFFER" : "ANSWER", audio, video);
 	janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AGENT);
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_START);
+	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_NEGOTIATED);
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_READY);
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_STOP);
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT);

--- a/ice.h
+++ b/ice.h
@@ -177,6 +177,7 @@ typedef struct janus_ice_trickle janus_ice_trickle;
 #define JANUS_ICE_HANDLE_WEBRTC_READY				(1 << 2)
 #define JANUS_ICE_HANDLE_WEBRTC_STOP				(1 << 3)
 #define JANUS_ICE_HANDLE_WEBRTC_ALERT				(1 << 4)
+#define JANUS_ICE_HANDLE_WEBRTC_NEGOTIATED			(1 << 5)
 #define JANUS_ICE_HANDLE_WEBRTC_TRICKLE				(1 << 7)
 #define JANUS_ICE_HANDLE_WEBRTC_ALL_TRICKLES		(1 << 8)
 #define JANUS_ICE_HANDLE_WEBRTC_TRICKLE_SYNCED		(1 << 9)


### PR DESCRIPTION
This patch attempts to fix the issue described in #1591, by basically introducing proper support of incoming re-INVITEs in the SIP plugin. In fact, when we added support for renegotiations in #1099 we modified the SIP plugin to be able to send re-INVITEs, while we still handled incoming re-INVITEs the same way we did before: sending a 200 OK without involving the client. Of course, while this _kinda_ worked for scenarios like onhold, it broke scenarios like the one described in #1591 (changing the payload type for DTMF tones), and probably more.

The patch fixes it by introducing a new property you can set when sending a `call` or `accept`, named `autoaccept_reinvites`. By default, if you don't pass it, it will be `TRUE`, meaning that the SIP plugin will keep on behaving as it always has: this is to ensure backwards compatibility with clients written before this PR. If set to `FALSE`, instead, the plugin will forward the new SDP to the client, and expect an answer to send back: this explains why we default to `TRUE` (not answering an incoming re-INVITE, which is what "older" clients would do, would break the session). The event to signal the re-INVITE is called `updatingcall`, and will include a JSEP with the new offer pretty much as `incomingcall` does; as a client, you're expected to send your answer back with an `update` request. In case you implemented active renegotiations before, you may have noticed that `update` is also the request you use to send a re-INVITE yourself: I basically just updated the method to do both, meaning that if you send an offer it will be an INVITE, while if you send an answer it will be a 200 OK instead.

I tested this with a simple SIPp-based UAS that triggers a renegotiation to change the payload type (as, again, #1591 was what brought me here), and it seems to be working as expected (Chrome does change the payload type for outgoing DTMF tones after the re-INVITE). Of course, I'd love some feedback to be sure this works as expected in other scenarios as well, and that most importantly it doesn't break anything that was working before. If I don't get any feedback, I'll just assume it works for you guys and merge.