### PR TITLE
VP9 SVC fixes

### DIFF
--- a/html/vp9svctest.js
+++ b/html/vp9svctest.js
@@ -646,7 +646,7 @@ function addSvcButtons(feed) {
 				$('#sl' + index + '-1').removeClass('btn-primary btn-info').addClass('btn-primary');
 			if(!$('#sl' + index + '-0').hasClass('btn-success'))
 				$('#sl' + index + '-0').removeClass('btn-primary btn-info').addClass('btn-primary');
-			feeds[index].send({message: { request: "configure", spatial_layer: 1 }});
+			feeds[index].send({message: { request: "configure", spatial_layer: 2 }});
 		});
 	$('#tl' + index + '-0').removeClass('btn-primary btn-success').addClass('btn-primary')
 		.unbind('click').click(function() {

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1525,6 +1525,7 @@ typedef struct janus_videoroom_subscriber {
 	/* The following are only relevant if we're doing VP9 SVC, and are not to be confused with plain
 	 * simulcast, which has similar info (substream/templayer) but in a completely different context */
 	int spatial_layer, target_spatial_layer;
+	gint64 last_spatial_layer[2];
 	int temporal_layer, target_temporal_layer;
 	volatile gint destroyed;
 	janus_refcount ref;
@@ -1539,9 +1540,7 @@ typedef struct janus_videoroom_rtp_relay_packet {
 	uint16_t seq_number;
 	/* The following are only relevant if we're doing VP9 SVC*/
 	gboolean svc;
-	int spatial_layer;
-	int temporal_layer;
-	uint8_t pbit, dbit, ubit, bbit, ebit;
+	janus_vp9_svc_info svc_info;
 } janus_videoroom_rtp_relay_packet;
 
 
@@ -4512,19 +4511,10 @@ void janus_videoroom_incoming_rtp(janus_plugin_session *handle, int video, char 
 			char *payload = janus_rtp_payload(buf, len, &plen);
 			if(payload == NULL)
 				return;
-			uint8_t pbit = 0, dbit = 0, ubit = 0, bbit = 0, ebit = 0;
-			int found = 0, spatial_layer = 0, temporal_layer = 0;
-			if(janus_vp9_parse_svc(payload, plen, &found, &spatial_layer, &temporal_layer, &pbit, &dbit, &ubit, &bbit, &ebit) == 0) {
-				if(found) {
-					packet.svc = TRUE;
-					packet.spatial_layer = spatial_layer;
-					packet.temporal_layer = temporal_layer;
-					packet.pbit = pbit;
-					packet.dbit = dbit;
-					packet.ubit = ubit;
-					packet.bbit = bbit;
-					packet.ebit = ebit;
-				}
+			gboolean found = FALSE;
+			memset(&packet.svc_info, 0, sizeof(packet.svc_info));
+			if(janus_vp9_parse_svc(payload, plen, &found, &packet.svc_info) == 0) {
+				packet.svc = found;
 			}
 		}
 		packet.ssrc[0] = (sc != -1 ? participant->ssrc[0] : 0);
@@ -6067,6 +6057,9 @@ static void *janus_videoroom_handler(void *data) {
 					 * let's assume we're interested in all layers for the time being */
 					subscriber->spatial_layer = -1;
 					subscriber->target_spatial_layer = 2;		/* FIXME Chrome sends 0, 1 and 2 (if using EnabledByFlag_3SL3TL) */
+					subscriber->last_spatial_layer[0] = 0;
+					subscriber->last_spatial_layer[1] = 0;
+					subscriber->last_spatial_layer[2] = 0;
 					subscriber->temporal_layer = -1;
 					subscriber->target_temporal_layer = 2;	/* FIXME Chrome sends 0, 1 and 2 */
 				}
@@ -6509,68 +6502,63 @@ static void janus_videoroom_relay_rtp_packet(gpointer data, gpointer user_data) 
 			/* There is: check if this is a layer that can be dropped for this viewer
 			 * Note: Following core inspired by the excellent job done by Sergio Garcia Murillo here:
 			 * https://github.com/medooze/media-server/blob/master/src/vp9/VP9LayerSelector.cpp */
+			int plen = 0;
+			char *payload = janus_rtp_payload((char *)packet->data, packet->length, &plen);
+			gboolean keyframe = janus_vp9_is_keyframe((const char *)payload, plen);
 			gboolean override_mark_bit = FALSE, has_marker_bit = packet->data->markerbit;
-			int temporal_layer = subscriber->temporal_layer;
-			if(subscriber->target_temporal_layer > subscriber->temporal_layer) {
-				/* We need to upscale */
-				JANUS_LOG(LOG_HUGE, "We need to upscale temporally:\n");
-				if(packet->ubit && packet->bbit && packet->temporal_layer <= subscriber->target_temporal_layer) {
-					JANUS_LOG(LOG_HUGE, "  -- Upscaling temporal layer: %u --> %u\n",
-						packet->temporal_layer, subscriber->target_temporal_layer);
-					subscriber->temporal_layer = packet->temporal_layer;
-					temporal_layer = subscriber->temporal_layer;
-					/* Notify the viewer */
-					json_t *event = json_object();
-					json_object_set_new(event, "videoroom", json_string("event"));
-					json_object_set_new(event, "room", json_integer(subscriber->room_id));
-					json_object_set_new(event, "temporal_layer", json_integer(subscriber->temporal_layer));
-					gateway->push_event(subscriber->session->handle, &janus_videoroom_plugin, NULL, event, NULL);
-					json_decref(event);
-				}
-			} else if(subscriber->target_temporal_layer < subscriber->temporal_layer) {
-				/* We need to downscale */
-				JANUS_LOG(LOG_HUGE, "We need to downscale temporally:\n");
-				if(packet->ebit) {
-					JANUS_LOG(LOG_HUGE, "  -- Downscaling temporal layer: %u --> %u\n",
-						subscriber->temporal_layer, subscriber->target_temporal_layer);
-					subscriber->temporal_layer = subscriber->target_temporal_layer;
-					/* Notify the viewer */
-					json_t *event = json_object();
-					json_object_set_new(event, "videoroom", json_string("event"));
-					json_object_set_new(event, "room", json_integer(subscriber->room_id));
-					json_object_set_new(event, "temporal_layer", json_integer(subscriber->temporal_layer));
-					gateway->push_event(subscriber->session->handle, &janus_videoroom_plugin, NULL, event, NULL);
-					json_decref(event);
-				}
-			}
-			if(temporal_layer < packet->temporal_layer) {
-				/* Drop the packet: update the context to make sure sequence number is increased normally later */
-				JANUS_LOG(LOG_HUGE, "Dropping packet (temporal layer %d < %d)\n", temporal_layer, packet->temporal_layer);
-				subscriber->context.v_base_seq++;
-				return;
-			}
 			int spatial_layer = subscriber->spatial_layer;
+			gint64 now = janus_get_monotonic_time();
+			if(packet->svc_info.spatial_layer >= 0 && packet->svc_info.spatial_layer <= 2)
+				subscriber->last_spatial_layer[packet->svc_info.spatial_layer] = now;
 			if(subscriber->target_spatial_layer > subscriber->spatial_layer) {
-				JANUS_LOG(LOG_HUGE, "We need to upscale spatially:\n");
-				/* We need to upscale */
-				if(packet->pbit == 0 && packet->bbit && packet->spatial_layer == subscriber->spatial_layer+1) {
-					JANUS_LOG(LOG_HUGE, "  -- Upscaling spatial layer: %u --> %u\n",
-						packet->spatial_layer, subscriber->target_spatial_layer);
-					subscriber->spatial_layer = packet->spatial_layer;
-					spatial_layer = subscriber->spatial_layer;
-					/* Notify the viewer */
-					json_t *event = json_object();
-					json_object_set_new(event, "videoroom", json_string("event"));
-					json_object_set_new(event, "room", json_integer(subscriber->room_id));
-					json_object_set_new(event, "spatial_layer", json_integer(subscriber->spatial_layer));
-					gateway->push_event(subscriber->session->handle, &janus_videoroom_plugin, NULL, event, NULL);
-					json_decref(event);
+				JANUS_LOG(LOG_HUGE, "We need to upscale spatially: (%d < %d)\n",
+					subscriber->spatial_layer, subscriber->target_spatial_layer);
+				/* We need to upscale: wait for a keyframe */
+				if(keyframe) {
+					int new_spatial_layer = subscriber->target_spatial_layer;
+					while(new_spatial_layer > subscriber->spatial_layer && new_spatial_layer > 0) {
+						if(now - subscriber->last_spatial_layer[new_spatial_layer] >= 250000) {
+							/* We haven't received packets from this layer for a while, try a lower layer */
+							JANUS_LOG(LOG_HUGE, "Haven't received packets from layer %d for a while, trying %d instead...\n",
+								new_spatial_layer, new_spatial_layer-1);
+							new_spatial_layer--;
+						} else {
+							break;
+						}
+					}
+					if(new_spatial_layer > subscriber->spatial_layer) {
+						JANUS_LOG(LOG_HUGE, "  -- Upscaling spatial layer: %d --> %d (need %d)\n",
+							subscriber->spatial_layer, new_spatial_layer, subscriber->target_spatial_layer);
+						subscriber->spatial_layer = new_spatial_layer;
+						spatial_layer = subscriber->spatial_layer;
+						/* Notify the viewer */
+						json_t *event = json_object();
+						json_object_set_new(event, "videoroom", json_string("event"));
+						json_object_set_new(event, "room", json_integer(subscriber->room_id));
+						json_object_set_new(event, "spatial_layer", json_integer(subscriber->spatial_layer));
+						if(subscriber->temporal_layer == -1) {
+							/* We just started: initialize the temporal layer and notify that too */
+							subscriber->temporal_layer = 0;
+							json_object_set_new(event, "temporal_layer", json_integer(subscriber->temporal_layer));
+						}
+						gateway->push_event(subscriber->session->handle, &janus_videoroom_plugin, NULL, event, NULL);
+						json_decref(event);
+					}
 				}
 			} else if(subscriber->target_spatial_layer < subscriber->spatial_layer) {
 				/* We need to downscale */
-				JANUS_LOG(LOG_HUGE, "We need to downscale spatially:\n");
-				if(packet->ebit) {
-					JANUS_LOG(LOG_HUGE, "  -- Downscaling spatial layer: %u --> %u\n",
+				JANUS_LOG(LOG_HUGE, "We need to downscale spatially: (%d > %d)\n",
+					subscriber->spatial_layer, subscriber->target_spatial_layer);
+				gboolean downscaled = FALSE;
+				if(!packet->svc_info.fbit && keyframe) {
+					/* Non-flexible mode: wait for a keyframe */
+					downscaled = TRUE;
+				} else if(packet->svc_info.fbit && packet->svc_info.ebit) {
+					/* Flexible mode: check the E bit */
+					downscaled = TRUE;
+				}
+				if(downscaled) {
+					JANUS_LOG(LOG_HUGE, "  -- Downscaling spatial layer: %d --> %d\n",
 						subscriber->spatial_layer, subscriber->target_spatial_layer);
 					subscriber->spatial_layer = subscriber->target_spatial_layer;
 					/* Notify the viewer */
@@ -6582,19 +6570,62 @@ static void janus_videoroom_relay_rtp_packet(gpointer data, gpointer user_data) 
 					json_decref(event);
 				}
 			}
-			if(spatial_layer < packet->spatial_layer) {
+			if(spatial_layer < packet->svc_info.spatial_layer) {
 				/* Drop the packet: update the context to make sure sequence number is increased normally later */
-				JANUS_LOG(LOG_HUGE, "Dropping packet (spatial layer %d < %d)\n", spatial_layer, packet->spatial_layer);
+				JANUS_LOG(LOG_HUGE, "Dropping packet (spatial layer %d < %d)\n", spatial_layer, packet->svc_info.spatial_layer);
 				subscriber->context.v_base_seq++;
 				return;
-			} else if(packet->ebit && spatial_layer == packet->spatial_layer) {
+			} else if(packet->svc_info.ebit && spatial_layer == packet->svc_info.spatial_layer) {
 				/* If we stop at layer 0, we need a marker bit now, as the one from layer 1 will not be received */
 				override_mark_bit = TRUE;
+			}
+			int temporal_layer = subscriber->temporal_layer;
+			if(subscriber->target_temporal_layer > subscriber->temporal_layer) {
+				/* We need to upscale */
+				JANUS_LOG(LOG_HUGE, "We need to upscale temporally: (%d < %d)\n",
+					subscriber->temporal_layer, subscriber->target_temporal_layer);
+				if(packet->svc_info.ubit && packet->svc_info.bbit &&
+						packet->svc_info.temporal_layer > subscriber->temporal_layer &&
+						packet->svc_info.temporal_layer <= subscriber->target_temporal_layer) {
+					JANUS_LOG(LOG_HUGE, "  -- Upscaling temporal layer: %d --> %d (want %d)\n",
+						subscriber->temporal_layer, packet->svc_info.temporal_layer, subscriber->target_temporal_layer);
+					subscriber->temporal_layer = packet->svc_info.temporal_layer;
+					temporal_layer = subscriber->temporal_layer;
+					/* Notify the viewer */
+					json_t *event = json_object();
+					json_object_set_new(event, "videoroom", json_string("event"));
+					json_object_set_new(event, "room", json_integer(subscriber->room_id));
+					json_object_set_new(event, "temporal_layer", json_integer(subscriber->temporal_layer));
+					gateway->push_event(subscriber->session->handle, &janus_videoroom_plugin, NULL, event, NULL);
+					json_decref(event);
+				}
+			} else if(subscriber->target_temporal_layer < subscriber->temporal_layer) {
+				/* We need to downscale */
+				JANUS_LOG(LOG_HUGE, "We need to downscale temporally: (%d > %d)\n",
+					subscriber->temporal_layer, subscriber->target_temporal_layer);
+				if(packet->svc_info.ebit && packet->svc_info.temporal_layer == subscriber->target_temporal_layer) {
+					JANUS_LOG(LOG_HUGE, "  -- Downscaling temporal layer: %d --> %d\n",
+						subscriber->temporal_layer, subscriber->target_temporal_layer);
+					subscriber->temporal_layer = subscriber->target_temporal_layer;
+					/* Notify the viewer */
+					json_t *event = json_object();
+					json_object_set_new(event, "videoroom", json_string("event"));
+					json_object_set_new(event, "room", json_integer(subscriber->room_id));
+					json_object_set_new(event, "temporal_layer", json_integer(subscriber->temporal_layer));
+					gateway->push_event(subscriber->session->handle, &janus_videoroom_plugin, NULL, event, NULL);
+					json_decref(event);
+				}
+			}
+			if(temporal_layer < packet->svc_info.temporal_layer) {
+				/* Drop the packet: update the context to make sure sequence number is increased normally later */
+				JANUS_LOG(LOG_HUGE, "Dropping packet (temporal layer %d < %d)\n", temporal_layer, packet->svc_info.temporal_layer);
+				subscriber->context.v_base_seq++;
+				return;
 			}
 			/* If we got here, we can send the frame: this doesn't necessarily mean it's
 			 * one of the layers the user wants, as there may be dependencies involved */
 			JANUS_LOG(LOG_HUGE, "Sending packet (spatial=%d, temporal=%d)\n",
-				packet->spatial_layer, packet->temporal_layer);
+				packet->svc_info.spatial_layer, packet->svc_info.temporal_layer);
 			/* Fix sequence number and timestamp (publisher switching may be involved) */
 			janus_rtp_header_update(packet->data, &subscriber->context, TRUE, 4500);
 			if(override_mark_bit && !has_marker_bit) {

--- a/utils.h
+++ b/utils.h
@@ -270,21 +270,19 @@ int janus_vp8_parse_descriptor(char *buffer, int len,
  * @param[in] switched Whether there has been a source switch or not (important to compute offsets) */
 void janus_vp8_simulcast_descriptor_update(char *buffer, int len, janus_vp8_simulcast_context *context, gboolean switched);
 
+/*! \brief VP9 SVC info, as parsed from a payload descriptor */
+typedef struct janus_vp9_svc_info {
+	int spatial_layer, temporal_layer;
+	uint8_t fbit, pbit, dbit, ubit, bbit, ebit;
+} janus_vp9_svc_info;
+
 /*! \brief Helper method to parse a VP9 payload descriptor for SVC-related info (e.g., when SVC is enabled)
  * @param[in] buffer The RTP payload to process
  * @param[in] len The length of the RTP payload
  * @param[out] found Whether any SVC related info has been found or not
- * @param[out] spatial_layer Spatial layer of the packet
- * @param[out] temporal_layer Temporal layer of the packet
- * @param[out] p Inter-picture predicted picture bit
- * @param[out] d Inter-layer dependency used bit
- * @param[out] u Switching up point bit
- * @param[out] b Start of a frame bit
- * @param[out] e End of a frame bit
+ * @param[out] info Pointer to a janus_vp9_svc_info structure for passing the parsed info back
  * @returns 0 in case of success, a negative integer otherwise */
-int janus_vp9_parse_svc(char *buffer, int len, int *found,
-		int *spatial_layer, int *temporal_layer,
-		uint8_t *p, uint8_t *d, uint8_t *u, uint8_t *b, uint8_t *e);
+int janus_vp9_parse_svc(char *buffer, int len, gboolean *found, janus_vp9_svc_info *info);
 
 /*! \brief Helper method to push individual bits at the end of a word
  * @param[in] word Initial value of word


### PR DESCRIPTION
This PR tries to address some of the shortcomings we had in our existing VP9 SVC support.

Specifically, we only supported SVC when capturing webcams (regular video), but not for screensharing: this is because, in Chrome, different modes are used for the RTP VP9 packetization in the two cases (non-flexible for regular video, flexible for screensharing), and while we were parsing both, we were not using the parsed information properly for the packet pass/drop decisions. Besides, even for regular video the support was sometimes flaky, with video freezing at times when doing transitions from one layer to another.

This patch makes both modes work, now, and should improve the transition support as well. There are some things that can still be improved, like notifying the application when we drop to a lower layer if a higher layer is not available: in fact, unlike simulcast (where the transition must be done explicitly in that case), with SVC video will just work, since you always relay packets coming from lower layers anyway; what's missing is telling the application that you're now *only* sending those lower layers. We do have an "age" kind of property for the incoming layers (that we currently use to notify when we go up a layer after we receive a keyframe), so we may use that for the purpose in the future.

Since Chrome is working on making SVC usable via API as well and not only behind a flag as it is now, this patch should facilitate testing, hopefully at the upcoming IETF hackathon in Singapore as well.