### PR TITLE
Gzip compression utility in the core (and sample event handler)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A couple of plugins depend on a few more libraries:
 Additionally, you'll need the following libraries and tools:
 
 * [GLib](http://library.gnome.org/devel/glib/)
+* [zlib](https://zlib.net/)
 * [pkg-config](http://www.freedesktop.org/wiki/Software/pkg-config/)
 * [gengetopt](http://www.gnu.org/software/gengetopt/)
 

--- a/conf/janus.eventhandler.sampleevh.jcfg.sample
+++ b/conf/janus.eventhandler.sampleevh.jcfg.sample
@@ -13,14 +13,17 @@ general: {
 						# HTTP POST, JSON object), or if it's ok to group them
 						# (one or more per HTTP POST, JSON array with objects)
 						# The default is 'yes' to limit the number of connections.
+	json = "indented"	# Whether the JSON messages should be indented (default),
+						# plain (no indentation) or compact (no indentation and no spaces)
+
+	#compress = true	# Optionally, the JSON messages can be compressed using zlib
+	#compression = 9	# In case, you can specify the compression factor, where 1 is
+						# the fastest (low compression), and 9 gives the best compression
 
 						# Address the plugin will send all events to as HTTP POST
 						# requests with an application/json payload. In case
 						# authentication is required to contact the backend, set
 						# the credentials as well (basic authentication only).
-	json = "indented"	# Whether the JSON messages should be indented (default),
-						# plain (no indentation) or compact (no indentation and no spaces)
-
 	backend = "http://your.webserver.here/and/a/path"
 	#backend_user = "myuser"
 	#backend_pwd = "mypwd"

--- a/configure.ac
+++ b/configure.ac
@@ -315,6 +315,7 @@ PKG_CHECK_MODULES([JANUS],
                     jansson >= $jansson_version
                     libssl >= $ssl_version
                     libcrypto
+                    zlib
                   ])
 JANUS_MANUAL_LIBS="${JANUS_MANUAL_LIBS} -lm"
 AC_SUBST(JANUS_MANUAL_LIBS)

--- a/events/janus_sampleevh.c
+++ b/events/janus_sampleevh.c
@@ -81,6 +81,10 @@ static janus_mutex evh_mutex;
 /* JSON serialization options */
 static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
 
+/* Compression, if any */
+static gboolean compress = FALSE;
+static int compression = 6;		/* Z_DEFAULT_COMPRESSION */
+
 /* Queue of events to handle */
 static GAsyncQueue *events = NULL;
 static gboolean group_events = TRUE;
@@ -215,6 +219,20 @@ int janus_sampleevh_init(const char *config_path) {
 						json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
 					}
 				}
+				/* Check if we need any compression */
+				item = janus_config_get(config, config_general, janus_config_type_item, "compress");
+				if(item && item->value && janus_is_true(item->value)) {
+					compress = TRUE;
+					item = janus_config_get(config, config_general, janus_config_type_item, "compression");
+					if(item && item->value) {
+						int c = atoi(item->value);
+						if(c < 0 || c > 9) {
+							JANUS_LOG(LOG_WARN, "Invalid compression factor '%d', falling back to '%d'...\n", c, compression);
+						} else {
+							compression = c;
+						}
+					}
+				}
 				/* Done */
 				enabled = TRUE;
 			}
@@ -342,13 +360,19 @@ json_t *janus_sampleevh_handle_request(json_t *request) {
 		/* Parameters we can change */
 		const char *req_events = NULL, *req_backend = NULL,
 			*req_backend_user = NULL, *req_backend_pwd = NULL;
-		int req_grouping = -1, req_maxretr = -1, req_backoff = -1;
+		int req_grouping = -1, req_maxretr = -1, req_backoff = -1,
+			req_compress = -1, req_compression = -1;
 		/* Events */
 		if(json_object_get(request, "events"))
 			req_events = json_string_value(json_object_get(request, "events"));
 		/* Grouping */
 		if(json_object_get(request, "grouping"))
 			req_grouping = json_is_true(json_object_get(request, "grouping"));
+		/* Compression */
+		if(json_object_get(request, "compress"))
+			req_compress = json_is_true(json_object_get(request, "compress"));
+		if(json_object_get(request, "compression"))
+			req_compress = json_integer_value(json_object_get(request, "compression"));
 		/* Backend stuff */
 		if(json_object_get(request, "backend"))
 			req_backend = json_string_value(json_object_get(request, "backend"));
@@ -368,12 +392,16 @@ json_t *janus_sampleevh_handle_request(json_t *request) {
 		if(json_object_get(request, "retransmissions_backoff"))
 			req_backoff = json_integer_value(json_object_get(request, "retransmissions_backoff"));
 		/* If we got here, we can enforce */
+		janus_mutex_lock(&evh_mutex);
 		if(req_events)
 			janus_events_edit_events_mask(req_events, &janus_sampleevh.events_mask);
 		if(req_grouping > -1)
 			group_events = req_grouping ? TRUE : FALSE;
+		if(req_compress > -1)
+			compress = req_compress ? TRUE : FALSE;
+		if(req_compression > -1 && req_compression < 10)
+			compression = req_compression;
 		if(req_backend || req_backend_user || req_backend_pwd) {
-			janus_mutex_lock(&evh_mutex);
 			if(req_backend) {
 				g_free(backend);
 				backend = g_strdup(req_backend);
@@ -386,12 +414,12 @@ json_t *janus_sampleevh_handle_request(json_t *request) {
 				g_free(backend_pwd);
 				backend_pwd = g_strdup(req_backend_pwd);
 			}
-			janus_mutex_unlock(&evh_mutex);
 		}
 		if(req_maxretr > -1)
 			max_retransmissions = req_maxretr;
 		if(req_backoff > -1)
 			retransmissions_backoff = req_backoff;
+		janus_mutex_unlock(&evh_mutex);
 	} else {
 		JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
 		error_code = JANUS_SAMPLEEVH_ERROR_INVALID_REQUEST;
@@ -418,6 +446,8 @@ static void *janus_sampleevh_handler(void *data) {
 	JANUS_LOG(LOG_VERB, "Joining SampleEventHandler handler thread\n");
 	json_t *event = NULL, *output = NULL;
 	char *event_text = NULL;
+	char compressed_text[8192];
+	size_t compressed_len = 0;
 	int count = 0, max = group_events ? 100 : 1;
 	int retransmit = 0;
 	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
@@ -695,11 +725,26 @@ static void *janus_sampleevh_handler(void *data) {
 			curl_easy_setopt(curl, CURLOPT_PASSWORD, backend_pwd);
 		}
 		janus_mutex_unlock(&evh_mutex);
-		headers = curl_slist_append(headers, "Accept: application/json");
-		headers = curl_slist_append(headers, "Content-Type: application/json");
+		/* Check if we need to compress the data */
+		if(compress) {
+			compressed_len = janus_gzip_compress(compression,
+				event_text, strlen(event_text),
+				compressed_text, sizeof(compressed_text));
+			if(compressed_len == 0) {
+				JANUS_LOG(LOG_ERR, "Failed to compress event (%zu bytes)...\n", strlen(event_text));
+				/* Nothing we can do... get rid of the event */
+				g_free(event_text);
+				json_decref(output);
+				output = NULL;
+				continue;
+			}
+		}
+		headers = curl_slist_append(headers, compress ? "Accept: application/gzip": "Accept: application/json");
+		headers = curl_slist_append(headers, compress ? "Content-Type: application/gzip" : "Content-Type: application/json");
 		headers = curl_slist_append(headers, "charsets: utf-8");
 		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, event_text);
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, compress ? compressed_text : event_text);
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, compress ? compressed_len : strlen(event_text));
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, janus_sampleehv_write_data);
 		/* Don't wait forever (let's say, 10 seconds) */
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10L);

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -95,6 +95,7 @@
  * - \b libopus: http://opus-codec.org/ (\c optional, only needed for the bridge plugin)
  * - \b libogg: http://xiph.org/ogg/ (\c optional, only needed for the voicemail plugin)
  * - \b libcurl: https://curl.haxx.se/libcurl/ (\c optional, only needed for the TURN REST API,
+ * RTSP support in the Streaming plugin and the sample Event Handler plugin)
  * - \b zlib: https://zlib.net/ (gzip compression utility)
  * - \b Lua: https://www.lua.org/download.html (\c optional, only needed for the Lua plugin)
  * - \b npm: https://docs.npmjs.com/ (\c optional, used during build for generating JavaScript modules)

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -95,7 +95,7 @@
  * - \b libopus: http://opus-codec.org/ (\c optional, only needed for the bridge plugin)
  * - \b libogg: http://xiph.org/ogg/ (\c optional, only needed for the voicemail plugin)
  * - \b libcurl: https://curl.haxx.se/libcurl/ (\c optional, only needed for the TURN REST API,
