### PR TITLE
rtp: drop unused step parameter from plugins

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -4667,7 +4667,7 @@ static void janus_audiobridge_relay_rtp_packet(gpointer data, gpointer user_data
 	/* Set the payload type */
 	packet->data->type = participant->opus_pt;
 	/* Fix sequence number and timestamp (room switching may be involved) */
-	janus_rtp_header_update(packet->data, &participant->context, FALSE, OPUS_SAMPLES);
+	janus_rtp_header_update(packet->data, &participant->context, FALSE, 0);
 	if(gateway != NULL)
 		gateway->relay_rtp(session->handle, 0, (char *)packet->data, packet->length);
 	/* Restore the timestamp and sequence number to what the publisher set them to */

--- a/plugins/janus_duktape.c
+++ b/plugins/janus_duktape.c
@@ -2322,7 +2322,7 @@ static void janus_duktape_relay_rtp_packet(gpointer data, gpointer user_data) {
 		return;
 	}
 	/* Fix sequence number and timestamp (publisher switching may be involved) */
-	janus_rtp_header_update(packet->data, &session->rtpctx, packet->is_video, packet->is_video ? 4500 : 960);
+	janus_rtp_header_update(packet->data, &session->rtpctx, packet->is_video, 0);
 	/* Send the packet */
 	if(janus_core != NULL)
 		janus_core->relay_rtp(session->handle, packet->is_video, (char *)packet->data, packet->length);

--- a/plugins/janus_lua.c
+++ b/plugins/janus_lua.c
@@ -1996,7 +1996,7 @@ static void janus_lua_relay_rtp_packet(gpointer data, gpointer user_data) {
 		return;
 	}
 	/* Fix sequence number and timestamp (publisher switching may be involved) */
-	janus_rtp_header_update(packet->data, &session->rtpctx, packet->is_video, packet->is_video ? 4500 : 960);
+	janus_rtp_header_update(packet->data, &session->rtpctx, packet->is_video, 0);
 	/* Send the packet */
 	if(janus_core != NULL)
 		janus_core->relay_rtp(session->handle, packet->is_video, (char *)packet->data, packet->length);

--- a/plugins/janus_nosip.c
+++ b/plugins/janus_nosip.c
@@ -2106,8 +2106,6 @@ static void *janus_nosip_relay_thread(void *data) {
 	/* Loop */
 	int num = 0;
 	gboolean goon = TRUE;
-	int astep = 0, vstep = 0;
-	guint32 ats = 0, vts = 0;
 	while(goon && session != NULL &&
 			!g_atomic_int_get(&session->destroyed) && !g_atomic_int_get(&session->hangingup)) {
 		if(session->media.updated) {
@@ -2260,27 +2258,7 @@ static void *janus_nosip_relay_thread(void *data) {
 					}
 					/* Check if the SSRC changed (e.g., after a re-INVITE or UPDATE) */
 					guint32 timestamp = ntohl(header->timestamp);
-					janus_rtp_header_update(header, &session->media.context, video,
-						(video ? (vstep ? vstep : 4500) : (astep ? astep : 960)));
-					if(video) {
-						if(vts == 0) {
-							vts = timestamp;
-						} else if(vstep == 0) {
-							vstep = timestamp-vts;
-							if(vstep < 0) {
-								vstep = 0;
-							}
-						}
-					} else {
-						if(ats == 0) {
-							ats = timestamp;
-						} else if(astep == 0) {
-							astep = timestamp-ats;
-							if(astep < 0) {
-								astep = 0;
-							}
-						}
-					}
+					janus_rtp_header_update(header, &session->media.context, video, 0);
 					/* Save the frame if we're recording */
 					janus_recorder_save_frame(video ? session->vrc_peer : session->arc_peer, buffer, bytes);
 					/* Relay to browser */

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4537,8 +4537,6 @@ static void *janus_sip_relay_thread(void *data) {
 	/* Loop */
 	int num = 0;
 	gboolean goon = TRUE;
-	int astep = 0, vstep = 0;
-	guint32 ats = 0, vts = 0;
 	while(goon && session != NULL && !g_atomic_int_get(&session->destroyed) &&
 			session->status > janus_sip_call_status_idle &&
 			session->status < janus_sip_call_status_closing) {	/* FIXME We need a per-call watchdog as well */
@@ -4681,14 +4679,7 @@ static void *janus_sip_relay_thread(void *data) {
 					}
 					/* Check if the SSRC changed (e.g., after a re-INVITE or UPDATE) */
 					guint32 timestamp = ntohl(header->timestamp);
-					janus_rtp_header_update(header, &session->media.context, FALSE, astep ? astep : 960);
-					if(ats == 0) {
-						ats = timestamp;
-					} else if(astep == 0) {
-						astep = timestamp-ats;
-						if(astep < 0)
-							astep = 0;
-					}
+					janus_rtp_header_update(header, &session->media.context, FALSE, 0);
 					/* Save the frame if we're recording */
 					janus_recorder_save_frame(session->arc_peer, buffer, bytes);
 					/* Relay to browser */
@@ -4745,15 +4736,7 @@ static void *janus_sip_relay_thread(void *data) {
 						bytes = buflen;
 					}
 					/* Check if the SSRC changed (e.g., after a re-INVITE or UPDATE) */
-					janus_rtp_header_update(header, &session->media.context, TRUE, vstep ? vstep : 4500);
-					guint32 timestamp = ntohl(header->timestamp);
-					if(vts == 0) {
-						vts = timestamp;
-					} else if(vstep == 0) {
-						vstep = timestamp-vts;
-						if(vstep < 0)
-							vstep = 0;
-					}
+					janus_rtp_header_update(header, &session->media.context, TRUE, 0);
 					/* Save the frame if we're recording */
 					janus_recorder_save_frame(session->vrc_peer, buffer, bytes);
 					/* Relay to browser */

--- a/plugins/janus_sipre.c
+++ b/plugins/janus_sipre.c
@@ -3275,8 +3275,6 @@ static void *janus_sipre_relay_thread(void *data) {
 	/* Loop */
 	int num = 0;
 	gboolean goon = TRUE;
-	int astep = 0, vstep = 0;
-	guint32 ats = 0, vts = 0;
 	while(goon && session != NULL && !g_atomic_int_get(&session->destroyed) &&
 			session->status > janus_sipre_call_status_idle &&
 			session->status < janus_sipre_call_status_closing) {	/* FIXME We need a per-call watchdog as well */
@@ -3436,27 +3434,7 @@ static void *janus_sipre_relay_thread(void *data) {
 					}
 					/* Check if the SSRC changed (e.g., after a re-INVITE or UPDATE) */
 					guint32 timestamp = ntohl(header->timestamp);
-					janus_rtp_header_update(header, &session->media.context, video,
-						(video ? (vstep ? vstep : 4500) : (astep ? astep : 960)));
-					if(video) {
-						if(vts == 0) {
-							vts = timestamp;
-						} else if(vstep == 0) {
-							vstep = timestamp-vts;
-							if(vstep < 0) {
-								vstep = 0;
-							}
-						}
-					} else {
-						if(ats == 0) {
-							ats = timestamp;
-						} else if(astep == 0) {
-							astep = timestamp-ats;
-							if(astep < 0) {
-								astep = 0;
-							}
-						}
-					}
+					janus_rtp_header_update(header, &session->media.context, video, 0);
 					/* Save the frame if we're recording */
 					janus_recorder_save_frame(video ? session->vrc_peer : session->arc_peer, buffer, bytes);
 					/* Relay to browser */

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -6793,7 +6793,7 @@ static void janus_streaming_relay_rtp_packet(gpointer data, gpointer user_data) 
 				JANUS_LOG(LOG_HUGE, "Sending packet (spatial=%d, temporal=%d)\n",
 					packet->spatial_layer, packet->temporal_layer);
 				/* Fix sequence number and timestamp (video source switching may be involved) */
-				janus_rtp_header_update(packet->data, &session->context, TRUE, 4500);
+				janus_rtp_header_update(packet->data, &session->context, TRUE, 0);
 				if(override_mark_bit && !has_marker_bit) {
 					packet->data->markerbit = 1;
 				}
@@ -6848,7 +6848,7 @@ static void janus_streaming_relay_rtp_packet(gpointer data, gpointer user_data) 
 					json_decref(event);
 				}
 				/* If we got here, update the RTP header and send the packet */
-				janus_rtp_header_update(packet->data, &session->context, TRUE, 4500);
+				janus_rtp_header_update(packet->data, &session->context, TRUE, 0);
 				char vp8pd[6];
 				if(packet->codec == JANUS_VIDEOCODEC_VP8) {
 					/* For VP8, we save the original payload descriptor, to restore it after */
@@ -6954,7 +6954,7 @@ static void janus_streaming_helper_rtprtcp_packet(gpointer data, gpointer user_d
 static void *janus_streaming_helper_thread(void *data) {
 	janus_streaming_helper *helper = (janus_streaming_helper *)data;
 	janus_streaming_mountpoint *mp = helper->mp;
-	JANUS_LOG(LOG_INFO, "[%s/#%d] Joining Streaming helper thread\n", mp->name, helper->id);
+	JANUS_LOG(LOG_INFO, "[%s/#%d] Starting Streaming helper thread\n", mp->name, helper->id);
 	janus_streaming_rtp_relay_packet *pkt = NULL;
 	while(!g_atomic_int_get(&stopping) && !g_atomic_int_get(&mp->destroyed)) {
 		pkt = g_async_queue_pop(helper->queued_packets);

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -756,7 +756,7 @@ void janus_videocall_incoming_rtp(janus_plugin_session *handle, int video, char 
 				json_decref(event);
 			}
 			/* If we got here, update the RTP header and send the packet */
-			janus_rtp_header_update(header, &peer->context, TRUE, 4500);
+			janus_rtp_header_update(header, &peer->context, TRUE, 0);
 			if(session->vcodec == JANUS_VIDEOCODEC_VP8) {
 				int plen = 0;
 				char *payload = janus_rtp_payload(buf, len, &plen);

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -4313,7 +4313,7 @@ void janus_videoroom_incoming_rtp(janus_plugin_session *handle, int video, char 
 				if(!janus_rtp_simulcasting_context_process_rtp(&rtp_forward->sim_context,
 						buf, len, participant->ssrc, participant->rid, participant->vcodec, &rtp_forward->context))
 					continue;
-				janus_rtp_header_update(rtp, &rtp_forward->context, TRUE, 4500);
+				janus_rtp_header_update(rtp, &rtp_forward->context, TRUE, 0);
 				/* By default we use a fixed SSRC (it may be overwritten later) */
 				rtp->ssrc = htonl(participant->user_id & 0xffffffff);
 			}
@@ -4370,7 +4370,7 @@ void janus_videoroom_incoming_rtp(janus_plugin_session *handle, int video, char 
 				uint32_t seq_number = ntohs(rtp->seq_number);
 				uint32_t timestamp = ntohl(rtp->timestamp);
 				uint32_t ssrc = ntohl(rtp->ssrc);
-				janus_rtp_header_update(rtp, &participant->rec_ctx, TRUE, 4500);
+				janus_rtp_header_update(rtp, &participant->rec_ctx, TRUE, 0);
 				/* We use a fixed SSRC for the whole recording */
 				rtp->ssrc = htonl(participant->user_id & 0xffffffff);
 				janus_recorder_save_frame(participant->vrc, buf, len);
@@ -6470,7 +6470,7 @@ static void janus_videoroom_relay_rtp_packet(gpointer data, gpointer user_data) 
 			JANUS_LOG(LOG_HUGE, "Sending packet (spatial=%d, temporal=%d)\n",
 				packet->spatial_layer, packet->temporal_layer);
 			/* Fix sequence number and timestamp (publisher switching may be involved) */
-			janus_rtp_header_update(packet->data, &subscriber->context, TRUE, 4500);
+			janus_rtp_header_update(packet->data, &subscriber->context, TRUE, 0);
 			if(override_mark_bit && !has_marker_bit) {
 				packet->data->markerbit = 1;
 			}
@@ -6523,7 +6523,7 @@ static void janus_videoroom_relay_rtp_packet(gpointer data, gpointer user_data) 
 				json_decref(event);
 			}
 			/* If we got here, update the RTP header and send the packet */
-			janus_rtp_header_update(packet->data, &subscriber->context, TRUE, 4500);
+			janus_rtp_header_update(packet->data, &subscriber->context, TRUE, 0);
 			char vp8pd[6];
 			if(subscriber->feed && subscriber->feed->vcodec == JANUS_VIDEOCODEC_VP8) {
 				/* For VP8, we save the original payload descriptor, to restore it after */
@@ -6543,7 +6543,7 @@ static void janus_videoroom_relay_rtp_packet(gpointer data, gpointer user_data) 
 			}
 		} else {
 			/* Fix sequence number and timestamp (publisher switching may be involved) */
-			janus_rtp_header_update(packet->data, &subscriber->context, TRUE, 4500);
+			janus_rtp_header_update(packet->data, &subscriber->context, TRUE, 0);
 			/* Send the packet */
 			if(gateway != NULL)
 				gateway->relay_rtp(session->handle, packet->is_video, (char *)packet->data, packet->length);
@@ -6558,7 +6558,7 @@ static void janus_videoroom_relay_rtp_packet(gpointer data, gpointer user_data) 
 			return;
 		}
 		/* Fix sequence number and timestamp (publisher switching may be involved) */
-		janus_rtp_header_update(packet->data, &subscriber->context, FALSE, 960);
+		janus_rtp_header_update(packet->data, &subscriber->context, FALSE, 0);
 		/* Send the packet */
 		if(gateway != NULL)
 			gateway->relay_rtp(session->handle, packet->is_video, (char *)packet->data, packet->length);


### PR DESCRIPTION
@atoppi @lminiero I've left the paratmer in place, but set it to zero everywhere to be able to drop some dead code.