### PR TITLE
New experimental debug mode with disabled WebRTC encryption

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -195,6 +195,7 @@ version.c: FORCE | $(dir_target)
 	echo "$(build_date)" | awk 'BEGIN {} {print "const char *janus_build_git_time = \""$$0"\";"} END {} ' >> version.c
 	echo "$(JANUS_VERSION)" | awk 'BEGIN {} {print "int janus_version = "$$0";"} END {} ' >> version.c
 	echo "$(JANUS_VERSION_STRING)" | awk 'BEGIN {} {print "const char *janus_version_string = \""$$0"\";"} END {} ' >> version.c
+	pkg-config --modversion nice | awk 'BEGIN {} {print "const char *libnice_version_string = \""$$0"\";"} END {} ' >> version.c
 
 $(dir_present):
 	`which git` rev-parse HEAD | awk 'BEGIN {print "#include \"version.h\""} {print "const char *janus_build_git_sha = \"" $$0"\";"} END {}' > version.c

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -105,6 +105,12 @@ general: {
 									# application in the related Janus API responses
 									# or events; in case you need them to be in the
 									# Janus API too, set this property to 'true'.
+	#hide_dependencies = true		# By default, a call to the "info" endpoint of
+									# either the Janus or Admin API now also returns
+									# the versions of the main dependencies (e.g.,
+									# libnice, libsrtp, which crypto library is in
+									# use and so on). Should you want that info not
+									# to be disclose, set 'hide_dependencies' to true.
 }
 
 # Certificate and key to use for DTLS (and passphrase if needed). If missing,

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -111,6 +111,11 @@ general: {
 									# libnice, libsrtp, which crypto library is in
 									# use and so on). Should you want that info not
 									# to be disclose, set 'hide_dependencies' to true.
+
+		# The following is ONLY useful when debugging RTP/RTCP packets,
+		# e.g., to look at unencrypted live traffic with a browser. By
+		# default it is obviously disabled, as WebRTC mandates encryption.
+	#no_webrtc_encryption = true
 }
 
 # Certificate and key to use for DTLS (and passphrase if needed). If missing,

