### PR TITLE
Configurable RTP range in Streaming plugin (replaces #1623, fixes #1616)

### DIFF
--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -83,6 +83,8 @@
 general: {
 	#admin_key = "supersecret"		# If set, mountpoints can be created via API
 									# only if this key is provided in the request
+	#rtp_port_range = "20000-40000"	# Range of ports to use for RTP/RTCP when '0' is
+									# passed as port for a mountpoint (default=10000-60000)
 	#events = false					# Whether events should be sent to event
 									# handlers (default=true)
 }


### PR DESCRIPTION
As the title says, this adds a new `rtp_port_range` to the Streaming plugin in the same vein as the one already available in the SIP, SIPre and NoSIP plugins. This range is only enforced when a random port is provided for a new mountpoint, and for RTSP negotiations: if a port is provided to create an RTP mountpoint and it exceeds the range, it is still allowed (we might want to change this in the future, though).

This replaces #1623 as that one only addressed RTSP, and I wanted something more general.

Tested briefly and it seems to work, but feedback welcome!