### PR TITLE
Allow payload type override when creating RTSP mountpoints

### DIFF
--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -189,7 +189,7 @@ file-ondemand-sample: {
 # authentication will only work if you installed libcurl >= 7.45.0)
 # NOTE WELL: the plugin does NOT transcode, so the RTSP stream MUST be
 # in a format the browser can digest (e.g., VP8 or H.264 baseline for video)
-# Again, you can override rtpmap and/or fmtp, if needed
+# Again, you can override payload type, rtpmap and/or fmtp, if needed
 #
 #rtsp-test: {
 	#type = "rtsp"


### PR DESCRIPTION
This is a simple fix, that addresses something I thought we had already and was actually missing, that is the ability to force a different payload type when creating an RTSP mountpoint. For some reason we only allowed the fmtp and rtmpap properties to be overridden, but not the payload type, which caused issues like the one described [here](https://groups.google.com/forum/#!topic/meetecho-janus/t25kHCx56Dc/discussion), where a camera was using a reserved payload type outside of the dynamic range for its video payload type, and the browser was obviously rejecting it.

I expect to merge soon, so please let me know if you notice any regression or typos.