### PR TITLE
Adding properties to config must replace old ones (fixes #1738)

### DIFF
--- a/config.c
+++ b/config.c
@@ -449,6 +449,10 @@ int janus_config_add(janus_config *config, janus_config_container *container, ja
 		return -1;
 	if(container != NULL && container->type != janus_config_type_category && container->type != janus_config_type_array)
 		return -2;
+	if(item->name) {
+		/* Remove any existing property with the same name in that container first, if any */
+		janus_config_remove(config, container, item->name);
+	}
 	if(container) {
 		/* Add to parent */
 		container->list = g_list_append(container->list, item);


### PR DESCRIPTION
As the title says, this should fix a broken behaviour the config utils had. Adding properties would simply append them to a list, but would not remove the old property with the same name: while most of the times whis still worked, it could happen that the new value wouldn't be enforced. This fixes it by implicitly removing the property with the same name from the specified container, before adding it again.