### PR TITLE
Added status messages to MQTT transport

### DIFF
--- a/conf/janus.transport.mqtt.jcfg.sample
+++ b/conf/janus.transport.mqtt.jcfg.sample
@@ -35,3 +35,17 @@ admin: {
 	publish_topic = "from-janus-admin"	# Topic for outgoing admin messages
 	#publish_qos = 1					# QoS for outgoing admin messages
 }
+
+status: {
+	enabled = false 			# Whether status messages must be enabled (default: false)
+
+	# Initial message sent to status topic. Nothing is being sent if not set.
+	#connect_message = "{\"online\": true}"
+
+	# Message sent after disconnect or as LWT. Nothing is being sent if not set.
+	#disconnect_message = "{\"online\": false}"
+
+	#topic = "status"			# Status topic (default: "status")
+	#qos = 1			      	# QoS for status messages (default: 1)
+	#retain = false		    # Whether status messages should be retained (default: false)
+}

--- a/events/janus_mqttevh.c
+++ b/events/janus_mqttevh.c
@@ -698,7 +698,7 @@ static int janus_mqttevh_init(const char *config_path) {
 			ctx->will.qos = atoi(will_qos_item->value);
 		}
 
-		/* Using the topic for LWT as configured for publish and prefixed with JANUS_MQTTEVH_STATUS_TOPIC. */
+		/* Using the topic for LWT as configured for publish and suffixed with JANUS_MQTTEVH_STATUS_TOPIC. */
 		char will_topic_buf[512];
 		snprintf(will_topic_buf, sizeof(will_topic_buf), "%s/%s", ctx->publish.topic, JANUS_MQTTEVH_STATUS_TOPIC);
 		ctx->will.topic = g_strdup(will_topic_buf);


### PR DESCRIPTION
This PR adds optional sending of connect and disconnect messages to MQTT transport plugin.

The reason why the same functionality in MQTT EVH plugin is not enough is that event handler plugins are being loaded before other plugins. So it sends the connect status message before the transport is ready which creates a race condition: when another service that sees the status and immediately sends a message janus may skip it if the transport is not ready yet.

The configuration is slightly different from the EVH plugin's. Personally I think it's more clear.

LWT message is also being sent and there's no option to disable it because I can't imagine any use case when one needs to send a regular disconnect message but doesn't need LWT.