### PR TITLE
Fix dynamic RTSP mountpoint creation hang when there are no free ports.

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -4619,8 +4619,10 @@ static int janus_streaming_create_fd(int port, in_addr_t mcast, const janus_netw
 		if(bind(fd, (struct sockaddr *)(&address), sizeof(struct sockaddr)) < 0) {
 			close(fd);
 			fd = -1;
-			if(!use_range && !quiet) {
+			if(!quiet){
 				JANUS_LOG(LOG_ERR, "[%s] Bind failed for %s (port %d)...\n", mountpointname, medianame, port);
+			}
+			if(!use_range) {
 				break;
 			}
 		} else {
@@ -5405,6 +5407,10 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 	int aresult;
 	aresult = janus_streaming_rtsp_parse_sdp(curldata->buffer, name, "audio", &apt,
 		atransport, ahost, artpmap, afmtp, acontrol, &source->audio_iface, &audio_fds);
+
+	if(vresult == -1 && aresult == -1) {
+		return -5;
+	}
 
 	if(vresult != -1) {
 		/* Send an RTSP SETUP for video */


### PR DESCRIPTION
Fixes #1762, also returns early when there is neither video nor audio sdp result.