### PR TITLE
Improved attach/reattach MediaStream helpers avoiding browser versions

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -297,31 +297,29 @@ Janus.init = function(options) {
 		}
 		// Helper methods to attach/reattach a stream to a video element (previously part of adapter.js)
 		Janus.attachMediaStream = function(element, stream) {
-			if(Janus.webRTCAdapter.browserDetails.browser === 'chrome') {
-				var chromever = Janus.webRTCAdapter.browserDetails.version;
-				if(chromever >= 52) {
-					element.srcObject = stream;
-				} else if(typeof element.src !== 'undefined') {
+			try {
+				element.srcObject = stream;
+			}
+			catch {
+				try {
 					element.src = URL.createObjectURL(stream);
-				} else {
+				}
+				catch {
 					Janus.error("Error attaching stream to element");
 				}
-			} else {
-				element.srcObject = stream;
 			}
 		};
 		Janus.reattachMediaStream = function(to, from) {
-			if(Janus.webRTCAdapter.browserDetails.browser === 'chrome') {
-				var chromever = Janus.webRTCAdapter.browserDetails.version;
-				if(chromever >= 52) {
-					to.srcObject = from.srcObject;
-				} else if(typeof to.src !== 'undefined') {
+			try {
+				to.srcObject = from.srcObject;
+			}
+			catch {
+				try {
 					to.src = from.src;
-				} else {
+				}
+				catch {
 					Janus.error("Error reattaching stream to element");
 				}
-			} else {
-				to.srcObject = from.srcObject;
 			}
 		};
 		// Detect tab close: make sure we don't loose existing onbeforeunload handlers

--- a/html/janus.js
+++ b/html/janus.js
@@ -299,12 +299,10 @@ Janus.init = function(options) {
 		Janus.attachMediaStream = function(element, stream) {
 			try {
 				element.srcObject = stream;
-			}
-			catch {
+			} catch {
 				try {
 					element.src = URL.createObjectURL(stream);
-				}
-				catch {
+				} catch {
 					Janus.error("Error attaching stream to element");
 				}
 			}
@@ -316,8 +314,7 @@ Janus.init = function(options) {
 			catch {
 				try {
 					to.src = from.src;
-				}
-				catch {
+				} catch {
 					Janus.error("Error reattaching stream to element");
 				}
 			}

--- a/html/janus.js
+++ b/html/janus.js
@@ -310,8 +310,7 @@ Janus.init = function(options) {
 		Janus.reattachMediaStream = function(to, from) {
 			try {
 				to.srcObject = from.srcObject;
-			}
-			catch {
+			} catch {
 				try {
 					to.src = from.src;
 				} catch {


### PR DESCRIPTION
As you know, the `createObjectURL()` is deprecated in some browsers. 
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject

With this PR we remove all browser and version checks and we try to use `srcObject` whenever possible.