### PR TITLE
Add test for -Wunused-but-set-variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,8 +65,10 @@ clang*)
 	CFLAGS="$CFLAGS \
 		-Wcast-align \
 		-Wno-override-init \
-		-Wunsafe-loop-optimizations \
-		-Wunused-but-set-variable"
+		-Wunsafe-loop-optimizations"
+
+	AX_CHECK_COMPILE_FLAG([-Wunused-but-set-variable],
+		[CFLAGS="$CFLAGS -Wunused-but-set-variable"])
 esac
 
 JANUS_VERSION=75


### PR DESCRIPTION
The -Wunused-but-set-variable option does not exist in some old gcc
versions (gcc 4.5.x), so using it unconditionally breaks the build
with such compilers.

This commit introduces the AX_CHECK_COMPILE_FLAG m4 macro taken from
the autoconf-archive
(http://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=blob_plain;f=m4/ax_check_compile_flag.m4),
and uses it to detect if the -Wunused-but-set-variable option is
supported, and only uses it in this case.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
(rebased against v0.1.0)
Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
(rebased against v0.6.3)
Signed-off-by: Adam Duskett <Aduskett@gmail.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/janus-gateway/0002-Add-test-for-Wunused-but-set-variable.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>