--- a/dtls.c
+++ b/dtls.c
@@ -903,6 +903,8 @@ done:
 }
 
 void janus_dtls_srtp_send_alert(janus_dtls_srtp *dtls) {
+	if(!dtls)
+		return;
 	/* Send alert */
 	janus_refcount_increase(&dtls->ref);
 	if(dtls != NULL && dtls->ssl != NULL) {

--- a/dtls.c
+++ b/dtls.c
@@ -323,6 +323,10 @@ error:
 	return -1;
 }
 
+/* Versioning info ( */
+const char *janus_get_ssl_version(void) {
+	return OPENSSL_VERSION_TEXT;
+}
 
 /* DTLS-SRTP initialization */
 gint janus_dtls_srtp_init(const char *server_pem, const char *server_key, const char *password, guint timeout) {

--- a/dtls.h
+++ b/dtls.h
@@ -24,6 +24,10 @@
 #include "refcount.h"
 #include "dtls-bio.h"
 
+/*! \brief Helper method to return info on the crypto library and its version
+ * @returns A pointer to a static string with the version */
+const char *janus_get_ssl_version(void);
+
 /*! \brief DTLS stuff initialization
  * @param[in] server_pem Path to the certificate to use
  * @param[in] server_key Path to the key to use

--- a/janus.1
+++ b/janus.1
@@ -121,6 +121,9 @@ Enable token-based authentication for all requests (default=off)
 .TP
 .BR \-e ", " \-\-event-handlers
 Enable event handlers (default=off)
+.TP
+.BR \-w ", " \-\-no-webrtc-encryption
+Disable WebRTC encryption, so no DTLS or SRTP (only for debugging!) (default=off)
 .SH EXAMPLES
 \fBjanus\fR \- Launch Janus with all options from configurations files
 .TP

--- a/janus.c
+++ b/janus.c
@@ -25,6 +25,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <poll.h>
+#ifdef HAVE_TURNRESTAPI
+#include <curl/curl.h>
+#endif
 
 #include "janus.h"
 #include "version.h"
@@ -229,6 +232,8 @@ static gboolean accept_new_sessions = TRUE;
 #define DEFAULT_CANDIDATES_TIMEOUT		45
 static uint candidates_timeout = DEFAULT_CANDIDATES_TIMEOUT;
 
+/* By default we list dependencies details, but some may prefer not to */
+static gboolean hide_dependencies = FALSE;
 
 /* Information */
 static json_t *janus_info(const char *transaction) {
@@ -278,6 +283,23 @@ static json_t *janus_info(const char *transaction) {
 	json_object_set_new(info, "auth_token", janus_auth_is_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "event_handlers", janus_events_is_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "opaqueid_in_api", janus_is_opaqueid_in_api_enabled() ? json_true() : json_false());
+	/* Dependencies */
+	if(!hide_dependencies) {
+		json_t *deps = json_object();
+		char glib2_version[20];
+		g_snprintf(glib2_version, sizeof(glib2_version), "%d.%d.%d", glib_major_version, glib_minor_version, glib_micro_version);
+		json_object_set_new(deps, "glib2", json_string(glib2_version));
+		json_object_set_new(deps, "jansson", json_string(JANSSON_VERSION));
+		json_object_set_new(deps, "libnice", json_string(libnice_version_string));
+		json_object_set_new(deps, "libsrtp", json_string(srtp_get_version_string()));
+	#ifdef HAVE_TURNRESTAPI
+		curl_version_info_data *curl_version = curl_version_info(CURLVERSION_NOW);
+		if(curl_version && curl_version->version)
+			json_object_set_new(deps, "libcurl", json_string(curl_version->version));
+	#endif
+		json_object_set_new(deps, "crypto", json_string(janus_get_ssl_version()));
+		json_object_set_new(info, "dependencies", deps);
+	}
 	/* Available transports */
 	json_t *t_data = json_object();
 	if(transports && g_hash_table_size(transports) > 0) {
@@ -3912,6 +3934,11 @@ gint main(int argc, char *argv[])
 	} else {
 		janus_recorder_init(FALSE, NULL);
 	}
+
+	/* Check if we should hide dependencies in "info" requests */
+	item = janus_config_get(config, config_general, janus_config_type_item, "hide_dependencies");
+	if(item && item->value && janus_is_true(item->value))
+		hide_dependencies = TRUE;
 
 	/* Setup ICE stuff (e.g., checking if the provided STUN server is correct) */
 	char *stun_server = NULL, *turn_server = NULL;

--- a/janus.c
+++ b/janus.c
@@ -232,12 +232,9 @@ static gboolean accept_new_sessions = TRUE;
 #define DEFAULT_CANDIDATES_TIMEOUT		45
 static uint candidates_timeout = DEFAULT_CANDIDATES_TIMEOUT;
 
-<<<<<<< HEAD
 /* By default we list dependencies details, but some may prefer not to */
 static gboolean hide_dependencies = FALSE;
 
-=======
->>>>>>> fddef3266ebad895dda8e6af9737dd22bae6320a
 /* WebRTC encryption is obviously enabled by default. In the rare cases
  * you want to disable it for debugging purposes, though, you can do
  * that either via command line (-w) or in the main configuration file */

--- a/janus.c
+++ b/janus.c
@@ -235,6 +235,14 @@ static uint candidates_timeout = DEFAULT_CANDIDATES_TIMEOUT;
 /* By default we list dependencies details, but some may prefer not to */
 static gboolean hide_dependencies = FALSE;
 
+/* WebRTC encryption is obviously enabled by default. In the rare cases
+ * you want to disable it for debugging purposes, though, you can do
+ * that either via command line (-w) or in the main configuration file */
+static gboolean webrtc_encryption = TRUE;
+gboolean janus_is_webrtc_encryption_enabled(void) {
+	return webrtc_encryption;
+}
+
 /* Information */
 static json_t *janus_info(const char *transaction) {
 	/* Prepare a summary on the Janus instance */
@@ -283,6 +291,8 @@ static json_t *janus_info(const char *transaction) {
 	json_object_set_new(info, "auth_token", janus_auth_is_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "event_handlers", janus_events_is_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "opaqueid_in_api", janus_is_opaqueid_in_api_enabled() ? json_true() : json_false());
+	if(!webrtc_encryption)
+		json_object_set_new(info, "webrtc_encryption", json_false());
 	/* Dependencies */
 	if(!hide_dependencies) {
 		json_t *deps = json_object();
@@ -3699,6 +3709,9 @@ gint main(int argc, char *argv[])
 	if(args_info.token_auth_secret_given) {
 		janus_config_add(config, config_general, janus_config_item_create("token_auth_secret", args_info.token_auth_secret_arg));
 	}
+	if(args_info.no_webrtc_encryption_given) {
+		janus_config_add(config, config_general, janus_config_item_create("no_webrtc_encryption", "yes"));
+	}
 	if(args_info.cert_pem_given) {
 		janus_config_add(config, config_certs, janus_config_item_create("cert_pem", args_info.cert_pem_arg));
 	}
@@ -3786,6 +3799,13 @@ gint main(int argc, char *argv[])
 		lock_debug = janus_is_true(item->value);
 	if(lock_debug) {
 		JANUS_PRINT("Lock/mutex debugging is enabled\n");
+	}
+
+	/* First of all, let's check if we're disabling WebRTC encryption for debugging purposes */
+	item = janus_config_get(config, config_general, janus_config_type_item, "no_webrtc_encryption");
+	if(item && item->value && janus_is_true(item->value)) {
+		JANUS_LOG(LOG_WARN, "Disabling WebRTC encryption: *THIS IS ONLY ACCEPTABLE WHEN DEBUGGING!*\n");
+		webrtc_encryption = FALSE;
 	}
 
 	/* Any IP/interface to enforce/ignore? */

--- a/janus.ggo
+++ b/janus.ggo
@@ -35,3 +35,4 @@ option "apisecret" a "API secret all requests need to pass in order to be accept
 option "token-auth" A "Enable token-based authentication for all requests" flag off
 option "token-auth-secret" - "Secret to verify HMAC-signed tokens with, to be used with -A" string typestr="randomstring" optional
 option "event-handlers" e "Enable event handlers" flag off
+option "no-webrtc-encryption" w "Disable WebRTC encryption, so no DTLS or SRTP (only for debugging!)" flag off

--- a/janus.h
+++ b/janus.h
@@ -253,5 +253,13 @@ void janus_set_public_ip(const char *ip);
 /*! \brief Helper method to check whether the server is being shut down */
 gint janus_is_stopping(void);
 
+/*! \brief Helper method to check whether WebRTC encryption is (as it should) enabled
+ * \note This is required by the ICE and DTLS portions of the code to decide whether
+ * to do the DTLS handshake, and whether SRTP encryption is required. Disabling the
+ * WebRTC encryption is supposed to be a debugging tool you can use with the Chrome
+ * setting with the same name, \c --disable-webrtc-encryption , and you should
+ * NEVER use it otherwise (it would simply not work with regular WebRTC endpoints).
+ * @returns TRUE if WebRTC encryption is enabled (the default), and FALSE otherwise */
+gboolean janus_is_webrtc_encryption_enabled(void);
 
 #endif

--- a/version.h
+++ b/version.h
@@ -3,13 +3,13 @@
  * \copyright GNU General Public License v3
  * \brief  Janus GitHub versioning (headers)
  * \details This exposes a quick an easy way to display the commit the
- * compiled version of Janus implements, and when it has been built. It 
+ * compiled version of Janus implements, and when it has been built. It
  * is based on this excellent comment: http://stackoverflow.com/a/1843783
  *
  * \ingroup core
  * \ref core
  */
- 
+
 #ifndef _JANUS_VERSION_H
 #define _JANUS_VERSION_H
 
@@ -17,5 +17,8 @@ extern int janus_version;
 extern const char *janus_version_string;
 extern const char *janus_build_git_time;
 extern const char *janus_build_git_sha;
+
+/* Dependencies (those we can't get programmatically) */
+const char *libnice_version_string;
 
 #endif


### PR DESCRIPTION
While we have native `.pcap` support in Janus, as explained in this [blog post](https://www.meetecho.com/blog/capturing-webrtc-traffic-in-janus/) I wrote some time ago, to look at unencrypted traffic for debugging purposes, sometimes it may be useful to do the same thing in a live session. Chrome unstable/canary has a `--disable-webrtc-encryption` command line flag that allows it to disable the WebRTC encryption layers (DTLS and SRTP) but keep all the rest, in order to exchange RTP/RTCP packets in the clear. Anyway, so far this couldn't interoperate with Janus, as we require all the layers, including encryption, to be active.

This patch tries to fix that, adding an experimental debug mode to allow Janus to act the same way too. If you pass the `-w` or `--no-webrtc-encryption` parameter on the command line, or set `no_webrtc_encryption=true` in `janus.jcfg`, then Janus will disable DTLS and SRTP, and do plain RTP/RTCP exactly as Chrome with the property introduced before enabled. Of course, if you enable that mode, regular WebRTC sessions will _NOT_ work, as we'll skip the DTLS negotiation and handshake entirely. Besides, notice that datachannels won't be usable either, as they do require DTLS as an application level transport protocol.

If you don't pass anything (the default) Janus should work exactly as it has always worked so far.

I tested this briefly with EchoTest and VideoRoom and it seems to do its job. I didn't test much more and to be honest I wouldn't really care if this mode is unstable or not, as it's really meant just for debugging under particular circumstances. Anyway, please let me know if you think this is useful, and if you have any feedback.