### PR TITLE
Refactored janus-pp-rec to support command line options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ Makefile.in
 /events/*.la
 /events/.libs
 /postprocessing/*.o
+/postprocessing/pp-cmdline.c
+/postprocessing/pp-cmdline.h
 /fuzzers/*.a
 /fuzzers/*.o
 /fuzzers/out

--- a/Makefile.am
+++ b/Makefile.am
@@ -515,6 +515,8 @@ if ENABLE_POST_PROCESSING
 bin_PROGRAMS += janus-pp-rec
 
 janus_pp_rec_SOURCES = \
+	postprocessing/pp-cmdline.c \
+	postprocessing/pp-cmdline.h \
 	postprocessing/pp-g711.c \
 	postprocessing/pp-g711.h \
 	postprocessing/pp-g722.c \
@@ -542,8 +544,20 @@ janus_pp_rec_CFLAGS = \
 janus_pp_rec_LDADD = \
 	$(POST_PROCESSING_LIBS) \
 	$(NULL)
-endif
+
+BUILT_SOURCES += postprocessing/pp-cmdline.c postprocessing/pp-cmdline.h
+
+postprocessing/pp-cmdline.h: postprocessing/pp-cmdline.c
+
+postprocessing/pp-cmdline.c: postprocessing/janus-pp-rec.c
+	gengetopt --set-package="janus-pp-rec" --set-version="$(VERSION)" -F postprocessing/pp-cmdline < postprocessing/janus-pp-rec.ggo
+
+EXTRA_DIST += postprocessing/janus-pp-rec.ggo
+CLEANFILES += postprocessing/pp-cmdline.c postprocessing/pp-cmdline.h
+
 dist_man1_MANS += postprocessing/janus-pp-rec.1
+
+endif
 
 ##
 # Docs

--- a/Makefile.am
+++ b/Makefile.am
@@ -418,9 +418,9 @@ endif
 if ENABLE_PLUGIN_STREAMING
 plugin_LTLIBRARIES += plugins/libjanus_streaming.la
 plugins_libjanus_streaming_la_SOURCES = plugins/janus_streaming.c
-plugins_libjanus_streaming_la_CFLAGS = $(plugins_cflags)
-plugins_libjanus_streaming_la_LDFLAGS = $(plugins_ldflags)
-plugins_libjanus_streaming_la_LIBADD = $(plugins_libadd)
+plugins_libjanus_streaming_la_CFLAGS = $(plugins_cflags) $(LIBCURL_CFLAGS)
+plugins_libjanus_streaming_la_LDFLAGS = $(plugins_ldflags) $(LIBCURL_LDFLAGS) $(LIBCURL_LIBS)
+plugins_libjanus_streaming_la_LIBADD = $(plugins_libadd) $(LIBCURL_LIBADD)
 conf_DATA += conf/janus.plugin.streaming.jcfg.sample
 stream_DATA += \
 	plugins/streams/music.mulaw \

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ or on the command line:
 
 	<installdir>/bin/janus --help
 
-	janus 0.7.2
+	janus 0.7.3
 
 	Usage: janus [OPTIONS]...
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "janus-gateway",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "homepage": "https://github.com/meetecho/janus-gateway",
   "authors": [
     "Lorenzo Miniero <lorenzo@meetecho.com>",

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([Janus WebRTC Server],[0.7.2],[https://github.com/meetecho/janus-gateway],[janus-gateway],[https://janus.conf.meetecho.com])
+AC_INIT([Janus WebRTC Server],[0.7.3],[https://github.com/meetecho/janus-gateway],[janus-gateway],[https://janus.conf.meetecho.com])
 AC_LANG(C)
 AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_MACRO_DIR([m4])
@@ -69,9 +69,9 @@ clang*)
 		-Wunused-but-set-variable"
 esac
 
-JANUS_VERSION=72
+JANUS_VERSION=73
 AC_SUBST(JANUS_VERSION)
-JANUS_VERSION_STRING="0.7.2"
+JANUS_VERSION_STRING="0.7.3"
 AC_SUBST(JANUS_VERSION_STRING)
 
 case "$host_os" in

--- a/docs/janus-doxygen.cfg
+++ b/docs/janus-doxygen.cfg
@@ -32,7 +32,7 @@ PROJECT_NAME           = "Janus"
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 0.7.2
+PROJECT_NUMBER         = 0.7.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer

--- a/html/admin.html
+++ b/html/admin.html
@@ -41,6 +41,7 @@
 					<li role="presentation" class="active"><a href="#home" aria-controls="home" role="tab" data-toggle="tab">Home</a></li>
 					<li role="presentation" class="disabled"><a href="#serverinfo" aria-controls="serverinfo" role="tab" data-toggle="tab">Server Info</a></li>
 					<li role="presentation" class="disabled"><a href="#settings" aria-controls="settings" role="tab" data-toggle="tab">Settings</a></li>
+					<li role="presentation" class="disabled"><a href="#plugins" aria-controls="plugins" role="tab" data-toggle="tab">Plugins</a></li>
 					<li role="presentation" class="disabled"><a href="#handlesinfo" aria-controls="handlesinfo" role="tab" data-toggle="tab">Handles</a></li>
 					<li role="presentation" class="disabled"><a href="#tokens" aria-controls="tokens" role="tab" data-toggle="tab">Stored Tokens</a></li>
 				</ul>
@@ -61,6 +62,9 @@
 						<p>The <code>Settings</code> tab instead allows you to inspect a
 						few of the current settings in Janus (e.g., debug level and so on)
 						and provides you with a way to change them dynamically.</p>
+						<p>The <code>Plugins</code> tab presents the list of media plugins
+						available in this Janus instance, and allows you to interact with
+						them, assuming they implement the <code>handle_admin_message</code> API.</p>
 						<p>The <code>Handles</code> tab allows you to browse the currently active sessions
 						and handles in Janus. Selecting a specific handle will provide you
 						with all the current info related to it, including plugin it is
@@ -80,37 +84,24 @@
 							<table class="table table-striped" id="server-details">
 							</table>
 						</div>
+						<h4>Dependencies</h4>
+						<div>
+							<table class="table table-striped" id="server-deps">
+							</table>
+						</div>
 						<h4>Plugins</h4>
 						<div>
 							<table class="table table-striped" id="server-plugins">
-								<tr>
-									<th>Name</th>
-									<th>Author</th>
-									<th>Description</th>
-									<th>Version</th>
-								</tr>
 							</table>
 						</div>
 						<h4>Transports</h4>
 						<div>
 							<table class="table table-striped" id="server-transports">
-								<tr>
-									<th>Name</th>
-									<th>Author</th>
-									<th>Description</th>
-									<th>Version</th>
-								</tr>
 							</table>
 						</div>
 						<h4>Event handlers</h4>
 						<div>
 							<table class="table table-striped" id="server-handlers">
-								<tr>
-									<th>Name</th>
-									<th>Author</th>
-									<th>Description</th>
-									<th>Version</th>
-								</tr>
 							</table>
 						</div>
 					</div>
@@ -119,6 +110,26 @@
 						<div>
 							<table class="table table-striped" id="server-settings">
 							</table>
+						</div>
+					</div>
+					<div role="tabpanel" class="tab-pane fade" id="plugins">
+						<h4>Plugins</h4>
+						<div class="row">
+							<div class="col-md-3">
+								<table class="table" id="plugins-list">
+								</table>
+							</div>
+							<div id="plugin-message" class="col-md-9 hide">
+								<div class="row">
+									<h5>Request</h5>
+									<table class="table" id="plugin-request">
+									</table>
+								</div>
+								<div class="row">
+									<h5>Response</h5>
+									<pre id="plugin-response"></pre>
+								</div>
+							</div>
 						</div>
 					</div>
 					<div role="tabpanel" class="tab-pane fade" id="handlesinfo">

--- a/janus.c
+++ b/janus.c
@@ -141,6 +141,10 @@ static struct janus_json_parameter queryhandler_parameters[] = {
 	{"handler", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
 	{"request", JSON_OBJECT, 0}
 };
+static struct janus_json_parameter messageplugin_parameters[] = {
+	{"plugin", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
+	{"request", JSON_OBJECT, 0}
+};
 static struct janus_json_parameter customevent_parameters[] = {
 	{"schema", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
 	{"data", JSON_OBJECT, JANUS_JSON_PARAM_REQUIRED}
@@ -1969,6 +1973,40 @@ int janus_process_incoming_admin_request(janus_request *request) {
 			/* Prepare JSON reply */
 			json_t *reply = janus_create_message("success", 0, transaction_text);
 			json_object_set_new(reply, "accept", accept_new_sessions ? json_true() : json_false());
