### PR TITLE
Fixed handling of offerless reINVITE.

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -758,10 +758,10 @@ static void update_session_status(janus_sip_session *session, janus_sip_call_sta
 	}
 }
 
-static int janus_sip_call_is_established(janus_sip_session *session) {
+static gboolean janus_sip_call_is_established(janus_sip_session *session) {
 	return (session->status == janus_sip_call_status_incall ||
 		session->status == janus_sip_call_status_incall_reinviting ||
-		session->status == janus_sip_call_status_incall_reinvited) ? 1 : 0;
+		session->status == janus_sip_call_status_incall_reinvited) ? TRUE : FALSE;
 }
 
 static void janus_sip_session_destroy(janus_sip_session *session) {

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -751,8 +751,8 @@ static janus_mutex sessions_mutex = JANUS_MUTEX_INITIALIZER;
 static void janus_sip_srtp_cleanup(janus_sip_session *session);
 static void janus_sip_media_reset(janus_sip_session *session);
 
-static void update_session_status(janus_sip_session *session, janus_sip_call_status new_status) {
-	if (session->status != new_status) {
+static void janus_sip_call_update_status(janus_sip_session *session, janus_sip_call_status new_status) {
+	if(session->status != new_status) {
 		JANUS_LOG(LOG_VERB, "[%s], session status change [%s]-->[%s]\n", session->account.username == NULL ? "null" : session->account.username, janus_sip_call_status_string(session->status), janus_sip_call_status_string(new_status));
 		session->status = new_status;
 	}
@@ -1534,7 +1534,7 @@ const char *janus_sip_get_package(void) {
 
 static janus_sip_session *janus_sip_lookup_session(janus_plugin_session *handle) {
 	janus_sip_session *session = NULL;
-	if (g_hash_table_contains(sessions, handle)) {
+	if(g_hash_table_contains(sessions, handle)) {
 		session = (janus_sip_session *)handle->plugin_handle;
 	}
 	return session;
@@ -2009,8 +2009,8 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 	janus_sip_recorder_close(session, TRUE, TRUE, TRUE, TRUE);
 	janus_mutex_unlock(&session->rec_mutex);
 	if(!(session->status == janus_sip_call_status_inviting ||
-		 session->status == janus_sip_call_status_invited ||
-		 janus_sip_call_is_established(session))) {
+			session->status == janus_sip_call_status_invited ||
+			janus_sip_call_is_established(session))) {
 		g_atomic_int_set(&session->establishing, 0);
 		g_atomic_int_set(&session->established, 0);
 		g_atomic_int_set(&session->hangingup, 0);
@@ -2024,7 +2024,7 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 		session->media.autoaccept_reinvites = TRUE;
 		session->media.ready = FALSE;
 		session->media.on_hold = FALSE;
-		update_session_status(session, janus_sip_call_status_closing);
+		janus_sip_call_update_status(session, janus_sip_call_status_closing);
 		nua_bye(session->stack->s_nh_i, TAG_END());
 		g_free(session->callee);
 		session->callee = NULL;
@@ -2179,7 +2179,7 @@ static void *janus_sip_handler(void *data) {
 			}
 			json_t *outbound_proxy = json_object_get(root, "outbound_proxy");
 			const char *obproxy_text = NULL;
-			if (outbound_proxy && !json_is_null(outbound_proxy)) {
+			if(outbound_proxy && !json_is_null(outbound_proxy)) {
 				/* Has to be validated separately because it could be null */
 				JANUS_VALIDATE_JSON_OBJECT(root, proxy_parameters,
 					error_code, error_cause, TRUE,
@@ -2188,7 +2188,7 @@ static void *janus_sip_handler(void *data) {
 					goto error;
 				obproxy_text = json_string_value(outbound_proxy);
 				janus_sip_uri_t outbound_proxy_uri;
-				if (janus_sip_parse_proxy_uri(&outbound_proxy_uri, obproxy_text) < 0) {
+				if(janus_sip_parse_proxy_uri(&outbound_proxy_uri, obproxy_text) < 0) {
 					JANUS_LOG(LOG_ERR, "Invalid outbound_proxy address %s\n", obproxy_text);
 					error_code = JANUS_SIP_ERROR_INVALID_ADDRESS;
 					g_snprintf(error_cause, 512, "Invalid outbound_proxy address %s\n", obproxy_text);
@@ -2622,11 +2622,11 @@ static void *janus_sip_handler(void *data) {
 				goto error;
 			}
 			g_atomic_int_set(&session->hangingup, 0);
-			update_session_status(session, janus_sip_call_status_inviting);
+			janus_sip_call_update_status(session, janus_sip_call_status_inviting);
 			char *callid;
 			json_t *request_callid = json_object_get(root, "call_id");
 			/* Take call-id from request, if it exists */
-			if (request_callid) {
+			if(request_callid) {
 				callid = g_strdup(json_string_value(request_callid));
 			} else {
 				/* If call-id does not exist in request, create a random one */
@@ -2829,7 +2829,7 @@ static void *janus_sip_handler(void *data) {
 				session->transaction = msg->transaction ? g_strdup(msg->transaction) : NULL;
 			}
 			g_atomic_int_set(&session->hangingup, 0);
-			update_session_status(session, janus_sip_call_status_incall);
+			janus_sip_call_update_status(session, janus_sip_call_status_incall);
 			if(session->stack->s_nh_i == NULL) {
 				JANUS_LOG(LOG_WARN, "NUA Handle for 200 OK still null??\n");
 			}
@@ -2910,7 +2910,7 @@ static void *janus_sip_handler(void *data) {
 				goto error;
 			}
 
-			if (session->status == janus_sip_call_status_incall_reinvited && offer) {
+			if(session->status == janus_sip_call_status_incall_reinvited && offer) {
 				/* We have re-INVITE in progress */
 				JANUS_LOG(LOG_VERB, "[SIP-%s] We have incoming offereless re-INVITE in progress\n", session->account.username);
 			} 
@@ -2969,7 +2969,7 @@ static void *janus_sip_handler(void *data) {
 			session->media.autoaccept_reinvites = TRUE;
 			session->media.ready = FALSE;
 			session->media.on_hold = FALSE;
-			update_session_status(session, janus_sip_call_status_closing);
+			janus_sip_call_update_status(session, janus_sip_call_status_closing);
 			if(session->stack->s_nh_i == NULL) {
 				JANUS_LOG(LOG_WARN, "NUA Handle for 200 OK still null??\n");
 			}
@@ -3094,7 +3094,7 @@ static void *janus_sip_handler(void *data) {
 			session->media.autoaccept_reinvites = TRUE;
 			session->media.ready = FALSE;
 			session->media.on_hold = FALSE;
-			update_session_status(session, janus_sip_call_status_closing);
+			janus_sip_call_update_status(session, janus_sip_call_status_closing);
 			nua_bye(session->stack->s_nh_i, TAG_END());
 			g_free(session->callee);
 			session->callee = NULL;
@@ -3104,7 +3104,7 @@ static void *janus_sip_handler(void *data) {
 		} else if(!strcasecmp(request_text, "recording")) {
 			/* Start or stop recording */
 			if(!(session->status == janus_sip_call_status_inviting || /* Presume it makes sense to start recording with early media? */
-				janus_sip_call_is_established(session))) {
+					janus_sip_call_is_established(session))) {
 				JANUS_LOG(LOG_ERR, "Wrong state (not in a call? status=%s)\n", janus_sip_call_status_string(session->status));
 				g_snprintf(error_cause, 512, "Wrong state (not in a call?)");
 				goto error;
@@ -3307,7 +3307,7 @@ static void *janus_sip_handler(void *data) {
 		} else if(!strcasecmp(request_text, "message")) {
 			/* Send a SIP MESSAGE request: we'll only need the content */
 			if(!(session->status == janus_sip_call_status_inviting || 
-				janus_sip_call_is_established(session))) {
+					janus_sip_call_is_established(session))) {
 				JANUS_LOG(LOG_ERR, "Wrong state (not established? status=%s)\n", janus_sip_call_status_string(session->status));
 				g_snprintf(error_cause, 512, "Wrong state (not in a call?)");
 				goto error;
@@ -3487,7 +3487,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				session->media.autoaccept_reinvites = TRUE;
 				session->media.ready = FALSE;
 				session->media.on_hold = FALSE;
-				update_session_status(session, janus_sip_call_status_idle);
+				janus_sip_call_update_status(session, janus_sip_call_status_idle);
 				session->stack->s_nh_i = NULL;
 				json_t *call = json_object();
 				json_object_set_new(call, "sip", json_string("event"));
@@ -3523,13 +3523,13 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				session->transaction = NULL;
 				if(g_atomic_int_get(&session->establishing) || g_atomic_int_get(&session->established))
 					gateway->close_pc(session->handle);
-			} else if (session->stack->s_nh_i == nh && callstate == nua_callstate_calling && session->status == janus_sip_call_status_incall) {
+			} else if(session->stack->s_nh_i == nh && callstate == nua_callstate_calling && session->status == janus_sip_call_status_incall) {
 				/* Have just sent re-INVITE */
-				update_session_status(session, janus_sip_call_status_incall_reinviting);
-			} else if (session->stack->s_nh_i == nh && callstate == nua_callstate_ready && 
-				(session->status == janus_sip_call_status_incall_reinviting || session->status == janus_sip_call_status_incall_reinvited)) {
+				janus_sip_call_update_status(session, janus_sip_call_status_incall_reinviting);
+			} else if(session->stack->s_nh_i == nh && callstate == nua_callstate_ready && 
+					(session->status == janus_sip_call_status_incall_reinviting || session->status == janus_sip_call_status_incall_reinvited)) {
 				/* Clear re-INVITE progress status */
-				update_session_status(session, janus_sip_call_status_incall);
+				janus_sip_call_update_status(session, janus_sip_call_status_incall);
 			}
 			break;
 		case nua_i_terminated:
@@ -3635,7 +3635,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 					g_hash_table_insert(callids, session->callid, session);
 					janus_mutex_unlock(&sessions_mutex);
 				}
-				update_session_status(session, janus_sip_call_status_invited);
+				janus_sip_call_update_status(session, janus_sip_call_status_invited);
 				/* Clean up SRTP stuff from before first, in case it's still needed */
 				janus_sip_srtp_cleanup(session);
 			}
@@ -3671,7 +3671,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			if(reinvite) {
 				session->media.update = TRUE;
 				/* Mark status as janus_sip_call_status_incall_reinvited only when handling reinvites ourselves*/
-				update_session_status(session, janus_sip_call_status_incall_reinvited); 
+				janus_sip_call_update_status(session, janus_sip_call_status_incall_reinvited); 
 			}
 
 			/* Notify the browser about the new incoming call or re-INVITE */
@@ -3927,7 +3927,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			}
 			/* Parse SDP */
 			JANUS_LOG(LOG_VERB, "Peer accepted our call:\n%s", sip->sip_payload->pl_data);
-			update_session_status(session, janus_sip_call_status_incall);
+			janus_sip_call_update_status(session, janus_sip_call_status_incall);
 			char *fixed_sdp = sip->sip_payload->pl_data;
 			gboolean changed = FALSE;
 			gboolean update = session->media.ready;
@@ -3942,7 +3942,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				session->media.autoaccept_reinvites = TRUE;
 				session->media.ready = FALSE;
 				session->media.on_hold = FALSE;
-				update_session_status(session, janus_sip_call_status_closing);
+				janus_sip_call_update_status(session, janus_sip_call_status_closing);
 				nua_bye(nh, TAG_END());
 				g_free(session->callee);
 				session->callee = NULL;
@@ -3958,7 +3958,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				session->media.autoaccept_reinvites = TRUE;
 				session->media.ready = FALSE;
 				session->media.on_hold = FALSE;
-				update_session_status(session, janus_sip_call_status_closing);
+				janus_sip_call_update_status(session, janus_sip_call_status_closing);
 				nua_bye(nh, TAG_END());
 				g_free(session->callee);
 				session->callee = NULL;
@@ -4178,12 +4178,14 @@ void janus_sip_sdp_process(janus_sip_session *session, janus_sdp *sdp, gboolean 
 	/* c= */
 	if(sdp->c_addr) {
 		if(update) {
-			if (changed && (!session->media.remote_audio_ip || strcmp(sdp->c_addr, session->media.remote_audio_ip)))
+			if(changed && (!session->media.remote_audio_ip || strcmp(sdp->c_addr, session->media.remote_audio_ip))) {
 				/* This is an update and an address changed */
 				*changed = TRUE;
-			if (changed && (!session->media.remote_video_ip || strcmp(sdp->c_addr, session->media.remote_video_ip)))
+			}
+			if(changed && (!session->media.remote_video_ip || strcmp(sdp->c_addr, session->media.remote_video_ip))) {
 				/* This is an update and an address changed */
 				*changed = TRUE;
+			}
 		}
 		/* Regardless if we audio and video are being negotiated we set their connection addresses
 		 * from session level c= header by default. If media level connection addresses are available
@@ -4245,7 +4247,7 @@ void janus_sip_sdp_process(janus_sip_session *session, janus_sdp *sdp, gboolean 
 			g_free(session->media.remote_audio_ip);
 			session->media.remote_audio_ip = g_strdup(m->c_addr);
 		}
-		else if (m->c_addr && m->type == JANUS_SDP_VIDEO) {
+		else if(m->c_addr && m->type == JANUS_SDP_VIDEO) {
 			if(update && (!session->media.remote_video_ip || strcmp(m->c_addr, session->media.remote_video_ip))) {
 				/* This is an update and an address changed */
 				if(changed)
@@ -4681,14 +4683,14 @@ static void *janus_sip_relay_thread(void *data) {
 			if(have_audio_server_ip || have_video_server_ip) {
 				janus_sip_connect_sockets(session, have_audio_server_ip ? &audio_server_addr : NULL,
 					have_video_server_ip ? &video_server_addr : NULL);
-			} else if (session->media.remote_audio_ip == NULL &&  session->media.remote_video_ip == NULL) {
+			} else if(session->media.remote_audio_ip == NULL &&  session->media.remote_video_ip == NULL) {
 				JANUS_LOG(LOG_ERR, "[SIP-%p] Couldn't update session details: both audio and video remote IP addresses are NULL\n",
 					session->account.username);
 			} else {
-				if (session->media.remote_audio_ip)
+				if(session->media.remote_audio_ip)
 					JANUS_LOG(LOG_ERR, "[SIP-%p] Couldn't update session details: audio remote IP address (%s) is invalid\n",
 						session->account.username, session->media.remote_audio_ip);
-				if (session->media.remote_video_ip)
+				if(session->media.remote_video_ip)
 					JANUS_LOG(LOG_ERR, "[SIP-%p] Couldn't update session details: video remote IP address (%s) is invalid\n",
 						session->account.username, session->media.remote_video_ip);
 			}


### PR DESCRIPTION
The fix is straightforward and is around introducing two new session states marking re-INVITE transaction progress. If I've missed or got something wrong please let me know and I will make corrections as required.

"Update" request is generated by client in two cases:
1. when initiating a session update, i.e. sending a re-INVITE request
2. when handling a session update, i.e. sending a re-INVITE response
There is a problem with the second case. When a re-INVITE with SDP offer is received everything is fine. However, if an offerless re-INVITE is received it is responded to with a re-INVITE request, which is wrong. The problem seems to be that the "update" request with sdp of type "offer" is hard-wired with sending a re-INVITE request and sdp of "answer" is hard-wired with sending a re-INVITE response. That obviously doesn't work when handling offerless re-INVITEs.

To fix the problem the re-INVITE response is sent when there is a re-INVITE request is in progress, otherwise, a new re-INVITE request is sent. The decision is based on the state of the session that now
recognises client or server re-INVITE progress. Accordingly, two new states are introduced and maintained: `janus_sip_call_status_incall_reinviting` and `janus_sip_call_status_incall_reinvited` as extension to the existing state `janus_sip_call_status_incall`. Additionally, having the new states
is helpful in preventing "glare" type of scenarios, for example, where client "update" request collides with SIP re-INVITE request.

For reliability, the new states transitions are driven by nua state events "ready", "calling" or when receiving a re-INVITE request. Also, added method update_session_status() that logs session state changes to assist debugging.

Handling of some client request types such as "hangup", "update", "hold", "unhold", "info", "dtmf_info" are allowed in session state janus_sip_call_status_inviting that seems to be a copy-and-paste error. Have corrected this as well.