### PR TITLE
Add support for domain names (and IPv6) to RTP forwarders

### DIFF
--- a/conf/janus.plugin.audiobridge.jcfg.sample
+++ b/conf/janus.plugin.audiobridge.jcfg.sample
@@ -18,6 +18,7 @@
 #     By default plain RTP is used, SRTP must be configured if needed
 # rtp_forward_id = numeric RTP forwarder ID for referencing it via API (optional: random ID used if missing)
 # rtp_forward_host = "<host address to forward RTP packets of mixed audio to>"
+# rtp_forward_host_family = "<ipv4|ipv6; by default, first family returned by DNS request>"
 # rtp_forward_port = port to forward RTP packets of mixed audio to
 # rtp_forward_ssrc = SSRC to use to use when streaming (optional: stream_id used if missing)
 # rtp_forward_ptype = payload type to use when streaming (optional: 100 used if missing)

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -1194,8 +1194,13 @@ static int janus_audiobridge_create_udp_socket_if_needed(janus_audiobridge_room 
 		return 0;
 	}
 
-	audiobridge->rtp_udp_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	audiobridge->rtp_udp_sock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
 	if(audiobridge->rtp_udp_sock <= 0) {
+		JANUS_LOG(LOG_ERR, "Could not open UDP socket for RTP forwarder (room %"SCNu64")\n", audiobridge->room_id);
+		return -1;
+	}
+	int v6only = 0;
+	if(setsockopt(audiobridge->rtp_udp_sock, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) != 0) {
 		JANUS_LOG(LOG_ERR, "Could not open UDP socket for RTP forwarder (room %"SCNu64")\n", audiobridge->room_id);
 		return -1;
 	}

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -1287,14 +1287,13 @@ static int janus_audiobridge_create_static_rtp_forwarder(janus_config_category *
 	struct addrinfo *res = NULL, *start = NULL;
 	janus_network_address addr;
 	janus_network_address_string_buffer addr_buf;
-	if(getaddrinfo(host, NULL, NULL, &res) == 0) {
+	struct addrinfo hints;
+	memset(&hints, 0, sizeof(hints));
+	if(family != 0)
+		hints.ai_family = family;
+	if(getaddrinfo(host, NULL, family != 0 ? &hints : NULL, &res) == 0) {
 		start = res;
 		while(res != NULL) {
-			if(family != 0 && family != res->ai_family) {
-				/* We're looking for a specific family */
-				res = res->ai_next;
-				continue;
-			}
 			if(janus_network_address_from_sockaddr(res->ai_addr, &addr) == 0 &&
 					janus_network_address_to_string_buffer(&addr, &addr_buf) == 0) {
 				/* Resolved */
@@ -2573,14 +2572,13 @@ static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_s
 		struct addrinfo *res = NULL, *start = NULL;
 		janus_network_address addr;
 		janus_network_address_string_buffer addr_buf;
-		if(getaddrinfo(host, NULL, NULL, &res) == 0) {
+		struct addrinfo hints;
+		memset(&hints, 0, sizeof(hints));
+		if(family != 0)
+			hints.ai_family = family;
+		if(getaddrinfo(host, NULL, family != 0 ? &hints : NULL, &res) == 0) {
 			start = res;
 			while(res != NULL) {
-				if(family != 0 && family != res->ai_family) {
-					/* We're looking for a specific family */
-					res = res->ai_next;
-					continue;
-				}
 				if(janus_network_address_from_sockaddr(res->ai_addr, &addr) == 0 &&
 						janus_network_address_to_string_buffer(&addr, &addr_buf) == 0) {
 					/* Resolved */

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -3445,14 +3445,13 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 		struct addrinfo *res = NULL, *start = NULL;
 		janus_network_address addr;
 		janus_network_address_string_buffer addr_buf;
-		if(getaddrinfo(host, NULL, NULL, &res) == 0) {
+		struct addrinfo hints;
+		memset(&hints, 0, sizeof(hints));
+		if(family != 0)
+			hints.ai_family = family;
+		if(getaddrinfo(host, NULL, family != 0 ? &hints : NULL, &res) == 0) {
 			start = res;
 			while(res != NULL) {
-				if(family != 0 && family != res->ai_family) {
-					/* We're looking for a specific family */
-					res = res->ai_next;
-					continue;
-				}
 				if(janus_network_address_from_sockaddr(res->ai_addr, &addr) == 0 &&
 						janus_network_address_to_string_buffer(&addr, &addr_buf) == 0) {
 					/* Resolved */

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1735,8 +1735,15 @@ static guint32 janus_videoroom_rtp_forwarder_add_helper(janus_videoroom_publishe
 	int fd = -1;
 	uint16_t local_rtcp_port = 0;
 	if(!is_data && rtcp_port > -1) {
-		fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+		fd = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
 		if(fd < 0) {
+			janus_mutex_unlock(&p->rtp_forwarders_mutex);
+			JANUS_LOG(LOG_ERR, "Error creating RTCP socket for new RTP forwarder... %d (%s)\n",
+				errno, strerror(errno));
+			return 0;
+		}
+		int v6only = 0;
+		if(setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) != 0) {
 			janus_mutex_unlock(&p->rtp_forwarders_mutex);
 			JANUS_LOG(LOG_ERR, "Error creating RTCP socket for new RTP forwarder... %d (%s)\n",
 				errno, strerror(errno));
@@ -1748,7 +1755,7 @@ static guint32 janus_videoroom_rtp_forwarder_add_helper(janus_videoroom_publishe
 		address.sin6_family = AF_INET6;
 		address.sin6_port = htons(0);	/* The RTCP port we received is the remote one */
 		address.sin6_addr = in6addr_any;
-		if(bind(fd, (struct sockaddr *)&address, sizeof(struct sockaddr)) < 0 ||
+		if(bind(fd, (struct sockaddr *)&address, len) < 0 ||
 				getsockname(fd, (struct sockaddr *)&address, &len) < 0) {
 			janus_mutex_unlock(&p->rtp_forwarders_mutex);
 			JANUS_LOG(LOG_ERR, "Error binding RTCP socket for new RTP forwarder... %d (%s)\n",
@@ -3485,14 +3492,16 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 		}
 		janus_refcount_increase(&publisher->ref);	/* This is just to handle the request for now */
 		if(publisher->udp_sock <= 0) {
-			publisher->udp_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-			if(publisher->udp_sock <= 0) {
+			publisher->udp_sock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+			int v6only = 0;
+			if(publisher->udp_sock <= 0 ||
+					setsockopt(publisher->udp_sock, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) != 0) {
 				janus_refcount_decrease(&publisher->ref);
 				janus_mutex_unlock(&videoroom->mutex);
 				janus_refcount_decrease(&videoroom->ref);
-				JANUS_LOG(LOG_ERR, "Could not open UDP socket for rtp stream for publisher (%"SCNu64")\n", publisher_id);
+				JANUS_LOG(LOG_ERR, "Could not open UDP socket for RTP stream for publisher (%"SCNu64")\n", publisher_id);
 				error_code = JANUS_VIDEOROOM_ERROR_UNKNOWN_ERROR;
-				g_snprintf(error_cause, 512, "Could not open UDP socket for rtp stream");
+				g_snprintf(error_cause, 512, "Could not open UDP socket for RTP stream");
 				goto prepare_response;
 			}
 		}


### PR DESCRIPTION
As the title says, this is an alternative implementation to #1774. It adds support for domain names as the `host` part of RTP forwarders, which so far they had to be IP addresses. Incidentally, it also includes support for IPv6, as that's that the domain name may resolve to: this meant updating all the socket stuff related to RTP forwarders in both AudioBridge and VideoRoom, as they were hardcoded to IPv4.

What still needs to be updated is the Streaming plugin, which still only supports binding to IPv4 addresses: as such, you won't be able to test an IPv6 RTP forwarder with the Streaming plugin for now. I'll probably add that as part of this pull request, so that everything is updated consistently.

Please test and provide feedback.