### PR TITLE
A couple of fixes on SIP race conditions after hangups

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -1301,6 +1301,7 @@ static void janus_ice_plugin_session_free(const janus_refcount *app_handle_ref) 
 void janus_ice_webrtc_hangup(janus_ice_handle *handle, const char *reason) {
 	if(handle == NULL)
 		return;
+	g_atomic_int_set(&handle->closepc, 0);
 	if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT))
 		return;
 	janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT);
@@ -3131,6 +3132,7 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 		return -2;
 	}
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Setting ICE locally: got %s (%d audios, %d videos)\n", handle->handle_id, offer ? "OFFER" : "ANSWER", audio, video);
+	g_atomic_int_set(&handle->closepc, 0);
 	janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AGENT);
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_START);
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_NEGOTIATED);

--- a/ice.h
+++ b/ice.h
@@ -332,6 +332,8 @@ struct janus_ice_handle {
 	janus_text2pcap *text2pcap;
 	/*! \brief Mutex to lock/unlock the ICE session */
 	janus_mutex mutex;
+	/*! \brief Whether a close_pc was requested recently on the PeerConnection */
+	volatile gint closepc;
 	/*! \brief Atomic flag to check if this instance has been destroyed */
 	volatile gint destroyed;
 	/*! \brief Reference counter for this instance */

--- a/janus.c
+++ b/janus.c
@@ -3312,7 +3312,7 @@ static gboolean janus_plugin_close_pc_internal(gpointer user_data) {
 	/* We actually enforce the close_pc here */
 	janus_plugin_session *plugin_session = (janus_plugin_session *) user_data;
 	janus_ice_handle *ice_handle = (janus_ice_handle *)plugin_session->gateway_handle;
-	if(!ice_handle) {
+	if(!ice_handle || !g_atomic_int_compare_and_exchange(&ice_handle->closepc, 1, 0)) {
 		janus_refcount_decrease(&plugin_session->ref);
 		return G_SOURCE_REMOVE;
 	}
@@ -3335,6 +3335,9 @@ static gboolean janus_plugin_close_pc_internal(gpointer user_data) {
 void janus_plugin_close_pc(janus_plugin_session *plugin_session) {
 	/* A plugin asked to get rid of a PeerConnection: enqueue it as a timed source */
 	if(!janus_plugin_session_is_alive(plugin_session))
+		return;
+	janus_ice_handle *ice_handle = (janus_ice_handle *)plugin_session->gateway_handle;
+	if(!ice_handle || !g_atomic_int_compare_and_exchange(&ice_handle->closepc, 0, 1))
 		return;
 	janus_refcount_increase(&plugin_session->ref);
 	GSource *timeout_source = g_timeout_source_new_seconds(0);

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -3435,7 +3435,8 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				session->callid = NULL;
 				g_free(session->transaction);
 				session->transaction = NULL;
-				gateway->close_pc(session->handle);
+				if(g_atomic_int_get(&session->establishing) || g_atomic_int_get(&session->established))
+					gateway->close_pc(session->handle);
 			}
 			break;
 		case nua_i_terminated:

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -3455,10 +3455,12 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				break;
 			}
 			gboolean reinvite = FALSE, busy = FALSE;
-			if(g_atomic_int_get(&session->establishing) || g_atomic_int_get(&session->established)) {
-				/* Still busy establishing another call (or maybe still cleaning up the previous call) */
-				busy = TRUE;
-			} else if(session->stack->s_nh_i != NULL) {
+			if(session->stack->s_nh_i == NULL) {
+				if(g_atomic_int_get(&session->establishing) || g_atomic_int_get(&session->established)) {
+					/* Still busy establishing another call (or maybe still cleaning up the previous call) */
+					busy = TRUE;
+				}
+			} else {
 				if(session->stack->s_nh_i == nh) {
 					/* re-INVITE, we'll check what changed later */
 					reinvite = TRUE;

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1550,7 +1550,6 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.pipefd[1] = -1;
 	session->media.updated = FALSE;
 	janus_mutex_init(&session->rec_mutex);
-	JANUS_LOG(LOG_FATAL, "establishing=0\n");
 	g_atomic_int_set(&session->establishing, 0);
 	g_atomic_int_set(&session->established, 0);
 	g_atomic_int_set(&session->hangingup, 0);
@@ -1680,7 +1679,6 @@ void janus_sip_setup_media(janus_plugin_session *handle) {
 		return;
 	}
 	g_atomic_int_set(&session->established, 1);
-	JANUS_LOG(LOG_FATAL, "establishing=0\n");
 	g_atomic_int_set(&session->establishing, 0);
 	g_atomic_int_set(&session->hangingup, 0);
 	janus_mutex_unlock(&sessions_mutex);
@@ -1944,7 +1942,6 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 	if(!(session->status == janus_sip_call_status_inviting ||
 		 session->status == janus_sip_call_status_invited ||
 		 session->status == janus_sip_call_status_incall)) {
-		JANUS_LOG(LOG_FATAL, "establishing=0\n");
 		g_atomic_int_set(&session->establishing, 0);
 		g_atomic_int_set(&session->established, 0);
 		g_atomic_int_set(&session->hangingup, 0);
@@ -1958,7 +1955,6 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 	msg->transaction = NULL;
 	msg->jsep = NULL;
 	g_async_queue_push(messages, msg);
-	JANUS_LOG(LOG_FATAL, "establishing=0\n");
 	g_atomic_int_set(&session->establishing, 0);
 	g_atomic_int_set(&session->established, 0);
 	g_atomic_int_set(&session->hangingup, 0);
@@ -2594,7 +2590,6 @@ static void *janus_sip_handler(void *data) {
 			janus_mutex_lock(&sessions_mutex);
 			g_hash_table_insert(callids, session->callid, session);
 			janus_mutex_unlock(&sessions_mutex);
-			JANUS_LOG(LOG_FATAL, "establishing=1\n");
 			g_atomic_int_set(&session->establishing, 1);
 			nua_invite(session->stack->s_nh_i,
 				SIPTAG_FROM_STR(from_hdr),
@@ -3502,7 +3497,6 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				break;
 			}
 			if(!reinvite) {
-				JANUS_LOG(LOG_FATAL, "establishing=1\n");
 				g_atomic_int_set(&session->establishing, 1);
 			}
 			/* Check if there's an SDP to process */

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -727,7 +727,7 @@ typedef struct janus_sip_session {
 	janus_recorder *vrc_peer;	/* The Janus recorder instance for the peer's video, if enabled */
 	janus_mutex rec_mutex;		/* Mutex to protect the recorders from race conditions */
 	GThread *relayer_thread;
-	volatile gint established;
+	volatile gint establishing, established;
 	volatile gint hangingup;
 	volatile gint destroyed;
 	janus_refcount ref;
@@ -1550,6 +1550,7 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.pipefd[1] = -1;
 	session->media.updated = FALSE;
 	janus_mutex_init(&session->rec_mutex);
+	g_atomic_int_set(&session->establishing, 0);
 	g_atomic_int_set(&session->established, 0);
 	g_atomic_int_set(&session->hangingup, 0);
 	g_atomic_int_set(&session->destroyed, 0);
@@ -1629,6 +1630,7 @@ json_t *janus_sip_query_session(janus_plugin_session *handle) {
 			json_object_set_new(recording, "video-peer", json_string(session->vrc_peer->filename));
 		json_object_set_new(info, "recording", recording);
 	}
+	json_object_set_new(info, "establishing", json_integer(g_atomic_int_get(&session->establishing)));
 	json_object_set_new(info, "established", json_integer(g_atomic_int_get(&session->established)));
 	json_object_set_new(info, "hangingup", json_integer(g_atomic_int_get(&session->hangingup)));
 	json_object_set_new(info, "destroyed", json_integer(g_atomic_int_get(&session->destroyed)));
@@ -1677,6 +1679,7 @@ void janus_sip_setup_media(janus_plugin_session *handle) {
 		return;
 	}
 	g_atomic_int_set(&session->established, 1);
+	g_atomic_int_set(&session->establishing, 1);
 	g_atomic_int_set(&session->hangingup, 0);
 	janus_mutex_unlock(&sessions_mutex);
 	/* TODO Only relay RTP/RTCP when we get this event */
@@ -1939,6 +1942,7 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 	if(!(session->status == janus_sip_call_status_inviting ||
 		 session->status == janus_sip_call_status_invited ||
 		 session->status == janus_sip_call_status_incall)) {
+		g_atomic_int_set(&session->establishing, 0);
 		g_atomic_int_set(&session->established, 0);
 		g_atomic_int_set(&session->hangingup, 0);
 		return;
@@ -1951,6 +1955,7 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 	msg->transaction = NULL;
 	msg->jsep = NULL;
 	g_async_queue_push(messages, msg);
+	g_atomic_int_set(&session->establishing, 0);
 	g_atomic_int_set(&session->established, 0);
 	g_atomic_int_set(&session->hangingup, 0);
 }
@@ -2585,6 +2590,7 @@ static void *janus_sip_handler(void *data) {
 			janus_mutex_lock(&sessions_mutex);
 			g_hash_table_insert(callids, session->callid, session);
 			janus_mutex_unlock(&sessions_mutex);
+			g_atomic_int_set(&session->establishing, 1);
 			nua_invite(session->stack->s_nh_i,
 				SIPTAG_FROM_STR(from_hdr),
 				SIPTAG_TO_STR(uri_text),
@@ -3454,7 +3460,8 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 					/* re-INVITE, we'll check what changed later */
 					reinvite = TRUE;
 					JANUS_LOG(LOG_VERB, "Got a re-INVITE...\n");
-				} else if(session->status >= janus_sip_call_status_inviting || g_atomic_int_get(&session->established)) {
+				} else if(session->status >= janus_sip_call_status_inviting
+						|| g_atomic_int_get(&session->establishing) || g_atomic_int_get(&session->established)) {
 					/* Busy with another call */
 					JANUS_LOG(LOG_VERB, "\tAlready in a call (busy, status=%s)\n", janus_sip_call_status_string(session->status));
 					nua_respond(nh, 486, sip_status_phrase(486), TAG_END());
@@ -3484,6 +3491,8 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 					break;
 				}
 			}
+			if(!reinvite)
+				g_atomic_int_set(&session->establishing, 1);
 			/* Check if there's an SDP to process */
 			janus_sdp *sdp = NULL;
 			if(!sip->sip_payload) {
@@ -3493,6 +3502,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				sdp = janus_sdp_parse(sip->sip_payload->pl_data, sdperror, sizeof(sdperror));
 				if(!sdp) {
 					JANUS_LOG(LOG_ERR, "\tError parsing SDP! %s\n", sdperror);
+					g_atomic_int_set(&session->establishing, 0);
 					nua_respond(nh, 488, sip_status_phrase(488), TAG_END());
 					break;
 				}
@@ -3521,12 +3531,14 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				janus_sip_sdp_process(session, sdp, FALSE, reinvite, &changed);
 				/* Check if offer has neither audio nor video, fail with 488 */
 				if(!session->media.has_audio && !session->media.has_video) {
+					g_atomic_int_set(&session->establishing, 0);
 					nua_respond(nh, 488, sip_status_phrase(488), TAG_END());
 					janus_sdp_destroy(sdp);
 					break;
 				}
 				/* Also fail with 488 if there's no remote IP address that can be used for RTP */
 				if(!session->media.remote_ip) {
+					g_atomic_int_set(&session->establishing, 0);
 					nua_respond(nh, 488, sip_status_phrase(488), TAG_END());
 					janus_sdp_destroy(sdp);
 					break;

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1550,6 +1550,7 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.pipefd[1] = -1;
 	session->media.updated = FALSE;
 	janus_mutex_init(&session->rec_mutex);
+	JANUS_LOG(LOG_FATAL, "establishing=0\n");
 	g_atomic_int_set(&session->establishing, 0);
 	g_atomic_int_set(&session->established, 0);
 	g_atomic_int_set(&session->hangingup, 0);
@@ -1679,7 +1680,8 @@ void janus_sip_setup_media(janus_plugin_session *handle) {
 		return;
 	}
 	g_atomic_int_set(&session->established, 1);
-	g_atomic_int_set(&session->establishing, 1);
+	JANUS_LOG(LOG_FATAL, "establishing=0\n");
+	g_atomic_int_set(&session->establishing, 0);
 	g_atomic_int_set(&session->hangingup, 0);
 	janus_mutex_unlock(&sessions_mutex);
 	/* TODO Only relay RTP/RTCP when we get this event */
@@ -1942,6 +1944,7 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 	if(!(session->status == janus_sip_call_status_inviting ||
 		 session->status == janus_sip_call_status_invited ||
 		 session->status == janus_sip_call_status_incall)) {
+		JANUS_LOG(LOG_FATAL, "establishing=0\n");
 		g_atomic_int_set(&session->establishing, 0);
 		g_atomic_int_set(&session->established, 0);
 		g_atomic_int_set(&session->hangingup, 0);
@@ -1955,6 +1958,7 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 	msg->transaction = NULL;
 	msg->jsep = NULL;
 	g_async_queue_push(messages, msg);
+	JANUS_LOG(LOG_FATAL, "establishing=0\n");
 	g_atomic_int_set(&session->establishing, 0);
 	g_atomic_int_set(&session->established, 0);
 	g_atomic_int_set(&session->hangingup, 0);
@@ -2590,6 +2594,7 @@ static void *janus_sip_handler(void *data) {
 			janus_mutex_lock(&sessions_mutex);
 			g_hash_table_insert(callids, session->callid, session);
 			janus_mutex_unlock(&sessions_mutex);
+			JANUS_LOG(LOG_FATAL, "establishing=1\n");
 			g_atomic_int_set(&session->establishing, 1);
 			nua_invite(session->stack->s_nh_i,
 				SIPTAG_FROM_STR(from_hdr),
@@ -3491,8 +3496,10 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 					break;
 				}
 			}
-			if(!reinvite)
+			if(!reinvite) {
+				JANUS_LOG(LOG_FATAL, "establishing=1\n");
 				g_atomic_int_set(&session->establishing, 1);
+			}
 			/* Check if there's an SDP to process */
 			janus_sdp *sdp = NULL;
 			if(!sip->sip_payload) {

--- a/plugins/janus_sipre.c
+++ b/plugins/janus_sipre.c
@@ -509,7 +509,7 @@ struct janus_sipre_session {
 	janus_recorder *vrc_peer;	/* The Janus recorder instance for the peer's video, if enabled */
 	janus_mutex rec_mutex;		/* Mutex to protect the recorders from race conditions */
 	GThread *relayer_thread;
-	volatile gint established;
+	volatile gint establishing, established;
 	volatile gint hangingup;
 	volatile gint destroyed;
 	janus_refcount ref;
@@ -1299,6 +1299,7 @@ void janus_sipre_create_session(janus_plugin_session *handle, int *error) {
 	session->media.updated = FALSE;
 	janus_mutex_init(&session->rec_mutex);
 	g_atomic_int_set(&session->destroyed, 0);
+	g_atomic_int_set(&session->establishing, 0);
 	g_atomic_int_set(&session->established, 0);
 	g_atomic_int_set(&session->hangingup, 0);
 	janus_mutex_init(&session->mutex);
@@ -1376,6 +1377,7 @@ json_t *janus_sipre_query_session(janus_plugin_session *handle) {
 			json_object_set_new(recording, "video-peer", json_string(session->vrc_peer->filename));
 		json_object_set_new(info, "recording", recording);
 	}
+	json_object_set_new(info, "establishing", json_integer(g_atomic_int_get(&session->establishing)));
 	json_object_set_new(info, "established", json_integer(g_atomic_int_get(&session->established)));
 	json_object_set_new(info, "hangingup", json_integer(g_atomic_int_get(&session->hangingup)));
 	json_object_set_new(info, "destroyed", json_integer(g_atomic_int_get(&session->destroyed)));
@@ -1424,6 +1426,7 @@ void janus_sipre_setup_media(janus_plugin_session *handle) {
 		return;
 	}
 	g_atomic_int_set(&session->established, 1);
+	g_atomic_int_set(&session->establishing, 0);
 	g_atomic_int_set(&session->hangingup, 0);
 	janus_mutex_unlock(&sessions_mutex);
 	/* TODO Only relay RTP/RTCP when we get this event */
@@ -1628,6 +1631,7 @@ static void janus_sipre_hangup_media_internal(janus_plugin_session *handle) {
 	janus_sipre_recorder_close(session, TRUE, TRUE, TRUE, TRUE);
 	janus_mutex_unlock(&session->rec_mutex);
 	g_atomic_int_set(&session->hangingup, 0);
+	g_atomic_int_set(&session->establishing, 0);
 	g_atomic_int_set(&session->established, 0);
 	if(!(session->status == janus_sipre_call_status_inviting ||
 		 session->status == janus_sipre_call_status_invited ||
@@ -2132,6 +2136,7 @@ static void *janus_sipre_handler(void *data) {
 				session->account.secret_type = janus_sipre_secret_type_plaintext;
 			}
 			/* Enqueue the INVITE */
+			g_atomic_int_set(&session->establishing, 1);
 			session->callee = g_strdup(uri_text);
 			session->callid = callid;
 			g_hash_table_insert(callids, session->callid, session);
@@ -3669,7 +3674,7 @@ void janus_sipre_cb_incoming(const struct sip_msg *msg, void *arg) {
 	g_snprintf(callid, sizeof(callid), "%.*s", (int)msg->callid.l, msg->callid.p);
 	JANUS_LOG(LOG_HUGE, "[SIPre-%s]   -- Call-ID: %s\n", session->account.username, callid);
 	/* Make sure we're not in a call already */
-	if(session->stack.sess != NULL || g_atomic_int_get(&session->established)) {
+	if(session->stack.sess != NULL || g_atomic_int_get(&session->establishing) || g_atomic_int_get(&session->established)) {
 		/* Already in a call */
 		JANUS_LOG(LOG_VERB, "Already in a call (busy, status=%s)\n", janus_sipre_call_status_string(session->status));
 		mqueue_push(mq, janus_sipre_mqueue_event_do_rcode, janus_sipre_mqueue_payload_create(session, msg, 486, session));
@@ -3699,6 +3704,7 @@ void janus_sipre_cb_incoming(const struct sip_msg *msg, void *arg) {
 		return;
 	}
 	/* New incoming call, check if there's an SDP to process */
+	g_atomic_int_set(&session->establishing, 1);
 	char sdp_offer[1024];
 	janus_sdp *sdp = NULL;
 	const char *offer = (const char *)mbuf_buf(msg->mb);
@@ -3712,6 +3718,7 @@ void janus_sipre_cb_incoming(const struct sip_msg *msg, void *arg) {
 		sdp = janus_sdp_parse(sdp_offer, sdperror, sizeof(sdperror));
 		if(!sdp) {
 			JANUS_LOG(LOG_ERR, "Error parsing SDP! %s\n", sdperror);
+			g_atomic_int_set(&session->establishing, 0);
 			mqueue_push(mq, janus_sipre_mqueue_event_do_rcode, janus_sipre_mqueue_payload_create(session, msg, 488, NULL));
 			return;
 		}
@@ -3729,12 +3736,14 @@ void janus_sipre_cb_incoming(const struct sip_msg *msg, void *arg) {
 		janus_sipre_sdp_process(session, sdp, FALSE, FALSE, &changed);
 		/* Check if offer has neither audio nor video, fail with 488 */
 		if(!session->media.has_audio && !session->media.has_video) {
+			g_atomic_int_set(&session->establishing, 0);
 			mqueue_push(mq, janus_sipre_mqueue_event_do_rcode, janus_sipre_mqueue_payload_create(session, msg, 488, NULL));
 			janus_sdp_destroy(sdp);
 			return;
 		}
 		/* Also fail with 488 if there's no remote IP address that can be used for RTP */
 		if(!session->media.remote_ip) {
+			g_atomic_int_set(&session->establishing, 0);
 			mqueue_push(mq, janus_sipre_mqueue_event_do_rcode, janus_sipre_mqueue_payload_create(session, msg, 488, NULL));
 			janus_sdp_destroy(sdp);
 			return;


### PR DESCRIPTION
This patch includes a few fixes on some race conditions we experienced with the SIP plugin, especially in cases where new calls would be received immediately after hanging up a call. Due to the asynchronous nature of the messaging, and the management of the state, this could at times result in calls being hung up right after they were accepted (due to a previous cleanup still taking place), or broken audio.

Please let me know if you notice any regression with these fixes, as I plan to merge soon.