### PR TITLE
Hook Lua print function(s) to Janus logger

### DIFF
--- a/plugins/janus_lua.c
+++ b/plugins/janus_lua.c
@@ -383,6 +383,23 @@ static void *janus_lua_async_event_helper(void *data) {
 
 
 /* Methods that we expose to the Lua script */
+static int janus_lua_method_januslog(lua_State *s) {
+	/* This method allows the Lua script to use the Janus internal logger */
+	int n = lua_gettop(s);
+	if(n != 2) {
+		JANUS_LOG(LOG_ERR, "Wrong number of arguments: %d (expected 3)\n", n);
+		return 0;
+	}
+	int level = lua_tonumber(s, 1);
+	const char *text = lua_tostring(s, 2);
+	if(text == NULL) {
+		/* Ignore */
+		return 0;
+	}
+	JANUS_LOG(level, "%s\n", text);
+	return 0;
+}
+
 static int janus_lua_method_pokescheduler(lua_State *s) {
 	/* This method allows the Lua script to poke the scheduler and have it wake up ASAP */
 	g_async_queue_push(events, GUINT_TO_POINTER(janus_lua_event_resume));
@@ -1143,6 +1160,7 @@ int janus_lua_init(janus_callbacks *callback, const char *config_path) {
 	}
 
 	/* Register our functions */
+	lua_register(lua_state, "janusLog", janus_lua_method_januslog);
 	lua_register(lua_state, "pokeScheduler", janus_lua_method_pokescheduler);
 	lua_register(lua_state, "timeCallback", janus_lua_method_timecallback);
 	lua_register(lua_state, "pushEvent", janus_lua_method_pushevent);

--- a/plugins/lua/janus-logger.lua
+++ b/plugins/lua/janus-logger.lua
@@ -20,6 +20,14 @@ function JANUSLOG.print(text)
 	end
 end
 
+function JANUSLOG.verbose(text)
+	if text ~= nil then
+		janusLog(5, logPrefix .. text)
+	else
+		janusLog(5, logPrefix .. "(nil)")
+	end
+end
+
 function JANUSLOG.warn(text)
 	if text ~= nil then
 		janusLog(3, logPrefix .. text)

--- a/plugins/lua/janus-logger.lua
+++ b/plugins/lua/janus-logger.lua
@@ -14,9 +14,25 @@ end
 
 function JANUSLOG.print(text)
 	if text ~= nil then
-		print(logPrefix .. text)
+		janusLog(4, logPrefix .. text)
 	else
-		print(logPrefix .. "(nil)")
+		janusLog(4, logPrefix .. "(nil)")
+	end
+end
+
+function JANUSLOG.warn(text)
+	if text ~= nil then
+		janusLog(3, logPrefix .. text)
+	else
+		janusLog(3, logPrefix .. "(nil)")
+	end
+end
+
+function JANUSLOG.error(text)
+	if text ~= nil then
+		janusLog(2, logPrefix .. text)
+	else
+		janusLog(2, logPrefix .. "(nil)")
 	end
 end
 


### PR DESCRIPTION
This is the Lua counterpart of what #1781 does for Duktape, and basically ensures that, if you use the integrated Lua logger, it ends up in the Janus logging mechanism, and not on regular stdout: this ensures, for instance, that if you're logging to file, the Lua prints end there too. Besides, the patch adds a `logger.warn` and a `logger.err` as well, that map to the warning/error flags in our logs (and so use the related prefix in the logs too); `logger.print` works exactly as before, but in now maps to `LOG_INFO`: so, should you want to reduce the verbosity to, let's say, `LOG_VERB`, you just have to change the `4` to `5` in `janus-logger.lua`.

Feedback welcome.