+			/* Send the success reply */
+			ret = janus_process_success(request, reply);
+			goto jsondone;
+		} else if(!strcasecmp(message_text, "message_plugin")) {
+			/* Contact a plugin and expect a response */
+			JANUS_VALIDATE_JSON_OBJECT(root, messageplugin_parameters,
+				error_code, error_cause, FALSE,
+				JANUS_ERROR_MISSING_MANDATORY_ELEMENT, JANUS_ERROR_INVALID_ELEMENT_TYPE);
+			if(error_code != 0) {
+				ret = janus_process_error_string(request, session_id, transaction_text, error_code, error_cause);
+				goto jsondone;
+			}
+			json_t *plugin = json_object_get(root, "plugin");
+			const char *plugin_value = json_string_value(plugin);
+			janus_plugin *p = janus_plugin_find(plugin_value);
+			if(p == NULL) {
+				/* No such handler... */
+				g_snprintf(error_cause, sizeof(error_cause), "%s", "Invalid plugin");
+				ret = janus_process_error_string(request, session_id, transaction_text, JANUS_ERROR_PLUGIN_NOT_FOUND, error_cause);
+				goto jsondone;
+			}
+			if(p->handle_admin_message == NULL) {
+				/* Handler doesn't implement the hook... */
+				g_snprintf(error_cause, sizeof(error_cause), "%s", "Plugin doesn't support Admin API messages");
+				ret = janus_process_error_string(request, session_id, transaction_text, JANUS_ERROR_UNKNOWN, error_cause);
+				goto jsondone;
+			}
+			json_t *query = json_object_get(root, "request");
+			json_t *response = p->handle_admin_message(query);
+			/* Prepare JSON reply */
+			json_t *reply = json_object();
+			json_object_set_new(reply, "janus", json_string("success"));
+			json_object_set_new(reply, "transaction", json_string(transaction_text));
+			json_object_set_new(reply, "response", response ? response : json_object());
 			/* Send the success reply */
 			ret = janus_process_success(request, reply);
 			goto jsondone;

--- a/janus.ggo
+++ b/janus.ggo
@@ -1,4 +1,4 @@
-#Janus 0.7.2 gengetopt file
+#Janus 0.7.3 gengetopt file
 option "daemon" b "Launch Janus in background as a daemon" flag off
 option "pid-file" p "Open the specified PID file when starting Janus (default=none)" string typestr="path" optional
 option "disable-stdout" N "Disable stdout based logging" flag off

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -3095,6 +3095,12 @@ ldd janus | grep asan
  * 		<td><a href="https://github.com/monstasat/janus-ocaml">Janus-ocaml</a></td>
  *		<td>Library for Janus WebRTC server handling written in OCaml (HTTP only)</td>
  * </tr>
+ * <tr>
+ * 		<td>Haskell</td>
+ * 		<td><a href="https://github.com/oofp">oofp</a></td>
+ * 		<td><a href="https://github.com/oofp/janus-connector">janus-connector</a></td>
+ *		<td>Haskell binding of Janus client protocol using WebSocket transport with examples</td>
+ * </tr>
  * </table>
  * <br/>
  *

--- a/plugins/duktape/echotest.js
+++ b/plugins/duktape/echotest.js
@@ -7,8 +7,8 @@
 name = "echotest.js";
 
 // Let's add more info to errors
-Error.prototype.toString = function () { 
-	return this.name + ': ' + this.message + ' (at line ' + this.lineNumber + ')'; 
+Error.prototype.toString = function () {
+	return this.name + ': ' + this.message + ' (at line ' + this.lineNumber + ')';
 };
 // Let's add a prefix to all console.log lines
 var originalConsoleLog = console.log;
@@ -144,6 +144,13 @@ function handleMessage(id, tr, msg, jsep) {
 		// Asynchronous response: return value is a positive integer
 		return 1;
 	}
+}
+
+function handleAdminMessage(message) {
+	// This is just to showcase how you can handle incoming messages
+	// coming from the Admin API: we return the same message as a test
+	console.log("Got admin message:", message);
+	return message;
 }
 
 function setupMedia(id) {

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -667,6 +667,7 @@ const char *janus_audiobridge_get_author(void);
 const char *janus_audiobridge_get_package(void);
 void janus_audiobridge_create_session(janus_plugin_session *handle, int *error);
 struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
+json_t *janus_audiobridge_handle_admin_message(json_t *message);
 void janus_audiobridge_setup_media(janus_plugin_session *handle);
 void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_audiobridge_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
@@ -690,6 +691,7 @@ static janus_plugin janus_audiobridge_plugin =
 
 		.create_session = janus_audiobridge_create_session,
 		.handle_message = janus_audiobridge_handle_message,
+		.handle_admin_message = janus_audiobridge_handle_admin_message,
 		.setup_media = janus_audiobridge_setup_media,
 		.incoming_rtp = janus_audiobridge_incoming_rtp,
 		.incoming_rtcp = janus_audiobridge_incoming_rtcp,
@@ -1687,56 +1689,17 @@ json_t *janus_audiobridge_query_session(janus_plugin_session *handle) {
 	return info;
 }
 
-struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
-	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
-		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
+/* Helper method to process synchronous requests */
+static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_session *session, json_t *message) {
+	json_t *request = json_object_get(message, "request");
+	const char *request_text = json_string_value(request);
 
-	/* Pre-parse the message */
+	/* Parse the message */
 	int error_code = 0;
 	char error_cause[512];
 	json_t *root = message;
 	json_t *response = NULL;
 
-	janus_mutex_lock(&sessions_mutex);
-	janus_audiobridge_session *session = janus_audiobridge_lookup_session(handle);
-	if(!session) {
-		janus_mutex_unlock(&sessions_mutex);
-		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
-		error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
-		g_snprintf(error_cause, 512, "%s", "No session associated with this handle...");
-		goto plugin_response;
-	}
-	/* Increase the reference counter for this session: we'll decrease it after we handle the message */
-	janus_refcount_increase(&session->ref);
-	janus_mutex_unlock(&sessions_mutex);
-	if(g_atomic_int_get(&session->destroyed)) {
-		JANUS_LOG(LOG_ERR, "Session has already been marked as destroyed...\n");
-		error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
-		g_snprintf(error_cause, 512, "%s", "Session has already been marked as destroyed...");
-		goto plugin_response;
-	}
-
-	if(message == NULL) {
-		JANUS_LOG(LOG_ERR, "No message??\n");
-		error_code = JANUS_AUDIOBRIDGE_ERROR_NO_MESSAGE;
-		g_snprintf(error_cause, 512, "%s", "No message??");
-		goto plugin_response;
-	}
-	if(!json_is_object(root)) {
-		JANUS_LOG(LOG_ERR, "JSON error: not an object\n");
-		error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_JSON;
-		g_snprintf(error_cause, 512, "JSON error: not an object");
-		goto plugin_response;
-	}
-	/* Get the request first */
-	JANUS_VALIDATE_JSON_OBJECT(root, request_parameters,
-		error_code, error_cause, TRUE,
-		JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
-	if(error_code != 0)
-		goto plugin_response;
-	json_t *request = json_object_get(root, "request");
-	/* Some requests ('create', 'destroy', 'exists', 'list') can be handled synchronously */
-	const char *request_text = json_string_value(request);
 	if(!strcasecmp(request_text, "create")) {
 		/* Create a new audiobridge */
 		JANUS_LOG(LOG_VERB, "Creating a new audiobridge\n");
@@ -1744,18 +1707,18 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		if(admin_key != NULL) {
 			/* An admin key was specified: make sure it was provided, and that it's valid */
 			JANUS_VALIDATE_JSON_OBJECT(root, adminkey_parameters,
 				error_code, error_cause, TRUE,
 				JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 			JANUS_CHECK_SECRET(admin_key, root, "admin_key", error_code, error_cause,
 				JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_UNAUTHORIZED);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 		}
 		json_t *desc = json_object_get(root, "description");
 		json_t *secret = json_object_get(root, "secret");
@@ -1787,7 +1750,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 				JANUS_LOG(LOG_ERR, "Invalid element in the allowed array (not a string)\n");
 				error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT;
 				g_snprintf(error_cause, 512, "Invalid element in the allowed array (not a string)");
-				goto plugin_response;
+				goto prepare_response;
 			}
 		}
 		gboolean save = permanent ? json_is_true(permanent) : FALSE;
@@ -1795,7 +1758,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No configuration file, can't create permanent room\n");
 			error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "No configuration file, can't create permanent room");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		guint64 room_id = 0;
 		json_t *room = json_object_get(root, "room");
@@ -1812,7 +1775,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 				JANUS_LOG(LOG_ERR, "Room %"SCNu64" already exists!\n", room_id);
 				error_code = JANUS_AUDIOBRIDGE_ERROR_ROOM_EXISTS;
 				g_snprintf(error_cause, 512, "Room %"SCNu64" already exists", room_id);
-				goto plugin_response;
+				goto prepare_response;
 			}
 		}
 		/* Create the audio bridge room */
@@ -1875,7 +1838,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 				JANUS_LOG(LOG_ERR, "Unsupported sampling rate %"SCNu32"...\n", audiobridge->sampling_rate);
 				error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
 				g_snprintf(error_cause, 512, "We currently only support 16kHz (wideband) as a sampling rate for audio rooms, %"SCNu32" TBD...", audiobridge->sampling_rate);
