### PR TITLE
Set remote candidates when handling an answer with at least one known candidate.

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -819,9 +819,10 @@ static void janus_request_ice_handle_answer(janus_ice_handle *handle, int audio,
 			janus_ice_trickle_destroy(trickle);
 		}
 	}
+
+	gboolean candidates_found = (handle->stream && handle->stream->component && g_slist_length(handle->stream->component->candidates) > 0);
 	/* This was an answer, check if it's time to start ICE */
-	if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_TRICKLE) &&
-		!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALL_TRICKLES)) {
+	if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_TRICKLE) && !candidates_found) {
 		JANUS_LOG(LOG_VERB, "[%"SCNu64"]   -- ICE Trickling is supported by the browser, waiting for remote candidates...\n", handle->handle_id);
 		janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_START);
 	} else {


### PR DESCRIPTION
This PR changes the behavior of Janus when handling an SDP answer.

*Context*: in order to let the ICE handshake proceed, Janus must invoke `janus_ice_setup_remote_candidates` at least once.

**BEFORE the proposed changes**
Upon receipt of a SDP Answer, in case of ICE trickling supported by the remote, Janus invokes `janus_ice_setup_remote_candidates` if it has previously received a gathering complete notification from the remote peer (because JANUS_ICE_HANDLE_WEBRTC_ALL_TRICKLES was set when handling a `completed: true` or `null` candidate).
Conversely (still no end of candidates) the answer handler just sets the flag JANUS_ICE_HANDLE_WEBRTC_START, leaving the invokation of `janus_ice_setup_remote_candidates` to the handler of the next valid trickle candidate sent by the client.

*Issue*: in any scenario involving, in this order:
- SDP offer out  from Janus
- zero or more valid trickle candidates (Janus en-queues the candidates)
- SDP answer (Janus en-queues the candidates and sets JANUS_ICE_HANDLE_WEBRTC_START)
- zero or more `completed: true` or `null` candidates

the ICE process basically hangs because `janus_ice_setup_remote_candidates` can be invoked only by a valid candidate or a SDP answer with the flag JANUS_ICE_HANDLE_WEBRTC_ALL_TRICKLES set.

**AFTER the proposed changes**
Upon receipt of a SDP Answer, in case of ICE trickling supported by the remote, Janus sets the remote candidates if it knows at least one remote candidate (coming from a previous trickle or from the SDP itself). Think about this in these terms: Janus should act the same way when receiving the SDP answer and one candidate in this order or in the opposite. This is the case now, but not before the PR.
In this PR the value of the flag JANUS_ICE_HANDLE_WEBRTC_ALL_TRICKLES is ignored when handling an answer. IMHO, given that messages on the signalling channel might arrive out of order and a client might be buggy or make the choice to never send this specific message, the "end of candidates" could be received out of order or not received at all, so we should not rely on that to make the handshake progress.

Fixes #1641 