- * RTSP support in the Streaming plugin and the sample Event Handler plugin)
+ * - \b zlib: https://zlib.net/ (gzip compression utility)
  * - \b Lua: https://www.lua.org/download.html (\c optional, only needed for the Lua plugin)
  * - \b npm: https://docs.npmjs.com/ (\c optional, used during build for generating JavaScript modules)
  *
@@ -3490,6 +3490,7 @@ ldd janus | grep asan
  * - \b libogg: http://xiph.org/ogg/ (\c optional, only needed for the voicemail plugin)
  * - \b libcurl: https://curl.haxx.se/libcurl/ (\c optional, only needed for the TURN REST API,
  * RTSP support in the Streaming plugin and the sample Event Handler plugin)
+ * - \b zlib: https://zlib.net/ (gzip compression utility)
  * - \b Lua: https://www.lua.org/download.html (\c optional, only needed for the Lua plugin)
  * - \b npm: https://docs.npmjs.com/ (\c optional, used during build for generating JavaScript modules)
  *

--- a/utils.c
+++ b/utils.c
@@ -20,6 +20,8 @@
 #include <arpa/inet.h>
 #include <inttypes.h>
 
+#include <zlib.h>
+
 #include "utils.h"
 #include "debug.h"
 
@@ -998,4 +1000,42 @@ inline void janus_set4(guint8 *data,size_t i,guint32 val) {
 	data[i+2] = (guint8)(val>>8);
 	data[i+1] = (guint8)(val>>16);
 	data[i]   = (guint8)(val>>24);
+}
+
+size_t janus_gzip_compress(int compression, char *text, size_t tlen, char *compressed, size_t zlen) {
+	if(text == NULL || tlen < 1 || compressed == NULL || zlen < 1)
+		return -1;
+	if(compression < 0 || compression > 9) {
+		JANUS_LOG(LOG_WARN, "Invalid compression factor %d, falling back to default compression...\n", compression);
+		compression = Z_DEFAULT_COMPRESSION;
+	}
+
+	/* Initialize the deflater, and clarify we need gzip */
+	z_stream zs;
+	zs.zalloc = Z_NULL;
+	zs.zfree = Z_NULL;
+	zs.opaque = Z_NULL;
+	zs.next_in = (Bytef *)text;
+	zs.avail_in = (uInt)tlen+1;
+	zs.next_out = (Bytef *)compressed;
+	zs.avail_out = (uInt)zlen;
+	int res = deflateInit2(&zs, compression, Z_DEFLATED, 15 | 16, 8, Z_DEFAULT_STRATEGY);
+	if(res != Z_OK) {
+		JANUS_LOG(LOG_ERR, "deflateInit error: %d\n", res);
+		return 0;
+	}
+	/* Deflate the string */
+	res = deflate(&zs, Z_FINISH);
+	if(res != Z_STREAM_END) {
+		JANUS_LOG(LOG_ERR, "deflate error: %d\n", res);
+		return 0;
+	}
+	res = deflateEnd(&zs);
+	if(res != Z_OK) {
+		JANUS_LOG(LOG_ERR, "deflateEnd error: %d\n", res);
+		return 0;
+	}
+
+	/* Done, return the size of the compressed data */
+	return zs.total_out;
 }

