### PR TITLE
Fix bitrate_cap in Firefox

### DIFF
--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -514,8 +514,8 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen) {
 							break;
 						}
 						*semicolon = '\0';
-						if(strcmp(line, "AS")) {
-							/* We only support b=AS, skip */
+						if(strcmp(line, "AS") && strcmp(line, "TIAS")) {
+							/* We only support b=AS and b=TIAS, skip */
 							break;
 						}
 						mline->b_name = g_strdup(line);


### PR DESCRIPTION
This PR simply extends the conditional added in #1662 to include TIAS to fix the bandwidth_cap functionality in Firefox

This has been tested and confirmed working on Firefox and Chrome, both the b=TIAS and b=AS lines are set correctly in the answer depending on the browser