### PR TITLE
Fix RTSP SETUP when url includes query string parameters (fixes #1869)

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -5589,14 +5589,17 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 		g_free(curldata->buffer);
 		curldata->buffer = g_malloc0(1);
 		curldata->size = 0;
+		gboolean add_qs = (rtsp_querystring != NULL);
+		if(add_qs && strstr(vcontrol, rtsp_querystring) != NULL)
+			add_qs = FALSE;
 		if(strstr(vcontrol, rtsp_url) == vcontrol) {
 			/* The control attribute already contains the whole URL? */
 			g_snprintf(uri, sizeof(uri), "%s%s%s", vcontrol,
-				rtsp_querystring ? "?" : "", rtsp_querystring ? rtsp_querystring : "");
+				add_qs ? "?" : "", add_qs ? rtsp_querystring : "");
 		} else {
 			/* Append the control attribute to the URL */
 			g_snprintf(uri, sizeof(uri), "%s/%s%s%s", rtsp_url, vcontrol,
-				rtsp_querystring ? "?" : "", rtsp_querystring ? rtsp_querystring : "");
+				add_qs ? "?" : "", add_qs ? rtsp_querystring : "");
 		}
 		curl_easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, uri);
 		curl_easy_setopt(curl, CURLOPT_RTSP_TRANSPORT, vtransport);
@@ -5767,14 +5770,17 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 		g_free(curldata->buffer);
 		curldata->buffer = g_malloc0(1);
 		curldata->size = 0;
-		if(strstr(acontrol, source->rtsp_url) == acontrol) {
+		gboolean add_qs = (rtsp_querystring != NULL);
+		if(add_qs && strstr(acontrol, rtsp_querystring) != NULL)
+			add_qs = FALSE;
+		if(strstr(acontrol, rtsp_url) == acontrol) {
 			/* The control attribute already contains the whole URL? */
 			g_snprintf(uri, sizeof(uri), "%s%s%s", acontrol,
-				rtsp_querystring ? "?" : "", rtsp_querystring ? rtsp_querystring : "");
+				add_qs ? "?" : "", add_qs ? rtsp_querystring : "");
 		} else {
 			/* Append the control attribute to the URL */
-			g_snprintf(uri, sizeof(uri), "%s/%s%s%s", source->rtsp_url, acontrol,
-				rtsp_querystring ? "?" : "", rtsp_querystring ? rtsp_querystring : "");
+			g_snprintf(uri, sizeof(uri), "%s/%s%s%s", rtsp_url, acontrol,
+				add_qs ? "?" : "", add_qs ? rtsp_querystring : "");
 		}
 		curl_easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, uri);
 		curl_easy_setopt(curl, CURLOPT_RTSP_TRANSPORT, atransport);

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -5576,17 +5576,27 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 		return -7;
 	}
 
+	/* Check if a query string is part of the URL, as that may impact the SETUP request */
+	char *rtsp_url = source->rtsp_url, *rtsp_querystring = NULL;
+	char **parts = g_strsplit(source->rtsp_url, "?", 2);
+	if(parts[0] != NULL) {
+		rtsp_url = parts[0];
+		rtsp_querystring = parts[1];
+	}
+
 	if(vresult != -1) {
 		/* Send an RTSP SETUP for video */
 		g_free(curldata->buffer);
 		curldata->buffer = g_malloc0(1);
 		curldata->size = 0;
-		if(strstr(vcontrol, source->rtsp_url) == vcontrol) {
+		if(strstr(vcontrol, rtsp_url) == vcontrol) {
 			/* The control attribute already contains the whole URL? */
-			g_snprintf(uri, sizeof(uri), "%s", vcontrol);
+			g_snprintf(uri, sizeof(uri), "%s%s%s", vcontrol,
+				rtsp_querystring ? "?" : "", rtsp_querystring ? rtsp_querystring : "");
 		} else {
 			/* Append the control attribute to the URL */
-			g_snprintf(uri, sizeof(uri), "%s/%s", source->rtsp_url, vcontrol);
+			g_snprintf(uri, sizeof(uri), "%s/%s%s%s", rtsp_url, vcontrol,
+				rtsp_querystring ? "?" : "", rtsp_querystring ? rtsp_querystring : "");
 		}
 		curl_easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, uri);
 		curl_easy_setopt(curl, CURLOPT_RTSP_TRANSPORT, vtransport);
@@ -5594,6 +5604,7 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 		res = curl_easy_perform(curl);
 		if(res != CURLE_OK) {
 			JANUS_LOG(LOG_ERR, "Couldn't send SETUP request: %s\n", curl_easy_strerror(res));
+			g_strfreev(parts);
 			curl_easy_cleanup(curl);
 			g_free(curldata->buffer);
 			g_free(curldata);
@@ -5604,6 +5615,7 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 			return -5;
 		} else if(code != 200) {
 			JANUS_LOG(LOG_ERR, "Couldn't get SETUP code: %ld\n", code);
+			g_strfreev(parts);
 			curl_easy_cleanup(curl);
 			g_free(curldata->buffer);
 			g_free(curldata);
@@ -5757,10 +5769,12 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 		curldata->size = 0;
 		if(strstr(acontrol, source->rtsp_url) == acontrol) {
 			/* The control attribute already contains the whole URL? */
-			g_snprintf(uri, sizeof(uri), "%s", acontrol);
+			g_snprintf(uri, sizeof(uri), "%s%s%s", acontrol,
+				rtsp_querystring ? "?" : "", rtsp_querystring ? rtsp_querystring : "");
 		} else {
 			/* Append the control attribute to the URL */
-			g_snprintf(uri, sizeof(uri), "%s/%s", source->rtsp_url, acontrol);
+			g_snprintf(uri, sizeof(uri), "%s/%s%s%s", source->rtsp_url, acontrol,
+				rtsp_querystring ? "?" : "", rtsp_querystring ? rtsp_querystring : "");
 		}
 		curl_easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, uri);
 		curl_easy_setopt(curl, CURLOPT_RTSP_TRANSPORT, atransport);
@@ -5768,6 +5782,7 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 		res = curl_easy_perform(curl);
 		if(res != CURLE_OK) {
 			JANUS_LOG(LOG_ERR, "Couldn't send SETUP request: %s\n", curl_easy_strerror(res));
+			g_strfreev(parts);
 			curl_easy_cleanup(curl);
 			g_free(curldata->buffer);
 			g_free(curldata);
@@ -5778,6 +5793,7 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 			return -6;
 		} else if(code != 200) {
 			JANUS_LOG(LOG_ERR, "Couldn't get SETUP code: %ld\n", code);
+			g_strfreev(parts);
 			curl_easy_cleanup(curl);
 			g_free(curldata->buffer);
 			g_free(curldata);
@@ -5928,6 +5944,7 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 			JANUS_LOG(LOG_WARN, "No host address for the RTSP audio stream, no latching will be performed\n");
 		}
 	}
+	g_strfreev(parts);
 
 	/* Update the source (but check if ptype/rtpmap/fmtp need to be overridden) */
 	if(mp->codecs.audio_pt == -1)


### PR DESCRIPTION
As the title says. This is supposed to fix #1869, but I don't have RTSP servers that accept query string parameters to test against, so looking forward to feedback.