### PR TITLE
enable dtls window size on non-MacOS machines

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,12 +81,11 @@ darwin*)
 	LDFLAGS="$LDFLAGS -Wl,-export_dynamic"
 	LDFLAGS="$LDFLAGS -L/usr/local/lib -L/usr/local/opt/openssl/lib -L/opt/local/lib -L/usr/local/libsrtp/lib"
 	AM_CONDITIONAL([DARWIN_OS], true)
-	AM_CONDITIONAL([HAS_DTLS_WINDOW_SIZE], false)
 ;;
 *)
 	LDFLAGS="$LDFLAGS -Wl,--export-dynamic"
 	AM_CONDITIONAL([DARWIN_OS], false)
-	AM_CONDITIONAL([HAS_DTLS_WINDOW_SIZE], true)
+	AC_DEFINE(HAS_DTLS_WINDOW_SIZE, 1)
 esac
 
 glib_version=2.34


### PR DESCRIPTION
 because HAS_DTLS_WINDOW_SIZE is *NOT* defined anywhere, we can't
change dtls window size. define HAS_DTLS_WINDOW_SIZE for non-MacOS
machines