### PR TITLE
Adding received time to the plugin callback for RTCP packets.

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -2640,6 +2640,9 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 		}
 		return;
 	} else if(janus_is_rtcp(buf, len)) {
+		/* Record the time when we first get the RTCP packet, so it's as accurate as possible */
+		gint64 received_time_us = g_get_monotonic_time();
+
 		/* This is RTCP */
 		JANUS_LOG(LOG_HUGE, "[%"SCNu64"]  Got an RTCP packet\n", handle->handle_id);
 		if(janus_is_webrtc_encryption_enabled() && (!component->dtls || !component->dtls->srtp_valid || !component->dtls->srtp_in)) {
@@ -2836,7 +2839,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 				if(plugin && plugin->incoming_rtcp && handle->app_handle &&
 						!g_atomic_int_get(&handle->app_handle->stopped) &&
 						!g_atomic_int_get(&handle->destroyed))
-					plugin->incoming_rtcp(handle->app_handle, video, buf, buflen);
+					plugin->incoming_rtcp(handle->app_handle, video, buf, buflen, received_time_us);
 			}
 		}
 		return;

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -670,7 +670,7 @@ struct janus_plugin_result *janus_audiobridge_handle_message(janus_plugin_sessio
 json_t *janus_audiobridge_handle_admin_message(json_t *message);
 void janus_audiobridge_setup_media(janus_plugin_session *handle);
 void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_audiobridge_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_audiobridge_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_audiobridge_hangup_media(janus_plugin_session *handle);
 void janus_audiobridge_destroy_session(janus_plugin_session *handle, int *error);
 json_t *janus_audiobridge_query_session(janus_plugin_session *handle);
@@ -3145,7 +3145,7 @@ void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, int video, cha
 	}
 }
 
-void janus_audiobridge_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_audiobridge_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	/* FIXME Should we care? */

--- a/plugins/janus_duktape.c
+++ b/plugins/janus_duktape.c
@@ -214,7 +214,7 @@ struct janus_plugin_result *janus_duktape_handle_message(janus_plugin_session *h
 json_t *janus_duktape_handle_admin_message(json_t *message);
 void janus_duktape_setup_media(janus_plugin_session *handle);
 void janus_duktape_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_duktape_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_duktape_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_duktape_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
 void janus_duktape_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_duktape_hangup_media(janus_plugin_session *handle);
@@ -2097,7 +2097,7 @@ void janus_duktape_incoming_rtp(janus_plugin_session *handle, int video, char *b
 	}
 }
 
-void janus_duktape_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_duktape_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	if(handle == NULL || handle->stopped || g_atomic_int_get(&duktape_stopping) || !g_atomic_int_get(&duktape_initialized))
 		return;
 	janus_duktape_session *session = (janus_duktape_session *)handle->plugin_handle;

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -143,7 +143,7 @@ struct janus_plugin_result *janus_echotest_handle_message(janus_plugin_session *
 json_t *janus_echotest_handle_admin_message(json_t *message);
 void janus_echotest_setup_media(janus_plugin_session *handle);
 void janus_echotest_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_echotest_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_echotest_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_echotest_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
 void janus_echotest_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_echotest_hangup_media(janus_plugin_session *handle);
@@ -610,7 +610,7 @@ void janus_echotest_incoming_rtp(janus_plugin_session *handle, int video, char *
 	}
 }
 
-void janus_echotest_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_echotest_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	/* Simple echo test */

--- a/plugins/janus_lua.c
+++ b/plugins/janus_lua.c
@@ -215,7 +215,7 @@ struct janus_plugin_result *janus_lua_handle_message(janus_plugin_session *handl
 json_t *janus_lua_handle_admin_message(json_t *message);
 void janus_lua_setup_media(janus_plugin_session *handle);
 void janus_lua_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_lua_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_lua_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_lua_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
 void janus_lua_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_lua_hangup_media(janus_plugin_session *handle);
@@ -1795,7 +1795,7 @@ void janus_lua_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 	}
 }
 
