### PR TITLE
[Fix]: janus.js client bug, 'for in loop on array' is a risk since it…

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1829,7 +1829,7 @@ function Janus(gatewayCallbacks) {
 					config.remoteSdp = jsep.sdp;
 					// Any trickle candidate we cached?
 					if(config.candidates && config.candidates.length > 0) {
-						for(var i in config.candidates) {
+						for(var i = 0; i< config.candidates.length; i++) {
 							var candidate = config.candidates[i];
 							Janus.debug("Adding remote candidate:", candidate);
 							if(!candidate || candidate.completed === true) {
@@ -2406,7 +2406,7 @@ function Janus(gatewayCallbacks) {
 					config.remoteSdp = jsep.sdp;
 					// Any trickle candidate we cached?
 					if(config.candidates && config.candidates.length > 0) {
-						for(var i in config.candidates) {
+						for(var i = 0; i< config.candidates.length; i++) {
 							var candidate = config.candidates[i];
 							Janus.debug("Adding remote candidate:", candidate);
 							if(!candidate || candidate.completed === true) {


### PR DESCRIPTION
'for in loop on array' is a risk since it's take in account any object defined on array as key, for example, if you has prototyped a array herite it, as 
```js
Array.prototype.mean = function (){... } 

for (var i in config.candidate){
 /* it will try with 'mean'  config.candidates['mean'] */
var candidate = config.candidates[i];
if(!candidate || candidate.completed === true) {
  // end-of-candidates
  config.pc.addIceCandidate({candidate:''});
  } else {
      // New candidate
      config.pc.addIceCandidate(candidate);
 }

}

```
it will fail, it happens to me =(