### PR TITLE
Add exception var to catch stmt to fix rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ Makefile.in
 
 # CLion
 .idea
+
+.vscode

--- a/html/janus.js
+++ b/html/janus.js
@@ -299,10 +299,10 @@ Janus.init = function(options) {
 		Janus.attachMediaStream = function(element, stream) {
 			try {
 				element.srcObject = stream;
-			} catch {
+			} catch (e) {
 				try {
 					element.src = URL.createObjectURL(stream);
-				} catch {
+				} catch (e) {
 					Janus.error("Error attaching stream to element");
 				}
 			}
@@ -310,10 +310,10 @@ Janus.init = function(options) {
 		Janus.reattachMediaStream = function(to, from) {
 			try {
 				to.srcObject = from.srcObject;
-			} catch {
+			} catch (e) {
 				try {
 					to.src = from.src;
-				} catch {
+				} catch (e) {
 					Janus.error("Error reattaching stream to element");
 				}
 			}


### PR DESCRIPTION
The command `npm run rollup -- --o /path/to/desired/output/file-name.js --f cjs # or es, iffe, umd, amd, ...
` which you can find in [here](https://janus.conf.meetecho.com/docs/js-modules.html) was not working due to an invalid ES syntax.

Error thrown when executing the given command:
```
apolo@apolo-ThinkPad-T480  ~/projects/apolo/janus-gateway/npm   master  npm run rollup

> janus@ rollup /home/apolo/projects/apolo/janus-gateway/npm
> rollup -c rollup.config.js


module.js → stdout...
[!] Error: Unexpected token
module.js (310:11)
308:       try {
309:         element.srcObject = stream;
310:       } catch {
                   ^
311:         try {
312:           element.src = URL.createObjectURL(stream);

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! janus@ rollup: `rollup -c rollup.config.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the janus@ rollup script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/apolo/.npm/_logs/2019-11-04T02_54_07_177Z-debug.log
```

Hope this fix helps people trying to include this awesome system into their apps.

My use case, if it helps, is that I want to build the janus script in my `postinstall` as an `umd` module but I can't use the webpack plugin because I'm using `@angular/cli` to build my frontend. So I want to reference the script but in production mode this script does not work the way that it's written at the moment.