### PR TITLE
Use the correct range for small delta twcc feedbacks and handle overflows

### DIFF
--- a/rtcp.c
+++ b/rtcp.c
@@ -1455,7 +1455,7 @@ int janus_rtcp_transport_wide_cc_feedback(char *packet, size_t size, guint32 ssr
 			else
 				delta = -(int)((timestamp-stat->timestamp)/250);
 			/* If it is negative or too big */
-			if (delta<0 || delta> 127) {
+			if (delta<0 || delta> 255) {
 				/* Big one */
 				status = janus_rtp_packet_status_largeornegativedelta;
 			} else {
@@ -1463,6 +1463,7 @@ int janus_rtcp_transport_wide_cc_feedback(char *packet, size_t size, guint32 ssr
 				status = janus_rtp_packet_status_smalldelta;
 			}
 			/* Store delta */
+			/* Overflows are possible here */
 			g_queue_push_tail(deltas, GINT_TO_POINTER(delta));
 			/* Set last time */
 			timestamp = stat->timestamp;
@@ -1656,9 +1657,15 @@ int janus_rtcp_transport_wide_cc_feedback(char *packet, size_t size, guint32 ssr
 		/* Get next delta */
 		gint delta = GPOINTER_TO_INT(g_queue_pop_head (deltas));
 		/* Check size */
-		if (delta<0 || delta>127) {
+		if (delta<0 || delta>255) {
+			short reported_delta = (short)delta;
+			/* Overflow */
+			if (reported_delta != delta) {
+				reported_delta = delta > 0 ? SHRT_MAX : SHRT_MIN;
+				JANUS_LOG(LOG_ERR, "Delta value (%d) too large, reporting it as %d\n", delta, reported_delta);
+			}
 			/* 2 bytes */
-			janus_set2(data, len, (short)delta);
+			janus_set2(data, len, reported_delta);
 			/* Inc */
 			len += 2;
 		} else {


### PR DESCRIPTION
This PR makes two fixes [according to the draft](https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#section-3.1.5):
1) Small delta values are defined in the range [0-255] and lead to 8 bit unsigned report.
2) Large delta values can potentially overflow because we calculate them in 32 bits while the reported value is in 16 bits. We handle this unlikely scenario by capping the reported values to the short limits `SHRT_MAX` and `SHRT_MIN`.