### PR TITLE
H.264 temporal scalability support via frame-marking extension

### DIFF
--- a/html/echotest.js
+++ b/html/echotest.js
@@ -214,7 +214,7 @@ $(document).ready(function() {
 									if((substream !== null && substream !== undefined) || (temporal !== null && temporal !== undefined)) {
 										if(!simulcastStarted) {
 											simulcastStarted = true;
-											addSimulcastButtons(msg["videocodec"] === "vp8");
+											addSimulcastButtons(msg["videocodec"] === "vp8" || msg["videocodec"] === "h264");
 										}
 										// We just received notice that there's been a switch, update the buttons
 										updateSimulcastButtons(substream, temporal);

--- a/html/videocalltest.js
+++ b/html/videocalltest.js
@@ -274,7 +274,7 @@ $(document).ready(function() {
 												if((substream !== null && substream !== undefined) || (temporal !== null && temporal !== undefined)) {
 													if(!simulcastStarted) {
 														simulcastStarted = true;
-														addSimulcastButtons(result["videocodec"] === "vp8");
+														addSimulcastButtons(result["videocodec"] === "vp8" || result["videocodec"] === "h264");
 													}
 													// We just received notice that there's been a switch, update the buttons
 													updateSimulcastButtons(substream, temporal);

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -517,7 +517,7 @@ function newRemoteFeed(id, display, audio, video) {
 							if(!remoteFeed.simulcastStarted) {
 								remoteFeed.simulcastStarted = true;
 								// Add some new buttons
-								addSimulcastButtons(remoteFeed.rfindex, remoteFeed.videoCodec === "vp8");
+								addSimulcastButtons(remoteFeed.rfindex, remoteFeed.videoCodec === "vp8" || remoteFeed.videoCodec === "h264");
 							}
 							// We just received notice that there's been a switch, update the buttons
 							updateSimulcastButtons(remoteFeed.rfindex, substream, temporal);

--- a/ice.h
+++ b/ice.h
@@ -400,6 +400,8 @@ struct janus_ice_stream {
 	gint mid_ext_id;
 	/*! \brief RTP Stream extension ID, and the related rtx one */
 	gint rid_ext_id, ridrtx_ext_id;
+	/*! \brief Frame marking extension ID */
+	gint framemarking_ext_id;
 	/*! \brief Whether we do transport wide cc for video */
 	gboolean do_transport_wide_cc;
 	/*! \brief Transport wide cc rtp ext ID */

--- a/janus.c
+++ b/janus.c
@@ -1256,6 +1256,8 @@ int janus_process_incoming_request(janus_request *request) {
 					/* Check if the RTP Stream ID extension is being negotiated */
 					handle->stream->rid_ext_id = janus_rtp_header_extension_get_id(jsep_sdp, JANUS_RTP_EXTMAP_RID);
 					handle->stream->ridrtx_ext_id = janus_rtp_header_extension_get_id(jsep_sdp, JANUS_RTP_EXTMAP_REPAIRED_RID);
+					/* Check if the frame marking ID extension is being negotiated */
+					handle->stream->framemarking_ext_id = janus_rtp_header_extension_get_id(jsep_sdp, JANUS_RTP_EXTMAP_FRAME_MARKING);
 					/* Check if transport wide CC is supported */
 					int transport_wide_cc_ext_id = janus_rtp_header_extension_get_id(jsep_sdp, JANUS_RTP_EXTMAP_TRANSPORT_WIDE_CC);
 					handle->stream->do_transport_wide_cc = transport_wide_cc_ext_id > 0 ? TRUE : FALSE;
@@ -1363,6 +1365,8 @@ int janus_process_incoming_request(janus_request *request) {
 							json_array_append_new(ssrcs, json_integer(handle->stream->video_ssrc_peer[2]));
 						json_object_set_new(simulcast, "ssrcs", ssrcs);
 					}
+					if(handle->stream->framemarking_ext_id > 0)
+						json_object_set_new(simulcast, "framemarking-ext", json_integer(handle->stream->framemarking_ext_id));
 					json_object_set_new(body_jsep, "simulcast", simulcast);
 				}
 			}

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -826,9 +826,10 @@ static void *janus_echotest_handler(void *data) {
 		json_t *msg_simulcast = json_object_get(msg->jsep, "simulcast");
 		if(msg_simulcast) {
 			JANUS_LOG(LOG_VERB, "EchoTest client is going to do simulcasting\n");
-			int rid_ext_id = -1;
-			janus_rtp_simulcasting_prepare(msg_simulcast, &rid_ext_id, session->ssrc, session->rid);
+			int rid_ext_id = -1, framemarking_ext_id = -1;
+			janus_rtp_simulcasting_prepare(msg_simulcast, &rid_ext_id, &framemarking_ext_id, session->ssrc, session->rid);
 			session->sim_context.rid_ext_id = rid_ext_id;
+			session->sim_context.framemarking_ext_id = framemarking_ext_id;
 			session->sim_context.substream_target = 2;	/* Let's aim for the highest quality */
 			session->sim_context.templayer_target = 2;	/* Let's aim for all temporal layers */
 		}
@@ -1029,6 +1030,7 @@ static void *janus_echotest_handler(void *data) {
 				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_MID,
 				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_RID,
 				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_REPAIRED_RID,
+				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_FRAME_MARKING,
 				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_TRANSPORT_WIDE_CC,
 				JANUS_SDP_OA_DONE);
 			/* If we ended up sendonly, switch to inactive (as we don't really send anything ourselves) */

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -1552,6 +1552,7 @@ recdone:
 				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_MID,
 				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_RID,
 				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_REPAIRED_RID,
+				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_FRAME_MARKING,
 				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_TRANSPORT_WIDE_CC,
 				JANUS_SDP_OA_DONE);
 			g_free(answer->s_name);
@@ -1570,9 +1571,10 @@ recdone:
 			json_t *msg_simulcast = json_object_get(msg->jsep, "simulcast");
 			if(msg_simulcast) {
 				JANUS_LOG(LOG_VERB, "Recording client negotiated simulcasting\n");
-				int rid_ext_id = -1;
-				janus_rtp_simulcasting_prepare(msg_simulcast, &rid_ext_id, session->ssrc, session->rid);
+				int rid_ext_id = -1, framemarking_ext_id = -1;
+				janus_rtp_simulcasting_prepare(msg_simulcast, &rid_ext_id, &framemarking_ext_id, session->ssrc, session->rid);
 				session->sim_context.rid_ext_id = rid_ext_id;
+				session->sim_context.framemarking_ext_id = framemarking_ext_id;
 				session->sim_context.substream_target = 2;	/* Let's aim for the highest quality */
 				session->sim_context.templayer_target = 2;	/* Let's aim for all temporal layers */
 				if(rec->vcodec != JANUS_VIDEOCODEC_VP8 && rec->vcodec != JANUS_VIDEOCODEC_H264) {

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -1202,9 +1202,10 @@ static void *janus_videocall_handler(void *data) {
 				json_t *msg_simulcast = json_object_get(msg->jsep, "simulcast");
 				if(msg_simulcast) {
 					JANUS_LOG(LOG_VERB, "VideoCall caller (%s) is going to do simulcasting\n", session->username);
-					int rid_ext_id = -1;
-					janus_rtp_simulcasting_prepare(msg_simulcast, &rid_ext_id, session->ssrc, session->rid);
+					int rid_ext_id = -1, framemarking_ext_id = -1;
+					janus_rtp_simulcasting_prepare(msg_simulcast, &rid_ext_id, &framemarking_ext_id, session->ssrc, session->rid);
 					session->sim_context.rid_ext_id = rid_ext_id;
+					session->sim_context.framemarking_ext_id = framemarking_ext_id;
 				}
 				/* Send SDP to our peer */
 				json_t *call = json_object();

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1438,6 +1438,7 @@ typedef struct janus_videoroom_publisher {
 	uint32_t ssrc[3];		/* Only needed in case VP8 (or H.264) simulcasting is involved */
 	char *rid[3];			/* Only needed if simulcasting is rid-based */
 	int rid_extmap_id;		/* rid extmap ID */
+	int framemarking_ext_id;			/* Frame marking extmap ID */
 	guint8 audio_level_extmap_id;		/* Audio level extmap ID */
 	guint8 video_orient_extmap_id;		/* Video orientation extmap ID */
 	guint8 playout_delay_extmap_id;		/* Playout delay extmap ID */
@@ -5999,6 +6000,7 @@ static void *janus_videoroom_handler(void *data) {
 					JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_MID,
 					JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_RID,
 					JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_REPAIRED_RID,
+					JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_FRAME_MARKING,
 					JANUS_SDP_OA_ACCEPT_EXTMAP, videoroom->audiolevel_ext ? JANUS_RTP_EXTMAP_AUDIO_LEVEL : NULL,
 					JANUS_SDP_OA_ACCEPT_EXTMAP, videoroom->videoorient_ext ? JANUS_RTP_EXTMAP_VIDEO_ORIENTATION : NULL,
 					JANUS_SDP_OA_ACCEPT_EXTMAP, videoroom->playoutdelay_ext ? JANUS_RTP_EXTMAP_PLAYOUT_DELAY : NULL,
@@ -6102,7 +6104,9 @@ static void *janus_videoroom_handler(void *data) {
 					if(msg_simulcast && (participant->vcodec == JANUS_VIDEOCODEC_VP8 ||
 							participant->vcodec == JANUS_VIDEOCODEC_H264)) {
 						JANUS_LOG(LOG_VERB, "Publisher is going to do simulcasting\n");
-						janus_rtp_simulcasting_prepare(msg_simulcast, &participant->rid_extmap_id,
+						janus_rtp_simulcasting_prepare(msg_simulcast,
+							&participant->rid_extmap_id,
+							&participant->framemarking_ext_id,
 							participant->ssrc, participant->rid);
 					} else {
 						/* No simulcasting involved */

--- a/rtp.c
+++ b/rtp.c
@@ -145,18 +145,18 @@ static int janus_rtp_header_extension_find(char *buf, int len, int id,
 				uint8_t extid = 0, idlen;
 				int i = 0;
 				while(i < extlen) {
-					extid = buf[hlen+i] >> 4;
+					extid = (uint8_t)buf[hlen+i] >> 4;
 					if(extid == reserved) {
 						break;
 					} else if(extid == padding) {
 						i++;
 						continue;
 					}
-					idlen = (buf[hlen+i] & 0xF)+1;
+					idlen = ((uint8_t)buf[hlen+i] & 0xF)+1;
 					if(extid == id) {
 						/* Found! */
 						if(byte)
-							*byte = buf[hlen+i+1];
+							*byte = (uint8_t)buf[hlen+i+1];
 						if(word && idlen >= 3 && (i+3) < extlen) {
 							memcpy(word, buf+hlen+i, sizeof(uint32_t));
 							*word = ntohl(*word);
@@ -265,6 +265,26 @@ int janus_rtp_header_extension_parse_rid(char *buf, int len, int id,
 	}
 	memcpy(sdes_item, ext+1, val_len);
 	*(sdes_item+val_len) = '\0';
+	return 0;
+}
+
+int janus_rtp_header_extension_parse_framemarking(char *buf, int len, int id, janus_videocodec codec, uint8_t *tid) {
+	char *ext = NULL;
+	if(janus_rtp_header_extension_find(buf, len, id, NULL, NULL, &ext) < 0)
+		return -1;
+	/*  0                   1                   2                   3
+	    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |  ID=? |  L=2  |S|E|I|D|B| TID |   LID         |    TL0PICIDX  |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	*/
+	if(ext == NULL)
+		return -2;
+	int val_len = (*ext & 0x0F) + 1;
+	if (val_len < 2 || val_len > len-(ext-buf)-1)
+		return -3;
+	if(tid)
+		*tid = (*(ext+1) & 0x07);
 	return 0;
 }
 
@@ -868,7 +888,7 @@ void janus_rtp_simulcasting_context_reset(janus_rtp_simulcasting_context *contex
 	context->templayer = -1;
 }
 
-void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, uint32_t *ssrcs, char **rids) {
+void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, int *framemarking_ext_id, uint32_t *ssrcs, char **rids) {
 	if(simulcast == NULL)
 		return;
 	json_t *r = json_object_get(simulcast, "rids");
@@ -897,6 +917,9 @@ void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, uint32_t
 				ssrcs[i] = json_integer_value(ssrc);
 		}
 	}
+	json_t *fm_ext = json_object_get(simulcast, "framemarking-ext");
+	if(framemarking_ext_id != NULL)
+		*framemarking_ext_id = json_integer_value(fm_ext);
 }
 
 gboolean janus_rtp_simulcasting_context_process_rtp(janus_rtp_simulcasting_context *context,
@@ -984,7 +1007,7 @@ gboolean janus_rtp_simulcasting_context_process_rtp(janus_rtp_simulcasting_conte
 		return FALSE;
 	}
 	context->last_relayed = janus_get_monotonic_time();
-	/* Temporal layers are only available for VP8, so don't do anything else for other codecs */
+	/* Temporal layers are only available for VP8 and (partially) H.264, so don't do anything else for other codecs */
 	if(vcodec == JANUS_VIDEOCODEC_VP8) {
 		/* Check if there's any temporal scalability to take into account */
 		uint16_t picid = 0;
@@ -994,6 +1017,27 @@ gboolean janus_rtp_simulcasting_context_process_rtp(janus_rtp_simulcasting_conte
 		uint8_t keyidx = 0;
 		if(janus_vp8_parse_descriptor(payload, plen, &picid, &tlzi, &tid, &ybit, &keyidx) == 0) {
 			//~ JANUS_LOG(LOG_WARN, "%"SCNu16", %u, %u, %u, %u\n", picid, tlzi, tid, ybit, keyidx);
+			if(context->templayer != context->templayer_target && tid == context->templayer_target) {
+				/* FIXME We should be smarter in deciding when to switch */
+				context->templayer = context->templayer_target;
+				/* Notify the caller that the temporal layer changed */
+				context->changed_temporal = TRUE;
+			}
+			if(context->templayer != -1 && tid > context->templayer) {
+				JANUS_LOG(LOG_HUGE, "Dropping packet (it's temporal layer %d, but we're capping at %d)\n",
+					tid, context->templayer);
+				/* We increase the base sequence number, or there will be gaps when delivering later */
+				if(sc)
+					sc->v_base_seq++;
+				return FALSE;
+			}
+		}
+	} else if(vcodec == JANUS_VIDEOCODEC_H264) {
+		/* Use the frame-marking extension to account for temporal scalability */
+		uint8_t tid = 0;
+		if(janus_rtp_header_extension_parse_framemarking(buf, len,
+				context->framemarking_ext_id, JANUS_VIDEOCODEC_H264, &tid) == 0) {
+			JANUS_LOG(LOG_HUGE, "Frame marking extension found: tid=%d\n", tid);
 			if(context->templayer != context->templayer_target && tid == context->templayer_target) {
 				/* FIXME We should be smarter in deciding when to switch */
 				context->templayer = context->templayer_target;

--- a/rtp.h
+++ b/rtp.h
@@ -86,8 +86,34 @@ typedef struct janus_rtp_header_extension {
 #define JANUS_RTP_EXTMAP_RID				"urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id"
 /*! \brief a=extmap:5 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id */
 #define JANUS_RTP_EXTMAP_REPAIRED_RID		"urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id"
+/*! \brief a=extmap:8 http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07 */
+#define JANUS_RTP_EXTMAP_FRAME_MARKING		"http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07"
 /*! \brief \note Note: We don't support encrypted extensions yet */
 #define JANUS_RTP_EXTMAP_ENCRYPTED			"urn:ietf:params:rtp-hdrext:encrypt"
+
+
+typedef enum janus_audiocodec {
+	JANUS_AUDIOCODEC_NONE,
+	JANUS_AUDIOCODEC_OPUS,
+	JANUS_AUDIOCODEC_PCMU,
+	JANUS_AUDIOCODEC_PCMA,
+	JANUS_AUDIOCODEC_G722,
+	JANUS_AUDIOCODEC_ISAC_32K,
+	JANUS_AUDIOCODEC_ISAC_16K
+} janus_audiocodec;
+const char *janus_audiocodec_name(janus_audiocodec acodec);
+janus_audiocodec janus_audiocodec_from_name(const char *name);
+int janus_audiocodec_pt(janus_audiocodec acodec);
+
+typedef enum janus_videocodec {
+	JANUS_VIDEOCODEC_NONE,
+	JANUS_VIDEOCODEC_VP8,
+	JANUS_VIDEOCODEC_VP9,
+	JANUS_VIDEOCODEC_H264
+} janus_videocodec;
+const char *janus_videocodec_name(janus_videocodec vcodec);
+janus_videocodec janus_videocodec_from_name(const char *name);
+int janus_videocodec_pt(janus_videocodec vcodec);
 
 
 /*! \brief Helper method to demultiplex RTP from other protocols
@@ -165,6 +191,16 @@ int janus_rtp_header_extension_parse_mid(char *buf, int len, int id,
 int janus_rtp_header_extension_parse_rid(char *buf, int len, int id,
 	char *sdes_item, int sdes_len);
 
+/*! \brief Helper to parse a frame-marking RTP extension (http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07)
+ * \note This is currently only used to get temporal layers for H.264 simulcasting
+ * @param[in] buf The packet data
+ * @param[in] len The packet data length in bytes
+ * @param[in] id The extension ID to look for
+ * @param[in] codec The video codec (as a janus_videocodec instance) the extension refers to
+ * @param[out] tid Temporal layer ID of the frame
+ * @returns 0 if found, -1 otherwise */
+int janus_rtp_header_extension_parse_framemarking(char *buf, int len, int id, janus_videocodec codec, uint8_t *tid);
+
 /*! \brief Helper to parse a transport wide sequence number (https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01)
  * @param[in] buf The packet data
  * @param[in] len The packet data length in bytes
@@ -227,34 +263,13 @@ int janus_rtp_skew_compensate_audio(janus_rtp_header *header, janus_rtp_switchin
  * @returns 0 if no compensation is needed, -N if a N packets drop must be performed, N if a N sequence numbers jump has been performed */
 int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switching_context *context, gint64 now);
 
-typedef enum janus_audiocodec {
-	JANUS_AUDIOCODEC_NONE,
-	JANUS_AUDIOCODEC_OPUS,
-	JANUS_AUDIOCODEC_PCMU,
-	JANUS_AUDIOCODEC_PCMA,
-	JANUS_AUDIOCODEC_G722,
-	JANUS_AUDIOCODEC_ISAC_32K,
-	JANUS_AUDIOCODEC_ISAC_16K
-} janus_audiocodec;
-const char *janus_audiocodec_name(janus_audiocodec acodec);
-janus_audiocodec janus_audiocodec_from_name(const char *name);
-int janus_audiocodec_pt(janus_audiocodec acodec);
-
-typedef enum janus_videocodec {
-	JANUS_VIDEOCODEC_NONE,
-	JANUS_VIDEOCODEC_VP8,
-	JANUS_VIDEOCODEC_VP9,
-	JANUS_VIDEOCODEC_H264
-} janus_videocodec;
-const char *janus_videocodec_name(janus_videocodec vcodec);
-janus_videocodec janus_videocodec_from_name(const char *name);
-int janus_videocodec_pt(janus_videocodec vcodec);
-
 
 /*! \brief Helper struct for processing and tracking simulcast streams */
 typedef struct janus_rtp_simulcasting_context {
 	/*! \brief RTP Stream extension ID, if any */
 	gint rid_ext_id;
+	/*! \brief Frame marking extension ID, if any */
+	gint framemarking_ext_id;
 	/*! \brief Which simulcast substream we should forward back */
 	int substream;
 	/*! \brief As above, but to handle transitions (e.g., wait for keyframe, or get this if available) */
@@ -281,9 +296,10 @@ void janus_rtp_simulcasting_context_reset(janus_rtp_simulcasting_context *contex
  * the simulcast object the core passes to plugins for new PeerConnections
  * @param[in] simulcast JSON object containing SSRCs and rids
  * @param[in] rid_ext_id The rid RTP extension ID to set, if any
+ * @param[in] framemarking_ext_id The frame marking RTP extension ID to set, if any
  * @param[in] ssrcs The list of simulcast SSRCs to update, if any
  * @param[in] rids The list of rids to update, if any (items will be allocated) */
-void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, uint32_t *ssrcs, char **rids);
+void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, int *framemarking_ext_id, uint32_t *ssrcs, char **rids);
 
 /*! \brief Process an RTP packet, and decide whether this should be relayed or not, updating the context accordingly
  * \note Calling this method resets the \c changed_substream , \c changed_temporal and \c need_pli


### PR DESCRIPTION
While Chrome has supported H.264 simulcast for a while, temporal scalability support as in VP8 was missing, as there wasn't a way to convey that information to SFUs. In order to do that, [frame marking](https://bugs.chromium.org/p/webrtc/issues/detail_ezt?id=10579) support would be needed instead, that in the meanwhile has been [implemented](https://webrtc-review.googlesource.com/c/src/+/86200).

As such, to complement our existing simulcast support, this patch now uses the [frame marking RTP extension](https://tools.ietf.org/html/draft-ietf-avtext-framemarking-07) when H.264 simulcast is used to involve temporal scalability as well. The demos using simulcast have been updated to now show the temporal scalability buttons for H.264 as well: notice, though, that if you're using an older version of Chrome, those buttons will do nothing at all of course. Besides, you most likely need rid-based simulcasting for this to work (`?simulcast2=true` in the demos query string) for this to work.

Planning to merge soon, so as usual feedback is welcome.