### PR TITLE
Allow for capturing desktop audio when sharing screen

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2207,7 +2207,7 @@ function Janus(gatewayCallbacks) {
 						// The new experimental getDisplayMedia API is available, let's use that
 						// https://groups.google.com/forum/#!topic/discuss-webrtc/Uf0SrR4uxzk
 						// https://webrtchacks.com/chrome-screensharing-getdisplaymedia/
-						navigator.mediaDevices.getDisplayMedia({ video: true })
+						navigator.mediaDevices.getDisplayMedia({ video: true, audio: media.captureDesktopAudio })
 							.then(function(stream) {
 								pluginHandle.consentDialog(false);
 								if(isAudioSendEnabled(media) && !media.keepAudio) {


### PR DESCRIPTION
Janus.js already has the option of adding a microphone audio track to screenshares, but capturing audio directly from the desktop wasn't possible. This feature only works in Chrome on Windows at the moment, but it's still nice being able to configure it.