-				goto plugin_response;
+				goto prepare_response;
 		}
 		audiobridge->record = FALSE;
 		if(record && json_is_true(record))
@@ -1925,7 +1888,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			janus_refcount_decrease(&audiobridge->ref);
 			g_hash_table_remove(rooms, &audiobridge->room_id);
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		if(save) {
 			/* This room is permanent: save to the configuration file too
@@ -1978,17 +1941,17 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			json_t *info = json_object();
 			json_object_set_new(info, "event", json_string("created"));
 			json_object_set_new(info, "room", json_integer(audiobridge->room_id));
-			gateway->notify_event(&janus_audiobridge_plugin, session->handle, info);
+			gateway->notify_event(&janus_audiobridge_plugin, session ? session->handle : NULL, info);
 		}
 		janus_mutex_unlock(&rooms_mutex);
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "edit")) {
 		JANUS_LOG(LOG_VERB, "Attempt to edit an existing audiobridge room\n");
 		JANUS_VALIDATE_JSON_OBJECT(root, edit_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		/* We only allow for a limited set of properties to be edited */
 		json_t *room = json_object_get(root, "room");
 		json_t *desc = json_object_get(root, "new_description");
@@ -2001,7 +1964,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No configuration file, can't edit room permanently\n");
 			error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "No configuration file, can't edit room permanently");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -2011,7 +1974,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_mutex_lock(&audiobridge->mutex);
 		/* A secret may be required for this action */
