### PR TITLE
Fix macro names to not use reserved identifiers (fixes #1725)

### DIFF
--- a/apierror.h
+++ b/apierror.h
@@ -10,8 +10,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_API_ERROR_H
-#define _JANUS_API_ERROR_H
+#ifndef JANUS_API_ERROR_H
+#define JANUS_API_ERROR_H
 
 /*! \brief Success (no error) */
 #define JANUS_OK								0

--- a/auth.h
+++ b/auth.h
@@ -10,13 +10,13 @@
  * completely up to the controlling application: these tokens are
  * completely opaque to Janus, and treated as strings, which means
  * Janus will only check if the token exists or not when asked.
- * 
+ *
  * \ingroup core
  * \ref core
  */
- 
-#ifndef _JANUS_AUTH_H
-#define _JANUS_AUTH_H
+
+#ifndef JANUS_AUTH_H
+#define JANUS_AUTH_H
 
 #include <glib.h>
 

--- a/config.h
+++ b/config.h
@@ -8,8 +8,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_CONFIG_H
-#define _JANUS_CONFIG_H
+#ifndef JANUS_CONFIG_H
+#define JANUS_CONFIG_H
 
 #include <glib.h>
 

--- a/debug.h
+++ b/debug.h
@@ -8,8 +8,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_DEBUG_H
-#define _JANUS_DEBUG_H
+#ifndef JANUS_DEBUG_H
+#define JANUS_DEBUG_H
 
 #include <glib.h>
 #include <glib/gprintf.h>

--- a/dtls-bio.h
+++ b/dtls-bio.h
@@ -3,13 +3,13 @@
  * \copyright GNU General Public License v3
  * \brief    OpenSSL BIO agent writer
  * \details  OpenSSL BIO that writes packets to a libnice agent.
- * 
+ *
  * \ingroup protocols
  * \ref protocols
  */
- 
-#ifndef _JANUS_DTLS_BIO_H
-#define _JANUS_DTLS_BIO_H
+
+#ifndef JANUS_DTLS_BIO_H
+#define JANUS_DTLS_BIO_H
 
 #include <openssl/opensslv.h>
 #include <openssl/err.h>

--- a/dtls.h
+++ b/dtls.h
@@ -12,8 +12,8 @@
  * \ref protocols
  */
 
-#ifndef _JANUS_DTLS_H
-#define _JANUS_DTLS_H
+#ifndef JANUS_DTLS_H
+#define JANUS_DTLS_H
 
 #include <inttypes.h>
 #include <glib.h>

--- a/events.h
+++ b/events.h
@@ -10,8 +10,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_EVENTS_H
-#define _JANUS_EVENTS_H
+#ifndef JANUS_EVENTS_H
+#define JANUS_EVENTS_H
 
 #include "debug.h"
 #include "events/eventhandler.h"

--- a/events/eventhandler.h
+++ b/events/eventhandler.h
@@ -16,7 +16,7 @@
  * send them to an external tool for statistics purposes or troubleshooting.
  * Whatever the aim, the structures to make the interaction between core
  * and event handlers possible are defined here.
- * 
+ *
  * An event handler plugin that wants to register at the Janus core needs to
  * implement the \c janus_eventhandler interface. This includes callbacks
  * the Janus core can use to pass and request information, and a mask of
@@ -25,7 +25,7 @@
  * core itself, in order to be dynamically loaded at startup it needs
  * to implement the \c create_e() hook as well, that should return a
  * pointer to the plugin instance. This is an example of such a step:
- * 
+ *
 \verbatim
 static janus_eventhandler myhandler = {
 	[..]
@@ -36,14 +36,14 @@ janus_eventhandler *create(void) {
 	return &myhandler;
 }
 \endverbatim
- * 
+ *
  * This will make sure that your event handler plugin is loaded at startup
  * by the Janus core, if it is deployed in the proper folder.
- * 
+ *
  * As anticipated and described in the above example, an event handler plugin
  * must basically be an instance of the \c janus_eventhandler type. As such,
  * it must implement the following methods and callbacks for the core:
- * 
+ *
  * - \c init(): this is called by the Janus core as soon as your event handler
  * plugin is started; this is where you should setup your event handler plugin
  * (e.g., static stuff and reading the configuration file);
@@ -56,17 +56,17 @@ janus_eventhandler *create(void) {
  * - \c get_name(): this method should return a short display name for your event handler plugin (e.g., "My Amazing Event Handler");
  * - \c get_package(): this method should return a unique package identifier for your event handler plugin (e.g., "janus.eventhandler.myeventhandler");
  * - \c incoming_event(): this callack informs the event handler that an event is available for consumption.
- * 
+ *
  * All the above methods and callbacks are mandatory: the Janus core will
  * reject an event handler plugin that doesn't implement any of the
  * mandatory callbacks.
- * 
+ *
  * Additionally, a \c janus_eventhandler instance must also include a
  * mask of the events it is interested in, a \c events_mask janus_flag
  * object that must refer to the available types defined in this header.
  * The core, in fact, will refer to that mask to check whether your event
- * handler is interested in a specific event or not.   
- * 
+ * handler is interested in a specific event or not.
+ *
  * Unlike other kind of modules (transports, plugins), the \c init() method
  * here only passes the path to the configurations files folder, as event
  * handlers never need to contact the Janus core themselves. This path can be used to read and
@@ -77,14 +77,14 @@ janus_eventhandler *create(void) {
  * as it doesn't collide with existing ones. Besides, the existing eventhandler
  * plugins use the same INI format for configuration files the core
  * uses (relying on the \c janus_config helpers for the purpose) but
- * again, if you prefer a different format (XML, JSON, etc.) that's up to you. 
- * 
+ * again, if you prefer a different format (XML, JSON, etc.) that's up to you.
+ *
  * \ingroup eventhandlerapi
  * \ref eventhandlerapi
  */
 
-#ifndef _JANUS_EVENTHANDLER_H
-#define _JANUS_EVENTHANDLER_H
+#ifndef JANUS_EVENTHANDLER_H
+#define JANUS_EVENTHANDLER_H
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -104,15 +104,15 @@ janus_eventhandler *create(void) {
 #define JANUS_EVENTHANDLER_API_VERSION	3
 
 /*! \brief Initialization of all event handler plugin properties to NULL
- * 
+ *
  * \note All event handler plugins MUST add this as the FIRST line when initializing
  * their event handler plugin structure, e.g.:
- * 
+ *
 \verbatim
 static janus_eventhandler janus_fake_eventhandler handler plugin =
 	{
 		JANUS_EVENTHANDLER_INIT,
-		
+
 		.init = janus_fake_init,
 		[..]
 \endverbatim

--- a/ice.h
+++ b/ice.h
@@ -14,8 +14,8 @@
  * \ref protocols
  */
 
-#ifndef _JANUS_ICE_H
-#define _JANUS_ICE_H
+#ifndef JANUS_ICE_H
+#define JANUS_ICE_H
 
 #include <glib.h>
 #include <agent.h>

--- a/ip-utils.h
+++ b/ip-utils.h
@@ -14,8 +14,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_IP_UTILS_H
-#define _JANUS_IP_UTILS_H
+#ifndef JANUS_IP_UTILS_H
+#define JANUS_IP_UTILS_H
 
 #include <ifaddrs.h>
 #include <netinet/in.h>

--- a/janus.h
+++ b/janus.h
@@ -15,8 +15,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_CORE_H
-#define _JANUS_CORE_H
+#ifndef JANUS_CORE_H
+#define JANUS_CORE_H
 
 #include <inttypes.h>
 #include <stdlib.h>

--- a/log.h
+++ b/log.h
@@ -11,8 +11,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_LOG_H
-#define _JANUS_LOG_H
+#ifndef JANUS_LOG_H
+#define JANUS_LOG_H
 
 #include <stdio.h>
 #include <glib.h>

--- a/mutex.h
+++ b/mutex.h
@@ -2,13 +2,13 @@
  * \author   Lorenzo Miniero <lorenzo@meetecho.com>
  * \brief    Semaphors, Mutexes and Conditions
  * \details  Implementation (based on GMutex or pthread_mutex) of a locking mechanism based on mutexes and conditions.
- * 
+ *
  * \ingroup core
  * \ref core
  */
- 
-#ifndef _JANUS_MUTEX_H
-#define _JANUS_MUTEX_H
+
+#ifndef JANUS_MUTEX_H
+#define JANUS_MUTEX_H
 
 #include <pthread.h>
 #include <errno.h>

--- a/plugins/janus_duktape_data.h
+++ b/plugins/janus_duktape_data.h
@@ -20,8 +20,8 @@
  * \ref jspapi
  */
 
-#ifndef _JANUS_DUKTAPE_DATA_H
-#define _JANUS_DUKTAPE_DATA_H
+#ifndef JANUS_DUKTAPE_DATA_H
+#define JANUS_DUKTAPE_DATA_H
 
 #include "duktape-deps/duktape.h"
 #include "duktape-deps/duk_console.h"

--- a/plugins/janus_duktape_extra.h
+++ b/plugins/janus_duktape_extra.h
@@ -21,8 +21,8 @@
  * \ref jspapi
  */
 
-#ifndef _JANUS_DUKTAPE_EXTRA_H
-#define _JANUS_DUKTAPE_EXTRA_H
+#ifndef JANUS_DUKTAPE_EXTRA_H
+#define JANUS_DUKTAPE_EXTRA_H
 
 #include "duktape-deps/duktape.h"
 

--- a/plugins/janus_lua_data.h
+++ b/plugins/janus_lua_data.h
@@ -20,8 +20,8 @@
  * \ref luapapi
  */
 
-#ifndef _JANUS_LUA_DATA_H
-#define _JANUS_LUA_DATA_H
+#ifndef JANUS_LUA_DATA_H
+#define JANUS_LUA_DATA_H
 
 #include <lua.h>
 #include <lualib.h>

--- a/plugins/janus_lua_extra.h
+++ b/plugins/janus_lua_extra.h
@@ -21,8 +21,8 @@
  * \ref luapapi
  */
 
-#ifndef _JANUS_LUA_EXTRA_H
-#define _JANUS_LUA_EXTRA_H
+#ifndef JANUS_LUA_EXTRA_H
+#define JANUS_LUA_EXTRA_H
 
 #include <lua.h>
 #include <lualib.h>

--- a/plugins/plugin.h
+++ b/plugins/plugin.h
@@ -145,8 +145,8 @@ janus_plugin *create(void) {
  * \ref pluginapi
  */
 
-#ifndef _JANUS_PLUGIN_H
-#define _JANUS_PLUGIN_H
+#ifndef JANUS_PLUGIN_H
+#define JANUS_PLUGIN_H
 
 #include <stdlib.h>
 #include <stdint.h>

--- a/postprocessing/pp-g711.h
+++ b/postprocessing/pp-g711.h
@@ -9,8 +9,8 @@
  * \ref postprocessing
  */
 
-#ifndef _JANUS_PP_G711
-#define _JANUS_PP_G711
+#ifndef JANUS_PP_G711
+#define JANUS_PP_G711
 
 #include <stdio.h>
 

--- a/postprocessing/pp-g722.h
+++ b/postprocessing/pp-g722.h
@@ -9,8 +9,8 @@
  * \ref postprocessing
  */
 
-#ifndef _JANUS_PP_G722
-#define _JANUS_PP_G722
+#ifndef JANUS_PP_G722
+#define JANUS_PP_G722
 
 #include <stdio.h>
 

--- a/postprocessing/pp-h264.h
+++ b/postprocessing/pp-h264.h
@@ -9,8 +9,8 @@
  * \ref postprocessing
  */
 
-#ifndef _JANUS_PP_H264
-#define _JANUS_PP_H264
+#ifndef JANUS_PP_H264
+#define JANUS_PP_H264
 
 #include <stdio.h>
 

--- a/postprocessing/pp-opus.h
+++ b/postprocessing/pp-opus.h
@@ -9,8 +9,8 @@
  * \ref postprocessing
  */
 
-#ifndef _JANUS_PP_OPUS
-#define _JANUS_PP_OPUS
+#ifndef JANUS_PP_OPUS
+#define JANUS_PP_OPUS
 
 #include <stdio.h>
 

--- a/postprocessing/pp-rtp.h
+++ b/postprocessing/pp-rtp.h
@@ -10,8 +10,8 @@
  * \ref postprocessing
  */
 
-#ifndef _JANUS_PP_RTP
-#define _JANUS_PP_RTP
+#ifndef JANUS_PP_RTP
+#define JANUS_PP_RTP
 
 #ifdef __MACH__
 #include <machine/endian.h>

--- a/postprocessing/pp-srt.h
+++ b/postprocessing/pp-srt.h
@@ -9,8 +9,8 @@
  * \ref postprocessing
  */
 
-#ifndef _JANUS_PP_SRT
-#define _JANUS_PP_SRT
+#ifndef JANUS_PP_SRT
+#define JANUS_PP_SRT
 
 #include <stdio.h>
 

--- a/postprocessing/pp-webm.h
+++ b/postprocessing/pp-webm.h
@@ -9,8 +9,8 @@
  * \ref postprocessing
  */
 
-#ifndef _JANUS_PP_WEBM
-#define _JANUS_PP_WEBM
+#ifndef JANUS_PP_WEBM
+#define JANUS_PP_WEBM
 
 #include <stdio.h>
 

--- a/record.h
+++ b/record.h
@@ -17,8 +17,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_RECORD_H
-#define _JANUS_RECORD_H
+#ifndef JANUS_RECORD_H
+#define JANUS_RECORD_H
 
 #include <inttypes.h>
 #include <string.h>

--- a/refcount.h
+++ b/refcount.h
@@ -54,8 +54,8 @@ void my_free_function(janus_refcount *counter) {
  * \ref core
  */
 
-#ifndef _JANUS_REFCOUNT_H
-#define _JANUS_REFCOUNT_H
+#ifndef JANUS_REFCOUNT_H
+#define JANUS_REFCOUNT_H
 
 #include <glib.h>
 #include "mutex.h"

--- a/rtcp.h
+++ b/rtcp.h
@@ -13,8 +13,8 @@
  * \ref protocols
  */
 
-#ifndef _JANUS_RTCP_H
-#define _JANUS_RTCP_H
+#ifndef JANUS_RTCP_H
+#define JANUS_RTCP_H
 
 #include <arpa/inet.h>
 #ifdef __MACH__

--- a/rtp.h
+++ b/rtp.h
@@ -10,8 +10,8 @@
  * \ref protocols
  */
 
-#ifndef _JANUS_RTP_H
-#define _JANUS_RTP_H
+#ifndef JANUS_RTP_H
+#define JANUS_RTP_H
 
 #include <arpa/inet.h>
 #ifdef __MACH__

--- a/rtpsrtp.h
+++ b/rtpsrtp.h
@@ -5,13 +5,13 @@
  * \details  Definitions of the SRTP usage. This header tries to abstract
  * the differences there may be between libsrtp and libsrtp2, with respect
  * to the structs and defines (e.g., errors), plus adding some helpers.
- * 
+ *
  * \ingroup protocols
  * \ref protocols
  */
 
-#ifndef _JANUS_RTPSRTP_H
-#define _JANUS_RTPSRTP_H
+#ifndef JANUS_RTPSRTP_H
+#define JANUS_RTPSRTP_H
 
 #ifdef HAVE_SRTP_2
 #include <srtp2/srtp.h>

--- a/sctp.h
+++ b/sctp.h
@@ -16,8 +16,8 @@
  * \ref protocols
  */
 
-#ifndef _JANUS_SCTP_H
-#define _JANUS_SCTP_H
+#ifndef JANUS_SCTP_H
+#define JANUS_SCTP_H
 
 #ifdef HAVE_SCTP
 

--- a/sdp-utils.h
+++ b/sdp-utils.h
@@ -12,8 +12,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_SDP_UTILS_H
-#define _JANUS_SDP_UTILS_H
+#ifndef JANUS_SDP_UTILS_H
+#define JANUS_SDP_UTILS_H
 
 
 #include <inttypes.h>

--- a/sdp.h
+++ b/sdp.h
@@ -11,18 +11,18 @@
  * it is sent to the peers. The actual SDP processing (parsing SDP strings,
  * representation of SDP as an internal format, and so on) is done via
  * the tools provided in sdp-utils.h.
- * 
+ *
  * \todo Right now, we only support sessions with up to a single audio
  * and/or a single video stream (as in, a single audio and/or video
  * m-line) plus an optional DataChannel. Later versions of the server
  * will add support for more media streams of the same type in a session.
- * 
+ *
  * \ingroup protocols
  * \ref protocols
  */
- 
-#ifndef _JANUS_SDP_H
-#define _JANUS_SDP_H
+
+#ifndef JANUS_SDP_H
+#define JANUS_SDP_H
 
 
 #include <inttypes.h>

--- a/text2pcap.h
+++ b/text2pcap.h
@@ -33,8 +33,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_TEXT2PCAP_H
-#define _JANUS_TEXT2PCAP_H
+#ifndef JANUS_TEXT2PCAP_H
+#define JANUS_TEXT2PCAP_H
 
 #include <glib.h>
 

--- a/transports/transport.h
+++ b/transports/transport.h
@@ -79,8 +79,8 @@ janus_transport *create(void) {
  * \ref transportapi
  */
 
-#ifndef _JANUS_TRANSPORT_H
-#define _JANUS_TRANSPORT_H
+#ifndef JANUS_TRANSPORT_H
+#define JANUS_TRANSPORT_H
 
 #include <stdlib.h>
 #include <stdint.h>

--- a/turnrest.h
+++ b/turnrest.h
@@ -13,8 +13,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_TURNREST_H
-#define _JANUS_TURNREST_H
+#ifndef JANUS_TURNREST_H
+#define JANUS_TURNREST_H
 
 #ifdef HAVE_TURNRESTAPI
 

--- a/utils.h
+++ b/utils.h
@@ -9,8 +9,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_UTILS_H
-#define _JANUS_UTILS_H
+#ifndef JANUS_UTILS_H
+#define JANUS_UTILS_H
 
 #include <stdint.h>
 #include <glib.h>

--- a/version.h
+++ b/version.h
@@ -10,8 +10,8 @@
  * \ref core
  */
 
-#ifndef _JANUS_VERSION_H
-#define _JANUS_VERSION_H
+#ifndef JANUS_VERSION_H
+#define JANUS_VERSION_H
 
 extern int janus_version;
 extern const char *janus_version_string;


### PR DESCRIPTION
As the title says. No feature change, just a fix on that. Please let me know if that works @elfring and if I missed anything.