-void janus_lua_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_lua_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	if(handle == NULL || handle->stopped || g_atomic_int_get(&lua_stopping) || !g_atomic_int_get(&lua_initialized))
 		return;
 	janus_lua_session *session = (janus_lua_session *)handle->plugin_handle;

--- a/plugins/janus_nosip.c
+++ b/plugins/janus_nosip.c
@@ -195,7 +195,7 @@ void janus_nosip_create_session(janus_plugin_session *handle, int *error);
 struct janus_plugin_result *janus_nosip_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
 void janus_nosip_setup_media(janus_plugin_session *handle);
 void janus_nosip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_nosip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_nosip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_nosip_hangup_media(janus_plugin_session *handle);
 void janus_nosip_destroy_session(janus_plugin_session *handle, int *error);
 json_t *janus_nosip_query_session(janus_plugin_session *handle);
@@ -1038,7 +1038,7 @@ void janus_nosip_incoming_rtp(janus_plugin_session *handle, int video, char *buf
 	}
 }
 
-void janus_nosip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_nosip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	if(handle == NULL || handle->stopped || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	if(gateway) {

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -296,7 +296,7 @@ struct janus_plugin_result *janus_recordplay_handle_message(janus_plugin_session
 json_t *janus_recordplay_handle_admin_message(json_t *message);
 void janus_recordplay_setup_media(janus_plugin_session *handle);
 void janus_recordplay_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_recordplay_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_recordplay_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_recordplay_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_recordplay_hangup_media(janus_plugin_session *handle);
 void janus_recordplay_destroy_session(janus_plugin_session *handle, int *error);
@@ -1228,7 +1228,7 @@ void janus_recordplay_incoming_rtp(janus_plugin_session *handle, int video, char
 	janus_recordplay_send_rtcp_feedback(handle, video, buf, len);
 }
 
-void janus_recordplay_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_recordplay_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 }

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -470,7 +470,7 @@ void janus_sip_create_session(janus_plugin_session *handle, int *error);
 struct janus_plugin_result *janus_sip_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
 void janus_sip_setup_media(janus_plugin_session *handle);
 void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_sip_hangup_media(janus_plugin_session *handle);
 void janus_sip_destroy_session(janus_plugin_session *handle, int *error);
 json_t *janus_sip_query_session(janus_plugin_session *handle);
@@ -1821,7 +1821,7 @@ void janus_sip_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 	}
 }
 
-void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_sip_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	if(gateway) {

--- a/plugins/janus_sipre.c
+++ b/plugins/janus_sipre.c
@@ -111,7 +111,7 @@ void janus_sipre_create_session(janus_plugin_session *handle, int *error);
 struct janus_plugin_result *janus_sipre_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
 void janus_sipre_setup_media(janus_plugin_session *handle);
 void janus_sipre_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_sipre_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_sipre_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_sipre_hangup_media(janus_plugin_session *handle);
 void janus_sipre_destroy_session(janus_plugin_session *handle, int *error);
 json_t *janus_sipre_query_session(janus_plugin_session *handle);
@@ -1519,7 +1519,7 @@ void janus_sipre_incoming_rtp(janus_plugin_session *handle, int video, char *buf
 	}
 }
 
