### PR TITLE
Add audio skew compensation to janus-pp-rec.

### DIFF
--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -110,7 +110,6 @@ Usage: janus-pp-rec [OPTIONS] source.mjr [destination.[opus|wav|webm|mp4|srt]]
 #define htonll(x) ((1==htonl(1)) ? (x) : ((gint64)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
 #define ntohll(x) ((1==ntohl(1)) ? (x) : ((gint64)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
 
-
 int janus_log_level = 4;
 gboolean janus_log_timestamps = FALSE;
 gboolean janus_log_colors = TRUE;
@@ -123,6 +122,10 @@ static int working = 0;
 #define DEFAULT_POST_RESET_TRIGGER	200
 static int post_reset_trigger = DEFAULT_POST_RESET_TRIGGER;
 static int ignore_first_packets = 0;
+
+#define SKEW_DETECTION_WAIT_TIME_SECS 10
+#define DEFAULT_AUDIO_SKEW_TH 0
+static int audioskew_th = DEFAULT_AUDIO_SKEW_TH;
 
 
 /* Signal handler */
@@ -137,6 +140,16 @@ static int janus_pp_rtp_header_extension_parse_audio_level(char *buf, int len, i
 static int video_orient_extmap_id = -1;
 static int janus_pp_rtp_header_extension_parse_video_orientation(char *buf, int len, int id, int *rotation);
 
+typedef struct janus_pp_rtp_skew_context {
+	guint32 ssrc, rate;
+	guint32 reference_time, start_time, evaluating_start_time;
+	guint32 start_ts, last_ts, prev_ts, target_ts;
+	guint16 last_seq, prev_seq;
+	gint32 prev_delay, active_delay;
+	guint32 ts_offset;
+	gint16 seq_offset;
+} janus_pp_rtp_skew_context;
+static gint janus_pp_skew_compensate_audio(janus_pp_frame_packet *pkt, janus_pp_rtp_skew_context *context);
 
 /* Main Code */
 int main(int argc, char *argv[])
@@ -198,7 +211,11 @@ int main(int argc, char *argv[])
 	}
 	if(args_info.faststart_given)
 		janus_faststart = TRUE;
-
+	if(args_info.audioskew_given || (g_getenv("JANUS_PPREC_AUDIOSKEW") != NULL)) {
+		int val = args_info.audioskew_given ? args_info.audioskew_arg : atoi(g_getenv("JANUS_PPREC_AUDIOSKEW"));
+		if(val >= 0)
+			audioskew_th = val;
+	}
 
 	/* Evaluate arguments to find source and target */
 	char *source = NULL, *destination = NULL, *setting = NULL;
@@ -219,7 +236,8 @@ int main(int argc, char *argv[])
 				(strcmp(setting, "-a")) && (strcmp(setting, "--audiolevel-ext")) &&
 				(strcmp(setting, "-v")) && (strcmp(setting, "--videoorient-ext")) &&
 				(strcmp(setting, "-d")) && (strcmp(setting, "--debug-level")) &&
-				(strcmp(setting, "-f")) && (strcmp(setting, "--format"))
+				(strcmp(setting, "-f")) && (strcmp(setting, "--format")) &&
+				(strcmp(setting, "-S")) && (strcmp(setting, "--audioskew"))
 		)) {
 			if(source == NULL)
 				source = argv[i];
@@ -243,6 +261,8 @@ int main(int argc, char *argv[])
 			JANUS_LOG(LOG_INFO, "Metadata: %s\n", metadata);
 		if(post_reset_trigger != DEFAULT_POST_RESET_TRIGGER)
 			JANUS_LOG(LOG_INFO, "Post reset trigger: %d\n", post_reset_trigger);
+		if(audioskew_th != DEFAULT_AUDIO_SKEW_TH)
+			JANUS_LOG(LOG_INFO, "Audio skew threshold: %d\n", audioskew_th);
 		if(ignore_first_packets > 0)
 			JANUS_LOG(LOG_INFO, "Ignoring first packets: %d\n", ignore_first_packets);
 		if(audio_level_extmap_id > 0)
@@ -690,6 +710,7 @@ int main(int argc, char *argv[])
 		}
 		/* Generate frame packet and insert in the ordered list */
 		janus_pp_frame_packet *p = g_malloc0(sizeof(janus_pp_frame_packet));
+		p->header = rtp;
 		p->version = has_timestamps ? 2 : 1;
 		p->p_ts = pkt_ts;
 		p->seq = ntohs(rtp->seq_number);
