### PR TITLE
Remove option to enable rtx (now always supported, when negotiated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,6 @@ or on the command line:
 	-T, --ice-tcp                 Whether to enable ICE-TCP or not (warning: only
                                   works with ICE Lite)
                                   (default=off)
-	-R, --rfc-4588                Whether to enable RFC4588 retransmissions
-                                  support or not  (default=off)
 	-q, --max-nack-queue=number   Maximum size of the NACK queue (in ms) per user
                                   for retransmissions
 	-t, --no-media-timer=number   Time (in s) that should pass with no media

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -130,10 +130,9 @@ certificates: {
 }
 
 # Media-related stuff: you can configure whether if you want
-# to enable IPv6 support, if RFC4588 support for retransmissions
-# should be negotiated or not (off by default), the maximum size
-# of the NACK queue (in milliseconds, defaults to 500ms) for retransmissions, the
-# range of ports to use for RTP and RTCP (by default, no range is envisaged), the
+# to enable IPv6 support, the maximum size of the NACK queue (in
+# milliseconds, defaults to 500ms) for retransmissions, the range of
+# ports to use for RTP and RTCP (by default, no range is envisaged), the
 # starting MTU for DTLS (1200 by default, it adapts automatically),
 # how much time, in seconds, should pass with no media (audio or
 # video) being received before Janus notifies you about this (default=1s,
@@ -149,7 +148,6 @@ certificates: {
 media: {
 	#ipv6 = true
 	#max_nack_queue = 500
-	#rfc_4588 = true
 	#rtp_port_range = "20000-40000"
 	#dtls_mtu = 1200
 	#no_media_timer = 1

--- a/ice.c
+++ b/ice.c
@@ -439,16 +439,6 @@ uint janus_get_twcc_period(void) {
 }
 
 
-/* RFC4588 support */
-static gboolean rfc4588_enabled = FALSE;
-void janus_set_rfc4588_enabled(gboolean enabled) {
-	rfc4588_enabled = enabled;
-	JANUS_LOG(LOG_VERB, "RFC4588 support is %s\n", rfc4588_enabled ? "enabled" : "disabled");
-}
-gboolean janus_is_rfc4588_enabled(void) {
-	return rfc4588_enabled;
-}
-
 static inline void janus_ice_free_rtp_packet(janus_rtp_packet *pkt) {
 	if(pkt == NULL) {
 		return;

--- a/ice.h
+++ b/ice.h
@@ -146,12 +146,6 @@ void janus_set_twcc_period(uint period);
 /*! \brief Method to get the current TWCC period (see above)
  * @returns The current TWCC period */
 uint janus_get_twcc_period(void);
-/*! \brief Method to enable or disable the RFC4588 support negotiation
- * @param[in] enabled The new timer value, in seconds */
-void janus_set_rfc4588_enabled(gboolean enabled);
-/*! \brief Method to check whether the RFC4588 support is enabled
- * @returns TRUE if it's enabled, FALSE otherwise */
-gboolean janus_is_rfc4588_enabled(void);
 /*! \brief Method to modify the event handler statistics period (i.e., the number of seconds that should pass before Janus notifies event handlers about media statistics for a PeerConnection)
  * @param[in] period The new period value, in seconds */
 void janus_ice_set_event_stats_period(int period);

--- a/janus.1
+++ b/janus.1
@@ -80,9 +80,6 @@ Whether to enable the ICE Lite mode or not (default=off)
 .BR \-T ", " \-\-ice-tcp
 Whether to enable ICE-TCP or not (warning: only works with ICE Lite) (default=off)
 .TP
-.BR \-R ", " \-\-rfc-4588
-Whether to enable RFC4588 retransmissions support or not (default=off)
-.TP
 .BR \-q ", " \-\-max-nack-queue=\fInumber\fR
 Maximum size of the NACK queue per user for retransmissions
 .TP
@@ -137,7 +134,7 @@ Disable WebRTC encryption, so no DTLS or SRTP (only for debugging!) (default=off
 .TP
 \fBjanus \-6\fR \- Launch Janus with IPv6 support enabled
 .TP
-\fBjanus \-f \-R\fR \- Launch Janus with full-trickle and RFC4588 retransmissions enabled
+\fBjanus \-f \fR \- Launch Janus with full-trickle enabled
 .SH BUGS
 .TP
 If you think you found a bug or want to contribute a feature, you can issue or a pull request on https://github.com/meetecho/janus-gateway/issues.

--- a/janus.1
+++ b/janus.1
@@ -134,7 +134,7 @@ Disable WebRTC encryption, so no DTLS or SRTP (only for debugging!) (default=off
 .TP
 \fBjanus \-6\fR \- Launch Janus with IPv6 support enabled
 .TP
-\fBjanus \-f \fR \- Launch Janus with full-trickle enabled
+\fBjanus \-f\fR \- Launch Janus with full-trickle enabled
 .SH BUGS
 .TP
 If you think you found a bug or want to contribute a feature, you can issue or a pull request on https://github.com/meetecho/janus-gateway/issues.

--- a/janus.c
+++ b/janus.c
@@ -289,7 +289,6 @@ static json_t *janus_info(const char *transaction) {
 	json_object_set_new(info, "ice-lite", janus_ice_is_ice_lite_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "ice-tcp", janus_ice_is_ice_tcp_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "full-trickle", janus_ice_is_full_trickle_enabled() ? json_true() : json_false());
-	json_object_set_new(info, "rfc-4588", janus_is_rfc4588_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "twcc-period", json_integer(janus_get_twcc_period()));
 	if(janus_ice_get_stun_server() != NULL) {
 		char server[255];
@@ -3222,10 +3221,8 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 			}
 		}
 		if(ice_handle->agent == NULL) {
-			if(janus_is_rfc4588_enabled()) {
-				/* We still need to configure the WebRTC stuff: negotiate RFC4588 by default */
-				janus_flags_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX);
-			}
+			/* We still need to configure the WebRTC stuff: negotiate RFC4588 by default */
+			janus_flags_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX);
 			/* Process SDP in order to setup ICE locally (this is going to result in an answer from the browser) */
 			janus_mutex_lock(&ice_handle->mutex);
 			if(janus_ice_setup_local(ice_handle, 0, audio, video, data, 1) < 0) {
@@ -3945,9 +3942,6 @@ gint main(int argc, char *argv[])
 		g_snprintf(tp, 20, "%d", args_info.twcc_period_arg);
 		janus_config_add(config, config_media, janus_config_item_create("twcc_period", tp));
 	}
-	if(args_info.rfc_4588_given) {
-		janus_config_add(config, config_media, janus_config_item_create("rfc_4588", "yes"));
-	}
 	if(args_info.rtp_port_range_given) {
 		janus_config_add(config, config_media, janus_config_item_create("rtp_port_range", args_info.rtp_port_range_arg));
 	}
@@ -4339,11 +4333,6 @@ gint main(int argc, char *argv[])
 		} else {
 			janus_set_twcc_period(tp);
 		}
-	}
-	/* RFC4588 support */
-	item = janus_config_get(config, config_media, janus_config_type_item, "rfc_4588");
-	if(item && item->value) {
-		janus_set_rfc4588_enabled(janus_is_true(item->value));
 	}
 
 	/* Setup OpenSSL stuff */

--- a/janus.ggo
+++ b/janus.ggo
@@ -20,7 +20,6 @@ option "libnice-debug" l "Whether to enable libnice debugging or not" flag off
 option "full-trickle" f "Do full-trickle instead of half-trickle" flag off
 option "ice-lite" I "Whether to enable the ICE Lite mode or not" flag off
 option "ice-tcp" T "Whether to enable ICE-TCP or not (warning: only works with ICE Lite)" flag off
-option "rfc-4588" R "Whether to enable RFC4588 retransmissions support or not" flag off
 option "max-nack-queue" q "Maximum size of the NACK queue (in ms) per user for retransmissions" int typestr="number" optional
 option "no-media-timer" t "Time (in s) that should pass with no media (audio or video) being received before Janus notifies you about this" int typestr="number" optional
 option "slowlink-threshold" W "Number of lost packets (per s) that should trigger a 'slowlink' Janus API event to users" int typestr="number" optional

--- a/sdp.c
+++ b/sdp.c
@@ -505,13 +505,11 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 						if(sscanf(a->value, "%d apt=%d", &rtx_ptype, &ptype) != 2) {
 							JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to parse fmtp/apt attribute...\n", handle->handle_id);
 						} else {
-							if(janus_is_rfc4588_enabled()) {
-								rtx = TRUE;
-								janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX);
-								if(stream->rtx_payload_types == NULL)
-									stream->rtx_payload_types = g_hash_table_new(NULL, NULL);
-								g_hash_table_insert(stream->rtx_payload_types, GINT_TO_POINTER(ptype), GINT_TO_POINTER(rtx_ptype));
-							}
+							rtx = TRUE;
+							janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX);
+							if(stream->rtx_payload_types == NULL)
+								stream->rtx_payload_types = g_hash_table_new(NULL, NULL);
+							g_hash_table_insert(stream->rtx_payload_types, GINT_TO_POINTER(ptype), GINT_TO_POINTER(rtx_ptype));
 						}
 					}
 				} else if(!strcasecmp(a->name, "rtpmap")) {


### PR DESCRIPTION
For a while, we've kept RFC4588 (rtx) support behind a property you had to enable yourself, either via config or command line: without it, retransmissions would be sent the "old" way. Enabling it didn't mean it would be used, of course, since this still had to be negotiated via SDP: as such, the "old" way would still be used for endpoints that don't support it.

Considering there are advantages to using it when it's available, it doesn't make much sense to keep it that way anymore, so this patch removes that property from the configuration settings, and enables it by default. Again, endpoints not supporting it won't use it, so no harm done.

Submitted as a pull request just to isolate the changes on that part: I'm planning to merge soon.