### PR TITLE
ice: fix inline warning

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -443,7 +443,7 @@ static inline void janus_ice_free_rtp_packet(janus_rtp_packet *pkt) {
 	g_free(pkt);
 }
 
-static inline void janus_ice_free_queued_packet(janus_ice_queued_packet *pkt) {
+static void janus_ice_free_queued_packet(janus_ice_queued_packet *pkt) {
 	if(pkt == NULL || pkt == &janus_ice_dtls_handshake ||
 			pkt == &janus_ice_hangup_peerconnection || pkt == &janus_ice_detach_handle) {
 		return;


### PR DESCRIPTION
Fixes 3 instances of the following warning:
```
ice.c:446:20: warning: inlining failed in call to ‘janus_ice_free_queued_packet’: call is unlikely and code size would grow [-Winline]
```
with gcc (Ubuntu 8.2.0-7ubuntu1) 8.2.0