@@ -852,7 +873,7 @@ int main(int argc, char *argv[])
 	while(tmp) {
 		count++;
 		if(!data)
-			JANUS_LOG(LOG_VERB, "[%10lu][%4d] seq=%"SCNu16", ts=%"SCNu64", time=%"SCNu64"s\n", tmp->offset, tmp->len, tmp->seq, tmp->ts, (tmp->ts-list->ts)/rate);
+			JANUS_LOG(LOG_VERB, "[%10lu][%4d] seq=%"SCNu16", ts=%"SCNu64", time=%.2fs pts=%.2fs\n", tmp->offset, tmp->len, tmp->seq, tmp->ts, (double)(tmp->ts-list->ts)/(double)rate, (double)tmp->p_ts/1000);
 		else
 			JANUS_LOG(LOG_VERB, "[%10lu][%4d] time=%"SCNu64"s\n", tmp->offset, tmp->len, tmp->ts);
 		tmp = tmp->next;
@@ -888,6 +909,33 @@ int main(int argc, char *argv[])
 		JANUS_LOG(LOG_INFO, "Parsing and reordering completed, bye!\n");
 		cmdline_parser_free(&args_info);
 		exit(0);
+	}
+
+	if(!video && !data && audioskew_th > 0) {
+		tmp = list;
+		janus_pp_rtp_skew_context context = {};
+		context.ssrc = ssrc;
+		context.rate = rate;
+		context.reference_time = tmp->p_ts;
+		context.start_time = tmp->p_ts;
+		context.start_ts = tmp->ts;
+		janus_pp_frame_packet *to_drop;
+		while(tmp) {
+			int ret = janus_pp_skew_compensate_audio(tmp, &context);
+			if(ret < 0) {
+				JANUS_LOG(LOG_WARN, "audio skew SSRC=%"SCNu32" dropping %d packets, source clock is too fast\n", ssrc, -ret);
+				to_drop = tmp;
+				/* Actually returns -1, so drop just one pkt */
+				if (tmp->prev != NULL)
+					tmp->prev->next = tmp->next;
+				if (tmp->next != NULL)
+					tmp->next->prev = tmp->prev;
+				g_free(to_drop);
+			} else if(ret > 0) {
+				JANUS_LOG(LOG_WARN, "audio skew SSRC=%"SCNu32" jumping %d RTP sequence numbers, source clock is too slow\n", ssrc, ret);
+			}
+			tmp = tmp->next;
+		}
 	}
 
 	if(!video && !data) {
@@ -1082,4 +1130,117 @@ static int janus_pp_rtp_header_extension_parse_video_orientation(char *buf, int 
 			*rotation = 270;
 	}
 	return 0;
+}
+
+static gint janus_pp_skew_compensate_audio(janus_pp_frame_packet *pkt, janus_pp_rtp_skew_context *context) {
+	/* N 	: a N sequence number jump has been performed on the packet */
+	/* 0  	: no skew compensation needs to be done */
+	/* -N  	: a N packets drop must be performed by the caller */
+	gint exit_status = 0;
+
+	context->prev_seq = context->last_seq;
+	context->last_seq = pkt->seq;
+	context->prev_ts = context->last_ts;
+	context->last_ts = pkt->ts;
+
+	guint32 pts = pkt->p_ts;
+	guint32 akhz = context->rate / 1000;
+
+	/* Do not execute skew analysis in the first seconds */
+	if (pts - context->reference_time < SKEW_DETECTION_WAIT_TIME_SECS / 2 * 1000) {
+		return 0;
+	} else if (!context->start_time) {
+		context->start_time = pts;
+		if (!context->start_time)
+			context->start_time = 1;
+		context->evaluating_start_time = context->start_time;
+		context->start_ts = context->last_ts;
+		JANUS_LOG(LOG_INFO, "audio skew SSRC=%"SCNu32" evaluation phase start, start_time=%"SCNu32" start_ts=%"SCNu32"\n", context->ssrc, context->start_time, context->start_ts);
+	}
+
+	/* Skew analysis */
+	/* Are we waiting for a target timestamp? (a negative skew has been evaluated in a previous iteration) */
+	if (context->target_ts > 0 && (gint32)(context->target_ts - context->last_ts) > 0) {
+		context->seq_offset--;
+		exit_status = -1;
+	} else {
+		context->target_ts = 0;
+		/* Do not execute analysis for out of order packets or multi-packets frame */
+		if (context->last_seq == context->prev_seq + 1 && context->last_ts != context->prev_ts) {
+			/* Evaluate the local RTP timestamp according to the local clock */
+			guint32 expected_ts = ((pts - context->start_time) * akhz) + context->start_ts;
+			/* Evaluate current delay */
+			gint32 delay_now = context->last_ts - expected_ts;
+			/* Exponentially weighted moving average estimation */
+			gint32 delay_estimate = (63 * context->prev_delay + delay_now) / 64;
+			/* Save previous delay for the next iteration*/
+			context->prev_delay = delay_estimate;
+			/* Evaluate the distance between active delay and current delay estimate */
+			gint32 offset = context->active_delay - delay_estimate;
+			JANUS_LOG(LOG_HUGE, "audio skew SSRC=%"SCNu32" status RECVD_TS=%"SCNu32" EXPTD_TS=%"SCNu32" AVG_OFFSET=%"SCNi32" TS_OFFSET=%"SCNi32" SEQ_OFFSET=%"SCNi16"\n", context->ssrc, context->last_ts, expected_ts, offset, context->ts_offset, context->seq_offset);
+			gint32 skew_th = audioskew_th * akhz;
+
+			/* Evaluation phase */
+			if (context->evaluating_start_time) {
+				/* Check if the offset has surpassed half the threshold during the evaluating phase */
+				if (pts - context->evaluating_start_time <= SKEW_DETECTION_WAIT_TIME_SECS / 2 * 1000) {
+					if (abs(offset) <= skew_th/2) {
+						JANUS_LOG(LOG_HUGE, "audio skew SSRC=%"SCNu32" evaluation phase continue\n", context->ssrc);
+					} else {
+						JANUS_LOG(LOG_VERB, "audio skew SSRC=%"SCNu32" evaluation phase reset\n", context->ssrc);
+						context->start_time = pts;
+						if (!context->start_time)
+							context->start_time = 1;
+						context->evaluating_start_time = context->start_time;
+						context->start_ts = context->last_ts;
+					}
+				} else {
+					JANUS_LOG(LOG_INFO, "audio skew SSRC=%"SCNu32" evaluation phase stop, start_time=%"SCNu32" start_ts=%"SCNu32"\n", context->ssrc, context->start_time, context->start_ts);
+					context->evaluating_start_time = 0;
+				}
+				return 0;
+			}
+
+			/* Check if the offset has surpassed the threshold */
+			if (offset >= skew_th) {
+				/* The source is slowing down */
+				/* Update active delay */
+				context->active_delay = delay_estimate;
+				/* Adjust ts offset */
+				context->ts_offset += skew_th;
+				/* Calculate last ts increase */
+				guint32 ts_incr = context->last_ts - context->prev_ts;
+				/* Evaluate sequence number jump */
+				guint16 jump = (skew_th + ts_incr - 1) / ts_incr;
+				/* Adjust seq num offset */
+				context->seq_offset += jump;
+				exit_status = jump;
+			} else if (offset <= -skew_th) {
+				/* The source is speeding up*/
+				/* Update active delay */
+				context->active_delay = delay_estimate;
+				/* Adjust ts offset */
+				context->ts_offset -= skew_th;
+				/* Set target ts */
+				context->target_ts = context->last_ts + skew_th;
+				if (context->target_ts == 0)
+					context->target_ts = 1;
+				/* Adjust seq num offset */
+				context->seq_offset--;
+				exit_status = -1;
+			}
+		}
+	}
+
+	/* Skew compensation */
+	/* Fix header timestamp considering the active offset */
+	guint32 fixed_rtp_ts = context->last_ts + context->ts_offset;
+	pkt->ts = fixed_rtp_ts;
+	pkt->header->timestamp = htonl(fixed_rtp_ts);
+	/* Fix header sequence number considering the total offset */
+	guint16 fixed_rtp_seq = context->last_seq + context->seq_offset;
+	pkt->seq = fixed_rtp_seq;
+	pkt->header->seq_number = htons(fixed_rtp_seq);
+
+	return exit_status;
 }

