### PR TITLE
Set ICE remote credentials when receiving remote SDP, instead of later

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -3107,12 +3107,6 @@ void janus_ice_setup_remote_candidates(janus_ice_handle *handle, guint stream_id
 		JANUS_LOG(LOG_VERB, "[%"SCNu64"]   Password:   %s\n", handle->handle_id, c->password);
 		gsc = gsc->next;
 	}
-	if(rufrag && rpwd) {
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"]  Setting remote credentials...\n", handle->handle_id);
-		if(!nice_agent_set_remote_credentials(handle->agent, stream_id, rufrag, rpwd)) {
-			JANUS_LOG(LOG_ERR, "[%"SCNu64"]  failed to set remote credentials!\n", handle->handle_id);
-		}
-	}
 	guint added = nice_agent_set_remote_candidates(handle->agent, stream_id, component_id, component->candidates);
 	if(added < g_slist_length(component->candidates)) {
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to set remote candidates :-( (added %u, expected %u)\n",

--- a/sdp.c
+++ b/sdp.c
@@ -364,6 +364,13 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 				rfingerprint = NULL;
 				return -2;
 			}
+			/* If we received the ICE credentials for the first time, enforce them */
+			if(ruser && !stream->ruser && rpass && !stream->rpass) {
+				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Setting remote credentials...\n", handle->handle_id);
+				if(!nice_agent_set_remote_credentials(handle->agent, handle->stream_id, ruser, rpass)) {
+					JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to set remote credentials!\n", handle->handle_id);
+				}
+			} else
 			/* If this is a renegotiation, check if this is an ICE restart */
 			if((ruser && stream->ruser && strcmp(ruser, stream->ruser)) ||
 					(rpass && stream->rpass && strcmp(rpass, stream->rpass))) {


### PR DESCRIPTION
The subject basically says it all. So far we've been setting the remote ICE credentials, using `nice_agent_set_remote_credentials()`, only when calling `janus_ice_setup_remote_candidates()`, that is when we believe the ICE checks should start. Anyway, it makes more sense to set them as soon as we're aware of them, that is when we receive the first remote SDP offer or answer, which should also help in case of early prflx candidates.

The only reason this is a pull request and not a direct commit is that I want to make sure it doesn't break anything. There may have been a reason why we were delaying setting the remote credentials to a later stage, but I couldn't find anything in my notes: I've checked with a few of our demos and everything seems to work as expected, but if you can make a quick test as well and let me know that would help. Planning to merge soon if I get no objection.