### PR TITLE
add configurable maxBitrate values for simulcast encodings

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -512,6 +512,22 @@ function Janus(gatewayCallbacks) {
 	if(isNaN(longPollTimeout))
 		longPollTimeout = 60000;
 
+	// overrides for default maxBitrate values for simulcasting
+	var simulcastMaxBitrates = {
+		high: 900000,
+		medium: 300000,
+		low: 100000,
+	};
+
+	if (gatewayCallbacks.simulcastMaxBitrates !== undefined && gatewayCallbacks.simulcastMaxBitrates !== undefined ) {
+		if (gatewayCallbacks.simulcastMaxBitrates.high)
+			simulcastMaxBitrates.high = gatewayCallbacks.simulcastMaxBitrates.high;
+		if (gatewayCallbacks.simulcastMaxBitrates.medium)
+			simulcastMaxBitrates.medium = gatewayCallbacks.simulcastMaxBitrates.medium;
+		if (gatewayCallbacks.simulcastMaxBitrates.low)
+			simulcastMaxBitrates.low = gatewayCallbacks.simulcastMaxBitrates.low;
+	}
+
 	var connected = false;
 	var sessionId = null;
 	var pluginHandles = {};
@@ -1802,9 +1818,9 @@ function Janus(gatewayCallbacks) {
 							direction: "sendrecv",
 							streams: [stream],
 							sendEncodings: [
-								{ rid: "h", active: true, maxBitrate: 900000 },
-								{ rid: "m", active: true, maxBitrate: 300000, scaleResolutionDownBy: 2 },
-								{ rid: "l", active: true, maxBitrate: 100000, scaleResolutionDownBy: 4 }
+								{ rid: "h", active: true, maxBitrate: simulcastMaxBitrates.high },
+								{ rid: "m", active: true, maxBitrate: simulcastMaxBitrates.medium, scaleResolutionDownBy: 2 },
+								{ rid: "l", active: true, maxBitrate: simulcastMaxBitrates.low, scaleResolutionDownBy: 4 }
 							]
 						});
 					}
@@ -2589,9 +2605,9 @@ function Janus(gatewayCallbacks) {
 				if(!parameters)
 					parameters = {};
 				parameters.encodings = [
-					{ rid: "h", active: true, maxBitrate: 900000 },
-					{ rid: "m", active: true, maxBitrate: 300000, scaleResolutionDownBy: 2 },
-					{ rid: "l", active: true, maxBitrate: 100000, scaleResolutionDownBy: 4 }
+					{ rid: "h", active: true, maxBitrate: simulcastMaxBitrates.high },
+					{ rid: "m", active: true, maxBitrate: simulcastMaxBitrates.medium, scaleResolutionDownBy: 2 },
+					{ rid: "l", active: true, maxBitrate: simulcastMaxBitrates.low, scaleResolutionDownBy: 4 }
 				];
 				sender.setParameters(parameters);
 			}
@@ -2829,9 +2845,9 @@ function Janus(gatewayCallbacks) {
 			var parameters = sender.getParameters();
 			Janus.log(parameters);
 			sender.setParameters({encodings: [
-				{ rid: "high", active: true, priority: "high", maxBitrate: 1000000 },
-				{ rid: "medium", active: true, priority: "medium", maxBitrate: 300000 },
-				{ rid: "low", active: true, priority: "low", maxBitrate: 100000 }
+				{ rid: "high", active: true, priority: "high", maxBitrate: simulcastMaxBitrates.high },
+				{ rid: "medium", active: true, priority: "medium", maxBitrate: simulcastMaxBitrates.medium },
+				{ rid: "low", active: true, priority: "low", maxBitrate: simulcastMaxBitrates.low }
 			]});
 		}
 		config.pc.createAnswer(mediaConstraints)