--- a/postprocessing/janus-pp-rec.ggo
+++ b/postprocessing/janus-pp-rec.ggo
@@ -13,3 +13,4 @@ option "debug-timestamps" D "Enable debug/logging timestamps" flag off
 option "disable-colors" o "Disable color in the logging" flag off
 option "format" f "Specifies the output format (overrides the format from the destination)" string values="opus", "wav", "webm", "mp4", "srt" optional
 option "faststart" t "For mp4 files write the MOOV atom at the head of the file" flag off
+option "audioskew" S "Time threshold to trigger an audio skew compensation, disabled if 0 (default=0)" int typestr="milliseconds" optional

--- a/postprocessing/pp-rtp.h
+++ b/postprocessing/pp-rtp.h
@@ -53,6 +53,7 @@ typedef struct janus_pp_rtp_header_extension {
 } janus_pp_rtp_header_extension;
 
 typedef struct janus_pp_frame_packet {
+	janus_pp_rtp_header *header; /* Pointer to RTP header */
 	int version;	/* Version of the .mjr file (2=has timestamps) */
 	uint32_t p_ts;	/* Packet timestamp as saved by Janus (if available) */
 	uint16_t seq;	/* RTP Sequence number */


### PR DESCRIPTION
Thanks to the enhancements done in #1719 (timestamp markers in mjr packets) we can now import the skew compensation algorithm (for details see the original PR #1153) into the janus post processing tool.
This initial effort just covers the audio skew compensation, as we wish to collect some feedback before trying to implement the same on the video packets.

We have added a new `S` parameter to `janus-pp-rec` where basically the user needs to specify a threshold in milliseconds. This value represents the maximum drift between remote and local clock before the algorithm executes a compensation (that might be either a packet drop or a sequence number / RTP timestamp jump). 
The default value is `0` (skew compensation is disabled).

By choosing high values the rate of false positives (due to packet jitter) is reduced, while lower values let the algorithm compensate more often.
Our preliminary tests have been conducted with a `-S 120` value, compensating tracks drifted by several seconds and restoring the lip-sync to an acceptable range.