### PR TITLE
DNS and IP family rtp_forwarder

### DIFF
--- a/ip-utils.c
+++ b/ip-utils.c
@@ -325,11 +325,9 @@ char *janus_network_detect_local_ip_as_string(janus_network_query_options addr_t
 	return g_strdup(janus_network_address_string_from_buffer(&buf));
 }
 
-char *janus_network_dns_lookup_host(const char *host, const char *type)
-{
+char *janus_network_dns_lookup_host(const char *domain_name, const char *type) {
 	struct addrinfo hints, *res;
-	int errcode;
-	char addrstr[100] = NULL;
+	static char addrstr[100] = "127.0.0.1";
 	void *ptr;
 
 	memset(&hints, 0, sizeof(hints));
@@ -337,11 +335,12 @@ char *janus_network_dns_lookup_host(const char *host, const char *type)
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_flags |= AI_CANONNAME;
 
-	errcode = getaddrinfo(host, NULL, &hints, &res);
+	int errcode = getaddrinfo(domain_name, NULL, &hints, &res);
+	/* If there is an error return the localhost */
 	if (errcode != 0) {
-		return errcode;
+		return addrstr;
 	}
-
+	/* res will contain linked list of host typse, we need to try and see which one we need*/
 	while (res) {
 		if (!strcasecmp(type, "ipv4") && res->ai_family == AF_INET) {
 			ptr = &((struct sockaddr_in *)res->ai_addr)->sin_addr;

--- a/ip-utils.h
+++ b/ip-utils.h
@@ -248,6 +248,9 @@ char *janus_network_detect_local_ip_as_string(janus_network_query_options addr_t
 
 /*!
  * \brief convert DNS realm to human readable IP address IPv4 or IPv6
+ * note that this will add slight delay untill resolve is done
+ * \param host Can be DNS name or IP, if it is IP it wil resolve imediately,
+ * \param type Is necessary since getaddrinfo will return linked list (ipv4 and ipv6)
  */
 char *janus_network_dns_lookup_host(const char *host, const char *type);
 ///@}

--- a/ip-utils.h
+++ b/ip-utils.h
@@ -245,6 +245,11 @@ int janus_network_detect_local_ip(janus_network_query_options addr_type, janus_n
  * \return 0 in case of success, -EINVAL otherwise otherwise
  */
 char *janus_network_detect_local_ip_as_string(janus_network_query_options addr_type);
+
+/*!
+ * \brief convert DNS realm to human readable IP address IPv4 or IPv6
+ */
+char *janus_network_dns_lookup_host(const char *host, const char *type)
 ///@}
 
 #endif

--- a/ip-utils.h
+++ b/ip-utils.h
@@ -249,7 +249,7 @@ char *janus_network_detect_local_ip_as_string(janus_network_query_options addr_t
 /*!
  * \brief convert DNS realm to human readable IP address IPv4 or IPv6
  */
-char *janus_network_dns_lookup_host(const char *host, const char *type)
+char *janus_network_dns_lookup_host(const char *host, const char *type);
 ///@}
 
 #endif

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -670,6 +670,7 @@ room-<unique room ID>: {
 	"room" : <unique numeric ID of the room the publisher is in>,
 	"publisher_id" : <unique numeric ID of the publisher to relay externally>,
 	"host" : "<host address to forward the RTP and data packets to>",
+	"ip_family": "<type of IP family, ipv4 or ipv6>",
 	"audio_port" : <port to forward the audio RTP packets to>,
 	"audio_ssrc" : <audio SSRC to use to use when streaming; optional>,
 	"audio_pt" : <audio payload type to use when streaming; optional>,
@@ -1058,6 +1059,7 @@ room-<unique room ID>: {
 #include "../rtcp.h"
 #include "../record.h"
 #include "../sdp-utils.h"
+#include "../ip-utils.h"
 #include "../utils.h"
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -3394,9 +3396,7 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 		}
 		guint64 room_id = json_integer_value(room);
 		guint64 publisher_id = json_integer_value(pub_id);
-		const char *fwd_host = json_string_value(json_host);
-		const char *fwd_ip_family = json_string_value(json_ip_family);
-		const char *host = janus_network_dns_lookup_host(fwd_host, fwd_ip_family);
+		const char *host = janus_network_dns_lookup_host(json_string_value(json_host), json_string_value(json_ip_family));
 		janus_mutex_lock(&rooms_mutex);
 		janus_videoroom *videoroom = NULL;
 		error_code = janus_videoroom_access_room(root, TRUE, FALSE, &videoroom, error_cause, sizeof(error_cause));


### PR DESCRIPTION
This PR introduces one more rtp_forward mandatory element ip_family which is of type ipv4 or ipv6
Togather with DNS hostname it will resolve in helper function:
https://github.com/mirkobrankovic/janus-gateway/blob/master/ip-utils.c#L328
and give back the host of the chosen family.

It will look like this:
rtp_forward json:
`{"janus":"message","body":{"request":"rtp_forward","room":room, "publisher_id": publisher_id, "secret": "topsecret", "host": "google.com", "ip_family": "ipv4", "video_port": 5000, "video_stream_id": video_stream_id, "audio_port": 5001, "audio_stream_id":audio_stream_id}, "transaction":randomString(12),"session_id":session_id,"handle_id":handle_id}`
 videoroom will resolve to this:

> [Sun Sep 15 21:29:40 2019] [ERR] [plugins/janus_videoroom.c:janus_videoroom_process_synchronous_request:3402] We will forward to host: 172.217.20.78

and packets will start flowing:

```
U 192.168.64.39:39884 -> 172.217.20.78:5001
  .o......QV.<....00..x.$....v=.j..+.....H.(.{.!..,...<.:l+.....C.%B1a..........H.Y...Xf.)...).........              
#
U 192.168.64.39:39884 -> 172.217.20.78:5001
  .o......QV.<....00..x<..cC,..6.+Wm..._.[..5Zr0y.;g...<...UU.)....}k...2.XM.>T...;?#$..X..}.                        
#
U 192.168.64.39:39884 -> 172.217.20.78:5001
  .o.....@QV.<....00..x...2PZ_k..n...{ ..&..pD....n.......i....;....M...?.v...`....V.f.P....u.e.....w.......    
```
This introduces the delay in resolving time but if IP address is given it will be fast as before.

One improvement, ip_family can be empty string, but maybe it should default to ipv4 for example.

One problem: If I want IPv6 in previous request it will resolve the ip:

> [Sun Sep 15 21:30:38 2019] [ERR] [plugins/janus_videoroom.c:janus_videoroom_process_synchronous_request:3402] We will forward to host: 2a00:1450:400e:80c::200e

but packets will default to localhost as IPv6 is invalid address:

```
U 127.0.0.1:43818 -> 127.0.0.1:5001
  .o....p..&......00..x..|j.\.....~.8?../M...ax.Gz3...SN.A....M..kkT.....>B`T&..(Z....w..K.....n:.L.;`#<..           
#
U 127.0.0.1:43818 -> 127.0.0.1:5001
  .o. ..t@.&......00..x.....X'9...0..R#.G....+...xd...-|6.9yQ.L..!...F=j.......E...$}.QvO..N...J.).G..'6.P%./.       
#
U 127.0.0.1:43818 -> 127.0.0.1:5001
  .o.!..x..&......00..x..k..;..]....<.~....D.}8.SsT.Pu,..P..........Y._.....1....B.I.s(...... g,N~0..  
```
So there might be a problem further down in code that does the ipv4 check?

Thanks,
mirko