### PR TITLE
Write moov atom at the head of the MP4 file

### DIFF
--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -114,6 +114,7 @@ Usage: janus-pp-rec [OPTIONS] source.mjr [destination.[opus|wav|webm|mp4|srt]]
 int janus_log_level = 4;
 gboolean janus_log_timestamps = FALSE;
 gboolean janus_log_colors = TRUE;
+gboolean janus_faststart = FALSE;
 
 static janus_pp_frame_packet *list = NULL, *last = NULL;
 static char *metadata = NULL;
@@ -180,6 +181,7 @@ int main(int argc, char *argv[])
 		if(val >= 0)
 			ignore_first_packets = val;
 	}
+
 	if(args_info.audiolevel_ext_given || (g_getenv("JANUS_PPREC_AUDIOLEVELEXT") != NULL)) {
 		int val = args_info.audiolevel_ext_given ? args_info.audiolevel_ext_arg : atoi(g_getenv("JANUS_PPREC_AUDIOLEVELEXT"));
 		if(val >= 0)
@@ -194,6 +196,9 @@ int main(int argc, char *argv[])
 	if(args_info.format_given || (g_getenv("JANUS_PPREC_FORMAT") != NULL)) {
 		extension = g_strdup(args_info.format_given ? args_info.format_arg : g_getenv("JANUS_PPREC_FORMAT"));
 	}
+	if(args_info.faststart_given)
+		janus_faststart = TRUE;
+
 
 	/* Evaluate arguments to find source and target */
 	char *source = NULL, *destination = NULL, *setting = NULL;
@@ -275,6 +280,13 @@ int main(int argc, char *argv[])
 			exit(1);
 		}
 	}
+
+	if (janus_faststart && strcasecmp(extension, "mp4")) {
+		JANUS_LOG(LOG_ERR, "Faststart only supported for MP4");
+		cmdline_parser_free(&args_info);
+		exit(1);
+	}
+
 	FILE *file = fopen(source, "rb");
 	if(file == NULL) {
 		JANUS_LOG(LOG_ERR, "Could not open file %s\n", source);
@@ -912,7 +924,7 @@ int main(int argc, char *argv[])
 				exit(1);
 			}
 		} else if(h264) {
-			if(janus_pp_h264_create(destination, metadata) < 0) {
+			if(janus_pp_h264_create(destination, metadata, janus_faststart) < 0) {
 				JANUS_LOG(LOG_ERR, "Error creating .mp4 file...\n");
 				cmdline_parser_free(&args_info);
 				exit(1);

--- a/postprocessing/janus-pp-rec.ggo
+++ b/postprocessing/janus-pp-rec.ggo
@@ -12,3 +12,4 @@ option "debug-level" d "Debug/logging level (0=disable debugging, 7=maximum debu
 option "debug-timestamps" D "Enable debug/logging timestamps" flag off
 option "disable-colors" o "Disable color in the logging" flag off
 option "format" f "Specifies the output format (overrides the format from the destination)" string values="opus", "wav", "webm", "mp4", "srt" optional
+option "faststart" t "For mp4 files write the MOOV atom at the head of the file" flag off

--- a/postprocessing/pp-h264.c
+++ b/postprocessing/pp-h264.c
@@ -133,11 +133,14 @@ int janus_pp_h264_create(char *destination, char *metadata) {
 	//~ if (fctx->flags & AVFMT_GLOBALHEADER)
 		vStream->codec->flags |= CODEC_FLAG_GLOBAL_HEADER;
 #endif
-	if(avio_open(&fctx->pb, fctx->filename, AVIO_FLAG_WRITE) < 0) {
+	AVDictionary *options = NULL;
+	av_dict_set(&options, "movflags", "+faststart", 0);
+
+	if(avio_open2(&fctx->pb, fctx->filename, AVIO_FLAG_WRITE, NULL, &options) < 0) {
 		JANUS_LOG(LOG_ERR, "Error opening file for output\n");
 		return -1;
 	}
-	if(avformat_write_header(fctx, NULL) < 0) {
+	if(avformat_write_header(fctx, &options) < 0) {
 		JANUS_LOG(LOG_ERR, "Error writing header\n");
 		return -1;
 	}

--- a/postprocessing/pp-h264.c
+++ b/postprocessing/pp-h264.c
@@ -58,7 +58,7 @@ static AVCodecContext *vEncoder;
 static int max_width = 0, max_height = 0, fps = 0;
 
 
-int janus_pp_h264_create(char *destination, char *metadata) {
+int janus_pp_h264_create(char *destination, char *metadata, gboolean faststart) {
 	if(destination == NULL)
 		return -1;
 	/* Setup FFmpeg */
@@ -134,7 +134,8 @@ int janus_pp_h264_create(char *destination, char *metadata) {
 		vStream->codec->flags |= CODEC_FLAG_GLOBAL_HEADER;
 #endif
 	AVDictionary *options = NULL;
-	av_dict_set(&options, "movflags", "+faststart", 0);
+	if(faststart)
+		av_dict_set(&options, "movflags", "+faststart", 0);
 
 	if(avio_open2(&fctx->pb, fctx->filename, AVIO_FLAG_WRITE, NULL, &options) < 0) {
 		JANUS_LOG(LOG_ERR, "Error opening file for output\n");

--- a/postprocessing/pp-h264.h
+++ b/postprocessing/pp-h264.h
@@ -17,7 +17,7 @@
 #include "pp-rtp.h"
 
 /* H.264 stuff */
-int janus_pp_h264_create(char *destination, char *metadata);
+int janus_pp_h264_create(char *destination, char *metadata, gboolean faststart);
 int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list);
 int janus_pp_h264_process(FILE *file, janus_pp_frame_packet *list, int *working);
 void janus_pp_h264_close(void);


### PR DESCRIPTION
I modified janus-pp-rec so that it will add the MOOV atom to the header of the output file.

Note that this may be incompatible with my previous PR (https://github.com/meetecho/janus-gateway/pull/1777) if the output file "/dev/stdout" is used.  Let me know if you want this behind a command line flag.  (Or I could fopen the destination file and see if it is seekable?)