### PR TITLE
Update getStats() to use a promise instead of callback

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2946,18 +2946,19 @@ function Janus(gatewayCallbacks) {
 			if(config.volume[stream].timer === null || config.volume[stream].timer === undefined) {
 				Janus.log("Starting " + stream + " volume monitor");
 				config.volume[stream].timer = setInterval(function() {
-					config.pc.getStats(function(stats) {
-						var results = stats.result();
-						for(var i=0; i<results.length; i++) {
-							var res = results[i];
-							if(res.type == 'ssrc') {
-								if(remote && res.stat('audioOutputLevel'))
-									config.volume[stream].value = parseInt(res.stat('audioOutputLevel'));
-								else if(!remote && res.stat('audioInputLevel'))
-									config.volume[stream].value = parseInt(res.stat('audioInputLevel'));
+					config.pc.getStats()
+						.then(function(stats) {
+							var results = stats.result();
+							for(var i=0; i<results.length; i++) {
+								var res = results[i];
+								if(res.type == 'ssrc') {
+									if(remote && res.stat('audioOutputLevel'))
+										config.volume[stream].value = parseInt(res.stat('audioOutputLevel'));
+									else if(!remote && res.stat('audioInputLevel'))
+										config.volume[stream].value = parseInt(res.stat('audioInputLevel'));
+								}
 							}
-						}
-					});
+						});
 				}, 200);
 				return 0;	// We don't have a volume to return yet
 			}


### PR DESCRIPTION
Small update in janus.js for getStats() method. Now, it returns a promise which resolves the stats instead of a callback function.

https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getStats