--- a/html/janus.js
+++ b/html/janus.js
@@ -1818,7 +1818,7 @@ function Janus(gatewayCallbacks) {
 						config.pc.addTrack(track, stream);
 					} else {
 						Janus.log('Enabling rid-based simulcasting:', track);
-						const maxBitrates = getMaxBitrates(gatewayCallbacks.simulcastMaxBitrates);
+						const maxBitrates = getMaxBitrates(callbacks.simulcastMaxBitrates);
 						config.pc.addTransceiver(track, {
 							direction: "sendrecv",
 							streams: [stream],
@@ -2611,7 +2611,7 @@ function Janus(gatewayCallbacks) {
 					parameters = {};
 
 
-				const maxBitrates = getMaxBitrates(gatewayCallbacks.simulcastMaxBitrates);
+				const maxBitrates = getMaxBitrates(callbacks.simulcastMaxBitrates);
 				parameters.encodings = [
 					{ rid: "h", active: true, maxBitrate: maxBitrates.high },
 					{ rid: "m", active: true, maxBitrate: maxBitrates.medium, scaleResolutionDownBy: 2 },
@@ -2853,7 +2853,7 @@ function Janus(gatewayCallbacks) {
 			var parameters = sender.getParameters();
 			Janus.log(parameters);
 
-			const maxBitrates = getMaxBitrates(gatewayCallbacks.simulcastMaxBitrates);
+			const maxBitrates = getMaxBitrates(callbacks.simulcastMaxBitrates);
 			sender.setParameters({encodings: [
 				{ rid: "high", active: true, priority: "high", maxBitrate: maxBitrates.high },
 				{ rid: "medium", active: true, priority: "medium", maxBitrate: maxBitrates.medium },

--- a/html/janus.js
+++ b/html/janus.js
@@ -513,20 +513,20 @@ function Janus(gatewayCallbacks) {
 		longPollTimeout = 60000;
 
 	// overrides for default maxBitrate values for simulcasting
-	function getMaxBitrates() {
+	function getMaxBitrates(simulcastMaxBitrates) {
 		var maxBitrates = {
 			high: 900000,
 			medium: 300000,
 			low: 100000,
 		};
 
-		if (gatewayCallbacks.simulcastMaxBitrates !== undefined && gatewayCallbacks.simulcastMaxBitrates !== undefined ) {
-			if (gatewayCallbacks.simulcastMaxBitrates.high)
-				maxBitrates.high = gatewayCallbacks.simulcastMaxBitrates.high;
-			if (gatewayCallbacks.simulcastMaxBitrates.medium)
-				maxBitrates.medium = gatewayCallbacks.simulcastMaxBitrates.medium;
-			if (gatewayCallbacks.simulcastMaxBitrates.low)
-				maxBitrates.low = gatewayCallbacks.simulcastMaxBitrates.low;
+		if (simulcastMaxBitrates !== undefined && simulcastMaxBitrates !== null) {
+			if (simulcastMaxBitrates.high)
+				maxBitrates.high = simulcastMaxBitrates.high;
+			if (simulcastMaxBitrates.medium)
+				maxBitrates.medium = simulcastMaxBitrates.medium;
+			if (simulcastMaxBitrates.low)
+				maxBitrates.low = simulcastMaxBitrates.low;
 		}
 
 		return maxBitrates;
@@ -1818,7 +1818,7 @@ function Janus(gatewayCallbacks) {
 						config.pc.addTrack(track, stream);
 					} else {
 						Janus.log('Enabling rid-based simulcasting:', track);
-						const maxBitrates = getMaxBitrates();
+						const maxBitrates = getMaxBitrates(gatewayCallbacks.simulcastMaxBitrates);
 						config.pc.addTransceiver(track, {
 							direction: "sendrecv",
 							streams: [stream],
@@ -2611,7 +2611,7 @@ function Janus(gatewayCallbacks) {
 					parameters = {};
 
 
-				const maxBitrates = getMaxBitrates();
+				const maxBitrates = getMaxBitrates(gatewayCallbacks.simulcastMaxBitrates);
 				parameters.encodings = [
 					{ rid: "h", active: true, maxBitrate: maxBitrates.high },
 					{ rid: "m", active: true, maxBitrate: maxBitrates.medium, scaleResolutionDownBy: 2 },
@@ -2853,7 +2853,7 @@ function Janus(gatewayCallbacks) {
 			var parameters = sender.getParameters();
 			Janus.log(parameters);
 
-			const maxBitrates = getMaxBitrates();
+			const maxBitrates = getMaxBitrates(gatewayCallbacks.simulcastMaxBitrates);
 			sender.setParameters({encodings: [
 				{ rid: "high", active: true, priority: "high", maxBitrate: maxBitrates.high },
 				{ rid: "medium", active: true, priority: "medium", maxBitrate: maxBitrates.medium },

--- a/html/janus.js
+++ b/html/janus.js
@@ -513,19 +513,23 @@ function Janus(gatewayCallbacks) {
 		longPollTimeout = 60000;
 
 	// overrides for default maxBitrate values for simulcasting
-	var simulcastMaxBitrates = {
-		high: 900000,
-		medium: 300000,
-		low: 100000,
-	};
+	function getMaxBitrates() {
+		var maxBitrates = {
+			high: 900000,
+			medium: 300000,
+			low: 100000,
+		};
 
-	if (gatewayCallbacks.simulcastMaxBitrates !== undefined && gatewayCallbacks.simulcastMaxBitrates !== undefined ) {
-		if (gatewayCallbacks.simulcastMaxBitrates.high)
-			simulcastMaxBitrates.high = gatewayCallbacks.simulcastMaxBitrates.high;
-		if (gatewayCallbacks.simulcastMaxBitrates.medium)
-			simulcastMaxBitrates.medium = gatewayCallbacks.simulcastMaxBitrates.medium;
-		if (gatewayCallbacks.simulcastMaxBitrates.low)
-			simulcastMaxBitrates.low = gatewayCallbacks.simulcastMaxBitrates.low;
+		if (gatewayCallbacks.simulcastMaxBitrates !== undefined && gatewayCallbacks.simulcastMaxBitrates !== undefined ) {
+			if (gatewayCallbacks.simulcastMaxBitrates.high)
+				maxBitrates.high = gatewayCallbacks.simulcastMaxBitrates.high;
+			if (gatewayCallbacks.simulcastMaxBitrates.medium)
+				maxBitrates.medium = gatewayCallbacks.simulcastMaxBitrates.medium;
+			if (gatewayCallbacks.simulcastMaxBitrates.low)
+				maxBitrates.low = gatewayCallbacks.simulcastMaxBitrates.low;
+		}
+
+		return maxBitrates;
 	}
 
 	var connected = false;
@@ -1814,13 +1818,14 @@ function Janus(gatewayCallbacks) {
 						config.pc.addTrack(track, stream);
 					} else {
 						Janus.log('Enabling rid-based simulcasting:', track);
+						const maxBitrates = getMaxBitrates();
 						config.pc.addTransceiver(track, {
 							direction: "sendrecv",
 							streams: [stream],
 							sendEncodings: [
-								{ rid: "h", active: true, maxBitrate: simulcastMaxBitrates.high },
-								{ rid: "m", active: true, maxBitrate: simulcastMaxBitrates.medium, scaleResolutionDownBy: 2 },
-								{ rid: "l", active: true, maxBitrate: simulcastMaxBitrates.low, scaleResolutionDownBy: 4 }
+								{ rid: "h", active: true, maxBitrate: maxBitrates.high },
+								{ rid: "m", active: true, maxBitrate: maxBitrates.medium, scaleResolutionDownBy: 2 },
+								{ rid: "l", active: true, maxBitrate: maxBitrates.low, scaleResolutionDownBy: 4 }
 							]
 						});
 					}
@@ -2604,10 +2609,13 @@ function Janus(gatewayCallbacks) {
 				var parameters = sender.getParameters();
 				if(!parameters)
 					parameters = {};
+
+
+				const maxBitrates = getMaxBitrates();
 				parameters.encodings = [
-					{ rid: "h", active: true, maxBitrate: simulcastMaxBitrates.high },
-					{ rid: "m", active: true, maxBitrate: simulcastMaxBitrates.medium, scaleResolutionDownBy: 2 },
-					{ rid: "l", active: true, maxBitrate: simulcastMaxBitrates.low, scaleResolutionDownBy: 4 }
+					{ rid: "h", active: true, maxBitrate: maxBitrates.high },
+					{ rid: "m", active: true, maxBitrate: maxBitrates.medium, scaleResolutionDownBy: 2 },
+					{ rid: "l", active: true, maxBitrate: maxBitrates.low, scaleResolutionDownBy: 4 }
 				];
 				sender.setParameters(parameters);
 			}
@@ -2844,10 +2852,12 @@ function Janus(gatewayCallbacks) {
 			Janus.log(sender);
 			var parameters = sender.getParameters();
 			Janus.log(parameters);
+
+			const maxBitrates = getMaxBitrates();
 			sender.setParameters({encodings: [
-				{ rid: "high", active: true, priority: "high", maxBitrate: simulcastMaxBitrates.high },
-				{ rid: "medium", active: true, priority: "medium", maxBitrate: simulcastMaxBitrates.medium },
-				{ rid: "low", active: true, priority: "low", maxBitrate: simulcastMaxBitrates.low }
+				{ rid: "high", active: true, priority: "high", maxBitrate: maxBitrates.high },
+				{ rid: "medium", active: true, priority: "medium", maxBitrate: maxBitrates.medium },
+				{ rid: "low", active: true, priority: "low", maxBitrate: maxBitrates.low }
 			]});
 		}
 		config.pc.createAnswer(mediaConstraints)


### PR DESCRIPTION
While trying to simulcast higher resolution streams, I've ran into an issue whereby the hard-coded values for maxBitrate were not sufficient. I've added a option to configure these values individually when initializing Janus. 

By default they will remain as they were, but are now set in a single variable so they also remain consistent should the default values need changing for any reason.