### PR TITLE
Added arrival time of packets to .mjr files (backwards compatible)

### DIFF
--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -285,6 +285,7 @@ int main(int argc, char *argv[])
 	/* Pre-parse */
 	if(!jsonheader_only)
 		JANUS_LOG(LOG_INFO, "Pre-parsing file to generate ordered index...\n");
+	gboolean has_timestamps = FALSE;
 	gboolean parsed_header = FALSE;
 	gboolean video = FALSE, data = FALSE;
 	gboolean opus = FALSE, g711 = FALSE, g722 = FALSE,
@@ -375,6 +376,12 @@ int main(int argc, char *argv[])
 			}
 		} else if(prebuffer[1] == 'J') {
 			/* New .mjr format, the header may contain useful info */
+			if(prebuffer[2] == 'R' && prebuffer[3] == '0' && prebuffer[4] == '0' &&
+					prebuffer[5] == '0' && prebuffer[6] == '0' && prebuffer[7] == '2') {
+				/* Main header is MJR00002: this means we have timestamps too */
+				has_timestamps = TRUE;
+				JANUS_LOG(LOG_VERB, "New .mjr format, will parse timestamps too\n");
+			}
 			offset += 8;
 			bytes = fread(&len, sizeof(uint16_t), 1, file);
 			len = ntohs(len);
@@ -533,7 +540,7 @@ int main(int argc, char *argv[])
 		exit(0);
 	}
 	/* Now let's parse the frames and order them */
-	uint32_t last_ts = 0, reset = 0;
+	uint32_t pkt_ts = 0, last_ts = 0, reset = 0;
 	int times_resetted = 0;
 	int post_reset_pkts = 0;
 	int ignored = 0;
@@ -556,7 +563,12 @@ int main(int argc, char *argv[])
 			/* Broken packet? Stop here */
 			break;
 		}
-		prebuffer[8] = '\0';
+		if(has_timestamps) {
+			/* Read the packet timestamp */
+			memcpy(&pkt_ts, prebuffer+4, sizeof(uint32_t));
+			pkt_ts = ntohl(pkt_ts);
+		}
+		prebuffer[(has_timestamps && prebuffer[1] != 'J') ? 4 : 8] = '\0';
 		JANUS_LOG(LOG_VERB, "Header: %s\n", prebuffer);
 		offset += 8;
 		bytes = fread(&len, sizeof(uint16_t), 1, file);
@@ -568,6 +580,9 @@ int main(int argc, char *argv[])
 			JANUS_LOG(LOG_VERB, "  -- Not RTP, skipping\n");
 			offset += len;
 			continue;
+		}
+		if(has_timestamps) {
+			JANUS_LOG(LOG_VERB, "  -- Time: %"SCNu32"ms\n", pkt_ts);
 		}
 		if(!data && len > 2000) {
 			/* Way too large, very likely not RTP, skip */
@@ -590,6 +605,8 @@ int main(int argc, char *argv[])
 			len -= sizeof(gint64);
 			/* Generate frame packet and insert in the ordered list */
 			janus_pp_frame_packet *p = g_malloc(sizeof(janus_pp_frame_packet));
+			p->version = has_timestamps ? 2 : 1;
+			p->p_ts = pkt_ts;
 			p->seq = 0;
 			/* We "abuse" the timestamp field for the timing info */
 			p->ts = when-c_time;
@@ -652,6 +669,8 @@ int main(int argc, char *argv[])
 		}
 		/* Generate frame packet and insert in the ordered list */
 		janus_pp_frame_packet *p = g_malloc0(sizeof(janus_pp_frame_packet));
+		p->version = has_timestamps ? 2 : 1;
+		p->p_ts = pkt_ts;
 		p->seq = ntohs(rtp->seq_number);
 		p->pt = rtp->type;
 		/* Due to resets, we need to mess a bit with the original timestamps */

--- a/postprocessing/pp-rtp.h
+++ b/postprocessing/pp-rtp.h
@@ -53,6 +53,8 @@ typedef struct janus_pp_rtp_header_extension {
 } janus_pp_rtp_header_extension;
 
 typedef struct janus_pp_frame_packet {
+	int version;	/* Version of the .mjr file (2=has timestamps) */
+	uint32_t p_ts;	/* Packet timestamp as saved by Janus (if available) */
 	uint16_t seq;	/* RTP Sequence number */
 	uint64_t ts;	/* RTP Timestamp */
 	uint16_t len;	/* Length of the data */

--- a/record.h
+++ b/record.h
@@ -46,8 +46,8 @@ typedef struct janus_recorder {
 	FILE *file;
 	/*! \brief Codec the packets to record are encoded in ("vp8", "vp9", "h264", "opus", "pcma", "pcmu", "g722") */
 	char *codec;
-	/*! \brief When the recording file has been created */
-	gint64 created;
+	/*! \brief When the recording file has been created and started */
+	gint64 created, started;
 	/*! \brief Media this instance is recording */
 	janus_recorder_medium type;
 	/*! \brief Whether the info header for this recorder instance has already been written or not */


### PR DESCRIPTION
This complements the feature added in #1718, and lays the foundation for more advanced processing in the future. As the title says, now for all packets we save to an `.mjr` file, we also store a timestamp of when the packet was received. The timestamp is relative to the `u` (updated) info already available in `.mjr` files, and is in milliseconds: this means the first packet will always have value `0`, and others will have a value that is relative to that. If you need an absolute value (which is what we do when using `mjr2pcap` for instance) then you can use the `u` value in the global header as a starting point.

This is all backwards compatible, meaning that recordings saved with this version of Janus will still be processable by older versions of `janus-pp-rec`. In fact, the way we did this was by "abusing" the way too large `MEETECHO` string we use to separate packets: we left 4 characters for the string (`MEET`), and used the other 4 for the timestamps, which is a 32-bit unsigned integer. Since older versions of the tool only check the first two characters to check if it's a global or packet header, this still works, as they'll simply ignore the whole 8 bytes no matter what they contain. The new `janus-pp-rec`, instead, is aware of the new `MJR00002` global header, which when present means timestamps will be included.

At the moment we only use this information to "enrich" `.pcap` files created with `mjr2pcap` with a more realistic time for packets (which is in ms instead of us, but that doesn't really matter). In the future we may use it for more advanced features, e.g., better skew compensation in some edge cases.

Planning to merge soon, so please test and give feedback!