### PR TITLE
Use strtol more, and add checks when atoi is used

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -96,9 +96,9 @@ gboolean janus_auth_check_signature(const char *token, const char *realm) {
 	if(!data[0] || !data[1])
 		goto fail;
 	/* Verify timestamp */
-	gint64 expiry_time = atoi(data[0]);
+	gint64 expiry_time = strtoll(data[0], NULL, 10);
 	gint64 real_time = janus_get_real_time() / 1000000;
-	if(real_time > expiry_time)
+	if(expiry_time < 0 || real_time > expiry_time)
 		goto fail;
 	/* Verify realm */
 	if(strcmp(data[1], realm))
@@ -133,9 +133,9 @@ gboolean janus_auth_check_signature_contains(const char *token, const char *real
 	if(!data[0] || !data[1])
 		goto fail;
 	/* Verify timestamp */
-	gint64 expiry_time = atoi(data[0]);
+	gint64 expiry_time = strtoll(data[0], NULL, 10);
 	gint64 real_time = janus_get_real_time() / 1000000;
-	if(real_time > expiry_time)
+	if(expiry_time < 0 || real_time > expiry_time)
 		goto fail;
 	/* Verify realm */
 	if(strcmp(data[1], realm))

--- a/dtls.c
+++ b/dtls.c
@@ -111,7 +111,7 @@ gboolean janus_is_dtls(char *buf) {
 /* DTLS timeout base to enforce: notice that this can currently only be
  * modified if you're using BoringSSL, as OpenSSL uses 1s (1000ms) and
  * that value cannot be modified (it will in OpenSSL v1.1.1) */
-static guint dtls_timeout_base = 1000;
+static guint16 dtls_timeout_base = 1000;
 
 static SSL_CTX *ssl_ctx = NULL;
 static X509 *ssl_cert = NULL;
@@ -329,7 +329,7 @@ const char *janus_get_ssl_version(void) {
 }
 
 /* DTLS-SRTP initialization */
-gint janus_dtls_srtp_init(const char *server_pem, const char *server_key, const char *password, guint timeout) {
+gint janus_dtls_srtp_init(const char *server_pem, const char *server_key, const char *password, guint16 timeout) {
 	const char *crypto_lib = NULL;
 #if JANUS_USE_OPENSSL_PRE_1_1_API
 #if defined(LIBRESSL_VERSION_NUMBER)
@@ -551,7 +551,7 @@ janus_dtls_srtp *janus_dtls_srtp_create(void *ice_component, janus_dtls_role rol
 	SSL_set_tmp_ecdh(dtls->ssl, ecdh);
 	EC_KEY_free(ecdh);
 #ifdef HAVE_DTLS_SETTIMEOUT
-	JANUS_LOG(LOG_VERB, "[%"SCNu64"]   Setting DTLS initial timeout: %u\n", handle->handle_id, dtls_timeout_base);
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"]   Setting DTLS initial timeout: %"SCNu16"ms\n", handle->handle_id, dtls_timeout_base);
 	DTLSv1_set_initial_timeout_duration(dtls->ssl, dtls_timeout_base);
 #endif
 	dtls->ready = 0;

--- a/dtls.h
+++ b/dtls.h
@@ -32,9 +32,9 @@ const char *janus_get_ssl_version(void);
  * @param[in] server_pem Path to the certificate to use
  * @param[in] server_key Path to the key to use
  * @param[in] password Password needed to use the key, if any
- * @param[in] timeout DTLS timeout base to use for retransmissions (ignored if not using BoringSSL)
+ * @param[in] timeout DTLS timeout base, in ms, to use for retransmissions (ignored if not using BoringSSL)
  * @returns 0 in case of success, a negative integer on errors */
-gint janus_dtls_srtp_init(const char *server_pem, const char *server_key, const char *password, guint timeout);
+gint janus_dtls_srtp_init(const char *server_pem, const char *server_key, const char *password, guint16 timeout);
 /*! \brief Method to cleanup DTLS stuff before exiting */
 void janus_dtls_srtp_cleanup(void);
 /*! \brief Method to return a string representation (SHA-256) of the certificate fingerprint */

--- a/events/janus_mqttevh.c
+++ b/events/janus_mqttevh.c
@@ -644,14 +644,29 @@ static int janus_mqttevh_init(const char *config_path) {
 
 	/* Connect configuration */
 	keep_alive_interval_item = janus_config_get(config, config_general, janus_config_type_item, "keep_alive_interval");
-	ctx->connect.keep_alive_interval = (keep_alive_interval_item && keep_alive_interval_item->value) ? atoi(keep_alive_interval_item->value) : DEFAULT_KEEPALIVE;
+	ctx->connect.keep_alive_interval = (keep_alive_interval_item && keep_alive_interval_item->value) ?
+		atoi(keep_alive_interval_item->value) : DEFAULT_KEEPALIVE;
+	if(ctx->connect.keep_alive_interval < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid keep-alive value: %s (falling back to default)\n", keep_alive_interval_item->value);
+		ctx->connect.keep_alive_interval = DEFAULT_KEEPALIVE;
+	}
 
 	cleansession_item = janus_config_get(config, config_general, janus_config_type_item, "cleansession");
-	ctx->connect.cleansession = (cleansession_item && cleansession_item->value) ? atoi(cleansession_item->value) : DEFAULT_CLEANSESSION;
+	ctx->connect.cleansession = (cleansession_item && cleansession_item->value) ?
+		atoi(cleansession_item->value) : DEFAULT_CLEANSESSION;
+	if(ctx->connect.cleansession < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid clean-session value: %s (falling back to default)\n", cleansession_item->value);
+		ctx->connect.cleansession = DEFAULT_CLEANSESSION;
+	}
 
 	/* Disconnect configuration */
 	disconnect_timeout_item = janus_config_get(config, config_general, janus_config_type_item, "disconnect_timeout");
-	ctx->disconnect.timeout = (disconnect_timeout_item && disconnect_timeout_item->value) ? atoi(disconnect_timeout_item->value) : DEFAULT_DISCONNECT_TIMEOUT;
+	ctx->disconnect.timeout = (disconnect_timeout_item && disconnect_timeout_item->value) ?
+		atoi(disconnect_timeout_item->value) : DEFAULT_DISCONNECT_TIMEOUT;
+	if(ctx->disconnect.timeout < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid disconnect-timeout value: %s (falling back to default)\n", disconnect_timeout_item->value);
+		ctx->disconnect.timeout = DEFAULT_DISCONNECT_TIMEOUT;
+	}
 
 	topic_item = janus_config_get(config, config_general, janus_config_type_item, "topic");
 	if(!topic_item || !topic_item->value) {
@@ -666,10 +681,18 @@ static int janus_mqttevh_init(const char *config_path) {
 	retain_item = janus_config_get(config, config_general, janus_config_type_item, "retain");
 	if(retain_item && retain_item->value && janus_is_true(retain_item->value)) {
 		ctx->publish.retain = atoi(retain_item->value);;
+		if(ctx->publish.retain < 0) {
+			JANUS_LOG(LOG_ERR, "Invalid publish-retain value: %s (disabling)\n", retain_item->value);
+			ctx->publish.retain = 0;
+		}
 	}
 
 	qos_item = janus_config_get(config, config_general, janus_config_type_item, "qos");
 	ctx->publish.qos = (qos_item && qos_item->value) ? atoi(qos_item->value) : 1;
+	if(ctx->publish.qos < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid publish-qos value: %s (falling back to default)\n", qos_item->value);
+		ctx->publish.qos = 1;
+	}
 
 	connect_status_item = janus_config_get(config, config_general, janus_config_type_item, "connect_status");
 	if(connect_status_item && connect_status_item->value) {
@@ -698,6 +721,10 @@ static int janus_mqttevh_init(const char *config_path) {
 		will_qos_item = janus_config_get(config, config_general, janus_config_type_item, "will_qos");
 		if(will_qos_item && will_qos_item->value) {
 			ctx->will.qos = atoi(will_qos_item->value);
+			if(ctx->will.qos < 0) {
+				JANUS_LOG(LOG_ERR, "Invalid will-qos value: %s (setting to 0)\n", will_qos_item->value);
+				ctx->will.qos = 0;
+			}
 		}
 
 		/* Using the topic for LWT as configured for publish and suffixed with JANUS_MQTTEVH_STATUS_TOPIC. */

--- a/events/janus_rabbitmqevh.c
+++ b/events/janus_rabbitmqevh.c
@@ -193,10 +193,12 @@ int janus_rabbitmqevh_init(const char *config_path) {
 		rmqhost = g_strdup(item->value);
 	else
 		rmqhost = g_strdup("localhost");
-	int rmqport = AMQP_PROTOCOL_PORT;
+	uint16_t rmqport = AMQP_PROTOCOL_PORT;
 	item = janus_config_get(config, config_general, janus_config_type_item, "port");
-	if(item && item->value)
-		rmqport = atoi(item->value);
+	if(item && item->value && janus_string_to_uint16(item->value, &rmqport) < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid port (%s), falling back to default\n", item->value);
+		rmqport = AMQP_PROTOCOL_PORT;
+	}
 
 	/* Credentials and Virtual Host */
 	item = janus_config_get(config, config_general, janus_config_type_item, "vhost");

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -1269,21 +1269,34 @@ static int janus_audiobridge_create_static_rtp_forwarder(janus_config_category *
 	janus_config_item *forwarder_id_item = janus_config_get(config, cat, janus_config_type_item, "rtp_forward_id");
 	if(forwarder_id_item != NULL && forwarder_id_item->value != NULL)
 		forwarder_id = atoi(forwarder_id_item->value);
+	if(forwarder_id < 1) {
+		JANUS_LOG(LOG_ERR, "Invalid forwarder ID (%s)\n", forwarder_id_item->value);
+		return 0;
+	}
 
 	guint32 ssrc_value = 0;
 	janus_config_item *ssrc = janus_config_get(config, cat, janus_config_type_item, "rtp_forward_ssrc");
-	if(ssrc != NULL && ssrc->value != NULL)
-		ssrc_value = atoi(ssrc->value);
+	if(ssrc != NULL && ssrc->value != NULL && janus_string_to_uint32(ssrc->value, &ssrc_value) < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid SSRC (%s)\n", ssrc->value);
+		return 0;
+	}
 
 	int ptype = 100;
 	janus_config_item *pt = janus_config_get(config, cat, janus_config_type_item, "rtp_forward_ptype");
-	if(pt != NULL && pt->value != NULL)
+	if(pt != NULL && pt->value != NULL) {
 		ptype = atoi(pt->value);
+		if(ptype < 0 || ptype > 127) {
+			JANUS_LOG(LOG_ERR, "Invalid payload type (%s)\n", pt->value);
+			return 0;
+		}
+	}
 
 	janus_config_item *port_item = janus_config_get(config, cat, janus_config_type_item, "rtp_forward_port");
 	uint16_t port = 0;
-	if(port_item != NULL && port_item->value != NULL && strlen(port_item->value) > 0)
-		port = atoi(port_item->value);
+	if(port_item != NULL && port_item->value != NULL && janus_string_to_uint16(port_item->value, &port) < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid port (%s)\n", port_item->value);
+		return 0;
+	}
 	if(port == 0) {
 		return 0;
 	}
@@ -4440,6 +4453,8 @@ static void *janus_audiobridge_handler(void *data) {
 						if(a->value) {
 							if(strstr(a->value, JANUS_RTP_EXTMAP_AUDIO_LEVEL)) {
 								extmap_id = atoi(a->value);
+								if(extmap_id < 0)
+									extmap_id = 0;
 							}
 						}
 						ma = ma->next;

--- a/plugins/janus_nosip.c
+++ b/plugins/janus_nosip.c
@@ -691,8 +691,10 @@ int janus_nosip_init(janus_callbacks *callback, const char *config_path) {
 			if(maxport != NULL) {
 				*maxport = '\0';
 				maxport++;
-				rtp_range_min = atoi(item->value);
-				rtp_range_max = atoi(maxport);
+				if(janus_string_to_uint16(item->value, &rtp_range_min) < 0)
+					JANUS_LOG(LOG_WARN, "Invalid RTP min port value: %s (assuming 0)\n", item->value);
+				if(janus_string_to_uint16(maxport, &rtp_range_max) < 0)
+					JANUS_LOG(LOG_WARN, "Invalid RTP max port value: %s (assuming 0)\n", maxport);
 				maxport--;
 				*maxport = '-';
 			}

--- a/plugins/janus_sipre.c
+++ b/plugins/janus_sipre.c
@@ -1105,8 +1105,10 @@ int janus_sipre_init(janus_callbacks *callback, const char *config_path) {
 			if(maxport != NULL) {
 				*maxport = '\0';
 				maxport++;
-				rtp_range_min = atoi(item->value);
-				rtp_range_max = atoi(maxport);
+				if(janus_string_to_uint16(item->value, &rtp_range_min) < 0)
+					JANUS_LOG(LOG_WARN, "Invalid RTP min port value: %s (assuming 0)\n", item->value);
+				if(janus_string_to_uint16(maxport, &rtp_range_max) < 0)
+					JANUS_LOG(LOG_WARN, "Invalid RTP max port value: %s (assuming 0)\n", maxport);
 				maxport--;
 				*maxport = '-';
 			}

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -6226,11 +6226,14 @@ static void *janus_videoroom_handler(void *data) {
 							janus_sdp_attribute *a = (janus_sdp_attribute *)ma->data;
 							if(a->value) {
 								if(videoroom->audiolevel_ext && m->type == JANUS_SDP_AUDIO && strstr(a->value, JANUS_RTP_EXTMAP_AUDIO_LEVEL)) {
-									participant->audio_level_extmap_id = atoi(a->value);
+									if(janus_string_to_uint8(a->value, &participant->audio_level_extmap_id) < 0)
+										JANUS_LOG(LOG_WARN, "Invalid audio-level extension ID: %s\n", a->value);
 								} else if(videoroom->videoorient_ext && m->type == JANUS_SDP_VIDEO && strstr(a->value, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION)) {
-									participant->video_orient_extmap_id = atoi(a->value);
+									if(janus_string_to_uint8(a->value, &participant->video_orient_extmap_id) < 0)
+										JANUS_LOG(LOG_WARN, "Invalid video-orientation extension ID: %s\n", a->value);
 								} else if(videoroom->playoutdelay_ext && m->type == JANUS_SDP_VIDEO && strstr(a->value, JANUS_RTP_EXTMAP_PLAYOUT_DELAY)) {
-									participant->playout_delay_extmap_id = atoi(a->value);
+									if(janus_string_to_uint8(a->value, &participant->playout_delay_extmap_id) < 0)
+										JANUS_LOG(LOG_WARN, "Invalid playout-delay extension ID: %s\n", a->value);
 								} else if(m->type == JANUS_SDP_AUDIO && !strcasecmp(a->name, "fmtp") && strstr(a->value, "useinbandfec=1")) {
 									participant->do_opusfec = videoroom->do_opusfec;
 								}

--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -451,7 +451,11 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen) {
 								m->fmts = g_list_append(m->fmts, g_strdup(mline_parts[mindex]));
 								/* Add numeric payload type */
 								int ptype = atoi(mline_parts[mindex]);
-								m->ptypes = g_list_append(m->ptypes, GINT_TO_POINTER(ptype));
+								if(ptype < 0 || ptype > 127) {
+									JANUS_LOG(LOG_ERR, "Invalid payload type (%s)\n", mline_parts[mindex]);
+								} else {
+									m->ptypes = g_list_append(m->ptypes, GINT_TO_POINTER(ptype));
+								}
 								mindex++;
 							}
 							g_strfreev(mline_parts);
@@ -685,8 +689,11 @@ int janus_sdp_get_codec_pt(janus_sdp *sdp, const char *codec) {
 			janus_sdp_attribute *a = (janus_sdp_attribute *)ma->data;
 			if(a->name != NULL && a->value != NULL && !strcasecmp(a->name, "rtpmap")) {
 				int pt = atoi(a->value);
-				if(strstr(a->value, format) || strstr(a->value, format2))
+				if(pt < 0 || pt > 127) {
+					JANUS_LOG(LOG_ERR, "Invalid payload type (%s)\n", a->value);
+				} else if(strstr(a->value, format) || strstr(a->value, format2)) {
 					return pt;
+				}
 			}
 			ma = ma->next;
 		}
@@ -1421,6 +1428,11 @@ janus_sdp *janus_sdp_generate_answer(janus_sdp *offer, ...) {
 							if(strstr(a->value, extension)) {
 								/* Accept the extension */
 								int id = atoi(a->value);
+								if(id < 0) {
+									JANUS_LOG(LOG_ERR, "Invalid extension ID (%d)\n", id);
+									temp = temp->next;
+									continue;
+								}
 								const char *direction = NULL;
 								switch(a->direction) {
 									case JANUS_SDP_SENDONLY:

--- a/sdp.c
+++ b/sdp.c
@@ -1073,8 +1073,12 @@ int janus_sdp_anonymize(janus_sdp *anon) {
 			janus_sdp_attribute *a = (janus_sdp_attribute *)tempA->data;
 			if(a->value && (strstr(a->value, "red/90000") || strstr(a->value, "ulpfec/90000") || strstr(a->value, "rtx/90000"))) {
 				int ptype = atoi(a->value);
-				JANUS_LOG(LOG_VERB, "Will remove payload type %d (%s)\n", ptype, a->value);
-				purged_ptypes = g_list_append(purged_ptypes, GINT_TO_POINTER(ptype));
+				if(ptype < 0 || ptype > 127) {
+					JANUS_LOG(LOG_ERR, "Invalid payload type (%d)\n", ptype);
+				} else {
+					JANUS_LOG(LOG_VERB, "Will remove payload type %d (%s)\n", ptype, a->value);
+					purged_ptypes = g_list_append(purged_ptypes, GINT_TO_POINTER(ptype));
+				}
 			}
 			tempA = tempA->next;
 		}

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -766,10 +766,12 @@ int janus_http_init(janus_transport_callbacks *callback, const char *config_path
 		if(!item || !item->value || !janus_is_true(item->value)) {
 			JANUS_LOG(LOG_WARN, "HTTP webserver disabled\n");
 		} else {
-			int wsport = 8088;
+			uint16_t wsport = 8088;
 			item = janus_config_get(config, config_general, janus_config_type_item, "port");
-			if(item && item->value)
-				wsport = atoi(item->value);
+			if(item && item->value && janus_string_to_uint16(item->value, &wsport) < 0) {
+				JANUS_LOG(LOG_ERR, "Invalid port (%s), falling back to default\n", item->value);
+				wsport = 8088;
+			}
 			const char *interface = NULL;
 			item = janus_config_get(config, config_general, janus_config_type_item, "interface");
 			if(item && item->value)
@@ -812,10 +814,12 @@ int janus_http_init(janus_transport_callbacks *callback, const char *config_path
 			if(!server_key || !server_pem) {
 				JANUS_LOG(LOG_FATAL, "Missing certificate/key path\n");
 			} else {
-				int swsport = 8089;
+				uint16_t swsport = 8089;
 				item = janus_config_get(config, config_general, janus_config_type_item, "secure_port");
-				if(item && item->value)
-					swsport = atoi(item->value);
+				if(item && item->value && janus_string_to_uint16(item->value, &swsport) < 0) {
+					JANUS_LOG(LOG_ERR, "Invalid port (%s), falling back to default\n", item->value);
+					swsport = 8089;
+				}
 				const char *interface = NULL;
 				item = janus_config_get(config, config_general, janus_config_type_item, "secure_interface");
 				if(item && item->value)
@@ -855,10 +859,12 @@ int janus_http_init(janus_transport_callbacks *callback, const char *config_path
 		if(!item || !item->value || !janus_is_true(item->value)) {
 			JANUS_LOG(LOG_WARN, "Admin/monitor HTTP webserver disabled\n");
 		} else {
-			int wsport = 7088;
+			uint16_t wsport = 7088;
 			item = janus_config_get(config, config_admin, janus_config_type_item, "admin_port");
-			if(item && item->value)
-				wsport = atoi(item->value);
+			if(item && item->value && janus_string_to_uint16(item->value, &wsport) < 0) {
+				JANUS_LOG(LOG_ERR, "Invalid port (%s), falling back to default\n", item->value);
+				wsport = 7088;
+			}
 			const char *interface = NULL;
 			item = janus_config_get(config, config_admin, janus_config_type_item, "admin_interface");
 			if(item && item->value)
@@ -883,10 +889,12 @@ int janus_http_init(janus_transport_callbacks *callback, const char *config_path
 			if(!server_key) {
 				JANUS_LOG(LOG_FATAL, "Missing certificate/key path\n");
 			} else {
-				int swsport = 7889;
+				uint16_t swsport = 7889;
 				item = janus_config_get(config, config_admin, janus_config_type_item, "admin_secure_port");
-				if(item && item->value)
-					swsport = atoi(item->value);
+				if(item && item->value && janus_string_to_uint16(item->value, &swsport) < 0) {
+					JANUS_LOG(LOG_ERR, "Invalid port (%s), falling back to default\n", item->value);
+					swsport = 7889;
+				}
 				const char *interface = NULL;
 				item = janus_config_get(config, config_admin, janus_config_type_item, "admin_secure_interface");
 				if(item && item->value)

--- a/transports/janus_mqtt.c
+++ b/transports/janus_mqtt.c
@@ -368,10 +368,21 @@ int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path
 	}
 
 	janus_config_item *keep_alive_interval_item = janus_config_get(config, config_general, janus_config_type_item, "keep_alive_interval");
-	ctx->connect.keep_alive_interval = (keep_alive_interval_item && keep_alive_interval_item->value) ? atoi(keep_alive_interval_item->value) : 20;
+	keep_alive_interval_item = janus_config_get(config, config_general, janus_config_type_item, "keep_alive_interval");
+	ctx->connect.keep_alive_interval = (keep_alive_interval_item && keep_alive_interval_item->value) ?
+		atoi(keep_alive_interval_item->value) : 20;
+	if(ctx->connect.keep_alive_interval < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid keep-alive value: %s (falling back to default)\n", keep_alive_interval_item->value);
+		ctx->connect.keep_alive_interval = 20;
+	}
 
 	janus_config_item *cleansession_item = janus_config_get(config, config_general, janus_config_type_item, "cleansession");
-	ctx->connect.cleansession = (cleansession_item && cleansession_item->value) ? atoi(cleansession_item->value) : 0;
+	ctx->connect.cleansession = (cleansession_item && cleansession_item->value) ?
+		atoi(cleansession_item->value) : 0;
+	if(ctx->connect.cleansession < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid clean-session value: %s (falling back to default)\n", cleansession_item->value);
+		ctx->connect.cleansession = 0;
+	}
 
 	janus_config_item *enabled_item = janus_config_get(config, config_general, janus_config_type_item, "enabled");
 	if(enabled_item == NULL) {
@@ -395,6 +406,10 @@ int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path
 
 			janus_config_item *qos_item = janus_config_get(config, config_general, janus_config_type_item, "subscribe_qos");
 			ctx->subscribe.qos = (qos_item && qos_item->value) ? atoi(qos_item->value) : 1;
+			if(ctx->subscribe.qos < 0) {
+				JANUS_LOG(LOG_ERR, "Invalid subscribe-qos value: %s (falling back to default)\n", qos_item->value);
+				ctx->subscribe.qos = 1;
+			}
 		}
 
 		/* Publish configuration */
@@ -408,6 +423,10 @@ int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path
 
 			janus_config_item *qos_item = janus_config_get(config, config_general, janus_config_type_item, "publish_qos");
 			ctx->publish.qos = (qos_item && qos_item->value) ? atoi(qos_item->value) : 1;
+			if(ctx->publish.qos < 0) {
+				JANUS_LOG(LOG_ERR, "Invalid publish-qos value: %s (falling back to default)\n", qos_item->value);
+				ctx->publish.qos = 1;
+			}
 		}
 	} else {
 		janus_mqtt_api_enabled_ = FALSE;
@@ -417,7 +436,12 @@ int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path
 
 	/* Disconnect configuration */
 	janus_config_item *disconnect_timeout_item = janus_config_get(config, config_general, janus_config_type_item, "disconnect_timeout");
-	ctx->disconnect.timeout = (disconnect_timeout_item && disconnect_timeout_item->value) ? atoi(disconnect_timeout_item->value) : 100;
+	ctx->disconnect.timeout = (disconnect_timeout_item && disconnect_timeout_item->value) ?
+		atoi(disconnect_timeout_item->value) : 100;
+	if(ctx->disconnect.timeout < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid disconnect-timeout value: %s (falling back to default)\n", disconnect_timeout_item->value);
+		ctx->disconnect.timeout = 100;
+	}
 
 	/* Admin configuration */
 	janus_config_item *admin_enabled_item = janus_config_get(config, config_admin, janus_config_type_item, "admin_enabled");
@@ -442,6 +466,10 @@ int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path
 
 			janus_config_item *qos_item = janus_config_get(config, config_admin, janus_config_type_item, "subscribe_qos");
 			ctx->admin.subscribe.qos = (qos_item && qos_item->value) ? atoi(qos_item->value) : 1;
+			if(ctx->admin.subscribe.qos < 0) {
+				JANUS_LOG(LOG_ERR, "Invalid subscribe-qos value: %s (falling back to default)\n", qos_item->value);
+				ctx->admin.subscribe.qos = 1;
+			}
 		}
 
 		/* Admin publish configuration */
@@ -455,6 +483,10 @@ int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path
 
 			janus_config_item *qos_item = janus_config_get(config, config_admin, janus_config_type_item, "publish_qos");
 			ctx->admin.publish.qos = (qos_item && qos_item->value) ? atoi(qos_item->value) : 1;
+			if(ctx->admin.publish.qos < 0) {
+				JANUS_LOG(LOG_ERR, "Invalid publish-qos value: %s (falling back to default)\n", qos_item->value);
+				ctx->admin.publish.qos = 1;
+			}
 		}
 	} else {
 		janus_mqtt_admin_api_enabled_ = FALSE;
@@ -487,6 +519,10 @@ int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path
 		janus_config_item *status_qos_item = janus_config_get(config, config_status, janus_config_type_item, "qos");
 		if(status_qos_item && status_qos_item->value) {
 			ctx->status.qos = atoi(status_qos_item->value);
+			if(ctx->status.qos < 0) {
+				JANUS_LOG(LOG_ERR, "Invalid status-qos value: %s (disabling)\n", status_qos_item->value);
+				ctx->status.qos = 0;
+			}
 		}
 
 		janus_config_item *status_retain_item = janus_config_get(config, config_status, janus_config_type_item, "retain");

--- a/transports/janus_rabbitmq.c
+++ b/transports/janus_rabbitmq.c
@@ -219,10 +219,12 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 		rmqhost = g_strdup(item->value);
 	else
 		rmqhost = g_strdup("localhost");
-	int rmqport = AMQP_PROTOCOL_PORT;
+	uint16_t rmqport = AMQP_PROTOCOL_PORT;
 	item = janus_config_get(config, config_general, janus_config_type_item, "port");
-	if(item && item->value)
-		rmqport = atoi(item->value);
+	if(item && item->value && janus_string_to_uint16(item->value, &rmqport) < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid port (%s), falling back to default\n", item->value);
+		rmqport = AMQP_PROTOCOL_PORT;
+	}
 
 	/* Credentials and Virtual Host */
 	item = janus_config_get(config, config_general, janus_config_type_item, "vhost");

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -552,10 +552,12 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 		if(!item || !item->value || !janus_is_true(item->value)) {
 			JANUS_LOG(LOG_WARN, "WebSockets server disabled\n");
 		} else {
-			int wsport = 8188;
+			uint16_t wsport = 8188;
 			item = janus_config_get(config, config_general, janus_config_type_item, "ws_port");
-			if(item && item->value)
-				wsport = atoi(item->value);
+			if(item && item->value && janus_string_to_uint16(item->value, &wsport) < 0) {
+				JANUS_LOG(LOG_ERR, "Invalid port (%s), falling back to default\n", item->value);
+				wsport = 8188;
+			}
 			char *interface = NULL;
 			item = janus_config_get(config, config_general, janus_config_type_item, "ws_interface");
 			if(item && item->value)
@@ -596,10 +598,12 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 		if(!item || !item->value || !janus_is_true(item->value)) {
 			JANUS_LOG(LOG_WARN, "Secure WebSockets server disabled\n");
 		} else {
-			int wsport = 8989;
+			uint16_t wsport = 8989;
 			item = janus_config_get(config, config_general, janus_config_type_item, "wss_port");
-			if(item && item->value)
-				wsport = atoi(item->value);
+			if(item && item->value && janus_string_to_uint16(item->value, &wsport) < 0) {
+				JANUS_LOG(LOG_ERR, "Invalid port (%s), falling back to default\n", item->value);
+				wsport = 8989;
+			}
 			char *interface = NULL;
 			item = janus_config_get(config, config_general, janus_config_type_item, "wss_interface");
 			if(item && item->value)
@@ -660,10 +664,12 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 		if(!item || !item->value || !janus_is_true(item->value)) {
 			JANUS_LOG(LOG_WARN, "Admin WebSockets server disabled\n");
 		} else {
-			int wsport = 7188;
+			uint16_t wsport = 7188;
 			item = janus_config_get(config, config_admin, janus_config_type_item, "admin_ws_port");
-			if(item && item->value)
-				wsport = atoi(item->value);
+			if(item && item->value && janus_string_to_uint16(item->value, &wsport) < 0) {
+				JANUS_LOG(LOG_ERR, "Invalid port (%s), falling back to default\n", item->value);
+				wsport = 7188;
+			}
 			char *interface = NULL;
 			item = janus_config_get(config, config_admin, janus_config_type_item, "admin_ws_interface");
 			if(item && item->value)
@@ -704,10 +710,12 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 		if(!item || !item->value || !janus_is_true(item->value)) {
 			JANUS_LOG(LOG_WARN, "Secure Admin WebSockets server disabled\n");
 		} else {
-			int wsport = 7989;
+			uint16_t wsport = 7989;
 			item = janus_config_get(config, config_admin, janus_config_type_item, "admin_wss_port");
-			if(item && item->value)
-				wsport = atoi(item->value);
+			if(item && item->value && janus_string_to_uint16(item->value, &wsport) < 0) {
+				JANUS_LOG(LOG_ERR, "Invalid port (%s), falling back to default\n", item->value);
+				wsport = 7989;
+			}
 			char *interface = NULL;
 			item = janus_config_get(config, config_admin, janus_config_type_item, "admin_wss_interface");
 			if(item && item->value)

--- a/turnrest.c
+++ b/turnrest.c
@@ -26,6 +26,7 @@
 #include "debug.h"
 #include "mutex.h"
 #include "ip-utils.h"
+#include "utils.h"
 
 static const char *api_server = NULL;
 static const char *api_key = NULL;
@@ -262,8 +263,9 @@ janus_turnrest_response *janus_turnrest_request(void) {
 		if(uri_parts[2] == NULL) {
 			/* No port? Use 3478 by default */
 			instance->port = 3478;
-		} else {
-			instance->port = atoi(uri_parts[2]);
+		} else if(janus_string_to_uint16(uri_parts[2], &instance->port) < 0) {
+			JANUS_LOG(LOG_ERR, "Invalid TURN instance port: %s (falling back to 3478)\n", uri_parts[2]);
+			instance->port = 3478;
 		}
 		g_strfreev(uri_parts);
 		g_strfreev(parts);

--- a/utils.c
+++ b/utils.c
@@ -93,6 +93,36 @@ guint64 *janus_uint64_dup(guint64 num) {
 	return numdup;
 }
 
+int janus_string_to_uint8(const char *str, uint8_t *num) {
+	if(str == NULL || num == NULL)
+		return -EINVAL;
+	long int val = strtol(str, 0, 10);
+	if(val < 0 || val > UINT8_MAX)
+		return -ERANGE;
+	*num = val;
+	return errno;
+}
+
+int janus_string_to_uint16(const char *str, uint16_t *num) {
+	if(str == NULL || num == NULL)
+		return -EINVAL;
+	long int val = strtol(str, 0, 10);
+	if(val < 0 || val > UINT16_MAX)
+		return -ERANGE;
+	*num = val;
+	return errno;
+}
+
+int janus_string_to_uint32(const char *str, uint32_t *num) {
+	if(str == NULL || num == NULL)
+		return -EINVAL;
+	long long int val = strtoll(str, 0, 10);
+	if(val < 0 || val > UINT32_MAX)
+		return -ERANGE;
+	*num = val;
+	return errno;
+}
+
 void janus_flags_reset(janus_flags *flags) {
 	if(flags != NULL)
 		g_atomic_pointer_set(flags, 0);

--- a/utils.h
+++ b/utils.h
@@ -78,6 +78,27 @@ guint64 janus_random_uint64(void);
  * @returns A pointer to a guint64 number, if successful, NULL otherwise */
 guint64 *janus_uint64_dup(guint64 num);
 
+/*! \brief Helper method to convert a string to a uint8_t
+ * @note The value of \c num should be ignored, if the method returned an error
+ * @param[in] str The string to convert
+ * @param[out] num Pointer to the converted number
+ * @returns 0 if successful, or a negative integer otherwise (e.g., \c -ERANGE if the value is out of range) */
+int janus_string_to_uint8(const char *str, uint8_t *num);
+
+/*! \brief Helper method to convert a string to a uint16_t
+ * @note The value of \c num should be ignored, if the method returned an error
+ * @param[in] str The string to convert
+ * @param[out] num Pointer to the converted number
+ * @returns 0 if successful, or a negative integer otherwise (e.g., \c -ERANGE if the value is out of range) */
+int janus_string_to_uint16(const char *str, uint16_t *num);
+
+/*! \brief Helper method to convert a string to a uint32_t
+ * @note The value of \c num should be ignored, if the method returned an error
+ * @param[in] str The string to convert
+ * @param[out] num Pointer to the converted number
+ * @returns 0 if successful, or a negative integer otherwise (e.g., \c -ERANGE if the value is out of range) */
+int janus_string_to_uint32(const char *str, uint32_t *num);
+
 /** @name Flags helper methods
  */
 ///@{


### PR DESCRIPTION
As the title says, this is an attempt to rely less on `atoi`, and more on `strtol` instead: we didn't just replace it everywhere, but only where it made most sense, e.g., when parsing ports or when a type range is important. The patch adds a few helpers (e.g., `janus_string_to_uint16`) to make it all simpler to use in core and plugins.

Please test to make sure it doesn't break your applications (it shouldn't).