--- a/utils.h
+++ b/utils.h
@@ -321,4 +321,16 @@ void janus_set3(guint8 *data, size_t i, guint32 val);
  */
 void janus_set4(guint8 *data, size_t i, guint32 val);
 
+/*! \brief Helper method to compress a string to gzip (using zlib)
+ * \note It's up to you to provide a buffer large enough for the compressed
+ * data: in case the buffer isn't large enough, the request will fail
+ * @param[in] compression Compression factor (1=fastest, 9=best compression)
+ * @param[in] text Pointer to the string to compress
+ * @param[in] tlen Length of the string to compress
+ * @param[in] compressed Pointer to the buffer where to compress the string to
+ * @param[in] zlen Size of the output buffer
+ * @returns The size of the compressed data, if successful, or 0 otherwise
+ */
+size_t janus_gzip_compress(int compression, char *text, size_t tlen, char *compressed, size_t zlen);
+
 #endif


### PR DESCRIPTION
Pretty basic PR that adds a new method to the core `utils.c` to compress a string to `gzip`. The idea is that should be of help to all the plugins that may have a need for that, e.g., event handlers or, in the future, loggers (see #1814).

In this patch, as a proof of concept I only integrated it in the sample event handler: you can configure it to compress the events to send out (and the compression factor to use), and in case, HTTP requests will use `application/gzip` instead of `application/json`. Tested briefly with a node.js backend and it seems to be working as expected. In the future, this may be extended to other plugins as well.

For the moment I only added a way to compress a string to gzip-ed data, and not the other way around, as I didn't see a real need for that. Again, in the future we may want to add that part too if it turns out there's use cases where it may be useful.