### PR TITLE
configure.ac: add --disable-stack-protector option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,6 @@ LT_INIT
 # Common CFLAGS
 CFLAGS="$CFLAGS \
 	-fPIC \
-	-fstack-protector-all \
 	-fstrict-aliasing \
 	-ggdb3 \
 	-pthread \
@@ -95,6 +94,14 @@ jansson_version=2.5
 ##
 # Janus
 ##
+
+AC_ARG_ENABLE([stack-protector],
+              [AS_HELP_STRING([--disable-stack-protector],
+                              [Disable stack protector])],
+              [],
+              [enable_stack_protector=yes])
+AS_IF([test "x$enable_stack_protector" = "xyes"],
+      [CFLAGS="$CFLAGS -fstack-protector-all"])
 
 AC_ARG_ENABLE([docs],
               [AS_HELP_STRING([--enable-docs],


### PR DESCRIPTION
This option will allow the user to disable -fstack-protector-all as some
toolchains don't support it.
Option is enabled by default to keep current behavior

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>