### PR TITLE
Getting 'complteted:true' is received start ICE check if not started already 

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -713,6 +713,13 @@ gint janus_ice_trickle_parse(janus_ice_handle *handle, json_t *candidate, const 
 	if(!json_is_object(candidate) || json_object_get(candidate, "completed") != NULL) {
 		JANUS_LOG(LOG_VERB, "No more remote candidates for handle %"SCNu64"!\n", handle->handle_id);
 		janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALL_TRICKLES);
+		
+		if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_START)) {
+			JANUS_LOG(LOG_VERB, "[%"SCNu64"] No more remote candidates for handle and connectivity check has not started yet! Sending connectivity checks now...\n", handle->handle_id);
+			janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_START);
+			janus_ice_setup_remote_candidates(handle, handle->stream_id, 1);
+		}
+
 	} else {
 		/* Handle remote candidate */
 		json_t *mid = json_object_get(candidate, "sdpMid");


### PR DESCRIPTION
If trickle with 'complteted:true' is received  start ICE check  not started already