### PR TITLE
Make it possible to set RTSP client port range in the streaming config

### DIFF
--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -85,7 +85,7 @@ general: {
                                                 # only if this key is provided in the request
 	#events = false                             # Whether events should be sent to event
                                                 # handlers (default=true)
-	#rtsp_client_port_range = "10000-10100"     # If set, mountpoints of RTSP type
+	#rtsp_client_port_range = "41000-41100"     # If set, mountpoints of RTSP type
 												# will only use these UDP ports to establish
 												# client connections. Random available 
 												# free ports will be used otherwise.

--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -81,10 +81,14 @@
 #}
 
 general: {
-	#admin_key = "supersecret"		# If set, mountpoints can be created via API
-									# only if this key is provided in the request
-	#events = false					# Whether events should be sent to event
-									# handlers (default=true)
+	#admin_key = "supersecret"                  # If set, mountpoints can be created via API
+                                                # only if this key is provided in the request
+	#events = false                             # Whether events should be sent to event
+                                                # handlers (default=true)
+	#rtsp_client_port_range = "10000-10100"     # If set, mountpoints of RTSP type
+												# will only use these UDP ports to establish
+												# client connections. Random available 
+												# free ports will be used otherwise.
 }
 
 gstreamer-sample: {

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -5129,6 +5129,10 @@ static int janus_streaming_rtsp_parse_sdp(const char *buffer, const char *name, 
 		}
 
 		if(is_port_found) {
+			if(!should_select_random_port && port + 1 > max_port) {
+				JANUS_LOG(LOG_ERR, "[%s] Bind failed for port range %u-%u\n", name, min_port, max_port);
+				return -1;
+			}
 			JANUS_LOG(LOG_INFO, "[%s] Will use client ports %u and %u\n", name, port, port+1);
 			break;
 		}
@@ -5136,7 +5140,7 @@ static int janus_streaming_rtsp_parse_sdp(const char *buffer, const char *name, 
 		if(!should_select_random_port) {
 			port += 2;
 			if(port >= max_port) {
-				JANUS_LOG(LOG_ERR, "[%s] Bind failed for port range %u-%u...\n", name, min_port, max_port);
+				JANUS_LOG(LOG_ERR, "[%s] Bind failed for port range %u-%u\n", name, min_port, max_port);
 				return -1;
 			}
 		}

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -5112,6 +5112,9 @@ static int janus_streaming_rtsp_parse_sdp(const char *buffer, const char *name, 
 					} else {
 						port = sin_port;
 					}
+				} else if(port + 1 > max_port) {
+					close(fds->fd);
+					is_port_found = FALSE;
 				}
 				
 				if(is_port_found) {
@@ -5129,10 +5132,6 @@ static int janus_streaming_rtsp_parse_sdp(const char *buffer, const char *name, 
 		}
 
 		if(is_port_found) {
-			if(!should_select_random_port && port + 1 > max_port) {
-				JANUS_LOG(LOG_ERR, "[%s] Bind failed for port range %u-%u\n", name, min_port, max_port);
-				return -1;
-			}
 			JANUS_LOG(LOG_INFO, "[%s] Will use client ports %u and %u\n", name, port, port+1);
 			break;
 		}

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -5104,14 +5104,17 @@ static int janus_streaming_rtsp_parse_sdp(const char *buffer, const char *name, 
 				}
 				is_port_found = FALSE;
 			} else {
-				uint16_t sin_port = ntohs(address.sin_port);
 				if(should_select_random_port) {
-					port = sin_port;
+					uint16_t sin_port = ntohs(address.sin_port);
+					if(sin_port & 1) {
+						close(fds->fd);
+						is_port_found = FALSE;
+					} else {
+						port = sin_port;
+					}
 				}
-				if(sin_port & 1) {
-					close(fds->fd);
-					is_port_found = FALSE;
-				} else {
+				
+				if(is_port_found) {
 					fds->rtcp_fd = janus_streaming_create_fd(port+1, mcast, iface, media, media, name);
 					if(fds->rtcp_fd < 0) {
 						close(fds->fd);

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -5098,7 +5098,7 @@ static int janus_streaming_rtsp_parse_sdp(const char *buffer, const char *name, 
 		} else {
 			if(getsockname(fds->fd, (struct sockaddr *)&address, &len) < 0) {
 				close(fds->fd);
-				if (should_select_random_port) {
+				if(should_select_random_port) {
 					JANUS_LOG(LOG_ERR, "[%s] Bind failed for %s...\n", name, media);
 					return -1;
 				}


### PR DESCRIPTION
In order to fine-tune a local firewall it is necessary to have a possibility to set port ranges for RTSP connections. Currently these ports are chosen randomly. We've added a new general setting into streaming config called `rtsp_client_port_range`. The setting accepts valid port ranges and if set then RTSP listening ports will be chosen from this range. In case the setting is not present in the streaming config then the server behaviour is preserved.

We can also observe that janus always opens one random UDP port on startup for both IPv4 and IPv6 (the latter is always +1 greater), although we didn't see any particular `bind` call in the code where this might be happening. All plugins except of streaming and echo are disabled. @lminiero Could you please give us a hint on where to look for?