### PR TITLE
Add version of dependencies to server info (Janus and Admin API)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -195,6 +195,7 @@ version.c: FORCE | $(dir_target)
 	echo "$(build_date)" | awk 'BEGIN {} {print "const char *janus_build_git_time = \""$$0"\";"} END {} ' >> version.c
 	echo "$(JANUS_VERSION)" | awk 'BEGIN {} {print "int janus_version = "$$0";"} END {} ' >> version.c
 	echo "$(JANUS_VERSION_STRING)" | awk 'BEGIN {} {print "const char *janus_version_string = \""$$0"\";"} END {} ' >> version.c
+	pkg-config --modversion nice | awk 'BEGIN {} {print "const char *libnice_version_string = \""$$0"\";"} END {} ' >> version.c
 
 $(dir_present):
 	`which git` rev-parse HEAD | awk 'BEGIN {print "#include \"version.h\""} {print "const char *janus_build_git_sha = \"" $$0"\";"} END {}' > version.c

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -105,6 +105,12 @@ general: {
 									# application in the related Janus API responses
 									# or events; in case you need them to be in the
 									# Janus API too, set this property to 'true'.
+	#hide_dependencies = true		# By default, a call to the "info" endpoint of
+									# either the Janus or Admin API now also returns
+									# the versions of the main dependencies (e.g.,
+									# libnice, libsrtp, which crypto library is in
+									# use and so on). Should you want that info not
+									# to be disclose, set 'hide_dependencies' to true.
 }
 
 # Certificate and key to use for DTLS (and passphrase if needed). If missing,

--- a/dtls.c
+++ b/dtls.c
@@ -323,6 +323,10 @@ error:
 	return -1;
 }
 
