### PR TITLE
Update bower.json and package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,6 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "*",
-    "webrtc-adapter": "6.0.3"
+    "webrtc-adapter": "6.4.0"
   }
 }

--- a/html/janus.js
+++ b/html/janus.js
@@ -52,7 +52,7 @@ var defaultExtension = {
 	isInstalled: function() { return document.querySelector('#janus-extension-installed') !== null; },
 	getScreen: function (callback) {
 		var pending = window.setTimeout(function () {
-			error = new Error('NavigatorUserMediaError');
+			var error = new Error('NavigatorUserMediaError');
 			error.name = 'The required Chrome extension is not installed: click <a href="#">here</a> to install it. (NOTE: this will need you to refresh the page)';
 			return callback(error);
 		}, 1000);

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -794,6 +794,10 @@ echotest.createOffer({
  * -# By running NPM commands manually. This may be useful if you are looking to build just the JavaScript modules without
  *    incurring the overhead of a full build of Janus.
  *
+ * As an alternative to generating the module and copying it to your project, you can also tweak
+ * your module bundler to use \c janus.js directly from the official Janus repository. See more
+ * details (including concrete instructions for Webpack): \ref js-webpack
+ *
  * \section auto-build-js-modules Building modules using make
  * Each supported variant may be enabled by passing a corresponding \c --enable-javascript-*-module flag
  * (with or without a \c =yes directive) to \c configure before invoking \c make to build Janus.
@@ -840,6 +844,74 @@ echotest.createOffer({
  * -# https://rollupjs.org/#command-line-flags
  * -# https://rollupjs.org/#configuration-files
  *
+ * \section js-webpack Using janus.js directly with Webpack and other bundlers
+ *
+ * Generating a converted version of \c janus.js and copying it to your project is not always the best
+ * solution. In many situations it may be prefered to let your JavaScript module bundler (e.g.
+ * <a href="https://webpack.js.org">Webpack</a>) grab the file directly from the official Janus repository.
+ * Doing that you can manage \c janus.js just like any other dependency coming from Github or the npm Registry,
+ * getting rid of the manual copy step and letting the bundler take care of version management, updates
+ * and downloads.
+ *
+ * Of course, the first step is to include the official Janus repository as a dependency in your
+ * project by adding it to your \c packages.json file.
+ *
+ \verbatim
+ {
+   "dependencies": {
+     "janus-gateway": "git://github.com/meetecho/janus-gateway.git"
+   }
+ }
+ \endverbatim
+ *
+ * That will automatically drag in the dependency on the appropriate version of the
+ * <a href="https://www.npmjs.com/package/webrtc-adapter">WebRTC Adapter</a> from the npm Registry.
+ * But \c janus.js expects such adapter to be available as a global variable.
+ * So we have to make that happen for it to work properly. In the case of Webpack, is as easy as
+ * adding this to your \c webpack.config.js file.
+ \verbatim
+ const webpack = require('webpack');
+
+ module.exports = {
+   plugins: [
+     // janus.js does not use 'import' to access to the functionality of webrtc-adapter,
+     // instead it expects a global object called 'adapter' for that.
+     // Let's make that object available.
+     new webpack.ProvidePlugin({ adapter: 'webrtc-adapter' })
+   ]
+ }
+ \endverbatim
+ *
+ * On the other hand, \c janus.js defines the \c Janus object globally. So a small tweak is also
+ * needed to serve such object via \c export. That can be done using
+ * <a href="https://webpack.js.org/loaders/exports-loader/">exports-loader</a> and adding this to
+ * \c webpack.config.js
+ \verbatim
+ module.exports = {
+   module: {
+     rules: [
+       // janus.js does not use 'export' to provide its functionality to others, instead
+       // it creates a global variable called 'Janus' and expects consumers to use it.
+       // Let's use 'exports-loader' to simulate it uses 'export'.
+       {
+         test: require.resolve('janus-gateway'),
+         use: 'exports-loader?Janus=Janus'
+       }
+     ]
+   }
+ }
+ \endverbatim
+ *
+ * With that extra configuration, the official \c janus.js can be used directly in any modular
+ * JavaScript code base without any previous transformation of the file. That means you can simply
+ * do this to access to the Janus API from your modular code.
+ \verbatim
+ import { Janus } from 'janus-gateway';
+ \endverbatim
+
+ * For more detailed or updated documentation check the
+ * <a href="https://webpack.js.org/guides/shimming/">Webpack shimming guide</a> or the equivalent
+ * documentation for your bundler of choice.
  */
 
 /*!\page js-dependencies Working with custom janus.js dependencies

--- a/package.json
+++ b/package.json
@@ -1,13 +1,8 @@
 {
   "name": "janus-gateway",
-  "version": "0.1.0",
+  "version": "0.7.3",
   "description": "A javascript library for interacting with the C based Janus WebRTC Server",
   "main": "html/janus.js",
-  "files": [
-    "html/janus.js",
-    "html/janus.nojquery.js",
-    "html/adapter.js"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/meetecho/janus-gateway.git"
@@ -17,5 +12,8 @@
   "bugs": {
     "url": "https://github.com/meetecho/janus-gateway/issues"
   },
-  "homepage": "https://github.com/meetecho/janus-gateway#readme"
+  "homepage": "https://github.com/meetecho/janus-gateway#readme",
+  "dependencies": {
+    "webrtc-adapter": "6.4.0"
+  }
 }


### PR DESCRIPTION
The files `bower.json` and `package.json` were outdated, specially their dependencies. This fixes that. 

Those files allow to bundle `janus.js` in other JavaScript projects. The pull request also includes some documentation about how to do that without copying a modified version of `janus.js` into the project (which is possible and documented, but kind of ugly).

As a bonus track, this includes a fix for a minor bug found by ESLint.