### PR TITLE
Reset media attributes

### DIFF
--- a/plugins/janus_nosip.c
+++ b/plugins/janus_nosip.c
@@ -844,6 +844,22 @@ void janus_nosip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.pipefd[0] = -1;
 	session->media.pipefd[1] = -1;
 	session->media.updated = FALSE;
+	session->media.audio_srtp_in = NULL;
+	session->media.audio_srtp_out = NULL;
+	session->media.audio_remote_policy.key = NULL;
+	session->media.audio_remote_policy.ssrc.type = ssrc_any_inbound;
+	session->media.audio_remote_policy.next = NULL;
+	session->media.audio_local_policy.key = NULL;
+	session->media.audio_local_policy.ssrc.type = ssrc_any_inbound;
+	session->media.audio_local_policy.next = NULL;
+	session->media.video_srtp_in = NULL;
+	session->media.video_srtp_out = NULL;
+	session->media.video_remote_policy.key = NULL;
+	session->media.video_remote_policy.ssrc.type = ssrc_any_inbound;
+	session->media.video_remote_policy.next = NULL;
+	session->media.video_local_policy.key = NULL;
+	session->media.video_local_policy.ssrc.type = ssrc_any_inbound;
+	session->media.video_local_policy.next = NULL;
 	janus_mutex_init(&session->rec_mutex);
 	g_atomic_int_set(&session->destroyed, 0);
 	g_atomic_int_set(&session->hangingup, 0);
@@ -2061,7 +2077,10 @@ static void janus_nosip_media_cleanup(janus_nosip_session *session) {
 	}
 	session->media.local_audio_rtp_port = 0;
 	session->media.local_audio_rtcp_port = 0;
+	session->media.remote_audio_rtp_port = 0;
+	session->media.remote_audio_rtcp_port = 0;
 	session->media.audio_ssrc = 0;
