### PR TITLE
New Admin API method to make synchronous requests to plugins

### DIFF
--- a/html/admin.html
+++ b/html/admin.html
@@ -41,6 +41,7 @@
 					<li role="presentation" class="active"><a href="#home" aria-controls="home" role="tab" data-toggle="tab">Home</a></li>
 					<li role="presentation" class="disabled"><a href="#serverinfo" aria-controls="serverinfo" role="tab" data-toggle="tab">Server Info</a></li>
 					<li role="presentation" class="disabled"><a href="#settings" aria-controls="settings" role="tab" data-toggle="tab">Settings</a></li>
+					<li role="presentation" class="disabled"><a href="#plugins" aria-controls="plugins" role="tab" data-toggle="tab">Plugins</a></li>
 					<li role="presentation" class="disabled"><a href="#handlesinfo" aria-controls="handlesinfo" role="tab" data-toggle="tab">Handles</a></li>
 					<li role="presentation" class="disabled"><a href="#tokens" aria-controls="tokens" role="tab" data-toggle="tab">Stored Tokens</a></li>
 				</ul>
@@ -61,6 +62,9 @@
 						<p>The <code>Settings</code> tab instead allows you to inspect a
 						few of the current settings in Janus (e.g., debug level and so on)
 						and provides you with a way to change them dynamically.</p>
+						<p>The <code>Plugins</code> tab presents the list of media plugins
+						available in this Janus instance, and allows you to interact with
+						them, assuming they implement the <code>handle_admin_message</code> API.</p>
 						<p>The <code>Handles</code> tab allows you to browse the currently active sessions
 						and handles in Janus. Selecting a specific handle will provide you
 						with all the current info related to it, including plugin it is
@@ -119,6 +123,26 @@
 						<div>
 							<table class="table table-striped" id="server-settings">
 							</table>
+						</div>
+					</div>
+					<div role="tabpanel" class="tab-pane fade" id="plugins">
+						<h4>Plugins</h4>
+						<div class="row">
+							<div class="col-md-3">
+								<table class="table" id="plugins-list">
+								</table>
+							</div>
+							<div id="plugin-message" class="col-md-9 hide">
+								<div class="row">
+									<h5>Request</h5>
+									<table class="table" id="plugin-request">
+									</table>
+								</div>
+								<div class="row">
+									<h5>Response</h5>
+									<pre id="plugin-response"></pre>
+								</div>
+							</div>
 						</div>
 					</div>
 					<div role="tabpanel" class="tab-pane fade" id="handlesinfo">

--- a/html/admin.html
+++ b/html/admin.html
@@ -84,37 +84,24 @@
 							<table class="table table-striped" id="server-details">
 							</table>
 						</div>
+						<h4>Dependencies</h4>
+						<div>
+							<table class="table table-striped" id="server-deps">
+							</table>
+						</div>
 						<h4>Plugins</h4>
 						<div>
 							<table class="table table-striped" id="server-plugins">
-								<tr>
-									<th>Name</th>
-									<th>Author</th>
-									<th>Description</th>
-									<th>Version</th>
-								</tr>
 							</table>
 						</div>
 						<h4>Transports</h4>
 						<div>
 							<table class="table table-striped" id="server-transports">
-								<tr>
-									<th>Name</th>
-									<th>Author</th>
-									<th>Description</th>
-									<th>Version</th>
-								</tr>
 							</table>
 						</div>
 						<h4>Event handlers</h4>
 						<div>
 							<table class="table table-striped" id="server-handlers">
-								<tr>
-									<th>Name</th>
-									<th>Author</th>
-									<th>Description</th>
-									<th>Version</th>
-								</tr>
 							</table>
 						</div>
 					</div>

--- a/html/admin.js
+++ b/html/admin.js
@@ -15,7 +15,7 @@ var secret = "";
 var session = null;		// Selected session
 var handle = null;		// Selected handle
 
-var plugins = [];
+var plugins = [], pluginsIndex = [];
 var settings = {};
 
 var currentHandle = null;
@@ -124,6 +124,19 @@ function updateServerInfo() {
 					'	<td>' + v.description + '</td>' +
 					'	<td>' + v.version_string + '</td>' +
 					'</tr>');
+				pluginsIndex.push(p);
+				$('#plugins-list').append(
+					'<a id="plugin-'+(pluginsIndex.length-1)+'" href="#" class="list-group-item">'+p+'</a>'
+				);
+				$('#plugin-'+(pluginsIndex.length-1)).click(function(event) {
+					event.preventDefault();
+					var pi = parseInt($(this).attr('id').split('plugin-')[1]);
+					var plugin = pluginsIndex[pi];
+					console.log("Selected plugin:", plugin);
+					$('#plugins-list a').removeClass('active');
+					$('#plugin-'+pi).addClass('active');
+					resetPluginRequest();
+				});
 			}
 			for(var t in transportsJson) {
 				var v = transportsJson[t];
@@ -485,6 +498,130 @@ function sendSettingsRequest(request) {
 		dataType: "json"
 	});
 }