@@ -2020,7 +1983,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		if(error_code != 0) {
 			janus_mutex_unlock(&audiobridge->mutex);
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* Edit the room properties that were provided */
 		if(desc != NULL && strlen(json_string_value(desc)) > 0) {
@@ -2096,20 +2059,20 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			json_t *info = json_object();
 			json_object_set_new(info, "event", json_string("edited"));
 			json_object_set_new(info, "room", json_integer(room_id));
-			gateway->notify_event(&janus_audiobridge_plugin, session->handle, info);
+			gateway->notify_event(&janus_audiobridge_plugin, session ? session->handle : NULL, info);
 		}
 		janus_mutex_unlock(&audiobridge->mutex);
 		janus_mutex_unlock(&rooms_mutex);
 		/* Done */
 		JANUS_LOG(LOG_VERB, "Audiobridge room edited\n");
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "destroy")) {
 		JANUS_LOG(LOG_VERB, "Attempt to destroy an existing audiobridge room\n");
 		JANUS_VALIDATE_JSON_OBJECT(root, destroy_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *room = json_object_get(root, "room");
 		json_t *permanent = json_object_get(root, "permanent");
 		gboolean save = permanent ? json_is_true(permanent) : FALSE;
@@ -2117,7 +2080,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No configuration file, can't destroy room permanently\n");
 			error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "No configuration file, can't destroy room permanently");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -2127,7 +2090,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_mutex_lock(&audiobridge->mutex);
 		/* A secret may be required for this action */
@@ -2136,7 +2099,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		if(error_code != 0) {
 			janus_mutex_unlock(&audiobridge->mutex);
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* Remove room */
 		janus_refcount_increase(&audiobridge->ref);
@@ -2199,7 +2162,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			json_t *info = json_object();
 			json_object_set_new(info, "event", json_string("destroyed"));
 			json_object_set_new(info, "room", json_integer(room_id));
-			gateway->notify_event(&janus_audiobridge_plugin, session->handle, info);
+			gateway->notify_event(&janus_audiobridge_plugin, session ? session->handle : NULL, info);
 		}
 		janus_mutex_unlock(&audiobridge->mutex);
 		janus_mutex_unlock(&rooms_mutex);
@@ -2210,7 +2173,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_object_set_new(response, "room", json_integer(room_id));
 		json_object_set_new(response, "permanent", save ? json_true() : json_false());
 		JANUS_LOG(LOG_VERB, "Audiobridge room destroyed\n");
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "list")) {
 		/* List all rooms (but private ones) and their details (except for the secret, of course...) */
 		json_t *list = json_array();
@@ -2245,14 +2208,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		response = json_object();
 		json_object_set_new(response, "audiobridge", json_string("success"));
 		json_object_set_new(response, "list", list);
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "exists")) {
 		/* Check whether a given room exists or not, returns true/false */
 		JANUS_VALIDATE_JSON_OBJECT(root, room_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -2262,14 +2225,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_object_set_new(response, "audiobridge", json_string("success"));
 		json_object_set_new(response, "room", json_integer(room_id));
 		json_object_set_new(response, "exists", room_exists ? json_true() : json_false());
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "allowed")) {
 		JANUS_LOG(LOG_VERB, "Attempt to edit the list of allowed participants in an existing audiobridge room\n");
 		JANUS_VALIDATE_JSON_OBJECT(root, allowed_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *action = json_object_get(root, "action");
 		json_t *room = json_object_get(root, "room");
 		json_t *allowed = json_object_get(root, "allowed");
@@ -2279,7 +2242,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "Unsupported action '%s' (allowed)\n", action_text);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT;
 			g_snprintf(error_cause, 512, "Unsupported action '%s' (allowed)", action_text);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -2289,7 +2252,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_mutex_lock(&audiobridge->mutex);
 		/* A secret may be required for this action */
@@ -2298,7 +2261,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		if(error_code != 0) {
 			janus_mutex_unlock(&audiobridge->mutex);
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		if(!strcasecmp(action_text, "enable")) {
 			JANUS_LOG(LOG_VERB, "Enabling the check on allowed authorization tokens for room %"SCNu64"\n", room_id);
@@ -2327,7 +2290,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 					g_snprintf(error_cause, 512, "Invalid element in the allowed array (not a string)");
 					janus_mutex_unlock(&audiobridge->mutex);
 					janus_mutex_unlock(&rooms_mutex);
-					goto plugin_response;
+					goto prepare_response;
 				}
 				size_t i = 0;
 				for(i=0; i<json_array_size(allowed); i++) {
@@ -2362,14 +2325,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		janus_mutex_unlock(&audiobridge->mutex);
 		janus_mutex_unlock(&rooms_mutex);
 		JANUS_LOG(LOG_VERB, "Audiobridge room allowed list updated\n");
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "kick")) {
 		JANUS_LOG(LOG_VERB, "Attempt to kick a participant from an existing audiobridge room\n");
 		JANUS_VALIDATE_JSON_OBJECT(root, kick_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *room = json_object_get(root, "room");
 		json_t *id = json_object_get(root, "id");
 		guint64 room_id = json_integer_value(room);
@@ -2380,7 +2343,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_refcount_increase(&audiobridge->ref);
 		janus_mutex_lock(&audiobridge->mutex);
@@ -2391,7 +2354,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		if(error_code != 0) {
 			janus_mutex_unlock(&audiobridge->mutex);
 			janus_refcount_decrease(&audiobridge->ref);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		guint64 user_id = json_integer_value(id);
 		janus_audiobridge_participant *participant = g_hash_table_lookup(audiobridge->participants, &user_id);
@@ -2401,7 +2364,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such user %"SCNu64" in room %"SCNu64"\n", user_id, room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_USER;
 			g_snprintf(error_cause, 512, "No such user %"SCNu64" in room %"SCNu64, user_id, room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* Notify all participants about the kick */
 		json_t *event = json_object();
@@ -2424,7 +2387,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			json_object_set_new(info, "event", json_string("kicked"));
 			json_object_set_new(info, "room", json_integer(room_id));
 			json_object_set_new(info, "id", json_integer(user_id));
-			gateway->notify_event(&janus_audiobridge_plugin, session->handle, info);
+			gateway->notify_event(&janus_audiobridge_plugin, session ? session->handle : NULL, info);
 		}
 		/* Tell the core to tear down the PeerConnection, hangup_media will do the rest */
 		if(participant && participant->session)
@@ -2436,14 +2399,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		/* Done */
 		janus_mutex_unlock(&audiobridge->mutex);
 		janus_refcount_decrease(&audiobridge->ref);
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "listparticipants")) {
 		/* List all participants in a room */
 		JANUS_VALIDATE_JSON_OBJECT(root, room_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -2453,7 +2416,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_refcount_increase(&audiobridge->ref);
 		/* Return a list of all participants */
@@ -2479,37 +2442,37 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_object_set_new(response, "audiobridge", json_string("participants"));
 		json_object_set_new(response, "room", json_integer(room_id));
 		json_object_set_new(response, "participants", list);
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "resetdecoder")) {
 		/* Mark the Opus decoder for the participant invalid and recreate it */
-		janus_audiobridge_participant *participant = (janus_audiobridge_participant *)session->participant;
+		janus_audiobridge_participant *participant = (janus_audiobridge_participant *)(session ? session->participant : NULL);
 		if(participant == NULL || participant->room == NULL) {
 			JANUS_LOG(LOG_ERR, "Can't reset (not in a room)\n");
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NOT_JOINED;
 			g_snprintf(error_cause, 512, "Can't reset (not in a room)");
-			goto plugin_response;
+			goto prepare_response;
 		}
 		participant->reset = TRUE;
 		response = json_object();
 		json_object_set_new(response, "audiobridge", json_string("success"));
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "rtp_forward")) {
 		JANUS_VALIDATE_JSON_OBJECT(root, rtp_forward_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		if(lock_rtpfwd && admin_key != NULL) {
 			/* An admin key was specified: make sure it was provided, and that it's valid */
 			JANUS_VALIDATE_JSON_OBJECT(root, adminkey_parameters,
 				error_code, error_cause, TRUE,
 				JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 			JANUS_CHECK_SECRET(admin_key, root, "admin_key", error_code, error_cause,
 				JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_UNAUTHORIZED);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 		}
 		/* Parse arguments */
 		guint64 room_id = json_integer_value(json_object_get(root, "room"));
@@ -2526,7 +2489,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "Invalid port number (%d)\n", port);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT;
 			g_snprintf(error_cause, 512, "Invalid port number (%d)", port);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		json_t *json_host = json_object_get(root, "host");
 		const char *host = json_string_value(json_host);
@@ -2543,7 +2506,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 				JANUS_LOG(LOG_ERR, "Invalid SRTP suite (%d)\n", srtp_suite);
 				error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT;
 				g_snprintf(error_cause, 512, "Invalid SRTP suite (%d)", srtp_suite);
-				goto plugin_response;
+				goto prepare_response;
 			}
 			srtp_crypto = json_string_value(s_crypto);
 		}
@@ -2555,14 +2518,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* A secret may be required for this action */
 		JANUS_CHECK_SECRET(audiobridge->room_secret, root, "secret", error_code, error_cause,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_UNAUTHORIZED);
 		if(error_code != 0) {
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_mutex_lock(&audiobridge->mutex);
 		if(audiobridge->destroyed) {
@@ -2571,7 +2534,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 
 		if (janus_audiobridge_create_udp_socket_if_needed(audiobridge)) {
@@ -2579,7 +2542,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			janus_mutex_unlock(&rooms_mutex);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
 			g_snprintf(error_cause, 512, "Could not open UDP socket for RTP forwarder");
-			goto plugin_response;
+			goto prepare_response;
 		}
 
 		if (janus_audiobridge_create_opus_encoder_if_needed(audiobridge)) {
@@ -2587,7 +2550,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			janus_mutex_unlock(&rooms_mutex);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_LIBOPUS_ERROR;
 			g_snprintf(error_cause, 512, "Error creating Opus decoder for RTP forwarder");
-			goto plugin_response;
+			goto prepare_response;
 		}
 
 		guint32 stream_id = janus_audiobridge_rtp_forwarder_add_helper(audiobridge,
@@ -2602,24 +2565,24 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_object_set_new(response, "stream_id", json_integer(stream_id));
 		json_object_set_new(response, "host", json_string(host));
 		json_object_set_new(response, "port", json_integer(port));
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "stop_rtp_forward")) {
 		JANUS_VALIDATE_JSON_OBJECT(root, stop_rtp_forward_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		if(lock_rtpfwd && admin_key != NULL) {
 			/* An admin key was specified: make sure it was provided, and that it's valid */
 			JANUS_VALIDATE_JSON_OBJECT(root, adminkey_parameters,
 				error_code, error_cause, TRUE,
 				JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 			JANUS_CHECK_SECRET(admin_key, root, "admin_key", error_code, error_cause,
 				JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_UNAUTHORIZED);
 			if(error_code != 0)
-				goto plugin_response;
+				goto prepare_response;
 		}
 		/* Parse parameters */
 		guint64 room_id = json_integer_value(json_object_get(root, "room"));
@@ -2633,14 +2596,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* A secret may be required for this action */
 		JANUS_CHECK_SECRET(audiobridge->room_secret, root, "secret", error_code, error_cause,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_UNAUTHORIZED);
 		if(error_code != 0) {
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_mutex_lock(&audiobridge->mutex);
 		if(audiobridge->destroyed) {
@@ -2649,7 +2612,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		janus_mutex_lock(&audiobridge->rtp_mutex);
 		g_hash_table_remove(audiobridge->rtp_forwarders, GUINT_TO_POINTER(stream_id));
@@ -2660,14 +2623,14 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_object_set_new(response, "audiobridge", json_string("success"));
 		json_object_set_new(response, "room", json_integer(room_id));
 		json_object_set_new(response, "stream_id", json_integer(stream_id));
-		goto plugin_response;
+		goto prepare_response;
 	} else if(!strcasecmp(request_text, "listforwarders")) {
 		/* List all forwarders in a room */
 		JANUS_VALIDATE_JSON_OBJECT(root, room_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
 		if(error_code != 0)
-			goto plugin_response;
+			goto prepare_response;
 		json_t *room = json_object_get(root, "room");
 		guint64 room_id = json_integer_value(room);
 		janus_mutex_lock(&rooms_mutex);
@@ -2677,21 +2640,21 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		if(audiobridge->destroyed) {
 			JANUS_LOG(LOG_ERR, "No such room (%"SCNu64")\n", room_id);
 			error_code = JANUS_AUDIOBRIDGE_ERROR_NO_SUCH_ROOM;
 			g_snprintf(error_cause, 512, "No such room (%"SCNu64")", room_id);
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* A secret may be required for this action */
 		JANUS_CHECK_SECRET(audiobridge->room_secret, root, "secret", error_code, error_cause,
 			JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_UNAUTHORIZED);
 		if(error_code != 0) {
 			janus_mutex_unlock(&rooms_mutex);
-			goto plugin_response;
+			goto prepare_response;
 		}
 		/* Return a list of all forwarders */
 		json_t *list = json_array();
@@ -2719,6 +2682,85 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 		json_object_set_new(response, "audiobridge", json_string("forwarders"));
 		json_object_set_new(response, "room", json_integer(room_id));
 		json_object_set_new(response, "rtp_forwarders", list);
+		goto prepare_response;
+	} else {
+		/* Not a request we recognize, don't do anything */
+		return NULL;
+	}
+
+prepare_response:
+		{
+			if(error_code == 0 && !response) {
+				error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
+				g_snprintf(error_cause, 512, "Invalid response");
+			}
+			if(error_code != 0) {
+				/* Prepare JSON error event */
+				response = json_object();
+				json_object_set_new(response, "audiobridge", json_string("event"));
+				json_object_set_new(response, "error_code", json_integer(error_code));
+				json_object_set_new(response, "error", json_string(error_cause));
+			}
+			return response;
+		}
+
+}
+
+struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
+	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
+		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
+
+	/* Pre-parse the message */
+	int error_code = 0;
+	char error_cause[512];
+	json_t *root = message;
+	json_t *response = NULL;
+
+	janus_mutex_lock(&sessions_mutex);
+	janus_audiobridge_session *session = janus_audiobridge_lookup_session(handle);
+	if(!session) {
+		janus_mutex_unlock(&sessions_mutex);
+		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
+		error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
+		g_snprintf(error_cause, 512, "%s", "No session associated with this handle...");
+		goto plugin_response;
+	}
+	/* Increase the reference counter for this session: we'll decrease it after we handle the message */
+	janus_refcount_increase(&session->ref);
+	janus_mutex_unlock(&sessions_mutex);
+	if(g_atomic_int_get(&session->destroyed)) {
+		JANUS_LOG(LOG_ERR, "Session has already been marked as destroyed...\n");
+		error_code = JANUS_AUDIOBRIDGE_ERROR_UNKNOWN_ERROR;
+		g_snprintf(error_cause, 512, "%s", "Session has already been marked as destroyed...");
+		goto plugin_response;
+	}
+
+	if(message == NULL) {
+		JANUS_LOG(LOG_ERR, "No message??\n");
+		error_code = JANUS_AUDIOBRIDGE_ERROR_NO_MESSAGE;
+		g_snprintf(error_cause, 512, "%s", "No message??");
+		goto plugin_response;
+	}
+	if(!json_is_object(root)) {
+		JANUS_LOG(LOG_ERR, "JSON error: not an object\n");
+		error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_JSON;
+		g_snprintf(error_cause, 512, "JSON error: not an object");
+		goto plugin_response;
+	}
+	/* Get the request first */
+	JANUS_VALIDATE_JSON_OBJECT(root, request_parameters,
+		error_code, error_cause, TRUE,
+		JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
+	if(error_code != 0)
+		goto plugin_response;
+	json_t *request = json_object_get(root, "request");
+	/* Some requests ('create', 'destroy', 'exists', 'list') can be handled synchronously */
+	const char *request_text = json_string_value(request);
+	/* We have a separate method to process synchronous requests, as those may
+	 * arrive from the Admin API as well, and so we handle them the same way */
+	response = janus_audiobridge_process_synchronous_request(session, root);
+	if(response != NULL) {
+		/* We got a response, send it back */
 		goto plugin_response;
 	} else if(!strcasecmp(request_text, "join") || !strcasecmp(request_text, "configure")
 			|| !strcasecmp(request_text, "changeroom") || !strcasecmp(request_text, "leave")) {
@@ -2761,6 +2803,42 @@ plugin_response:
 			if(session != NULL)
 				janus_refcount_decrease(&session->ref);
 			return janus_plugin_result_new(JANUS_PLUGIN_OK, NULL, response);
+		}
+
+}
+
+json_t *janus_audiobridge_handle_admin_message(json_t *message) {
+	/* Some requests (e.g., 'create' and 'destroy') can be handled via Admin API */
+	int error_code = 0;
+	char error_cause[512];
+	json_t *response = NULL;
+
+	JANUS_VALIDATE_JSON_OBJECT(message, request_parameters,
+		error_code, error_cause, TRUE,
+		JANUS_AUDIOBRIDGE_ERROR_MISSING_ELEMENT, JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT);
+	if(error_code != 0)
+		goto admin_response;
+	json_t *request = json_object_get(message, "request");
+	const char *request_text = json_string_value(request);
+	if((response = janus_audiobridge_process_synchronous_request(NULL, message)) != NULL) {
+		/* We got a response, send it back */
+		goto admin_response;
+	} else {
+		JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
+		error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_REQUEST;
+		g_snprintf(error_cause, 512, "Unknown request '%s'", request_text);
+	}
+
+admin_response:
+		{
+			if(!response) {
+				/* Prepare JSON error event */
+				response = json_object();
+				json_object_set_new(response, "streaming", json_string("event"));
+				json_object_set_new(response, "error_code", json_integer(error_code));
+				json_object_set_new(response, "error", json_string(error_cause));
+			}
+			return response;
 		}
 
 }

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -3775,6 +3775,7 @@ static void *janus_audiobridge_handler(void *data) {
 			/* Is the sampling rate of the new room the same as the one in the old room, or should we update the decoder/encoder? */
 			janus_audiobridge_room *old_audiobridge = participant->room;
 			/* Leave the old room first... */
+			janus_refcount_increase(&participant->ref);
 			janus_mutex_lock(&old_audiobridge->mutex);
 			g_hash_table_remove(old_audiobridge->participants, &participant->user_id);
 			if(old_audiobridge->sampling_rate != audiobridge->sampling_rate) {

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -140,6 +140,7 @@ const char *janus_echotest_get_author(void);
 const char *janus_echotest_get_package(void);
 void janus_echotest_create_session(janus_plugin_session *handle, int *error);
 struct janus_plugin_result *janus_echotest_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
+json_t *janus_echotest_handle_admin_message(json_t *message);
 void janus_echotest_setup_media(janus_plugin_session *handle);
 void janus_echotest_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_echotest_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
@@ -165,6 +166,7 @@ static janus_plugin janus_echotest_plugin =
 
 		.create_session = janus_echotest_create_session,
 		.handle_message = janus_echotest_handle_message,
+		.handle_admin_message = janus_echotest_handle_admin_message,
 		.setup_media = janus_echotest_setup_media,
 		.incoming_rtp = janus_echotest_incoming_rtp,
 		.incoming_rtcp = janus_echotest_incoming_rtcp,
@@ -500,6 +502,13 @@ struct janus_plugin_result *janus_echotest_handle_message(janus_plugin_session *
 	 * (a JSON object with a "hint" string in it, that's what the core expects),
 	 * but we don't have to: other plugins don't put anything in there */
 	return janus_plugin_result_new(JANUS_PLUGIN_OK_WAIT, "I'm taking my time!", NULL);
+}
+
+json_t *janus_echotest_handle_admin_message(json_t *message) {
+	/* Just here as a proof of concept: since there's nothing to configure,
+	 * as an EchoTest plugin we echo this Admin request back as well */
+	json_t *response = json_deep_copy(message);
+	return response;
 }
 
 void janus_echotest_setup_media(janus_plugin_session *handle) {

--- a/plugins/lua/echotest.lua
+++ b/plugins/lua/echotest.lua
@@ -142,6 +142,13 @@ function handleMessage(id, tr, msg, jsep)
 	end
 end
 
+function handleAdminMessage(message)
+	-- This is just to showcase how you can handle incoming messages
+	-- coming from the Admin API: we return the same message as a test
+	logger.print("Got admin message: " .. dumpTable(message))
+	return message;
+end
+
 function setupMedia(id)
 	-- WebRTC is now available
 	logger.print("WebRTC PeerConnection is up for session: " .. id)
@@ -226,7 +233,7 @@ function processRequest(id, msg)
 			"audio", "opus", "/tmp", fnbase .. "-audio",
 			"video", "vp8", "/tmp", fnbase .. "-video",
 			"data", "text", "/tmp", fnbase .. "-data"
-		) 
+		)
 	elseif msg["record"] == false then
 		stopRecording(id, "audio", "video", "data")
 	end

--- a/plugins/plugin.h
+++ b/plugins/plugin.h
@@ -60,6 +60,7 @@ janus_plugin *create(void) {
  * - \c get_package(): this method should return a unique package identifier for your plugin (e.g., "janus.plugin.myplugin");
  * - \c create_session(): this method is called by the core to create a session between you and a peer;
  * - \c handle_message(): a callback to notify you the peer sent you a message/request;
+ * - \c handle_admin_message(): a callback to notify you a message/request came from the Admin API;
  * - \c setup_media(): a callback to notify you the peer PeerConnection is now ready to be used;
  * - \c incoming_rtp(): a callback to notify you a peer has sent you a RTP packet;
  * - \c incoming_rtcp(): a callback to notify you a peer has sent you a RTCP message;
@@ -169,7 +170,7 @@ janus_plugin *create(void) {
  * Janus instance or it will crash.
  *
  */
-#define JANUS_PLUGIN_API_VERSION	12
+#define JANUS_PLUGIN_API_VERSION	13
 
 /*! \brief Initialization of all plugin properties to NULL
  *
@@ -199,6 +200,7 @@ static janus_plugin janus_echotest_plugin =
 		.get_package = NULL,			\
 		.create_session = NULL,			\
 		.handle_message = NULL,			\
+		.handle_admin_message = NULL,	\
 		.setup_media = NULL,			\
 		.incoming_rtp = NULL,			\
 		.incoming_rtcp = NULL,			\
@@ -277,6 +279,10 @@ struct janus_plugin {
 	 * @returns A janus_plugin_result instance that may contain a response (for immediate/synchronous replies), an ack
 	 * (for asynchronously managed requests) or an error */
 	struct janus_plugin_result * (* const handle_message)(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
+	/*! \brief Method to handle an incoming Admin API message/request
+	 * @param[in] message The json_t object containing the message/request JSON
+	 * @returns A json_t instance containing the response */
+	struct json_t * (* const handle_admin_message)(json_t *message);
 	/*! \brief Callback to be notified when the associated PeerConnection is up and ready to be used
 	 * @param[in] handle The plugin/gateway session used for this peer */
 	void (* const setup_media)(janus_plugin_session *handle);

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -40,6 +40,34 @@
 ./janus-pp-rec --parse /path/to/source.mjr
 \endverbatim
  *
+ * For a more complete overview of the available command line settings,
+ * launch the tool with no arguments or by passing \c --help and it will
+ * show something like this:
+ *
+\verbatim
+Usage: janus-pp-rec [OPTIONS] source.mjr [destination.[opus|wav|webm|mp4|srt]]
+
+  -h, --help                    Print help and exit
+  -V, --version                 Print version and exit
+  -j, --json                    Only print JSON header  (default=off)
+  -H, --header                  Only parse .mjr header  (default=off)
+  -p, --parse                   Only parse and re-order packets  (default=off)
+  -m, --metadata=metadata       Save this metadata string in the target file
+  -r, --postreset-trigger=count Number of packets needed to detect a timestamp
+                                  reset (default=200)
+  -i, --ignore-first=count      Number of first packets to ignore when
+                                  processing, e.g., in case they're cause of
+                                  issues (default=0)
+  -a, --audiolevel-ext=id       ID of the audio-levels RTP extension
+                                  (default=none)
+  -v, --videoorient-ext=id      ID of the video-orientation RTP extension
+                                  (default=none)
+  -d, --debug-level=1-7         Debug/logging level (0=disable debugging,
+                                  7=maximum debug level; default=4)
+  -D, --debug-timestamps        Enable debug/logging timestamps  (default=off)
+  -o, --disable-colors          Disable color in the logging  (default=off)
+\endverbatim
+ *
  * \note This utility does not do any form of transcoding. It just
  * depacketizes the RTP frames in order to get the payload, and saves
  * the frames in a valid container. Any further post-processing (e.g.,
@@ -65,6 +93,7 @@
 
 #include "../debug.h"
 #include "../version.h"
+#include "pp-cmdline.h"
 #include "pp-rtp.h"
 #include "pp-webm.h"
 #include "pp-h264.h"
@@ -85,7 +114,8 @@ static janus_pp_frame_packet *list = NULL, *last = NULL;
 static char *metadata = NULL;
 static int working = 0;
 
-static int post_reset_trigger = 200;
+#define DEFAULT_POST_RESET_TRIGGER	200
+static int post_reset_trigger = DEFAULT_POST_RESET_TRIGGER;
 static int ignore_first_packets = 0;
 
 
@@ -105,80 +135,125 @@ static int janus_pp_rtp_header_extension_parse_video_orientation(char *buf, int 
 /* Main Code */
 int main(int argc, char *argv[])
 {
+	struct gengetopt_args_info args_info;
+	/* Let's call our cmdline parser */
+	if(cmdline_parser(argc, argv, &args_info) != 0)
+		exit(1);
+
 	janus_log_init(FALSE, TRUE, NULL);
 	atexit(janus_log_destroy);
 
 	/* If we're asked to print the JSON header as it is, we must not print anything else */
-	gboolean jsonheader_only = FALSE;
-	if(argc == 3)
-		jsonheader_only = !strcmp(argv[1], "--json");
+	gboolean jsonheader_only = FALSE, header_only = FALSE, parse_only = FALSE;
+	if(args_info.json_given)
+		jsonheader_only = TRUE;
+	if(args_info.header_given && !jsonheader_only)
+		header_only = TRUE;
+	if(args_info.parse_given && !jsonheader_only && !header_only)
+		parse_only = TRUE;
+
+	/* We support both command line arguments and, for backwards compatibility, env variables in some cases */
+	if(args_info.debug_level_given || (g_getenv("JANUS_PPREC_DEBUG") != NULL)) {
+		int val = args_info.debug_level_given ? args_info.debug_level_arg : atoi(g_getenv("JANUS_PPREC_DEBUG"));
+		if(val >= LOG_NONE && val <= LOG_MAX)
+			janus_log_level = val;
+	}
+	if(args_info.disable_colors_given)
+		janus_log_colors = FALSE;
+	if(args_info.debug_timestamps_given)
+		janus_log_timestamps = TRUE;
+	if(args_info.metadata_given || (g_getenv("JANUS_PPREC_METADATA") != NULL)) {
+		metadata = g_strdup(args_info.metadata_given ? args_info.metadata_arg : g_getenv("JANUS_PPREC_METADATA"));
+	}
+	if(args_info.postreset_trigger_given || (g_getenv("JANUS_PPREC_POSTRESETTRIGGER") != NULL)) {
+		int val = args_info.postreset_trigger_given ? args_info.postreset_trigger_arg : atoi(g_getenv("JANUS_PPREC_POSTRESETTRIGGER"));
+		if(val >= 0)
+			post_reset_trigger = val;
+	}
+	if(args_info.ignore_first_given || (g_getenv("JANUS_PPREC_IGNOREFIRST") != NULL)) {
+		int val = args_info.ignore_first_given ? args_info.ignore_first_arg : atoi(g_getenv("JANUS_PPREC_IGNOREFIRST"));
+		if(val >= 0)
+			ignore_first_packets = val;
+	}
+	if(args_info.audiolevel_ext_given || (g_getenv("JANUS_PPREC_AUDIOLEVELEXT") != NULL)) {
+		int val = args_info.audiolevel_ext_given ? args_info.audiolevel_ext_arg : atoi(g_getenv("JANUS_PPREC_AUDIOLEVELEXT"));
+		if(val >= 0)
+			audio_level_extmap_id = val;
+	}
+	if(args_info.videoorient_ext_given || (g_getenv("JANUS_PPREC_VIDEOORIENTEXT") != NULL)) {
+		int val = args_info.videoorient_ext_given ? args_info.videoorient_ext_arg : atoi(g_getenv("JANUS_PPREC_VIDEOORIENTEXT"));
+		if(val >= 0)
+			video_orient_extmap_id = val;
+	}
+
+	/* Evaluate arguments to find source and target */
+	char *source = NULL, *destination = NULL, *setting = NULL;
+	int i=0;
+	for(i=1; i<argc; i++) {
+		if(argv[i] == NULL || strlen(argv[i]) == 0) {
+			setting = NULL;
+			continue;
+		}
+		if(argv[i][0] == '-') {
+			setting = argv[i];
+			continue;
+		}
+		if(setting == NULL || (
+				(strcmp(setting, "-m")) && (strcmp(setting, "--metadata")) &&
+				(strcmp(setting, "-r")) && (strcmp(setting, "--postreset-trigger")) &&
+				(strcmp(setting, "-i")) && (strcmp(setting, "--ignore-first")) &&
+				(strcmp(setting, "-a")) && (strcmp(setting, "--audiolevel-ext")) &&
+				(strcmp(setting, "-v")) && (strcmp(setting, "--videoorient-ext")) &&
+				(strcmp(setting, "-d")) && (strcmp(setting, "--debug-level"))
+		)) {
+			if(source == NULL)
+				source = argv[i];
+			else if(destination == NULL)
+				destination = argv[i];
+		}
+		setting = NULL;
+	}
+	if(source == NULL || (destination == NULL && !jsonheader_only && !header_only && !parse_only)) {
+		cmdline_parser_print_help();
+		cmdline_parser_free(&args_info);
+		exit(1);
+	}
 
 	if(!jsonheader_only) {
 		JANUS_LOG(LOG_INFO, "Janus version: %d (%s)\n", janus_version, janus_version_string);
 		JANUS_LOG(LOG_INFO, "Janus commit: %s\n", janus_build_git_sha);
 		JANUS_LOG(LOG_INFO, "Compiled on:  %s\n\n", janus_build_git_time);
-	}
-
-	/* Check the JANUS_PPREC_DEBUG environment variable for the debugging level */
-	if(g_getenv("JANUS_PPREC_DEBUG") != NULL) {
-		int val = atoi(g_getenv("JANUS_PPREC_DEBUG"));
-		if(val >= LOG_NONE && val <= LOG_MAX)
-			janus_log_level = val;
 		JANUS_LOG(LOG_INFO, "Logging level: %d\n", janus_log_level);
-	}
-	if(g_getenv("JANUS_PPREC_METADATA") != NULL) {
-		metadata = g_strdup(g_getenv("JANUS_PPREC_METADATA"));
-		JANUS_LOG(LOG_INFO, "Metadata: %d\n", janus_log_level);
-	}
-	if(g_getenv("JANUS_PPREC_POSTRESETTRIGGER") != NULL) {
-		int val = atoi(g_getenv("JANUS_PPREC_POSTRESETTRIGGER"));
-		if(val >= 0)
-			post_reset_trigger = val;
-		JANUS_LOG(LOG_INFO, "Post reset trigger: %d\n", post_reset_trigger);
-	}
-	if(g_getenv("JANUS_PPREC_IGNOREFIRST") != NULL) {
-		int val = atoi(g_getenv("JANUS_PPREC_IGNOREFIRST"));
-		if(val >= 0)
-			ignore_first_packets = val;
-		JANUS_LOG(LOG_INFO, "Ignoring first packets: %d\n", ignore_first_packets);
-	}
-	if(g_getenv("JANUS_PPREC_AUDIOLEVELEXT") != NULL) {
-		int val = atoi(g_getenv("JANUS_PPREC_AUDIOLEVELEXT"));
-		if(val >= 0)
-			audio_level_extmap_id = val;
-		JANUS_LOG(LOG_INFO, "Audio level extension ID: %d\n", audio_level_extmap_id);
-	}
-	if(g_getenv("JANUS_PPREC_VIDEOORIENTEXT") != NULL) {
-		int val = atoi(g_getenv("JANUS_PPREC_VIDEOORIENTEXT"));
-		if(val >= 0)
-			video_orient_extmap_id = val;
-		JANUS_LOG(LOG_INFO, "Video orientation extension ID: %d\n", video_orient_extmap_id);
+		if(metadata)
+			JANUS_LOG(LOG_INFO, "Metadata: %s\n", metadata);
+		if(post_reset_trigger != DEFAULT_POST_RESET_TRIGGER)
+			JANUS_LOG(LOG_INFO, "Post reset trigger: %d\n", post_reset_trigger);
+		if(ignore_first_packets > 0)
+			JANUS_LOG(LOG_INFO, "Ignoring first packets: %d\n", ignore_first_packets);
+		if(audio_level_extmap_id > 0)
+			JANUS_LOG(LOG_INFO, "Audio level extension ID: %d\n", audio_level_extmap_id);
+		if(video_orient_extmap_id > 0)
+			JANUS_LOG(LOG_INFO, "Video orientation extension ID: %d\n", video_orient_extmap_id);
+		JANUS_LOG(LOG_INFO, "\n");
+		if(source != NULL)
+			JANUS_LOG(LOG_INFO, "Source file: %s\n", source);
+		if(header_only)
+			JANUS_LOG(LOG_INFO, "  -- Showing header only\n");
+		if(parse_only)
+			JANUS_LOG(LOG_INFO, "  -- Parsing header only\n");
+		if(destination != NULL)
+			JANUS_LOG(LOG_INFO, "Target file: %s\n", destination);
+		JANUS_LOG(LOG_INFO, "\n");
 	}
 
-	/* Evaluate arguments */
-	if(argc != 3) {
-		JANUS_LOG(LOG_INFO, "Usage: %s source.mjr destination.[opus|wav|webm|mp4|srt]\n", argv[0]);
-		JANUS_LOG(LOG_INFO, "       %s --json source.mjr (only print JSON header)\n", argv[0]);
-		JANUS_LOG(LOG_INFO, "       %s --header source.mjr (only parse header)\n", argv[0]);
-		JANUS_LOG(LOG_INFO, "       %s --parse source.mjr (only parse and re-order packets)\n", argv[0]);
-		return -1;
-	}
-	char *source = NULL, *destination = NULL, *extension = NULL;
-	gboolean header_only = !strcmp(argv[1], "--header");
-	gboolean parse_only = !strcmp(argv[1], "--parse");
-	if(jsonheader_only || header_only || parse_only) {
-		/* Only parse the .mjr header and/or re-order the packets, no processing */
-		source = argv[2];
-	} else {
-		/* Post-process the .mjr recording */
-		source = argv[1];
-		destination = argv[2];
-		JANUS_LOG(LOG_INFO, "%s --> %s\n", source, destination);
-		/* Check the extension */
+	char *extension = NULL;
+	if(destination != NULL) {
+		/* Check the extension of the target file */
 		extension = strrchr(destination, '.');
 		if(extension == NULL) {
 			/* No extension? */
 			JANUS_LOG(LOG_ERR, "No extension? Unsupported target file\n");
+			cmdline_parser_free(&args_info);
 			exit(1);
 		}
 		if(strcasecmp(extension, ".opus") && strcasecmp(extension, ".wav") &&
@@ -186,13 +261,15 @@ int main(int argc, char *argv[])
 				strcasecmp(extension, ".srt")) {
 			/* Unsupported extension? */
 			JANUS_LOG(LOG_ERR, "Unsupported extension '%s'\n", extension);
+			cmdline_parser_free(&args_info);
 			exit(1);
 		}
 	}
 	FILE *file = fopen(source, "rb");
 	if(file == NULL) {
 		JANUS_LOG(LOG_ERR, "Could not open file %s\n", source);
-		return -1;
+		cmdline_parser_free(&args_info);
+		exit(1);
 	}
 	fseek(file, 0L, SEEK_END);
 	long fsize = ftell(file);
@@ -225,6 +302,7 @@ int main(int argc, char *argv[])
 	while(working && offset < fsize) {
 		if(header_only && parsed_header) {
 			/* We only needed to parse the header */
+			cmdline_parser_free(&args_info);
 			exit(0);
 		}
 		/* Read frame header */
@@ -246,8 +324,10 @@ int main(int argc, char *argv[])
 				/* This is the main header */
 				parsed_header = TRUE;
 				JANUS_LOG(LOG_WARN, "Old .mjr header format\n");
-				if(jsonheader_only)	/* No JSON header to print */
+				if(jsonheader_only) {	/* No JSON header to print */
+					cmdline_parser_free(&args_info);
 					exit(1);
+				}
 				bytes = fread(prebuffer, sizeof(char), 5, file);
 				if(prebuffer[0] == 'v') {
 					JANUS_LOG(LOG_INFO, "This is a video recording, assuming VP8\n");
@@ -256,6 +336,7 @@ int main(int argc, char *argv[])
 					vp8 = TRUE;
 					if(extension && strcasecmp(extension, ".webm")) {
 						JANUS_LOG(LOG_ERR, "VP8 RTP packets can only be converted to a .webm file\n");
+						cmdline_parser_free(&args_info);
 						exit(1);
 					}
 				} else if(prebuffer[0] == 'a') {
@@ -265,6 +346,7 @@ int main(int argc, char *argv[])
 					opus = TRUE;
 					if(extension && strcasecmp(extension, ".opus")) {
 						JANUS_LOG(LOG_ERR, "Opus RTP packets can only be converted to an .opus file\n");
+						cmdline_parser_free(&args_info);
 						exit(1);
 					}
 				} else if(prebuffer[0] == 'd') {
@@ -273,10 +355,12 @@ int main(int argc, char *argv[])
 					data = TRUE;
 					if(extension && strcasecmp(extension, ".srt")) {
 						JANUS_LOG(LOG_ERR, "Data channel packets can only be converted to a .srt file\n");
+						cmdline_parser_free(&args_info);
 						exit(1);
 					}
 				} else {
 					JANUS_LOG(LOG_WARN, "Unsupported recording media type...\n");
+					cmdline_parser_free(&args_info);
 					exit(1);
 				}
 				offset += len;
@@ -304,6 +388,7 @@ int main(int argc, char *argv[])
 				if(jsonheader_only) {
 					/* Print the header as it is and exit */
 					JANUS_PRINT("%s\n", prebuffer);
+					cmdline_parser_free(&args_info);
 					exit(0);
 				}
 				json_error_t error;
@@ -311,12 +396,14 @@ int main(int argc, char *argv[])
 				if(!info) {
 					JANUS_LOG(LOG_ERR, "JSON error: on line %d: %s\n", error.line, error.text);
 					JANUS_LOG(LOG_WARN, "Error parsing info header...\n");
+					cmdline_parser_free(&args_info);
 					exit(1);
 				}
 				/* Is it audio or video? */
 				json_t *type = json_object_get(info, "t");
 				if(!type || !json_is_string(type)) {
 					JANUS_LOG(LOG_WARN, "Missing/invalid recording type in info header...\n");
+					cmdline_parser_free(&args_info);
 					exit(1);
 				}
 				const char *t = json_string_value(type);
@@ -331,12 +418,14 @@ int main(int argc, char *argv[])
 					data = TRUE;
 				} else {
 					JANUS_LOG(LOG_WARN, "Unsupported recording type '%s' in info header...\n", t);
+					cmdline_parser_free(&args_info);
 					exit(1);
 				}
 				/* What codec was used? */
 				json_t *codec = json_object_get(info, "c");
 				if(!codec || !json_is_string(codec)) {
 					JANUS_LOG(LOG_WARN, "Missing recording codec in info header...\n");
+					cmdline_parser_free(&args_info);
 					exit(1);
 				}
 				const char *c = json_string_value(codec);
@@ -345,22 +434,26 @@ int main(int argc, char *argv[])
 						vp8 = TRUE;
 						if(extension && strcasecmp(extension, ".webm")) {
 							JANUS_LOG(LOG_ERR, "VP8 RTP packets can only be converted to a .webm file\n");
+							cmdline_parser_free(&args_info);
 							exit(1);
 						}
 					} else if(!strcasecmp(c, "vp9")) {
 						vp9 = TRUE;
 						if(extension && strcasecmp(extension, ".webm")) {
 							JANUS_LOG(LOG_ERR, "VP9 RTP packets can only be converted to a .webm file\n");
+							cmdline_parser_free(&args_info);
 							exit(1);
 						}
 					} else if(!strcasecmp(c, "h264")) {
 						h264 = TRUE;
 						if(extension && strcasecmp(extension, ".mp4")) {
 							JANUS_LOG(LOG_ERR, "H.264 RTP packets can only be converted to a .mp4 file\n");
+							cmdline_parser_free(&args_info);
 							exit(1);
 						}
 					} else {
 						JANUS_LOG(LOG_WARN, "The post-processor only supports VP8, VP9 and H.264 video for now (was '%s')...\n", c);
+						cmdline_parser_free(&args_info);
 						exit(1);
 					}
 				} else if(!video && !data) {
@@ -368,31 +461,37 @@ int main(int argc, char *argv[])
 						opus = TRUE;
 						if(extension && strcasecmp(extension, ".opus")) {
 							JANUS_LOG(LOG_ERR, "Opus RTP packets can only be converted to a .opus file\n");
+							cmdline_parser_free(&args_info);
 							exit(1);
 						}
 					} else if(!strcasecmp(c, "g711") || !strcasecmp(c, "pcmu") || !strcasecmp(c, "pcma")) {
 						g711 = TRUE;
 						if(extension && strcasecmp(extension, ".wav")) {
 							JANUS_LOG(LOG_ERR, "G.711 RTP packets can only be converted to a .wav file\n");
+							cmdline_parser_free(&args_info);
 							exit(1);
 						}
 					} else if(!strcasecmp(c, "g722")) {
 						g722 = TRUE;
 						if(extension && strcasecmp(extension, ".wav")) {
 							JANUS_LOG(LOG_ERR, "G.722 RTP packets can only be converted to a .wav file\n");
+							cmdline_parser_free(&args_info);
 							exit(1);
 						}
 					} else {
 						JANUS_LOG(LOG_WARN, "The post-processor only supports Opus and G.711 audio for now (was '%s')...\n", c);
+						cmdline_parser_free(&args_info);
 						exit(1);
 					}
 				} else if(data) {
 					if(strcasecmp(c, "text")) {
 						JANUS_LOG(LOG_WARN, "The post-processor only supports text data for now (was '%s')...\n", c);
+						cmdline_parser_free(&args_info);
 						exit(1);
 					}
 					if(extension && strcasecmp(extension, ".srt")) {
 						JANUS_LOG(LOG_ERR, "Data channel packets can only be converted to a .srt file\n");
+						cmdline_parser_free(&args_info);
 						exit(1);
 					}
 				}
@@ -400,6 +499,7 @@ int main(int argc, char *argv[])
 				json_t *created = json_object_get(info, "s");
 				if(!created || !json_is_integer(created)) {
 					JANUS_LOG(LOG_WARN, "Missing recording created time in info header...\n");
+					cmdline_parser_free(&args_info);
 					exit(1);
 				}
 				c_time = json_integer_value(created);
@@ -407,6 +507,7 @@ int main(int argc, char *argv[])
 				json_t *written = json_object_get(info, "u");
 				if(!written || !json_is_integer(written)) {
 					JANUS_LOG(LOG_WARN, "Missing recording written time in info header...\n");
+					cmdline_parser_free(&args_info);
 					exit(1);
 				}
 				w_time = json_integer_value(written);
@@ -422,13 +523,16 @@ int main(int argc, char *argv[])
 			}
 		} else {
 			JANUS_LOG(LOG_ERR, "Invalid header...\n");
+			cmdline_parser_free(&args_info);
 			exit(1);
 		}
 		/* Skip data for now */
 		offset += len;
 	}
-	if(!working || jsonheader_only)
+	if(!working || jsonheader_only) {
+		cmdline_parser_free(&args_info);
 		exit(0);
+	}
 	/* Now let's parse the frames and order them */
 	uint32_t last_ts = 0, reset = 0;
 	int times_resetted = 0;
@@ -695,8 +799,10 @@ int main(int argc, char *argv[])
 		offset += len;
 		count++;
 	}
-	if(!working)
+	if(!working) {
+		cmdline_parser_free(&args_info);
 		exit(0);
+	}
 
 	JANUS_LOG(LOG_INFO, "Counted %"SCNu32" RTP packets\n", count);
 	janus_pp_frame_packet *tmp = list;
@@ -723,11 +829,13 @@ int main(int argc, char *argv[])
 		if(vp8 || vp9) {
 			if(janus_pp_webm_preprocess(file, list, vp8) < 0) {
 				JANUS_LOG(LOG_ERR, "Error pre-processing %s RTP frames...\n", vp8 ? "VP8" : "VP9");
+				cmdline_parser_free(&args_info);
 				exit(1);
 			}
 		} else if(h264) {
 			if(janus_pp_h264_preprocess(file, list) < 0) {
 				JANUS_LOG(LOG_ERR, "Error pre-processing H.264 RTP frames...\n");
+				cmdline_parser_free(&args_info);
 				exit(1);
 			}
 		}
@@ -736,6 +844,7 @@ int main(int argc, char *argv[])
 	if(parse_only) {
 		/* We only needed to parse and re-order the packets, we're done here */
 		JANUS_LOG(LOG_INFO, "Parsing and reordering completed, bye!\n");
+		cmdline_parser_free(&args_info);
 		exit(0);
 	}
 
@@ -743,33 +852,39 @@ int main(int argc, char *argv[])
 		if(opus) {
 			if(janus_pp_opus_create(destination, metadata) < 0) {
 				JANUS_LOG(LOG_ERR, "Error creating .opus file...\n");
+				cmdline_parser_free(&args_info);
 				exit(1);
 			}
 		} else if(g711) {
 			if(janus_pp_g711_create(destination, metadata) < 0) {
 				JANUS_LOG(LOG_ERR, "Error creating .wav file...\n");
+				cmdline_parser_free(&args_info);
 				exit(1);
 			}
 		} else if(g722) {
 			if(janus_pp_g722_create(destination, metadata) < 0) {
 				JANUS_LOG(LOG_ERR, "Error creating .wav file...\n");
+				cmdline_parser_free(&args_info);
 				exit(1);
 			}
 		}
 	} else if(data) {
 		if(janus_pp_srt_create(destination, metadata) < 0) {
 			JANUS_LOG(LOG_ERR, "Error creating .srt file...\n");
+			cmdline_parser_free(&args_info);
 			exit(1);
 		}
 	} else {
 		if(vp8 || vp9) {
 			if(janus_pp_webm_create(destination, metadata, vp8) < 0) {
 				JANUS_LOG(LOG_ERR, "Error creating .webm file...\n");
+				cmdline_parser_free(&args_info);
 				exit(1);
 			}
 		} else if(h264) {
 			if(janus_pp_h264_create(destination, metadata) < 0) {
 				JANUS_LOG(LOG_ERR, "Error creating .mp4 file...\n");
+				cmdline_parser_free(&args_info);
 				exit(1);
 			}
 		}
@@ -842,6 +957,8 @@ int main(int argc, char *argv[])
 		g_free(temp);
 		temp = next;
 	}
+
+	cmdline_parser_free(&args_info);
 
 	JANUS_LOG(LOG_INFO, "Bye!\n");
 	return 0;

--- a/postprocessing/janus-pp-rec.ggo
+++ b/postprocessing/janus-pp-rec.ggo
@@ -1,4 +1,4 @@
-#Janus-pp-rec 0.7.2 gengetopt file
+#Janus-pp-rec 0.7.3 gengetopt file
 usage "janus-pp-rec [OPTIONS] source.mjr [destination.[opus|wav|webm|mp4|srt]]"
 option "json" j "Only print JSON header" flag off
 option "header" H "Only parse .mjr header" flag off

--- a/postprocessing/janus-pp-rec.ggo
+++ b/postprocessing/janus-pp-rec.ggo
@@ -1,0 +1,13 @@
+#Janus-pp-rec 0.7.2 gengetopt file
+usage "janus-pp-rec [OPTIONS] source.mjr [destination.[opus|wav|webm|mp4|srt]]"
+option "json" j "Only print JSON header" flag off
+option "header" H "Only parse .mjr header" flag off
+option "parse" p "Only parse and re-order packets" flag off
+option "metadata" m "Save this metadata string in the target file" string typestr="metadata" optional
+option "postreset-trigger" r "Number of packets needed to detect a timestamp reset (default=200)" int typestr="count" optional
+option "ignore-first" i "Number of first packets to ignore when processing, e.g., in case they're cause of issues (default=0)" int typestr="count" optional
+option "audiolevel-ext" a "ID of the audio-levels RTP extension (default=none)" int typestr="id" optional
+option "videoorient-ext" v "ID of the video-orientation RTP extension (default=none)" int typestr="id" optional
+option "debug-level" d "Debug/logging level (0=disable debugging, 7=maximum debug level; default=4)" int typestr="1-7" optional
+option "debug-timestamps" D "Enable debug/logging timestamps" flag off
+option "disable-colors" o "Disable color in the logging" flag off

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -833,7 +833,7 @@ static void janus_websockets_destroy_client(
 		janus_websockets_client *ws_client,
 		struct lws *wsi,
 		const char *log_prefix) {
-	if(!ws_client)
+	if(!ws_client || !ws_client->ts)
 		return;
 	janus_mutex_lock(&ws_client->ts->mutex);
 	if(!g_atomic_int_compare_and_exchange(&ws_client->destroyed, 0, 1)) {


### PR DESCRIPTION
As the title says. It should be 100% compatible with the way before, with the difference that the values we previously only exposed via environment variables (which were undocumented, incidentally) are now exposed via command line as well (the env variables are still there, they're just ugly :slightly_smiling_face: ). Besides, the existing command line arguments are now more flexible. The new usage of the tool now prints:

```
Usage: janus-pp-rec [OPTIONS] source.mjr [destination.[opus|wav|webm|mp4|srt]]

  -h, --help                    Print help and exit
  -V, --version                 Print version and exit
  -j, --json                    Only print JSON header  (default=off)
  -H, --header                  Only parse .mjr header  (default=off)
  -p, --parse                   Only parse and re-order packets  (default=off)
  -m, --metadata=metadata       Save this metadata string in the target file
  -r, --postreset-trigger=count Number of packets needed to detect a timestamp
                                  reset (default=200)
  -i, --ignore-first=count      Number of first packets to ignore when
                                  processing, e.g., in case they're cause of
                                  issues (default=0)
  -a, --audiolevel-ext=id       ID of the audio-levels RTP extension
                                  (default=none)
  -v, --videoorient-ext=id      ID of the video-orientation RTP extension
                                  (default=none)
  -d, --debug-level=1-7         Debug/logging level (0=disable debugging,
                                  7=maximum debug level; default=4)
  -D, --debug-timestamps        Enable debug/logging timestamps  (default=off)
  -o, --disable-colors          Disable color in the logging  (default=off)
```

I'm planning to merge quite soon, so if you encounter any regression with this tool, please let me know. Pinging @tgabi333 in particular, as I know he uses the tool a lot.