### PR TITLE
Fix bandwidth_cap

### DIFF
--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -514,10 +514,6 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen) {
 							break;
 						}
 						*semicolon = '\0';
-						if(strcmp(line, "AS")) {
-							/* We only support b=AS, skip */
-							break;
-						}
 						mline->b_name = g_strdup(line);
 						mline->b_value = atol(semicolon+1);
 						*semicolon = ':';


### PR DESCRIPTION
I noticed that b=TIAS was no longer in the answer sent to Firefox when bandwidth_cap was true in master
Upon using git bisect I traced this back to the following commit; aa676253bf74f20ee2ab641f49b9b6c2bbf87e4c

It seems that the strcmp() function can return a positive integer when partially matching (and 0 when exactly matching) and thus evaluates to true when TIAS is matched against AS.
The break statement then prevents the line from being set instead of bypassing the error conditional as seemed to be the intention in (#1662), any other b= lines would still trigger the error conditional after the first one is set

Removing this break fixes the bandwidth_cap setting but to further address #1662 I think multiple b-lines should be supported as stated in RFC 4566
I'd imagine a g_list similar to the sdp attributes would be best suited for this but will leave that decision to you as you're much more familiar with all your sdp-utils use cases