+	session->media.audio_ssrc_peer = 0;
 	if(session->media.video_rtp_fd != -1) {
 		close(session->media.video_rtp_fd);
 		session->media.video_rtp_fd = -1;
@@ -2072,7 +2091,10 @@ static void janus_nosip_media_cleanup(janus_nosip_session *session) {
 	}
 	session->media.local_video_rtp_port = 0;
 	session->media.local_video_rtcp_port = 0;
+	session->media.remote_video_rtp_port = 0;
+	session->media.remote_video_rtcp_port = 0;
 	session->media.video_ssrc = 0;
+	session->media.video_ssrc_peer = 0;
 	session->media.simulcast_ssrc = 0;
 	if(session->media.pipefd[0] > 0) {
 		close(session->media.pipefd[0]);
@@ -2084,6 +2106,25 @@ static void janus_nosip_media_cleanup(janus_nosip_session *session) {
 	}
 	/* Clean up SRTP stuff, if needed */
 	janus_nosip_srtp_cleanup(session);
+
+	// media fields not cleaned up elsewhere
+	g_free(session->media.remote_audio_ip);
+	session->media.remote_audio_ip = NULL;
+	g_free(session->media.remote_video_ip);
+	session->media.remote_video_ip = NULL;
+	session->media.updated = FALSE;
+	session->media.ready = FALSE;
+	session->media.require_srtp = FALSE;
+	session->media.has_audio = 0;
+	session->media.audio_pt = -1;
+	session->media.audio_pt_name = NULL;	/* Immutable string, no need to free*/
+	session->media.audio_send = TRUE;
+	session->media.has_video = 0;
+	session->media.video_pt = -1;
+	session->media.video_pt_name = NULL;	/* Immutable string, no need to free*/
+	session->media.video_send = TRUE;
+	janus_rtp_switching_context_reset(&session->media.context);
+
 }
 
 /* Thread to relay RTP/RTCP frames coming from the peer */
@@ -2366,4 +2407,5 @@ static void *janus_nosip_relay_thread(void *data) {
 	g_thread_unref(g_thread_self());
 	return NULL;
 }
+
 

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -744,6 +744,8 @@ static janus_mutex sessions_mutex = JANUS_MUTEX_INITIALIZER;
 
 static void janus_sip_srtp_cleanup(janus_sip_session *session);
 
+static void janus_sip_media_reset(janus_sip_session *session);
+
 static void janus_sip_session_destroy(janus_sip_session *session) {
 	if(session && g_atomic_int_compare_and_exchange(&session->destroyed, 0, 1))
 		janus_refcount_decrease(&session->ref);
@@ -1062,6 +1064,33 @@ static void janus_sip_srtp_cleanup(janus_sip_session *session) {
 	session->media.video_srtp_in = NULL;
 	g_free(session->media.video_remote_policy.key);
 	session->media.video_remote_policy.key = NULL;
+}
+
+static void janus_sip_media_reset(janus_sip_session *session) {
+	if(session == NULL)
+		return;
+	g_free(session->media.remote_audio_ip);
+	session->media.remote_audio_ip = NULL;
+	g_free(session->media.remote_video_ip);
+	session->media.remote_video_ip = NULL;
+	session->media.earlymedia = FALSE;
+	session->media.update = FALSE;
+	session->media.updated = FALSE;
+	session->media.autoaccept_reinvites = TRUE;
+	session->media.ready = FALSE;
+	session->media.require_srtp = FALSE;
+	session->media.on_hold = FALSE;
+	session->media.has_audio = FALSE;
+	session->media.audio_pt = -1;
+	session->media.audio_pt_name = NULL;	/* Immutable string, no need to free*/
+	session->media.audio_send = TRUE;
+	session->media.pre_hold_audio_dir = JANUS_SDP_DEFAULT;
+	session->media.has_video = FALSE;
+	session->media.video_pt = -1;
+	session->media.video_pt_name = NULL;	/* Immutable string, no need to free*/
+	session->media.video_send = TRUE;
+	session->media.pre_hold_video_dir = JANUS_SDP_DEFAULT;
+	janus_rtp_switching_context_reset(&session->media.context);
 }
 
 
@@ -1565,22 +1594,10 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error) {
 	session->media.pipefd[0] = -1;
 	session->media.pipefd[1] = -1;
 	session->media.updated = FALSE;
-	session->media.audio_srtp_in = NULL;
-	session->media.audio_srtp_out = NULL;
-	session->media.audio_remote_policy.key = NULL;
 	session->media.audio_remote_policy.ssrc.type = ssrc_any_inbound;
-	session->media.audio_remote_policy.next = NULL;
-	session->media.audio_local_policy.key = NULL;
 	session->media.audio_local_policy.ssrc.type = ssrc_any_inbound;
-	session->media.audio_local_policy.next = NULL;
-	session->media.video_srtp_in = NULL;
-	session->media.video_srtp_out = NULL;
-	session->media.video_remote_policy.key = NULL;
 	session->media.video_remote_policy.ssrc.type = ssrc_any_inbound;
-	session->media.video_remote_policy.next = NULL;
-	session->media.video_local_policy.key = NULL;
 	session->media.video_local_policy.ssrc.type = ssrc_any_inbound;
-	session->media.video_local_policy.next = NULL;
 	janus_mutex_init(&session->rec_mutex);
 	g_atomic_int_set(&session->establishing, 0);
 	g_atomic_int_set(&session->established, 0);
@@ -4536,30 +4553,8 @@ static void janus_sip_media_cleanup(janus_sip_session *session) {
 	/* Clean up SRTP stuff, if needed */
 	janus_sip_srtp_cleanup(session);
 
-	// media fields not cleaned up elsewhere
-	g_free(session->media.remote_audio_ip);
-	session->media.remote_audio_ip = NULL;
-	g_free(session->media.remote_video_ip);
-	session->media.remote_video_ip = NULL;
-	session->media.earlymedia = FALSE;
-	session->media.update = FALSE;
-	session->media.updated = FALSE;
-	session->media.autoaccept_reinvites = TRUE;
-	session->media.ready = FALSE;
-	session->media.require_srtp = FALSE;
-	session->media.on_hold = FALSE;
-	session->media.has_audio = FALSE;
-	session->media.audio_pt = -1;
-	session->media.audio_pt_name = NULL;	/* Immutable string, no need to free*/
-	session->media.audio_send = TRUE;
-	session->media.pre_hold_audio_dir = JANUS_SDP_DEFAULT;
-	session->media.has_video = FALSE;
-	session->media.video_pt = -1;
-	session->media.video_pt_name = NULL;	/* Immutable string, no need to free*/
-	session->media.video_send = TRUE;
-	session->media.pre_hold_video_dir = JANUS_SDP_DEFAULT;
-	janus_rtp_switching_context_reset(&session->media.context);
-
+	/* Media fields not cleaned up elsewhere */
+	janus_sip_media_reset(session);
 }
 
 /* Thread to relay RTP/RTCP frames coming from the SIP peer */
@@ -4962,5 +4957,4 @@ gpointer janus_sip_sofia_thread(gpointer user_data) {
 	g_thread_unref(g_thread_self());
 	return NULL;
 }
-
 

--- a/plugins/janus_sipre.c
+++ b/plugins/janus_sipre.c
@@ -1303,6 +1303,22 @@ void janus_sipre_create_session(janus_plugin_session *handle, int *error) {
 	session->media.pipefd[0] = -1;
 	session->media.pipefd[1] = -1;
 	session->media.updated = FALSE;
+	session->media.audio_srtp_in = NULL;
+	session->media.audio_srtp_out = NULL;
+	session->media.audio_remote_policy.key = NULL;
+	session->media.audio_remote_policy.ssrc.type = ssrc_any_inbound;
+	session->media.audio_remote_policy.next = NULL;
+	session->media.audio_local_policy.key = NULL;
+	session->media.audio_local_policy.ssrc.type = ssrc_any_inbound;
+	session->media.audio_local_policy.next = NULL;
+	session->media.video_srtp_in = NULL;
+	session->media.video_srtp_out = NULL;
+	session->media.video_remote_policy.key = NULL;
+	session->media.video_remote_policy.ssrc.type = ssrc_any_inbound;
+	session->media.video_remote_policy.next = NULL;
+	session->media.video_local_policy.key = NULL;
+	session->media.video_local_policy.ssrc.type = ssrc_any_inbound;
+	session->media.video_local_policy.next = NULL;
 	janus_mutex_init(&session->rec_mutex);
 	g_atomic_int_set(&session->destroyed, 0);
 	g_atomic_int_set(&session->establishing, 0);
@@ -3225,7 +3241,10 @@ static void janus_sipre_media_cleanup(janus_sipre_session *session) {
 	}
 	session->media.local_audio_rtp_port = 0;
 	session->media.local_audio_rtcp_port = 0;
+	session->media.remote_audio_rtp_port = 0;
+	session->media.remote_audio_rtcp_port = 0;
 	session->media.audio_ssrc = 0;
+	session->media.audio_ssrc_peer = 0;
 	if(session->media.video_rtp_fd != -1) {
 		close(session->media.video_rtp_fd);
 		session->media.video_rtp_fd = -1;
@@ -3236,7 +3255,10 @@ static void janus_sipre_media_cleanup(janus_sipre_session *session) {
 	}
 	session->media.local_video_rtp_port = 0;
 	session->media.local_video_rtcp_port = 0;
+	session->media.remote_video_rtp_port = 0;
+	session->media.remote_video_rtcp_port = 0;
 	session->media.video_ssrc = 0;
+	session->media.video_ssrc_peer = 0;
 	session->media.simulcast_ssrc = 0;
 	if(session->media.pipefd[0] > 0) {
 		close(session->media.pipefd[0]);
@@ -3248,6 +3270,29 @@ static void janus_sipre_media_cleanup(janus_sipre_session *session) {
 	}
 	/* Clean up SRTP stuff, if needed */
 	janus_sipre_srtp_cleanup(session);
+
+	// media fields not cleaned up elsewhere
+	g_free(session->media.remote_audio_ip);
+	session->media.remote_audio_ip = NULL;
+	g_free(session->media.remote_video_ip);
+	session->media.remote_video_ip = NULL;
+	session->media.earlymedia = FALSE;
+	session->media.update = FALSE;
+	session->media.updated = FALSE;
+	session->media.ready = FALSE;
+	session->media.require_srtp = FALSE;
+	session->media.on_hold = FALSE;
+	session->media.has_audio = FALSE;
+	session->media.audio_pt = -1;
+	session->media.audio_pt_name = NULL;	/* Immutable string, no need to free*/
+	session->media.audio_send = TRUE;
+	session->media.pre_hold_audio_dir = JANUS_SDP_DEFAULT;
+	session->media.has_video = FALSE;
+	session->media.video_pt = -1;
+	session->media.video_pt_name = NULL;	/* Immutable string, no need to free*/
+	session->media.video_send = TRUE;
+	session->media.pre_hold_video_dir = JANUS_SDP_DEFAULT;
+	janus_rtp_switching_context_reset(&session->media.context);
 }
 
 /* Thread to relay RTP/RTCP frames coming from the SIPre peer */
@@ -4597,4 +4642,5 @@ void janus_sipre_mqueue_handler(int id, void *data, void *arg) {
 			break;
 	}
 }
+
 


### PR DESCRIPTION
Noted that session media attribute  `has_video` is not reset at the end of call and carried forward into the next call. This causes odd behavior: an audio only call allocates video media ports if previous call was audio and video call. Also, tidied up media attribute initialization when session is allocated and added code to reset other media attributes.