+
+// Plugins
+function resetPluginRequest() {
+	$('#plugin-request').empty().append(
+		'<tr style="background: #f9f9f9;">' +
+		'	<th width="25%">Name</th>' +
+		'	<th width="25%">Value</th>' +
+		'	<th width="25%">Type</th>' +
+		'	<th></th>' +
+		'</tr>' +
+		'<tr>' +
+		'	<td><i id="addattr" class="fa fa-plus-circle" style="cursor: pointer;"></i></td>' +
+		'	<td></td>' +
+		'	<td></td>' +
+		'	<td><button id="sendmsg" type="button" class="btn btn-xs btn-success pull-right">Send message</button></td>' +
+		'</tr>');
+	$('#addattr').click(addPluginMessageAttribute).click();
+	$('#sendmsg').click(function() {
+		var message = {};
+		var num = $('.pm-property').length;
+		for(var i=0; i<num; i++) {
+			var name = $('#attrname'+i).val();
+			if(name === '') {
+				bootbox.alert("Missing name in attribute #" + (i+1));
+				return;
+			}
+			if(message[name] !== null && message[name] !== undefined) {
+				bootbox.alert("Duplicate attribute '" + name + "'");
+				return;
+			}
+			var value = $('#attrvalue'+i).val();
+			if(value === '') {
+				bootbox.alert("Missing value in attribute #" + (i+1));
+				return;
+			}
+			var type = $('#attrtype'+i).val();
+			if(type === "number") {
+				value = parseInt(value);
+				if(isNaN(value)) {
+					bootbox.alert("Invalid value in attribute #" + (i+1) + " (expecting a number)");
+					return;
+				}
+			} else if(type === "boolean") {
+				if(value.toLowerCase() === "true") {
+					value = true;
+				} else if(value.toLowerCase() === "false") {
+					value = false;
+				} else {
+					bootbox.alert("Invalid value in attribute #" + (i+1) + " (expecting a boolean)");
+					return;
+				}
+			}
+			console.log("Type:", type);
+			message[name] = value;
+		}
+		sendPluginMessage($('#plugins-list .active').text(), message);
+	});
+	$('#plugin-message').removeClass('hide');
+}
+
+function addPluginMessageAttribute() {
+	var num = $('.pm-property').length;
+	$('#addattr').parent().parent().before(
+		'<tr>' +
+		'	<td><input type="text" id="attrname' + num + '" placeholder="Attribute name" onkeypress="return checkEnter(this, event);" style="width: 100%;" class="pm-property form-control input-sm"></td>' +
+		'	<td><input type="text" id="attrvalue' + num + '" placeholder="Attribute value" onkeypress="return checkEnter(this, event);" style="width: 100%;" class="form-control input-sm"></td>' +
+		'	<td>' +
+		'		<select id="attrtype' + num + '" class="form-control input-sm">' +
+		'			<option>string</option>' +
+		'			<option>number</option>' +
+		'			<option>boolean</option>' +
+		'		</select>' +
+		'	</td>' +
+		'	<td></td>' +
+		'</tr>'
+	);
+}
+
+function sendPluginMessage(plugin, message) {
+	console.log("Sending message to " + plugin + ":", message);
+	var request = {
+		janus: "message_plugin",
+		transaction: randomString(12),
+		admin_secret: secret,
+		plugin: plugin,
+		request: message
+	};
+	$.ajax({
+		type: 'POST',
+		url: server,
+		cache: false,
+		contentType: "application/json",
+		data: JSON.stringify(request),
+		success: function(json) {
+			if(json["janus"] !== "success") {
+				console.log("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+				var authenticate = (json["error"].code === 403);
+				if(!authenticate || (authenticate && !prompting && !alerted)) {
+					if(authenticate)
+						alerted = true;
+					bootbox.alert(json["error"].reason, function() {
+						if(authenticate) {
+							promptAccessDetails();
+							alerted = false;
+						}
+					});
+				}
+			}
+			$('#plugin-response').text(JSON.stringify(json, null, 4));
+		},
+		error: function(XMLHttpRequest, textStatus, errorThrown) {
+			console.log(textStatus + ": " + errorThrown);	// FIXME
+			if(!prompting && !alerted) {
+				alerted = true;
+				bootbox.alert("Couldn't contact the backend: is Janus down, or is the Admin/Monitor interface disabled?", function() {
+					promptAccessDetails();
+					alerted = false;
+				});
+			}
+		},
+		dataType: "json"
+	});
+}
+
 
 // Handles
 function updateSessions() {
@@ -1224,6 +1361,8 @@ function checkEnter(field, event) {
 	if(theCode == 13) {
 		if(field.id == 'token')
 			$('#addtoken').click();
+		else if(field.id.indexOf('attr') !== -1)
+			$('#sendmsg').click();
 		return false;
 	} else {
 		return true;

--- a/html/admin.js
+++ b/html/admin.js
@@ -79,6 +79,8 @@ function randomString(len) {
 
 // Server info
 function updateServerInfo() {
+	plugins = [];
+	pluginsIndex = [];
 	$.ajax({
 		type: 'GET',
 		url: server + "/info",
@@ -106,7 +108,25 @@ function updateServerInfo() {
 			delete json.plugins;
 			delete json.transports;
 			delete json.events;
+			$('#server-details').empty();
 			for(var k in json) {
+				if(k === "dependencies") {
+					$('#server-deps').html(
+						'<tr>' +
+						'	<th>Library</th>' +
+						'	<th>Version</th>' +
+						'</tr>'
+					);
+					for(var ln in json[k]) {
+						$('#server-deps').append(
+							'<tr>' +
+							'	<td>' + ln + '</td>' +
+							'	<td>' + json[k][ln] + '</td>' +
+							'</tr>'
+						);
+					}
+					continue;
+				}
 				var v = json[k];
 				$('#server-details').append(
 					'<tr>' +
@@ -114,6 +134,15 @@ function updateServerInfo() {
 					'	<td>' + v + '</td>' +
 					'</tr>');
 			}
+			$('#server-plugins').html(
+				'<tr>' +
+				'	<th>Name</th>' +
+				'	<th>Author</th>' +
+				'	<th>Description</th>' +
+				'	<th>Version</th>' +
+				'</tr>'
+			);
+			$('#plugins-list').empty();
 			for(var p in pluginsJson) {
 				plugins.push(p);
 				var v = pluginsJson[p];
@@ -138,6 +167,14 @@ function updateServerInfo() {
 					resetPluginRequest();
 				});
 			}
+			$('#server-transports').html(
+				'<tr>' +
+				'	<th>Name</th>' +
+				'	<th>Author</th>' +
+				'	<th>Description</th>' +
+				'	<th>Version</th>' +
+				'</tr>'
+			);
 			for(var t in transportsJson) {
 				var v = transportsJson[t];
 				$('#server-transports').append(
@@ -148,6 +185,14 @@ function updateServerInfo() {
 					'	<td>' + v.version_string + '</td>' +
 					'</tr>');
 			}
+			$('#server-handlers').html(
+				'<tr>' +
+				'	<th>Name</th>' +
+				'	<th>Author</th>' +
+				'	<th>Description</th>' +
+				'	<th>Version</th>' +
+				'</tr>'
+			);
 			for(var e in eventsJson) {
 				var v = eventsJson[e];
 				$('#server-handlers').append(

--- a/plugins/duktape/echotest.js
+++ b/plugins/duktape/echotest.js
@@ -7,8 +7,8 @@
 name = "echotest.js";
 
 // Let's add more info to errors
-Error.prototype.toString = function () { 
-	return this.name + ': ' + this.message + ' (at line ' + this.lineNumber + ')'; 
+Error.prototype.toString = function () {
+	return this.name + ': ' + this.message + ' (at line ' + this.lineNumber + ')';
 };
 // Let's add a prefix to all console.log lines
 var originalConsoleLog = console.log;
@@ -144,6 +144,13 @@ function handleMessage(id, tr, msg, jsep) {
 		// Asynchronous response: return value is a positive integer
 		return 1;
 	}
+}
+
+function handleAdminMessage(message) {
+	// This is just to showcase how you can handle incoming messages
+	// coming from the Admin API: we return the same message as a test
+	console.log("Got admin message:", message);
+	return message;
 }
 
 function setupMedia(id) {

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -667,6 +667,7 @@ const char *janus_audiobridge_get_author(void);
 const char *janus_audiobridge_get_package(void);
 void janus_audiobridge_create_session(janus_plugin_session *handle, int *error);
 struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
+json_t *janus_audiobridge_handle_admin_message(json_t *message);
 void janus_audiobridge_setup_media(janus_plugin_session *handle);
 void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_audiobridge_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
@@ -690,6 +691,7 @@ static janus_plugin janus_audiobridge_plugin =
 
 		.create_session = janus_audiobridge_create_session,
 		.handle_message = janus_audiobridge_handle_message,
+		.handle_admin_message = janus_audiobridge_handle_admin_message,
 		.setup_media = janus_audiobridge_setup_media,
 		.incoming_rtp = janus_audiobridge_incoming_rtp,
 		.incoming_rtcp = janus_audiobridge_incoming_rtcp,
@@ -1687,56 +1689,17 @@ json_t *janus_audiobridge_query_session(janus_plugin_session *handle) {
 	return info;
 }
 
-struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
-	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
-		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
+/* Helper method to process synchronous requests */
+static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_session *session, json_t *message) {
+	json_t *request = json_object_get(message, "request");
+	const char *request_text = json_string_value(request);
 
-	/* Pre-parse the message */
+	/* Parse the message */
 	int error_code = 0;
 	char error_cause[512];
 	json_t *root = message;
 	json_t *response = NULL;
 
-	janus_mutex_lock(&sessions_mutex);
-	janus_audiobridge_session *session = janus_audiobridge_lookup_session(handle);
-	if(!session) {
-		janus_mutex_unlock(&sessions_mutex);
-		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
-		error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
-		g_snprintf(error_cause, 512, "%s", "No session associated with this handle...");
-		goto plugin_response;
-	}
-	/* Increase the reference counter for this session: we'll decrease it after we handle the message */
-	janus_refcount_increase(&session->ref);
-	janus_mutex_unlock(&sessions_mutex);
-	if(g_atomic_int_get(&session->destroyed)) {
-		JANUS_LOG(LOG_ERR, "Session has already been marked as destroyed...\n");
-		error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
-		g_snprintf(error_cause, 512, "%s", "Session has already been marked as destroyed...");
-		goto plugin_response;
-	}
-
-	if(message == NULL) {
-		JANUS_LOG(LOG_ERR, "No message??\n");
-		error_code = JANUS_AUDIOBRIDGE_ERROR_NO_MESSAGE;
-		g_snprintf(error_cause, 512, "%s", "No message??");
-		goto plugin_response;
-	}
-	if(!json_is_object(root)) {
-		JANUS_LOG(LOG_ERR, "JSON error: not an object\n");
-		error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_JSON;
-		g_snprintf(error_cause, 512, "JSON error: not an object");
-		goto plugin_response;
-	}
-	/* Get the request first */
-	JANUS_VALIDATE_JSON_OBJECT(root, request_parameters,
-		error_code, error_cause, TRUE,
-		JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
-	if(error_code != 0)
-		goto plugin_response;
-	json_t *request = json_object_get(root, "request");
-	/* Some requests ('create', 'destroy', 'exists', 'list') can be handled synchronously */
-	const char *request_text = json_string_value(request);
 	if(!strcasecmp(request_text, "create")) {
 		/* Create a new audiobridge */
 		JANUS_LOG(LOG_VERB, "Creating a new audiobridge\n");
@@ -1744,18 +1707,18 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		if(admin_key != NULL) {
 			/* An admin key was specified: make sure it was provided, and that it's valid */
 			JANUS_VALIDATE_JSON_OBJECT(root, adminkey_parameters,
 				error_code, error_cause, TRUE,
 				JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 			JANUS_CHECK_SECRET(admin_key, root, "admin_key", error_code, error_cause,
 				JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_UNAUTHORIZED);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 		}
 		json_t *desc = json_object_get(root, "description");
 		json_t *secret = json_object_get(root, "secret");
@@ -1787,7 +1750,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 				JANUS_LOG(LOG_ERR, "Invalid element in the allowed array (not a string)\n");
 				error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT;
 				g_snprintf(error_cause, 512, "Invalid element in the allowed array (not a string)");
-				goto plugin_response;
+				goto prepare_response;
 			}
 		}
 		gboolean save = permanent ? json_is_true(permanent) : FALSE;
@@ -1795,7 +1758,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No configuration file, can't create permanent room\n");
 			error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "No configuration file, can't create permanent room");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		guint64 room_id = 0;
 		json_t *room = json_object_get(root, "room");
@@ -1812,7 +1775,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 				JANUS_LOG(LOG_ERR, "Room %"SCNu64" already exists!\n", room_id);
 				error_code = JANUS_AUDIOBRIDGE_ERROR_ROOM_EXISTS;
 				g_snprintf(error_cause, 512, "Room %"SCNu64" already exists", room_id);
-				goto plugin_response;
+				goto prepare_response;
 			}
 		}
 		/* Create the audio bridge room */
@@ -1875,7 +1838,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 				JANUS_LOG(LOG_ERR, "Unsupported sampling rate %"SCNu32"...\n", audiobridge->sampling_rate);
 				error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
 				g_snprintf(error_cause, 512, "We currently only support 16kHz (wideband) as a sampling rate for audio rooms, %"SCNu32" TBD...", audiobridge->sampling_rate);
-				goto plugin_response;
+				goto prepare_response;
 		}
 		audiobridge->record = FALSE;
 		if(record && json_is_true(record))
@@ -1925,7 +1888,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			janus_refcount_decrease(&audiobridge->ref);
 			g_hash_table_remove(rooms, &audiobridge->room_id);
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		if(save) {
 			/* This room is permanent: save to the configuration file too
@@ -1978,17 +1941,17 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			json_t *info = json_object();
 			json_object_set_new(info, "event", json_string("created"));
 			json_object_set_new(info, "room", json_integer(audiobridge->room_id));
-			gateway->notify_event(&janus_audiobridge_plugin, session->handle, info);
+			gateway->notify_event(&janus_audiobridge_plugin, session ? session->handle : NULL, info);
 		}
 		janus_mutex_unlock(&rooms_mutex);
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "edit")) {
 		JANUS_LOG(LOG_VERB, "Attempt to edit an existing audiobridge room\n");
 		JANUS_VALIDATE_JSON_OBJECT(root, edit_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		/* We only allow for a limited set of properties to be edited */
 		json_t *room = json_object_get(root, "room");
 		json_t *desc = json_object_get(root, "new_description");
@@ -2001,7 +1964,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No configuration file, can't edit room permanently\n");
 			error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "No configuration file, can't edit room permanently");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -2011,7 +1974,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_mutex_lock(&audiobridge->mutex);
 		/* A secret may be required for this action */
@@ -2020,7 +1983,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		if(error_code != 0) {
 			janus_mutex_unlock(&audiobridge->mutex);
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* Edit the room properties that were provided */
 		if(desc != NULL && strlen(json_string_value(desc)) > 0) {
@@ -2096,20 +2059,20 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			json_t *info = json_object();
 			json_object_set_new(info, "event", json_string("edited"));
 			json_object_set_new(info, "room", json_integer(room_id));
-			gateway->notify_event(&janus_audiobridge_plugin, session->handle, info);
+			gateway->notify_event(&janus_audiobridge_plugin, session ? session->handle : NULL, info);
 		}
 		janus_mutex_unlock(&audiobridge->mutex);
 		janus_mutex_unlock(&rooms_mutex);
 		/* Done */
 		JANUS_LOG(LOG_VERB, "Audiobridge room edited\n");
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "destroy")) {
 		JANUS_LOG(LOG_VERB, "Attempt to destroy an existing audiobridge room\n");
 		JANUS_VALIDATE_JSON_OBJECT(root, destroy_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *room = json_object_get(root, "room");
 		json_t *permanent = json_object_get(root, "permanent");
 		gboolean save = permanent ? json_is_true(permanent) : FALSE;
@@ -2117,7 +2080,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No configuration file, can't destroy room permanently\n");
 			error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "No configuration file, can't destroy room permanently");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -2127,7 +2090,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_mutex_lock(&audiobridge->mutex);
 		/* A secret may be required for this action */
@@ -2136,7 +2099,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		if(error_code != 0) {
 			janus_mutex_unlock(&audiobridge->mutex);
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* Remove room */
 		janus_refcount_increase(&audiobridge->ref);
@@ -2199,7 +2162,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			json_t *info = json_object();
 			json_object_set_new(info, "event", json_string("destroyed"));
 			json_object_set_new(info, "room", json_integer(room_id));
-			gateway->notify_event(&janus_audiobridge_plugin, session->handle, info);
+			gateway->notify_event(&janus_audiobridge_plugin, session ? session->handle : NULL, info);
 		}
 		janus_mutex_unlock(&audiobridge->mutex);
 		janus_mutex_unlock(&rooms_mutex);
@@ -2210,7 +2173,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_object_set_new(response, "room", json_integer(room_id));
 		json_object_set_new(response, "permanent", save ? json_true() : json_false());
 		JANUS_LOG(LOG_VERB, "Audiobridge room destroyed\n");
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "list")) {
 		/* List all rooms (but private ones) and their details (except for the secret, of course...) */
 		json_t *list = json_array();
@@ -2245,14 +2208,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		response = json_object();
 		json_object_set_new(response, "audiobridge", json_string("success"));
 		json_object_set_new(response, "list", list);
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "exists")) {
 		/* Check whether a given room exists or not, returns true/false */
 		JANUS_VALIDATE_JSON_OBJECT(root, room_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -2262,14 +2225,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_object_set_new(response, "audiobridge", json_string("success"));
 		json_object_set_new(response, "room", json_integer(room_id));
 		json_object_set_new(response, "exists", room_exists ? json_true() : json_false());
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "allowed")) {
 		JANUS_LOG(LOG_VERB, "Attempt to edit the list of allowed participants in an existing audiobridge room\n");
 		JANUS_VALIDATE_JSON_OBJECT(root, allowed_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *action = json_object_get(root, "action");
 		json_t *room = json_object_get(root, "room");
 		json_t *allowed = json_object_get(root, "allowed");
@@ -2279,7 +2242,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "Unsupported action '%s' (allowed)\n", action_text);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT;
 			g_snprintf(error_cause, 512, "Unsupported action '%s' (allowed)", action_text);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -2289,7 +2252,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_mutex_lock(&audiobridge->mutex);
 		/* A secret may be required for this action */
@@ -2298,7 +2261,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		if(error_code != 0) {
 			janus_mutex_unlock(&audiobridge->mutex);
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		if(!strcasecmp(action_text, "enable")) {
 			JANUS_LOG(LOG_VERB, "Enabling the check on allowed authorization tokens for room %"SCNu64"\n", room_id);
@@ -2327,7 +2290,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 					g_snprintf(error_cause, 512, "Invalid element in the allowed array (not a string)");
 					janus_mutex_unlock(&audiobridge->mutex);
 					janus_mutex_unlock(&rooms_mutex);
-					goto plugin_response;
+					goto prepare_response;
 				}
 				size_t i = 0;
 				for(i=0; i<json_array_size(allowed); i++) {
@@ -2362,14 +2325,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		janus_mutex_unlock(&audiobridge->mutex);
 		janus_mutex_unlock(&rooms_mutex);
 		JANUS_LOG(LOG_VERB, "Audiobridge room allowed list updated\n");
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "kick")) {
 		JANUS_LOG(LOG_VERB, "Attempt to kick a participant from an existing audiobridge room\n");
 		JANUS_VALIDATE_JSON_OBJECT(root, kick_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *room = json_object_get(root, "room");
 		json_t *id = json_object_get(root, "id");
 		guint64 room_id = json_integer_value(room);
@@ -2380,7 +2343,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_refcount_increase(&audiobridge->ref);
 		janus_mutex_lock(&audiobridge->mutex);
@@ -2391,7 +2354,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		if(error_code != 0) {
 			janus_mutex_unlock(&audiobridge->mutex);
 			janus_refcount_decrease(&audiobridge->ref);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		guint64 user_id = json_integer_value(id);
 		janus_audiobridge_participant *participant = g_hash_table_lookup(audiobridge->participants, &user_id);
@@ -2401,7 +2364,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such user %"SCNu64" in room %"SCNu64"\n", user_id, room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_USER;
 			g_snprintf(error_cause, 512, "No such user %"SCNu64" in room %"SCNu64, user_id, room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* Notify all participants about the kick */
 		json_t *event = json_object();
@@ -2424,7 +2387,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			json_object_set_new(info, "event", json_string("kicked"));
 			json_object_set_new(info, "room", json_integer(room_id));
 			json_object_set_new(info, "id", json_integer(user_id));
-			gateway->notify_event(&janus_audiobridge_plugin, session->handle, info);
+			gateway->notify_event(&janus_audiobridge_plugin, session ? session->handle : NULL, info);
 		}
 		/* Tell the core to tear down the PeerConnection, hangup_media will do the rest */
 		if(participant && participant->session)
@@ -2436,14 +2399,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		/* Done */
 		janus_mutex_unlock(&audiobridge->mutex);
 		janus_refcount_decrease(&audiobridge->ref);
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "listparticipants")) {
 		/* List all participants in a room */
 		JANUS_VALIDATE_JSON_OBJECT(root, room_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -2453,7 +2416,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_refcount_increase(&audiobridge->ref);
 		/* Return a list of all participants */
@@ -2479,37 +2442,37 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_object_set_new(response, "audiobridge", json_string("participants"));
 		json_object_set_new(response, "room", json_integer(room_id));
 		json_object_set_new(response, "participants", list);
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "resetdecoder")) {
 		/* Mark the Opus decoder for the participant invalid and recreate it */
-		janus_audiobridge_participant *participant = (janus_audiobridge_participant *)session->participant;
+		janus_audiobridge_participant *participant = (janus_audiobridge_participant *)(session ? session->participant : NULL);
 		if(participant == NULL || participant->room == NULL) {
 			JANUS_LOG(LOG_ERR, "Can't reset (not in a room)\n");
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NOT_JOINED;
 			g_snprintf(error_cause, 512, "Can't reset (not in a room)");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		participant->reset = TRUE;
 		response = json_object();
 		json_object_set_new(response, "audiobridge", json_string("success"));
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "rtp_forward")) {
 		JANUS_VALIDATE_JSON_OBJECT(root, rtp_forward_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		if(lock_rtpfwd && admin_key != NULL) {
 			/* An admin key was specified: make sure it was provided, and that it's valid */
 			JANUS_VALIDATE_JSON_OBJECT(root, adminkey_parameters,
 				error_code, error_cause, TRUE,
 				JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 			JANUS_CHECK_SECRET(admin_key, root, "admin_key", error_code, error_cause,
 				JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_UNAUTHORIZED);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 		}
 		/* Parse arguments */
 		guint64 room_id = json_integer_value(json_object_get(root, "room"));
@@ -2526,7 +2489,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "Invalid port number (%d)\n", port);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT;
 			g_snprintf(error_cause, 512, "Invalid port number (%d)", port);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		json_t *json_host = json_object_get(root, "host");
 		const char *host = json_string_value(json_host);
@@ -2543,7 +2506,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 				JANUS_LOG(LOG_ERR, "Invalid SRTP suite (%d)\n", srtp_suite);
 				error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT;
 				g_snprintf(error_cause, 512, "Invalid SRTP suite (%d)", srtp_suite);
-				goto plugin_response;
+				goto prepare_response;
 			}
 			srtp_crypto = json_string_value(s_crypto);
 		}
@@ -2555,14 +2518,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* A secret may be required for this action */
 		JANUS_CHECK_SECRET(audiobridge->room_secret, root, "secret", error_code, error_cause,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_UNAUTHORIZED);
 		if(error_code != 0) {
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_mutex_lock(&audiobridge->mutex);
 		if(audiobridge->destroyed) {
@@ -2571,7 +2534,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 
 		if (janus_audiobridge_create_udp_socket_if_needed(audiobridge)) {
@@ -2579,7 +2542,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			janus_mutex_unlock(&rooms_mutex);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "Could not open UDP socket for RTP forwarder");
-			goto plugin_response;
+			goto prepare_response;
 		}
 
 		if (janus_audiobridge_create_opus_encoder_if_needed(audiobridge)) {
@@ -2587,7 +2550,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			janus_mutex_unlock(&rooms_mutex);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_LIBOPUS_ERROR;
 			g_snprintf(error_cause, 512, "Error creating Opus decoder for RTP forwarder");
-			goto plugin_response;
+			goto prepare_response;
 		}
 
 		guint32 stream_id = janus_audiobridge_rtp_forwarder_add_helper(audiobridge,
@@ -2602,24 +2565,24 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_object_set_new(response, "stream_id", json_integer(stream_id));
 		json_object_set_new(response, "host", json_string(host));
 		json_object_set_new(response, "port", json_integer(port));
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "stop_rtp_forward")) {
 		JANUS_VALIDATE_JSON_OBJECT(root, stop_rtp_forward_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		if(lock_rtpfwd && admin_key != NULL) {
 			/* An admin key was specified: make sure it was provided, and that it's valid */
 			JANUS_VALIDATE_JSON_OBJECT(root, adminkey_parameters,
 				error_code, error_cause, TRUE,
 				JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 			JANUS_CHECK_SECRET(admin_key, root, "admin_key", error_code, error_cause,
 				JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_UNAUTHORIZED);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 		}
 		/* Parse parameters */
 		guint64 room_id = json_integer_value(json_object_get(root, "room"));
@@ -2633,14 +2596,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* A secret may be required for this action */
 		JANUS_CHECK_SECRET(audiobridge->room_secret, root, "secret", error_code, error_cause,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_UNAUTHORIZED);
 		if(error_code != 0) {
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_mutex_lock(&audiobridge->mutex);
 		if(audiobridge->destroyed) {
@@ -2649,7 +2612,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_mutex_lock(&audiobridge->rtp_mutex);
 		g_hash_table_remove(audiobridge->rtp_forwarders, GUINT_TO_POINTER(stream_id));
@@ -2660,14 +2623,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_object_set_new(response, "audiobridge", json_string("success"));
 		json_object_set_new(response, "room", json_integer(room_id));
 		json_object_set_new(response, "stream_id", json_integer(stream_id));
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "listforwarders")) {
 		/* List all forwarders in a room */
 		JANUS_VALIDATE_JSON_OBJECT(root, room_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -2677,21 +2640,21 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		if(audiobridge->destroyed) {
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* A secret may be required for this action */
 		JANUS_CHECK_SECRET(audiobridge->room_secret, root, "secret", error_code, error_cause,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_UNAUTHORIZED);
 		if(error_code != 0) {
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* Return a list of all forwarders */
 		json_t *list = json_array();
@@ -2719,6 +2682,85 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_object_set_new(response, "audiobridge", json_string("forwarders"));
 		json_object_set_new(response, "room", json_integer(room_id));
 		json_object_set_new(response, "rtp_forwarders", list);
+		goto prepare_response;
+	} else {
+		/* Not a request we recognize, don't do anything */
+		return NULL;
+	}
+
+prepare_response:
+		{
+			if(error_code == 0 && !response) {
+				error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
+				g_snprintf(error_cause, 512, "Invalid response");
+			}
+			if(error_code != 0) {
+				/* Prepare JSON error event */
+				response = json_object();
+				json_object_set_new(response, "audiobridge", json_string("event"));
+				json_object_set_new(response, "error_code", json_integer(error_code));
+				json_object_set_new(response, "error", json_string(error_cause));
+			}
+			return response;
+		}
+
+}
+
+struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
+	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
+		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
+
+	/* Pre-parse the message */
+	int error_code = 0;
+	char error_cause[512];
+	json_t *root = message;
+	json_t *response = NULL;
+
+	janus_mutex_lock(&sessions_mutex);
+	janus_audiobridge_session *session = janus_audiobridge_lookup_session(handle);
+	if(!session) {
+		janus_mutex_unlock(&sessions_mutex);
+		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
+		error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
+		g_snprintf(error_cause, 512, "%s", "No session associated with this handle...");
+		goto plugin_response;
+	}
+	/* Increase the reference counter for this session: we'll decrease it after we handle the message */
+	janus_refcount_increase(&session->ref);
+	janus_mutex_unlock(&sessions_mutex);
+	if(g_atomic_int_get(&session->destroyed)) {
+		JANUS_LOG(LOG_ERR, "Session has already been marked as destroyed...\n");
+		error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
+		g_snprintf(error_cause, 512, "%s", "Session has already been marked as destroyed...");
+		goto plugin_response;
+	}
+
+	if(message == NULL) {
+		JANUS_LOG(LOG_ERR, "No message??\n");
+		error_code = JANUS_AUDIOBRIDGE_ERROR_NO_MESSAGE;
+		g_snprintf(error_cause, 512, "%s", "No message??");
+		goto plugin_response;
+	}
+	if(!json_is_object(root)) {
+		JANUS_LOG(LOG_ERR, "JSON error: not an object\n");
+		error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_JSON;
+		g_snprintf(error_cause, 512, "JSON error: not an object");
+		goto plugin_response;
+	}
+	/* Get the request first */
+	JANUS_VALIDATE_JSON_OBJECT(root, request_parameters,
+		error_code, error_cause, TRUE,
+		JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
+	if(error_code != 0)
+		goto plugin_response;
+	json_t *request = json_object_get(root, "request");
+	/* Some requests ('create', 'destroy', 'exists', 'list') can be handled synchronously */
+	const char *request_text = json_string_value(request);
+	/* We have a separate method to process synchronous requests, as those may
+	 * arrive from the Admin API as well, and so we handle them the same way */
+	response = janus_audiobridge_process_synchronous_request(session, root);
+	if(response != NULL) {
+		/* We got a response, send it back */
 		goto plugin_response;
 	} else if(!strcasecmp(request_text, "join") || !strcasecmp(request_text, "configure")
 			|| !strcasecmp(request_text, "changeroom") || !strcasecmp(request_text, "leave")) {
@@ -2761,6 +2803,42 @@ plugin_response:
 			if(session != NULL)
 				janus_refcount_decrease(&session->ref);
 			return janus_plugin_result_new(JANUS_PLUGIN_OK, NULL, response);
+		}
+
+}
+
+json_t *janus_audiobridge_handle_admin_message(json_t *message) {
+	/* Some requests (e.g., 'create' and 'destroy') can be handled via Admin API */
+	int error_code = 0;
+	char error_cause[512];
+	json_t *response = NULL;
+
+	JANUS_VALIDATE_JSON_OBJECT(message, request_parameters,
+		error_code, error_cause, TRUE,
+		JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
+	if(error_code != 0)
+		goto admin_response;
+	json_t *request = json_object_get(message, "request");
+	const char *request_text = json_string_value(request);
+	if((response = janus_audiobridge_process_synchronous_request(NULL, message)) != NULL) {
+		/* We got a response, send it back */
+		goto admin_response;
+	} else {
+		JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
+		error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_REQUEST;
+		g_snprintf(error_cause, 512, "Unknown request '%s'", request_text);
+	}
+
+admin_response:
+		{
+			if(!response) {
+				/* Prepare JSON error event */
+				response = json_object();
+				json_object_set_new(response, "streaming", json_string("event"));
+				json_object_set_new(response, "error_code", json_integer(error_code));
+				json_object_set_new(response, "error", json_string(error_cause));
+			}
+			return response;
 		}
 
 }

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -140,6 +140,7 @@ const char *janus_echotest_get_author(void);
 const char *janus_echotest_get_package(void);
 void janus_echotest_create_session(janus_plugin_session *handle, int *error);
 struct janus_plugin_result *janus_echotest_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
+json_t *janus_echotest_handle_admin_message(json_t *message);
 void janus_echotest_setup_media(janus_plugin_session *handle);
 void janus_echotest_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_echotest_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
@@ -165,6 +166,7 @@ static janus_plugin janus_echotest_plugin =
 
 		.create_session = janus_echotest_create_session,
 		.handle_message = janus_echotest_handle_message,
+		.handle_admin_message = janus_echotest_handle_admin_message,
 		.setup_media = janus_echotest_setup_media,
 		.incoming_rtp = janus_echotest_incoming_rtp,
 		.incoming_rtcp = janus_echotest_incoming_rtcp,
@@ -500,6 +502,13 @@ struct janus_plugin_result *janus_echotest_handle_message(janus_plugin_session *
 	 * (a JSON object with a "hint" string in it, that's what the core expects),
 	 * but we don't have to: other plugins don't put anything in there */
 	return janus_plugin_result_new(JANUS_PLUGIN_OK_WAIT, "I'm taking my time!", NULL);
+}
+
+json_t *janus_echotest_handle_admin_message(json_t *message) {
+	/* Just here as a proof of concept: since there's nothing to configure,
+	 * as an EchoTest plugin we echo this Admin request back as well */
+	json_t *response = json_deep_copy(message);
+	return response;
 }
 
 void janus_echotest_setup_media(janus_plugin_session *handle) {

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -292,6 +292,7 @@ const char *janus_recordplay_get_author(void);
 const char *janus_recordplay_get_package(void);
 void janus_recordplay_create_session(janus_plugin_session *handle, int *error);
 struct janus_plugin_result *janus_recordplay_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
+json_t *janus_recordplay_handle_admin_message(json_t *message);
 void janus_recordplay_setup_media(janus_plugin_session *handle);
 void janus_recordplay_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_recordplay_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
@@ -316,6 +317,7 @@ static janus_plugin janus_recordplay_plugin =
 
 		.create_session = janus_recordplay_create_session,
 		.handle_message = janus_recordplay_handle_message,
+		.handle_admin_message = janus_recordplay_handle_admin_message,
 		.setup_media = janus_recordplay_setup_media,
 		.incoming_rtp = janus_recordplay_incoming_rtp,
 		.incoming_rtcp = janus_recordplay_incoming_rtcp,
@@ -1048,6 +1050,41 @@ plugin_response:
 			if(session != NULL)
 				janus_refcount_decrease(&session->ref);
 			return janus_plugin_result_new(JANUS_PLUGIN_OK, NULL, response);
+		}
+
+}
+
+json_t *janus_recordplay_handle_admin_message(json_t *message) {
+	/* Some requests (e.g., 'update') can be handled via Admin API */
+	int error_code = 0;
+	char error_cause[512];
+	json_t *response = NULL;
+
+	json_t *request = json_object_get(message, "request");
+	const char *request_text = json_string_value(request);
+	if(request_text != NULL && !strcasecmp(request_text, "update")) {
+		/* Update list of available recordings, scanning the folder again */
+		janus_recordplay_update_recordings_list();
+		/* Send info back */
+		response = json_object();
+		json_object_set_new(response, "recordplay", json_string("ok"));
+		goto admin_response;
+	} else {
+		JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
+		error_code = JANUS_RECORDPLAY_ERROR_INVALID_REQUEST;
+		g_snprintf(error_cause, 512, "Unknown request '%s'", request_text);
+	}
+
+admin_response:
+		{
+			if(!response) {
+				/* Prepare JSON error event */
+				response = json_object();
+				json_object_set_new(response, "recordplay", json_string("event"));
+				json_object_set_new(response, "error_code", json_integer(error_code));
+				json_object_set_new(response, "error", json_string(error_cause));
+			}
+			return response;
 		}
 
 }

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -1060,9 +1060,14 @@ json_t *janus_recordplay_handle_admin_message(json_t *message) {
 	char error_cause[512];
 	json_t *response = NULL;
 
+	JANUS_VALIDATE_JSON_OBJECT(message, request_parameters,
+		error_code, error_cause, TRUE,
+		JANUS_RECORDPLAY_ERROR_MISSING_ELEMENT, JANUS_RECORDPLAY_ERROR_INVALID_ELEMENT);
+	if(error_code != 0)
+		goto admin_response;
 	json_t *request = json_object_get(message, "request");
 	const char *request_text = json_string_value(request);
-	if(request_text != NULL && !strcasecmp(request_text, "update")) {
+	if(!strcasecmp(request_text, "update")) {
 		/* Update list of available recordings, scanning the folder again */
 		janus_recordplay_update_recordings_list();
 		/* Send info back */

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -703,6 +703,7 @@ const char *janus_streaming_get_author(void);
 const char *janus_streaming_get_package(void);
 void janus_streaming_create_session(janus_plugin_session *handle, int *error);
 struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
+json_t *janus_streaming_handle_admin_message(json_t *message);
 void janus_streaming_setup_media(janus_plugin_session *handle);
 void janus_streaming_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_streaming_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
@@ -727,6 +728,7 @@ static janus_plugin janus_streaming_plugin =
 
 		.create_session = janus_streaming_create_session,
 		.handle_message = janus_streaming_handle_message,
+		.handle_admin_message = janus_streaming_handle_admin_message,
 		.setup_media = janus_streaming_setup_media,
 		.incoming_rtp = janus_streaming_incoming_rtp,
 		.incoming_rtcp = janus_streaming_incoming_rtcp,
@@ -2009,57 +2011,18 @@ json_t *janus_streaming_query_session(janus_plugin_session *handle) {
 	return info;
 }
 
-struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
-	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
-		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
+/* Helper method to process synchronous requests */
+static json_t *janus_streaming_process_synchronous_request(janus_streaming_session *session, json_t *message) {
+	json_t *request = json_object_get(message, "request");
+	const char *request_text = json_string_value(request);
 
-	/* Pre-parse the message */
+	/* Parse the message */
 	int error_code = 0;
 	char error_cause[512];
 	json_t *root = message;
 	json_t *response = NULL;
 	struct ifaddrs *ifas = NULL;
 
-	janus_mutex_lock(&sessions_mutex);
-	janus_streaming_session *session = janus_streaming_lookup_session(handle);
-	if(!session) {
-		janus_mutex_unlock(&sessions_mutex);
-		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
-		error_code = JANUS_STREAMING_ERROR_UNKNOWN_ERROR;
-		g_snprintf(error_cause, 512, "%s", "No session associated with this handle...");
-		goto plugin_response;
-	}
-	/* Increase the reference counter for this session: we'll decrease it after we handle the message */
-	janus_refcount_increase(&session->ref);
-	janus_mutex_unlock(&sessions_mutex);
-	if(g_atomic_int_get(&session->destroyed)) {
-		JANUS_LOG(LOG_ERR, "Session has already been destroyed...\n");
-		error_code = JANUS_STREAMING_ERROR_UNKNOWN_ERROR;
-		g_snprintf(error_cause, 512, "%s", "Session has already been destroyed...");
-		goto plugin_response;
-	}
-
-	if(message == NULL) {
-		JANUS_LOG(LOG_ERR, "No message??\n");
-		error_code = JANUS_STREAMING_ERROR_NO_MESSAGE;
-		g_snprintf(error_cause, 512, "%s", "No message??");
-		goto plugin_response;
-	}
-	if(!json_is_object(root)) {
-		JANUS_LOG(LOG_ERR, "JSON error: not an object\n");
-		error_code = JANUS_STREAMING_ERROR_INVALID_JSON;
-		g_snprintf(error_cause, 512, "JSON error: not an object");
-		goto plugin_response;
-	}
-	/* Get the request first */
-	JANUS_VALIDATE_JSON_OBJECT(root, request_parameters,
-		error_code, error_cause, TRUE,
-		JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
-	if(error_code != 0)
-		goto plugin_response;
-	json_t *request = json_object_get(root, "request");
-	/* Some requests ('create' and 'destroy') can be handled synchronously */
-	const char *request_text = json_string_value(request);
 	if(!strcasecmp(request_text, "list")) {
 		json_t *list = json_array();
 		JANUS_LOG(LOG_VERB, "Request for the list of mountpoints\n");
@@ -2096,7 +2059,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		response = json_object();
 		json_object_set_new(response, "streaming", json_string("list"));
 		json_object_set_new(response, "list", list);
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "info")) {
 		JANUS_LOG(LOG_VERB, "Request info on a specific mountpoint\n");
 		/* Return info on a specific mountpoint */
@@ -2104,7 +2067,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			error_code, error_cause, TRUE,
 			JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *id = json_object_get(root, "id");
 		guint64 id_value = json_integer_value(id);
 		janus_mutex_lock(&mountpoints_mutex);
@@ -2114,7 +2077,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			JANUS_LOG(LOG_VERB, "No such mountpoint/stream %"SCNu64"\n", id_value);
 			error_code = JANUS_STREAMING_ERROR_NO_SUCH_MOUNTPOINT;
 			g_snprintf(error_cause, 512, "No such mountpoint/stream %"SCNu64"", id_value);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_refcount_increase(&mp->ref);
 		/* Return more info if the right secret is provided */
@@ -2244,25 +2207,25 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		response = json_object();
 		json_object_set_new(response, "streaming", json_string("info"));
 		json_object_set_new(response, "info", ml);
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "create")) {
 		/* Create a new stream */
 		JANUS_VALIDATE_JSON_OBJECT(root, create_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		if(admin_key != NULL) {
 			/* An admin key was specified: make sure it was provided, and that it's valid */
 			JANUS_VALIDATE_JSON_OBJECT(root, adminkey_parameters,
 				error_code, error_cause, TRUE,
 				JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 			JANUS_CHECK_SECRET(admin_key, root, "admin_key", error_code, error_cause,
 				JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT, JANUS_STREAMING_ERROR_UNAUTHORIZED);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 		}
 
 		if(getifaddrs(&ifas) == -1) {
@@ -2279,7 +2242,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			JANUS_LOG(LOG_ERR, "No configuration file, can't create permanent mountpoint\n");
 			error_code = JANUS_STREAMING_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "No configuration file, can't create permanent mountpoint");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_streaming_mountpoint *mp = NULL;
 		if(!strcasecmp(type_text, "rtp")) {
@@ -2289,7 +2252,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				error_code, error_cause, TRUE,
 				JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 			json_t *id = json_object_get(root, "id");
 			json_t *name = json_object_get(root, "name");
 			json_t *desc = json_object_get(root, "description");
@@ -2309,13 +2272,13 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream, no audio, video or data have to be streamed...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Can't add 'rtp' stream, no audio or video have to be streamed...");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			if(ssuite && json_integer_value(ssuite) != 32 && json_integer_value(ssuite) != 80) {
 				JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream, invalid SRTP suite...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Can't add 'rtp' stream, invalid SRTP suite...");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			uint16_t aport = 0;
 			uint16_t artcpport = 0;
@@ -2326,7 +2289,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					error_code, error_cause, TRUE,
 					JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 				if(error_code != 0)
-					goto plugin_response;
+					goto prepare_response;
 				json_t *audiomcast = json_object_get(root, "audiomcast");
 				amcast = (char *)json_string_value(audiomcast);
 				json_t *audioport = json_object_get(root, "audioport");
@@ -2347,7 +2310,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 						JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream '%s', invalid network interface configuration for audio...\n", (const char *)json_string_value(name));
 						error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 						g_snprintf(error_cause, 512, ifas ? "Invalid network interface configuration for audio" : "Unable to query network device information");
-						goto plugin_response;
+						goto prepare_response;
 					}
 				} else {
 					janus_network_address_nullify(&audio_iface);
@@ -2365,7 +2328,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					error_code, error_cause, TRUE,
 					JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 				if(error_code != 0)
-					goto plugin_response;
+					goto prepare_response;
 				json_t *videomcast = json_object_get(root, "videomcast");
 				vmcast = (char *)json_string_value(videomcast);
 				json_t *videoport = json_object_get(root, "videoport");
@@ -2399,7 +2362,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 						JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream '%s', invalid network interface configuration for video...\n", (const char *)json_string_value(name));
 						error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 						g_snprintf(error_cause, 512, ifas ? "Invalid network interface configuration for video" : "Unable to query network device information");
-						goto plugin_response;
+						goto prepare_response;
 					}
 				} else {
 					janus_network_address_nullify(&video_iface);
@@ -2416,7 +2379,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					error_code, error_cause, TRUE,
 					JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 				if(error_code != 0)
-					goto plugin_response;
+					goto prepare_response;
 #ifdef HAVE_SCTP
 				json_t *dataport = json_object_get(root, "dataport");
 				dport = json_integer_value(dataport);
@@ -2429,7 +2392,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 						JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream '%s', invalid network interface configuration for data...\n", (const char *)json_string_value(name));
 						error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 						g_snprintf(error_cause, 512, ifas ? "Invalid network interface configuration for data" : "Unable to query network device information");
-						goto plugin_response;
+						goto prepare_response;
 					}
 				} else {
 					janus_network_address_nullify(&data_iface);
@@ -2438,7 +2401,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream: no datachannels support...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Can't add 'rtp' stream: no datachannels support...");
-				goto plugin_response;
+				goto prepare_response;
 #endif
 			}
 			if(id == NULL) {
@@ -2452,7 +2415,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					JANUS_LOG(LOG_ERR, "A stream with the provided ID already exists\n");
 					error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 					g_snprintf(error_cause, 512, "A stream with the provided ID already exists");
-					goto plugin_response;
+					goto prepare_response;
 				}
 			}
 			JANUS_LOG(LOG_VERB, "Audio %s, Video %s\n", doaudio ? "enabled" : "NOT enabled", dovideo ? "enabled" : "NOT enabled");
@@ -2472,7 +2435,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_ERR, "Error creating 'rtp' stream...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Error creating 'rtp' stream");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			mp->is_private = is_private ? json_is_true(is_private) : FALSE;
 		} else if(!strcasecmp(type_text, "live")) {
@@ -2481,7 +2444,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				error_code, error_cause, TRUE,
 				JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 			json_t *id = json_object_get(root, "id");
 			json_t *name = json_object_get(root, "name");
 			json_t *desc = json_object_get(root, "description");
@@ -2496,21 +2459,21 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_ERR, "Can't add 'live' stream, we only support audio file streaming right now...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Can't add 'live' stream, we only support audio file streaming right now...");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			char *filename = (char *)json_string_value(file);
 			if(!strstr(filename, ".alaw") && !strstr(filename, ".mulaw")) {
 				JANUS_LOG(LOG_ERR, "Can't add 'live' stream, unsupported format (we only support raw mu-Law and a-Law files right now)\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Can't add 'live' stream, unsupported format (we only support raw mu-Law and a-Law files right now)");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			FILE *audiofile = fopen(filename, "rb");
 			if(!audiofile) {
 				JANUS_LOG(LOG_ERR, "Can't add 'live' stream, no such file '%s'...\n", filename);
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Can't add 'live' stream, no such file '%s'\n", filename);
-				goto plugin_response;
+				goto prepare_response;
 			}
 			fclose(audiofile);
 			if(id == NULL) {
@@ -2524,7 +2487,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					JANUS_LOG(LOG_ERR, "A stream with the provided ID already exists\n");
 					error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 					g_snprintf(error_cause, 512, "A stream with the provided ID already exists");
-					goto plugin_response;
+					goto prepare_response;
 				}
 			}
 			mp = janus_streaming_create_file_source(
@@ -2537,7 +2500,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_ERR, "Error creating 'live' stream...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Error creating 'live' stream");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			mp->is_private = is_private ? json_is_true(is_private) : FALSE;
 		} else if(!strcasecmp(type_text, "ondemand")) {
@@ -2546,7 +2509,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				error_code, error_cause, TRUE,
 				JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 			json_t *id = json_object_get(root, "id");
 			json_t *name = json_object_get(root, "name");
 			json_t *desc = json_object_get(root, "description");
@@ -2561,21 +2524,21 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_ERR, "Can't add 'ondemand' stream, we only support audio file streaming right now...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Can't add 'ondemand' stream, we only support audio file streaming right now...");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			char *filename = (char *)json_string_value(file);
 			if(!strstr(filename, ".alaw") && !strstr(filename, ".mulaw")) {
 				JANUS_LOG(LOG_ERR, "Can't add 'ondemand' stream, unsupported format (we only support raw mu-Law and a-Law files right now)\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Can't add 'ondemand' stream, unsupported format (we only support raw mu-Law and a-Law files right now)");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			FILE *audiofile = fopen(filename, "rb");
 			if(!audiofile) {
 				JANUS_LOG(LOG_ERR, "Can't add 'ondemand' stream, no such file '%s'...\n", filename);
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Can't add 'ondemand' stream, no such file '%s'\n", filename);
-				goto plugin_response;
+				goto prepare_response;
 			}
 			fclose(audiofile);
 			if(id == NULL) {
@@ -2589,7 +2552,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					JANUS_LOG(LOG_ERR, "A stream with the provided ID already exists\n");
 					error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 					g_snprintf(error_cause, 512, "A stream with the provided ID already exists");
-					goto plugin_response;
+					goto prepare_response;
 				}
 			}
 			mp = janus_streaming_create_file_source(
@@ -2602,7 +2565,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_ERR, "Error creating 'ondemand' stream...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Error creating 'ondemand' stream");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			mp->is_private = is_private ? json_is_true(is_private) : FALSE;
 		} else if(!strcasecmp(type_text, "rtsp")) {
@@ -2610,13 +2573,13 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			JANUS_LOG(LOG_ERR, "Can't create 'rtsp' mountpoint, libcurl support not compiled...\n");
 			error_code = JANUS_STREAMING_ERROR_INVALID_ELEMENT;
 			g_snprintf(error_cause, 512, "Can't create 'rtsp' mountpoint, libcurl support not compiled...\n");
-			goto plugin_response;
+			goto prepare_response;
 #else
 			JANUS_VALIDATE_JSON_OBJECT(root, rtsp_parameters,
 				error_code, error_cause, TRUE,
 				JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 			/* RTSP source*/
 			janus_network_address multicast_iface;
 			json_t *id = json_object_get(root, "id");
@@ -2643,7 +2606,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_ERR, "Can't add 'rtsp' stream, no audio or video have to be streamed...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Can't add 'rtsp' stream, no audio or video have to be streamed...");
-				goto plugin_response;
+				goto prepare_response;
 			} else {
 				if(iface) {
 					const char *miface = (const char *)json_string_value(iface);
@@ -2651,7 +2614,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 						JANUS_LOG(LOG_ERR, "Can't add 'rtsp' stream '%s', invalid network interface configuration for stream...\n", (const char *)json_string_value(name));
 						error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 						g_snprintf(error_cause, 512, ifas ? "Invalid network interface configuration for stream" : "Unable to query network device information");
-						goto plugin_response;
+						goto prepare_response;
 					}
 				} else {
 					janus_network_address_nullify(&multicast_iface);
@@ -2674,7 +2637,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_ERR, "Error creating 'rtsp' stream...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
 				g_snprintf(error_cause, 512, "Error creating 'RTSP' stream");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			mp->is_private = is_private ? json_is_true(is_private) : FALSE;
 #endif
@@ -2682,7 +2645,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			JANUS_LOG(LOG_ERR, "Unknown stream type '%s'...\n", type_text);
 			error_code = JANUS_STREAMING_ERROR_INVALID_ELEMENT;
 			g_snprintf(error_cause, 512, "Unknown stream type '%s'...\n", type_text);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* Any secret? */
 		if(secret)
@@ -2874,16 +2837,16 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			json_object_set_new(info, "event", json_string("created"));
 			json_object_set_new(info, "id", json_integer(mp->id));
 			json_object_set_new(info, "type", json_string(mp->streaming_type == janus_streaming_type_live ? "live" : "on demand"));
-			gateway->notify_event(&janus_streaming_plugin, session->handle, info);
+			gateway->notify_event(&janus_streaming_plugin, session ? session->handle : NULL, info);
 		}
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "edit")) {
 		JANUS_LOG(LOG_VERB, "Attempt to edit an existing streaming mountpoint\n");
 		JANUS_VALIDATE_JSON_OBJECT(root, edit_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		/* We only allow for a limited set of properties to be edited */
 		json_t *id = json_object_get(root, "id");
 		json_t *desc = json_object_get(root, "new_description");
@@ -2896,7 +2859,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			JANUS_LOG(LOG_ERR, "No configuration file, can't edit mountpoint permanently\n");
 			error_code = JANUS_STREAMING_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "No configuration file, can't edit mountpoint permanently");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		guint64 id_value = json_integer_value(id);
 		janus_mutex_lock(&mountpoints_mutex);
@@ -2906,7 +2869,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			JANUS_LOG(LOG_ERR, "No such mountpoint (%"SCNu64")\n", mp->id);
 			error_code = JANUS_STREAMING_ERROR_NO_SUCH_MOUNTPOINT;
 			g_snprintf(error_cause, 512, "No such mountpoint (%"SCNu64")", mp->id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_refcount_increase(&mp->ref);
 		janus_mutex_lock(&mp->mutex);
@@ -2917,7 +2880,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			janus_mutex_unlock(&mp->mutex);
 			janus_mutex_unlock(&mountpoints_mutex);
 			janus_refcount_decrease(&mp->ref);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* Edit the mountpoint properties that were provided */
 		if(desc != NULL && strlen(json_string_value(desc)) > 0) {
@@ -2935,7 +2898,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			janus_mutex_unlock(&mp->mutex);
 			janus_mutex_unlock(&mountpoints_mutex);
 			janus_refcount_decrease(&mp->ref);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		if(secret && strlen(json_string_value(secret)) > 0) {
 			char *old_secret = mp->secret;
@@ -3111,21 +3074,21 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			json_t *info = json_object();
 			json_object_set_new(info, "event", json_string("edited"));
 			json_object_set_new(info, "id", json_integer(mp->id));
-			gateway->notify_event(&janus_streaming_plugin, session->handle, info);
+			gateway->notify_event(&janus_streaming_plugin, session ? session->handle : NULL, info);
 		}
 		janus_mutex_unlock(&mp->mutex);
 		janus_mutex_unlock(&mountpoints_mutex);
 		janus_refcount_decrease(&mp->ref);
 		/* Done */
 		JANUS_LOG(LOG_VERB, "Streaming mountpoint edited\n");
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "destroy")) {
 		/* Get rid of an existing stream (notice this doesn't remove it from the config file, though) */
 		JANUS_VALIDATE_JSON_OBJECT(root, destroy_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *id = json_object_get(root, "id");
 		json_t *permanent = json_object_get(root, "permanent");
 		gboolean save = permanent ? json_is_true(permanent) : FALSE;
@@ -3133,7 +3096,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			JANUS_LOG(LOG_ERR, "No configuration file, can't destroy mountpoint permanently\n");
 			error_code = JANUS_STREAMING_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "No configuration file, can't destroy mountpoint permanently");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		guint64 id_value = json_integer_value(id);
 		janus_mutex_lock(&mountpoints_mutex);
@@ -3143,7 +3106,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			JANUS_LOG(LOG_VERB, "No such mountpoint/stream %"SCNu64"\n", id_value);
 			error_code = JANUS_STREAMING_ERROR_NO_SUCH_MOUNTPOINT;
 			g_snprintf(error_cause, 512, "No such mountpoint/stream %"SCNu64"", id_value);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_refcount_increase(&mp->ref);
 		/* A secret may be required for this action */
@@ -3152,7 +3115,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		if(error_code != 0) {
 			janus_refcount_decrease(&mp->ref);
 			janus_mutex_unlock(&mountpoints_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		JANUS_LOG(LOG_VERB, "Request to unmount mountpoint/stream %"SCNu64"\n", id_value);
 		/* Remove mountpoint from the hashtable: this will get it destroyed eventually */
@@ -3167,16 +3130,16 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		json_object_set_new(result, "status", json_string("stopped"));
 		json_object_set_new(event, "result", result);
 		while(viewer) {
-			janus_streaming_session *session = (janus_streaming_session *)viewer->data;
-			if(session != NULL) {
-				session->stopping = TRUE;
-				session->started = FALSE;
-				session->paused = FALSE;
-				session->mountpoint = NULL;
+			janus_streaming_session *s = (janus_streaming_session *)viewer->data;
+			if(s != NULL) {
+				s->stopping = TRUE;
+				s->started = FALSE;
+				s->paused = FALSE;
+				s->mountpoint = NULL;
 				/* Tell the core to tear down the PeerConnection, hangup_media will do the rest */
-				gateway->push_event(session->handle, &janus_streaming_plugin, NULL, event, NULL);
-				gateway->close_pc(session->handle);
-				janus_refcount_decrease(&session->ref);
+				gateway->push_event(s->handle, &janus_streaming_plugin, NULL, event, NULL);
+				gateway->close_pc(s->handle);
+				janus_refcount_decrease(&s->ref);
 				janus_refcount_decrease(&mp->ref);
 			}
 			if(mp->streaming_source == janus_streaming_source_rtp) {
@@ -3186,9 +3149,9 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					while(l) {
 						janus_streaming_helper *ht = (janus_streaming_helper *)l->data;
 						janus_mutex_lock(&ht->mutex);
-						if(g_list_find(ht->viewers, session) != NULL) {
+						if(g_list_find(ht->viewers, s) != NULL) {
 							ht->num_viewers--;
-							ht->viewers = g_list_remove_all(ht->viewers, session);
+							ht->viewers = g_list_remove_all(ht->viewers, s);
 							janus_mutex_unlock(&ht->mutex);
 							JANUS_LOG(LOG_VERB, "Removing viewer from helper thread #%d (destroy)\n", ht->id);
 							break;
@@ -3198,7 +3161,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					}
 				}
 			}
-			mp->viewers = g_list_remove_all(mp->viewers, session);
+			mp->viewers = g_list_remove_all(mp->viewers, s);
 			viewer = g_list_first(mp->viewers);
 		}
 		json_decref(event);
@@ -3221,28 +3184,28 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			json_t *info = json_object();
 			json_object_set_new(info, "event", json_string("destroyed"));
 			json_object_set_new(info, "id", json_integer(id_value));
-			gateway->notify_event(&janus_streaming_plugin, session->handle, info);
+			gateway->notify_event(&janus_streaming_plugin, session ? session->handle : NULL, info);
 		}
 		janus_mutex_unlock(&mountpoints_mutex);
 		/* Send info back */
 		response = json_object();
 		json_object_set_new(response, "streaming", json_string("destroyed"));
 		json_object_set_new(response, "destroyed", json_integer(id_value));
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "recording")) {
 		/* We can start/stop recording a live, RTP-based stream */
 		JANUS_VALIDATE_JSON_OBJECT(root, recording_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *action = json_object_get(root, "action");
 		const char *action_text = json_string_value(action);
 		if(strcasecmp(action_text, "start") && strcasecmp(action_text, "stop")) {
 			JANUS_LOG(LOG_ERR, "Invalid action (should be start|stop)\n");
 			error_code = JANUS_STREAMING_ERROR_INVALID_ELEMENT;
 			g_snprintf(error_cause, 512, "Invalid action (should be start|stop)");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		json_t *id = json_object_get(root, "id");
 		guint64 id_value = json_integer_value(id);
@@ -3253,7 +3216,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			JANUS_LOG(LOG_VERB, "No such mountpoint/stream %"SCNu64"\n", id_value);
 			error_code = JANUS_STREAMING_ERROR_NO_SUCH_MOUNTPOINT;
 			g_snprintf(error_cause, 512, "No such mountpoint/stream %"SCNu64"", id_value);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_refcount_increase(&mp->ref);
 		if(mp->streaming_type != janus_streaming_type_live || mp->streaming_source != janus_streaming_source_rtp) {
@@ -3262,7 +3225,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			JANUS_LOG(LOG_ERR, "Recording is only available on RTP-based live streams\n");
 			error_code = JANUS_STREAMING_ERROR_INVALID_REQUEST;
 			g_snprintf(error_cause, 512, "Recording is only available on RTP-based live streams");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* A secret may be required for this action */
 		JANUS_CHECK_SECRET(mp->secret, root, "secret", error_code, error_cause,
@@ -3270,7 +3233,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		if(error_code != 0) {
 			janus_refcount_decrease(&mp->ref);
 			janus_mutex_unlock(&mountpoints_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_streaming_rtp_source *source = mp->source;
 		if(!strcasecmp(action_text, "start")) {
@@ -3281,7 +3244,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			if(error_code != 0) {
 				janus_refcount_decrease(&mp->ref);
 				janus_mutex_unlock(&mountpoints_mutex);
-				goto plugin_response;
+				goto prepare_response;
 			}
 			json_t *audio = json_object_get(root, "audio");
 			json_t *video = json_object_get(root, "video");
@@ -3293,7 +3256,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_ERR, "Recording for audio, video and/or data already started for this stream\n");
 				error_code = JANUS_STREAMING_ERROR_INVALID_REQUEST;
 				g_snprintf(error_cause, 512, "Recording for audio, video and/or data already started for this stream");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			if(!audio && !video && !data) {
 				janus_refcount_decrease(&mp->ref);
@@ -3301,7 +3264,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_ERR, "Missing audio, video and/or data\n");
 				error_code = JANUS_STREAMING_ERROR_INVALID_REQUEST;
 				g_snprintf(error_cause, 512, "Missing audio, video and/or data");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			if(audio) {
 				const char *codec = NULL;
@@ -3323,7 +3286,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					janus_mutex_unlock(&mountpoints_mutex);
 					error_code = JANUS_STREAMING_ERROR_CANT_RECORD;
 					g_snprintf(error_cause, 512, "Error starting recorder for audio");
-					goto plugin_response;
+					goto prepare_response;
 				}
 				JANUS_LOG(LOG_INFO, "[%s] Audio recording started\n", mp->name);
 			}
@@ -3350,7 +3313,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					janus_mutex_unlock(&mountpoints_mutex);
 					error_code = JANUS_STREAMING_ERROR_CANT_RECORD;
 					g_snprintf(error_cause, 512, "Error starting recorder for video");
-					goto plugin_response;
+					goto prepare_response;
 				}
 				JANUS_LOG(LOG_INFO, "[%s] Video recording started\n", mp->name);
 			}
@@ -3373,7 +3336,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 					janus_mutex_unlock(&mountpoints_mutex);
 					error_code = JANUS_STREAMING_ERROR_CANT_RECORD;
 					g_snprintf(error_cause, 512, "Error starting recorder for data");
-					goto plugin_response;
+					goto prepare_response;
 				}
 				JANUS_LOG(LOG_INFO, "[%s] Data recording started\n", mp->name);
 			}
@@ -3388,7 +3351,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			/* Send a success response back */
 			response = json_object();
 			json_object_set_new(response, "streaming", json_string("ok"));
-			goto plugin_response;
+			goto prepare_response;
 		} else if(!strcasecmp(action_text, "stop")) {
 			/* Stop the recording */
 			JANUS_VALIDATE_JSON_OBJECT(root, recording_stop_parameters,
@@ -3396,7 +3359,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 			if(error_code != 0) {
 				janus_mutex_unlock(&mountpoints_mutex);
-				goto plugin_response;
+				goto prepare_response;
 			}
 			json_t *audio = json_object_get(root, "audio");
 			json_t *video = json_object_get(root, "video");
@@ -3406,7 +3369,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 				JANUS_LOG(LOG_ERR, "Missing audio and/or video\n");
 				error_code = JANUS_STREAMING_ERROR_INVALID_REQUEST;
 				g_snprintf(error_cause, 512, "Missing audio and/or video");
-				goto plugin_response;
+				goto prepare_response;
 			}
 			janus_mutex_lock(&source->rec_mutex);
 			if(audio && json_is_true(audio) && source->arc) {
@@ -3439,7 +3402,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			/* Send a success response back */
 			response = json_object();
 			json_object_set_new(response, "streaming", json_string("ok"));
-			goto plugin_response;
+			goto prepare_response;
 		}
 	} else if(!strcasecmp(request_text, "enable") || !strcasecmp(request_text, "disable")) {
 		/* A request to enable/disable a mountpoint */
@@ -3447,7 +3410,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			error_code, error_cause, TRUE,
 			JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *id = json_object_get(root, "id");
 		guint64 id_value = json_integer_value(id);
 		janus_mutex_lock(&mountpoints_mutex);
@@ -3457,7 +3420,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 			JANUS_LOG(LOG_VERB, "No such mountpoint/stream %"SCNu64"\n", id_value);
 			error_code = JANUS_STREAMING_ERROR_NO_SUCH_MOUNTPOINT;
 			g_snprintf(error_cause, 512, "No such mountpoint/stream %"SCNu64"", id_value);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_refcount_increase(&mp->ref);
 		/* A secret may be required for this action */
@@ -3466,7 +3429,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		if(error_code != 0) {
 			janus_refcount_decrease(&mp->ref);
 			janus_mutex_unlock(&mountpoints_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		if(!strcasecmp(request_text, "enable")) {
 			/* Enable a previously disabled mountpoint */
@@ -3511,6 +3474,89 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 		/* Send a success response back */
 		response = json_object();
 		json_object_set_new(response, "streaming", json_string("ok"));
+		goto prepare_response;
+	} else {
+		/* Not a request we recognize, don't do anything */
+		return NULL;
+	}
+
+prepare_response:
+		{
+			if(ifas) {
+				freeifaddrs(ifas);
+			}
+
+			if(error_code == 0 && !response) {
+				error_code = JANUS_STREAMING_ERROR_UNKNOWN_ERROR;
+				g_snprintf(error_cause, 512, "Invalid response");
+			}
+			if(error_code != 0) {
+				/* Prepare JSON error event */
+				response = json_object();
+				json_object_set_new(response, "streaming", json_string("event"));
+				json_object_set_new(response, "error_code", json_integer(error_code));
+				json_object_set_new(response, "error", json_string(error_cause));
+			}
+			return response;
+		}
+
+}
+
+struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
+	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
+		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
+
+	/* Pre-parse the message */
+	int error_code = 0;
+	char error_cause[512];
+	json_t *root = message;
+	json_t *response = NULL;
+
+	janus_mutex_lock(&sessions_mutex);
+	janus_streaming_session *session = janus_streaming_lookup_session(handle);
+	if(!session) {
+		janus_mutex_unlock(&sessions_mutex);
+		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
+		error_code = JANUS_STREAMING_ERROR_UNKNOWN_ERROR;
+		g_snprintf(error_cause, 512, "%s", "No session associated with this handle...");
+		goto plugin_response;
+	}
+	/* Increase the reference counter for this session: we'll decrease it after we handle the message */
+	janus_refcount_increase(&session->ref);
+	janus_mutex_unlock(&sessions_mutex);
+	if(g_atomic_int_get(&session->destroyed)) {
+		JANUS_LOG(LOG_ERR, "Session has already been destroyed...\n");
+		error_code = JANUS_STREAMING_ERROR_UNKNOWN_ERROR;
+		g_snprintf(error_cause, 512, "%s", "Session has already been destroyed...");
+		goto plugin_response;
+	}
+
+	if(message == NULL) {
+		JANUS_LOG(LOG_ERR, "No message??\n");
+		error_code = JANUS_STREAMING_ERROR_NO_MESSAGE;
+		g_snprintf(error_cause, 512, "%s", "No message??");
+		goto plugin_response;
+	}
+	if(!json_is_object(root)) {
+		JANUS_LOG(LOG_ERR, "JSON error: not an object\n");
+		error_code = JANUS_STREAMING_ERROR_INVALID_JSON;
+		g_snprintf(error_cause, 512, "JSON error: not an object");
+		goto plugin_response;
+	}
+	/* Get the request first */
+	JANUS_VALIDATE_JSON_OBJECT(root, request_parameters,
+		error_code, error_cause, TRUE,
+		JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
+	if(error_code != 0)
+		goto plugin_response;
+	json_t *request = json_object_get(root, "request");
+	/* Some requests ('create' and 'destroy') can be handled synchronously */
+	const char *request_text = json_string_value(request);
+	/* We have a separate method to process synchronous requests, as those may
+	 * arrive from the Admin API as well, and so we handle them the same way */
+	response = janus_streaming_process_synchronous_request(session, root);
+	if(response != NULL) {
+		/* We got a response, send it back */
 		goto plugin_response;
 	} else if(!strcasecmp(request_text, "watch") || !strcasecmp(request_text, "start")
 			|| !strcasecmp(request_text, "pause") || !strcasecmp(request_text, "stop")
@@ -3532,10 +3578,6 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 
 plugin_response:
 		{
-			if(ifas) {
-				freeifaddrs(ifas);
-			}
-
 			if(error_code == 0 && !response) {
 				error_code = JANUS_STREAMING_ERROR_UNKNOWN_ERROR;
 				g_snprintf(error_cause, 512, "Invalid response");
@@ -3557,6 +3599,40 @@ plugin_response:
 			if(session != NULL)
 				janus_refcount_decrease(&session->ref);
 			return janus_plugin_result_new(JANUS_PLUGIN_OK, NULL, response);
+		}
+
+}
+
+json_t *janus_streaming_handle_admin_message(json_t *message) {
+	/* Some requests (e.g., 'create' and 'destroy') can be handled via Admin API */
+	int error_code = 0;
+	char error_cause[512];
+	json_t *response = NULL;
+
+	json_t *request = json_object_get(message, "request");
+	const char *request_text = json_string_value(request);
+	if(request_text == NULL) {
+		error_code = JANUS_STREAMING_ERROR_MISSING_ELEMENT;
+		g_snprintf(error_cause, 512, "Missing mandatory element (request)");
+	} else if((response = janus_streaming_process_synchronous_request(NULL, message))  != NULL) {
+		/* We got a response, send it back */
+		goto admin_response;
+	} else {
+		JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
+		error_code = JANUS_STREAMING_ERROR_INVALID_REQUEST;
+		g_snprintf(error_cause, 512, "Unknown request '%s'", request_text);
+	}
+
+admin_response:
+		{
+			if(!response) {
+				/* Prepare JSON error event */
+				response = json_object();
+				json_object_set_new(response, "streaming", json_string("event"));
+				json_object_set_new(response, "error_code", json_integer(error_code));
+				json_object_set_new(response, "error", json_string(error_cause));
+			}
+			return response;
 		}
 
 }

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -3609,12 +3609,14 @@ json_t *janus_streaming_handle_admin_message(json_t *message) {
 	char error_cause[512];
 	json_t *response = NULL;
 
+	JANUS_VALIDATE_JSON_OBJECT(message, request_parameters,
+		error_code, error_cause, TRUE,
+		JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
+	if(error_code != 0)
+		goto admin_response;
 	json_t *request = json_object_get(message, "request");
 	const char *request_text = json_string_value(request);
-	if(request_text == NULL) {
-		error_code = JANUS_STREAMING_ERROR_MISSING_ELEMENT;
-		g_snprintf(error_cause, 512, "Missing mandatory element (request)");
-	} else if((response = janus_streaming_process_synchronous_request(NULL, message))  != NULL) {
+	if((response = janus_streaming_process_synchronous_request(NULL, message)) != NULL) {
 		/* We got a response, send it back */
 		goto admin_response;
 	} else {

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -470,6 +470,7 @@ const char *janus_textroom_get_author(void);
 const char *janus_textroom_get_package(void);
 void janus_textroom_create_session(janus_plugin_session *handle, int *error);
 struct janus_plugin_result *janus_textroom_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
+json_t *janus_textroom_handle_admin_message(json_t *message);
 void janus_textroom_setup_media(janus_plugin_session *handle);
 void janus_textroom_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_textroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
@@ -495,6 +496,7 @@ static janus_plugin janus_textroom_plugin =
 
 		.create_session = janus_textroom_create_session,
 		.handle_message = janus_textroom_handle_message,
+		.handle_admin_message = janus_textroom_handle_admin_message,
 		.setup_media = janus_textroom_setup_media,
 		.incoming_rtp = janus_textroom_incoming_rtp,
 		.incoming_rtcp = janus_textroom_incoming_rtcp,
@@ -1155,6 +1157,52 @@ plugin_response:
 
 }
 
+json_t *janus_textroom_handle_admin_message(json_t *message) {
+	/* Some requests (e.g., 'create' and 'destroy') can be handled via Admin API */
+	if(message == NULL)
+		return NULL;
+	int error_code = 0;
+	char error_cause[512];
+	json_t *response = NULL;
+
+	json_t *request = json_object_get(message, "textroom");
+	const char *request_text = json_string_value(request);
+	if(request_text != NULL && (!strcasecmp(request_text, "list")
+			|| !strcasecmp(request_text, "exists")
+			|| !strcasecmp(request_text, "create")
+			|| !strcasecmp(request_text, "edit")
+			|| !strcasecmp(request_text, "destroy"))) {
+		janus_plugin_result *result = janus_textroom_handle_incoming_request(NULL, NULL, message, FALSE);
+		if(result == NULL) {
+			JANUS_LOG(LOG_ERR, "JSON error: not an object\n");
+			error_code = JANUS_TEXTROOM_ERROR_INVALID_JSON;
+			g_snprintf(error_cause, 512, "JSON error: not an object");
+			goto admin_response;
+		}
+		response = result->content;
+		result->content = NULL;
+		janus_plugin_result_destroy(result);
+		return response;
+	} else {
+		JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
+		error_code = JANUS_TEXTROOM_ERROR_INVALID_REQUEST;
+		g_snprintf(error_cause, 512, "Unknown request '%s'", request_text);
+	}
+
+admin_response:
+		{
+			if(!response) {
+				/* Prepare JSON error event */
+				response = json_object();
+				json_object_set_new(response, "textroom", json_string("event"));
+				json_object_set_new(response, "error_code", json_integer(error_code));
+				json_object_set_new(response, "error", json_string(error_cause));
+			}
+			return response;
+		}
+
+}
+
 void janus_textroom_setup_media(janus_plugin_session *handle) {
 	JANUS_LOG(LOG_INFO, "WebRTC media is now available\n");
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
@@ -1210,7 +1258,9 @@ void janus_textroom_incoming_data(janus_plugin_session *handle, char *label, cha
 
 /* Helper method to handle incoming messages from the data channel */
 janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session *handle, char *text, json_t *json, gboolean internal) {
-	janus_textroom_session *session = (janus_textroom_session *)handle->plugin_handle;
+	janus_textroom_session *session = NULL;
+	if(handle)
+		session = (janus_textroom_session *)handle->plugin_handle;
 	/* Parse JSON, if needed */
 	json_error_t error;
 	json_t *root = text ? json_loads(text, 0, &error) : json;
@@ -1984,7 +2034,7 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 			json_t *info = json_object();
 			json_object_set_new(info, "event", json_string("created"));
 			json_object_set_new(info, "room", json_integer(room_id));
-			gateway->notify_event(&janus_textroom_plugin, session->handle, info);
+			gateway->notify_event(&janus_textroom_plugin, session ? session->handle : NULL, info);
 		}
 	} else if(!strcasecmp(request_text, "exists")) {
 		JANUS_VALIDATE_JSON_OBJECT(root, room_parameters,
@@ -2112,7 +2162,7 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 			json_t *info = json_object();
 			json_object_set_new(info, "event", json_string("edited"));
 			json_object_set_new(info, "room", json_integer(room_id));
-			gateway->notify_event(&janus_textroom_plugin, session->handle, info);
+			gateway->notify_event(&janus_textroom_plugin, session ? session->handle : NULL, info);
 		}
 	} else if(!strcasecmp(request_text, "destroy")) {
 		JANUS_VALIDATE_JSON_OBJECT(root, destroy_parameters,
@@ -2209,7 +2259,7 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 			json_t *info = json_object();
 			json_object_set_new(info, "event", json_string("destroyed"));
 			json_object_set_new(info, "room", json_integer(room_id));
-			gateway->notify_event(&janus_textroom_plugin, session->handle, info);
+			gateway->notify_event(&janus_textroom_plugin, session ? session->handle : NULL, info);
 		}
 	} else {
 		JANUS_LOG(LOG_ERR, "Unsupported request %s\n", request_text);

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -1180,7 +1180,7 @@ json_t *janus_textroom_handle_admin_message(json_t *message) {
 		response = result->content;
 		result->content = NULL;
 		janus_plugin_result_destroy(result);
-		return response;
+		goto admin_response;
 	} else {
 		JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
 		error_code = JANUS_TEXTROOM_ERROR_INVALID_REQUEST;

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -1163,13 +1163,18 @@ json_t *janus_textroom_handle_admin_message(json_t *message) {
 	char error_cause[512];
 	json_t *response = NULL;
 
+	JANUS_VALIDATE_JSON_OBJECT(message, request_parameters,
+		error_code, error_cause, TRUE,
+		JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT);
+	if(error_code != 0)
+		goto admin_response;
 	json_t *request = json_object_get(message, "textroom");
 	const char *request_text = json_string_value(request);
-	if(request_text != NULL && (!strcasecmp(request_text, "list")
+	if(!strcasecmp(request_text, "list")
 			|| !strcasecmp(request_text, "exists")
 			|| !strcasecmp(request_text, "create")
 			|| !strcasecmp(request_text, "edit")
-			|| !strcasecmp(request_text, "destroy"))) {
+			|| !strcasecmp(request_text, "destroy")) {
 		janus_plugin_result *result = janus_textroom_handle_incoming_request(NULL, NULL, message, FALSE);
 		if(result == NULL) {
 			JANUS_LOG(LOG_ERR, "JSON error: not an object\n");

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -1159,8 +1159,6 @@ plugin_response:
 
 json_t *janus_textroom_handle_admin_message(json_t *message) {
 	/* Some requests (e.g., 'create' and 'destroy') can be handled via Admin API */
-	if(message == NULL)
-		return NULL;
 	int error_code = 0;
 	char error_cause[512];
 	json_t *response = NULL;

--- a/plugins/lua/echotest.lua
+++ b/plugins/lua/echotest.lua
@@ -142,6 +142,13 @@ function handleMessage(id, tr, msg, jsep)
 	end
 end
 
+function handleAdminMessage(message)
+	-- This is just to showcase how you can handle incoming messages
+	-- coming from the Admin API: we return the same message as a test
+	logger.print("Got admin message: " .. dumpTable(message))
+	return message;
+end
+
 function setupMedia(id)
 	-- WebRTC is now available
 	logger.print("WebRTC PeerConnection is up for session: " .. id)
@@ -226,7 +233,7 @@ function processRequest(id, msg)
 			"audio", "opus", "/tmp", fnbase .. "-audio",
 			"video", "vp8", "/tmp", fnbase .. "-video",
 			"data", "text", "/tmp", fnbase .. "-data"
-		) 
+		)
 	elseif msg["record"] == false then
 		stopRecording(id, "audio", "video", "data")
 	end

--- a/plugins/plugin.h
+++ b/plugins/plugin.h
@@ -60,6 +60,7 @@ janus_plugin *create(void) {
  * - \c get_package(): this method should return a unique package identifier for your plugin (e.g., "janus.plugin.myplugin");
  * - \c create_session(): this method is called by the core to create a session between you and a peer;
  * - \c handle_message(): a callback to notify you the peer sent you a message/request;
+ * - \c handle_admin_message(): a callback to notify you a message/request came from the Admin API;
  * - \c setup_media(): a callback to notify you the peer PeerConnection is now ready to be used;
  * - \c incoming_rtp(): a callback to notify you a peer has sent you a RTP packet;
  * - \c incoming_rtcp(): a callback to notify you a peer has sent you a RTCP message;
@@ -169,7 +170,7 @@ janus_plugin *create(void) {
  * Janus instance or it will crash.
  *
  */
-#define JANUS_PLUGIN_API_VERSION	12
+#define JANUS_PLUGIN_API_VERSION	13
 
 /*! \brief Initialization of all plugin properties to NULL
  *
@@ -199,6 +200,7 @@ static janus_plugin janus_echotest_plugin =
 		.get_package = NULL,			\
 		.create_session = NULL,			\
 		.handle_message = NULL,			\
+		.handle_admin_message = NULL,	\
 		.setup_media = NULL,			\
 		.incoming_rtp = NULL,			\
 		.incoming_rtcp = NULL,			\
@@ -277,6 +279,10 @@ struct janus_plugin {
 	 * @returns A janus_plugin_result instance that may contain a response (for immediate/synchronous replies), an ack
 	 * (for asynchronously managed requests) or an error */
 	struct janus_plugin_result * (* const handle_message)(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
+	/*! \brief Method to handle an incoming Admin API message/request
+	 * @param[in] message The json_t object containing the message/request JSON
+	 * @returns A json_t instance containing the response */
+	struct json_t * (* const handle_admin_message)(json_t *message);
 	/*! \brief Callback to be notified when the associated PeerConnection is up and ready to be used
 	 * @param[in] handle The plugin/gateway session used for this peer */
 	void (* const setup_media)(janus_plugin_session *handle);


### PR DESCRIPTION
As the title explains, this introduces a new Admin API request, called `message_plugin`, that allows you to make synchronous requests to plugins using the Admin API instead of the Janus API.

The idea behind it is to allow plugins to expose a few selected requests via Admin API as well, so that they're easier to use: for instance, right now creating a room in the VideoRoom requires creating a session and a handle, which is not hard but is longer than it should (3 requests at least), and has the session-related overhead as part of that; having the ability to create a room via Admin API means that all you need is a single REST call and you're done, which means some management-related operations can be made much more straightforward to implement for developers.

Right now this only lays the foundation for this: I implemented the API mechanism itself and extended the plugin API with a new callback (`handle_admin_message`), but only implemented the callback in the EchoTest as a proof of concept. The EchoTest simply sends back whatever you put in the request, which made it easy for me to check everything works. Next step would be modifying the relevant plugins to support this, which will probably require a bit of a refactoring (e.g., moving the create/edit/destroy code to separate methods, since they might now be invoked in different places).

The Admin API method is very easy to use, as it looks like this:

```
{
        "janus": "message_plugin",
        "transaction": "<unique transaction ID>",
        "admin_secret": "<Admin API secret>",
        "plugin": "<plugin namespace, e.g., janus.plugin.videoroom>",
        "request": {
                // Content of the request
         }
}
```

which means a one-liner with curl is straightforward to implement, e.g.:

```
curl -X POST -H "Content-Type: application/json" -d '{"janus": "message_plugin", "transaction": "123", "admin_secret": "janusoverlord", "plugin": "janus.plugin.videoroom", "request": {"request": "list"}}' http://localhost:7088/admin/
```

To make things easy to test and use I also modified the `admin.html` page to include a `Plugins` tab, from where you can craft requests for a plugin in a visual way, e.g.:

![admin-message-plugin](https://user-images.githubusercontent.com/3684796/58637605-2622f600-82f3-11e9-9147-5a9e0c015068.png)

Feedback welcome!