### PR TITLE
moved destroySession connection condition

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -976,11 +976,6 @@ function Janus(gatewayCallbacks) {
 		if(callbacks.cleanupHandles !== undefined && callbacks.cleanupHandles !== null)
 			cleanupHandles = (callbacks.cleanupHandles === true);
 		Janus.log("Destroying session " + sessionId + " (async=" + asyncRequest + ")");
-		if(!connected) {
-			Janus.warn("Is the server down? (connected=false)");
-			callbacks.success();
-			return;
-		}
 		if(sessionId === undefined || sessionId === null) {
 			Janus.warn("No session to destroy");
 			callbacks.success();
@@ -991,6 +986,11 @@ function Janus(gatewayCallbacks) {
 		if(cleanupHandles) {
 			for(var handleId in pluginHandles)
 				destroyHandle(handleId, { noRequest: true });
+		}
+		if(!connected) {
+			Janus.warn("Is the server down? (connected=false)");
+			callbacks.success();
+			return;
 		}
 		// No need to destroy all handles first, Janus will do that itself
 		var request = { "janus": "destroy", "transaction": Janus.randomString(12) };


### PR DESCRIPTION
Moving the connection condition from destroySession allows handles to be cleaned locally even if there's no connection. When a connection is (temporarily) lost and destroySession is called (using the public method), it should clean the handles anyway, in case the connection gets restored. This avoids possible leaks with unexpected active PC.