+/* Versioning info ( */
+const char *janus_get_ssl_version(void) {
+	return OPENSSL_VERSION_TEXT;
+}
 
 /* DTLS-SRTP initialization */
 gint janus_dtls_srtp_init(const char *server_pem, const char *server_key, const char *password, guint timeout) {

--- a/dtls.h
+++ b/dtls.h
@@ -24,6 +24,10 @@
 #include "refcount.h"
 #include "dtls-bio.h"
 
+/*! \brief Helper method to return info on the crypto library and its version
+ * @returns A pointer to a static string with the version */
+const char *janus_get_ssl_version(void);
+
 /*! \brief DTLS stuff initialization
  * @param[in] server_pem Path to the certificate to use
  * @param[in] server_key Path to the key to use

--- a/janus.c
+++ b/janus.c
@@ -232,6 +232,8 @@ static gboolean accept_new_sessions = TRUE;
 #define DEFAULT_CANDIDATES_TIMEOUT		45
 static uint candidates_timeout = DEFAULT_CANDIDATES_TIMEOUT;
 
+/* By default we list dependencies details, but some may prefer not to */
+static gboolean hide_dependencies = FALSE;
 
 /* Information */
 static json_t *janus_info(const char *transaction) {
@@ -282,20 +284,22 @@ static json_t *janus_info(const char *transaction) {
 	json_object_set_new(info, "event_handlers", janus_events_is_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "opaqueid_in_api", janus_is_opaqueid_in_api_enabled() ? json_true() : json_false());
 	/* Dependencies */
-	json_t *deps = json_object();
-	char glib2_version[20];
-	g_snprintf(glib2_version, sizeof(glib2_version), "%d.%d.%d", glib_major_version, glib_minor_version, glib_micro_version);
-	json_object_set_new(deps, "glib2", json_string(glib2_version));
-	json_object_set_new(deps, "jansson", json_string(JANSSON_VERSION));
-	json_object_set_new(deps, "libnice", json_string(libnice_version_string));
-	json_object_set_new(deps, "libsrtp", json_string(srtp_get_version_string()));
-#ifdef HAVE_TURNRESTAPI
-	curl_version_info_data *curl_version = curl_version_info(CURLVERSION_NOW);
-	if(curl_version && curl_version->version)
-		json_object_set_new(deps, "libcurl", json_string(curl_version->version));
-#endif
-	json_object_set_new(deps, "crypto", json_string(janus_get_ssl_version()));
-	json_object_set_new(info, "dependencies", deps);
+	if(!hide_dependencies) {
+		json_t *deps = json_object();
+		char glib2_version[20];
+		g_snprintf(glib2_version, sizeof(glib2_version), "%d.%d.%d", glib_major_version, glib_minor_version, glib_micro_version);
+		json_object_set_new(deps, "glib2", json_string(glib2_version));
+		json_object_set_new(deps, "jansson", json_string(JANSSON_VERSION));
+		json_object_set_new(deps, "libnice", json_string(libnice_version_string));
+		json_object_set_new(deps, "libsrtp", json_string(srtp_get_version_string()));
+	#ifdef HAVE_TURNRESTAPI
+		curl_version_info_data *curl_version = curl_version_info(CURLVERSION_NOW);
+		if(curl_version && curl_version->version)
+			json_object_set_new(deps, "libcurl", json_string(curl_version->version));
+	#endif
+		json_object_set_new(deps, "crypto", json_string(janus_get_ssl_version()));
+		json_object_set_new(info, "dependencies", deps);
+	}
 	/* Available transports */
 	json_t *t_data = json_object();
 	if(transports && g_hash_table_size(transports) > 0) {
@@ -3926,6 +3930,11 @@ gint main(int argc, char *argv[])
 	} else {
 		janus_recorder_init(FALSE, NULL);
 	}
+
+	/* Check if we should hide dependencies in "info" requests */
+	item = janus_config_get(config, config_general, janus_config_type_item, "hide_dependencies");
+	if(item && item->value && janus_is_true(item->value))
+		hide_dependencies = TRUE;
 
 	/* Setup ICE stuff (e.g., checking if the provided STUN server is correct) */
 	char *stun_server = NULL, *turn_server = NULL;

--- a/version.h
+++ b/version.h
@@ -3,13 +3,13 @@
  * \copyright GNU General Public License v3
  * \brief  Janus GitHub versioning (headers)
  * \details This exposes a quick an easy way to display the commit the
- * compiled version of Janus implements, and when it has been built. It 
+ * compiled version of Janus implements, and when it has been built. It
  * is based on this excellent comment: http://stackoverflow.com/a/1843783
  *
  * \ingroup core
  * \ref core
  */
- 
+
 #ifndef _JANUS_VERSION_H
 #define _JANUS_VERSION_H
 
@@ -17,5 +17,8 @@ extern int janus_version;
 extern const char *janus_version_string;
 extern const char *janus_build_git_time;
 extern const char *janus_build_git_sha;
+
+/* Dependencies (those we can't get programmatically) */
+const char *libnice_version_string;
 
 #endif


### PR DESCRIPTION
Since most of the times, when debugging, we ask people which libraries they're using, which version, and so on, we thought about making this process more straightforward. This patch adds the main dependencies and their versions in the information returned by a `"janus":"info"`, `/janus/info` or `/admin/info` request. In my setup, it looks something like this:

```
   [..]
   "dependencies": {
      "glib2": "2.56.4",
      "jansson": "2.11",
      "libnice": "0.1.14.1",
      "libsrtp": "libsrtp2 2.1.0",
      "libcurl": "7.59.0",
      "crypto": "OpenSSL 1.1.0 (compatible; BoringSSL)"
   },
   [..]
```

Very simply, a new JSON object before the list of modules, listing the version of the main libraries. Most of the libraries have a programmatic way of exposing this information: libnice doesn't though (at least not that I'm aware of) so for that I had to add an external `pkg-config` call in the Makefile to have it added to our `version.c` generated file.

For the moment this only lists the main libraries, but in the future it might be useful to have the same done in all plugins as well, e.g., via a new methods plugins might expose to export their internal dependencies, if any.

Unless you have reasons why this shouldn't be done (breaks something? info should not be exposed?) I'm planning to merge soon, so "be quick or be dead" :wink: .