### PR TITLE
Add command line option to janus-pp-rec to specificy the output format

### DIFF
--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -67,10 +67,10 @@ Usage: janus-pp-rec [OPTIONS] source.mjr [destination.[opus|wav|webm|mp4|srt]]
                                   7=maximum debug level; default=4)
   -D, --debug-timestamps        Enable debug/logging timestamps  (default=off)
   -o, --disable-colors          Disable color in the logging  (default=off)
-	-f, --format=STRING           Specifies the output format (overrides the
-																	format from the destination)  (possible
-																	values="opus", "wav", "webm", "mp4",
-																	"srt")
+  -f, --format=STRING           Specifies the output format (overrides the
+                                  format from the destination)  (possible
+                                  values="opus", "wav", "webm", "mp4",
+                                  "srt")
 \endverbatim
  *
  * \note This utility does not do any form of transcoding. It just
@@ -265,7 +265,7 @@ int main(int argc, char *argv[])
 			cmdline_parser_free(&args_info);
 			exit(1);
 		}
-		extension ++;
+		extension++;
 		if(strcasecmp(extension, "opus") && strcasecmp(extension, "wav") &&
 				strcasecmp(extension, "webm") && strcasecmp(extension, "mp4") &&
 				strcasecmp(extension, "srt")) {

--- a/postprocessing/janus-pp-rec.ggo
+++ b/postprocessing/janus-pp-rec.ggo
@@ -11,3 +11,4 @@ option "videoorient-ext" v "ID of the video-orientation RTP extension (default=n
 option "debug-level" d "Debug/logging level (0=disable debugging, 7=maximum debug level; default=4)" int typestr="1-7" optional
 option "debug-timestamps" D "Enable debug/logging timestamps" flag off
 option "disable-colors" o "Disable color in the logging" flag off
+option "format" f "Specifies the output format (overrides the format from the destination)" string values="opus", "wav", "webm", "mp4", "srt" optional


### PR DESCRIPTION
I made a small change to janus-pp-rec to allow the user to specify the destination format as a separate option on the command line (rather than inferring the format from the destination filename).

This enables the user to pipe the output to stdout like:
```
janus-pp-rec -f opus -d 0 plugins/recordings/rec-sample-audio.mjr /dev/stdout > output.opus
```