-void janus_sipre_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_sipre_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	if(handle == NULL || handle->stopped || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	if(gateway) {

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -706,7 +706,7 @@ struct janus_plugin_result *janus_streaming_handle_message(janus_plugin_session 
 json_t *janus_streaming_handle_admin_message(json_t *message);
 void janus_streaming_setup_media(janus_plugin_session *handle);
 void janus_streaming_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_streaming_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_streaming_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_streaming_hangup_media(janus_plugin_session *handle);
 void janus_streaming_destroy_session(janus_plugin_session *handle, int *error);
 json_t *janus_streaming_query_session(janus_plugin_session *handle);
@@ -3741,7 +3741,7 @@ void janus_streaming_incoming_rtp(janus_plugin_session *handle, int video, char 
 	/* FIXME We don't care about what the browser sends us, we're sendonly */
 }
 
-void janus_streaming_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_streaming_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	janus_streaming_session *session = (janus_streaming_session *)handle->plugin_handle;

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -500,7 +500,7 @@ struct janus_plugin_result *janus_textroom_handle_message(janus_plugin_session *
 json_t *janus_textroom_handle_admin_message(json_t *message);
 void janus_textroom_setup_media(janus_plugin_session *handle);
 void janus_textroom_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_textroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_textroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_textroom_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
 void janus_textroom_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_textroom_hangup_media(janus_plugin_session *handle);
@@ -1258,7 +1258,7 @@ void janus_textroom_incoming_rtp(janus_plugin_session *handle, int video, char *
 	/* We don't do audio/video */
 }
 
-void janus_textroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_textroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	/* We don't do audio/video */
 }
 

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -289,7 +289,7 @@ void janus_videocall_create_session(janus_plugin_session *handle, int *error);
 struct janus_plugin_result *janus_videocall_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
 void janus_videocall_setup_media(janus_plugin_session *handle);
 void janus_videocall_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_videocall_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_videocall_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_videocall_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
 void janus_videocall_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_videocall_hangup_media(janus_plugin_session *handle);
@@ -782,7 +782,7 @@ void janus_videocall_incoming_rtp(janus_plugin_session *handle, int video, char 
 	}
 }
 
-void janus_videocall_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_videocall_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	if(gateway) {

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1073,7 +1073,7 @@ struct janus_plugin_result *janus_videoroom_handle_message(janus_plugin_session 
 json_t *janus_videoroom_handle_admin_message(json_t *message);
 void janus_videoroom_setup_media(janus_plugin_session *handle);
 void janus_videoroom_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_videoroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_videoroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_videoroom_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
 void janus_videoroom_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_videoroom_hangup_media(janus_plugin_session *handle);
@@ -4475,7 +4475,7 @@ void janus_videoroom_incoming_rtp(janus_plugin_session *handle, int video, char 
 	janus_videoroom_publisher_dereference_nodebug(participant);
 }
 
-void janus_videoroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_videoroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	janus_videoroom_session *session = (janus_videoroom_session *)handle->plugin_handle;

--- a/plugins/janus_voicemail.c
+++ b/plugins/janus_voicemail.c
@@ -137,7 +137,7 @@ void janus_voicemail_create_session(janus_plugin_session *handle, int *error);
 struct janus_plugin_result *janus_voicemail_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep);
 void janus_voicemail_setup_media(janus_plugin_session *handle);
 void janus_voicemail_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_voicemail_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
+void janus_voicemail_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 void janus_voicemail_hangup_media(janus_plugin_session *handle);
 void janus_voicemail_destroy_session(janus_plugin_session *handle, int *error);
 json_t *janus_voicemail_query_session(janus_plugin_session *handle);
@@ -600,7 +600,7 @@ void janus_voicemail_incoming_rtp(janus_plugin_session *handle, int video, char 
 	ogg_write(session);
 }
 
-void janus_voicemail_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len) {
+void janus_voicemail_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	/* FIXME Should we care? */

--- a/plugins/plugin.h
+++ b/plugins/plugin.h
@@ -296,8 +296,9 @@ struct janus_plugin {
 	 * @param[in] handle The plugin/gateway session used for this peer
 	 * @param[in] video Whether this is related to an audio or a video stream
 	 * @param[in] buf The message data (buffer)
-	 * @param[in] len The buffer lenght */
-	void (* const incoming_rtcp)(janus_plugin_session *handle, int video, char *buf, int len);
+	 * @param[in] len The buffer length
+	 * @param[in] received_time_us is the monotonic system time in microseconds when the packet was received. */
+	void (* const incoming_rtcp)(janus_plugin_session *handle, int video, char *buf, int len, uint64_t received_time_us);
 	/*! \brief Method to handle incoming SCTP/DataChannel data from a peer (text only, for the moment)
 	 * \note We currently only support text data, binary data will follow... please also notice that
 	 * DataChannels send unterminated strings, so you'll have to terminate them with a \0 yourself to


### PR DESCRIPTION
Adding the system time when an RTCP packet arrives enables accurate measurements of RTT for plugins.