### PR TITLE
valgrind: suppress internal openssl warnings

### DIFF
--- a/janus-valgrind.supp
+++ b/janus-valgrind.supp
@@ -644,3 +644,18 @@
 	fun:g_object_new_valist
 }
 
+# False positive
+{
+	ignore_libcrypto_conditional_jump_errors
+	Memcheck:Cond
+	...
+	obj:*/libcrypto.so.*
+}
+
+# False positive
+{
+	ignore_libcrypto_conditional_jump_errors
+	Memcheck:Value8
+	...
+	obj:*/libcrypto.so.*
+}


### PR DESCRIPTION
This avoids warnings about openssl's use of uninitialized values.