### PR TITLE
Binary data support in data channels

### DIFF
--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -47,6 +47,7 @@
 #		passed, which would then change the current SSRC (0=disabled)
 # dataport = local port for receiving data messages to relay
 # dataiface = network interface or IP address to bind to, if any (binds to all otherwise)
+# datatype = text|binary (type of data this mountpoint will relay, default=text)
 # databuffermsg = true|false (whether the plugin should store the latest
 #		message and send it immediately for new viewers)
 # threads = number of threads to assist with the relaying part, which can help
@@ -162,6 +163,7 @@ file-ondemand-sample: {
 	#video = false
 	#data = true
 	#dataport = 5008
+	#datatype = "text"
 #}
 
 #

--- a/dtls.c
+++ b/dtls.c
@@ -965,10 +965,10 @@ int janus_dtls_verify_callback(int preverify_ok, X509_STORE_CTX *ctx) {
 }
 
 #ifdef HAVE_SCTP
-void janus_dtls_wrap_sctp_data(janus_dtls_srtp *dtls, char *label, char *buf, int len) {
+void janus_dtls_wrap_sctp_data(janus_dtls_srtp *dtls, char *label, gboolean textdata, char *buf, int len) {
 	if(dtls == NULL || !dtls->ready || dtls->sctp == NULL || buf == NULL || len < 1)
 		return;
-	janus_sctp_send_data(dtls->sctp, label, buf, len);
+	janus_sctp_send_data(dtls->sctp, label, textdata, buf, len);
 }
 
 int janus_dtls_send_sctp_data(janus_dtls_srtp *dtls, char *buf, int len) {
@@ -982,7 +982,7 @@ int janus_dtls_send_sctp_data(janus_dtls_srtp *dtls, char *buf, int len) {
 	return res;
 }
 
-void janus_dtls_notify_data(janus_dtls_srtp *dtls, char *label, char *buf, int len) {
+void janus_dtls_notify_data(janus_dtls_srtp *dtls, char *label, gboolean textdata, char *buf, int len) {
 	if(dtls == NULL || buf == NULL || len < 1)
 		return;
 	janus_ice_component *component = (janus_ice_component *)dtls->component;
@@ -1000,7 +1000,7 @@ void janus_dtls_notify_data(janus_dtls_srtp *dtls, char *label, char *buf, int l
 		JANUS_LOG(LOG_ERR, "No handle...\n");
 		return;
 	}
-	janus_ice_incoming_data(handle, label, buf, len);
+	janus_ice_incoming_data(handle, label, textdata, buf, len);
 }
 #endif
 

--- a/dtls.h
+++ b/dtls.h
@@ -144,9 +144,10 @@ int janus_dtls_verify_callback(int preverify_ok, X509_STORE_CTX *ctx);
 /*! \brief Callback (called from the ICE handle) to encapsulate in DTLS outgoing SCTP data (DataChannel)
  * @param[in] dtls The janus_dtls_srtp instance to use
  * @param[in] label The label of the data channel to use
+ * @param[in] textdata Whether the buffer is text (domstring) or binary data
  * @param[in] buf The data buffer to encapsulate
  * @param[in] len The data length */
-void janus_dtls_wrap_sctp_data(janus_dtls_srtp *dtls, char *label, char *buf, int len);
+void janus_dtls_wrap_sctp_data(janus_dtls_srtp *dtls, char *label, gboolean textdata, char *buf, int len);
 
 /*! \brief Callback (called from the SCTP stack) to encapsulate in DTLS outgoing SCTP data (DataChannel)
  * @param[in] dtls The janus_dtls_srtp instance to use
@@ -158,9 +159,10 @@ int janus_dtls_send_sctp_data(janus_dtls_srtp *dtls, char *buf, int len);
 /*! \brief Callback to be notified about incoming SCTP data (DataChannel) to forward to the handle
  * @param[in] dtls The janus_dtls_srtp instance to use
  * @param[in] label The label of the data channel the message is from
+ * @param[in] textdata Whether the buffer is text (domstring) or binary data
  * @param[in] buf The data buffer
  * @param[in] len The data length */
-void janus_dtls_notify_data(janus_dtls_srtp *dtls, char *label, char *buf, int len);
+void janus_dtls_notify_data(janus_dtls_srtp *dtls, char *label, gboolean textdata, char *buf, int len);
 #endif
 
 /*! \brief DTLS retransmission timer

--- a/html/janus.js
+++ b/html/janus.js
@@ -1413,7 +1413,7 @@ function Janus(gatewayCallbacks) {
 	}
 
 	// Private method to create a data channel
-	function createDataChannel(handleId, dclabel, incoming, pendingText) {
+	function createDataChannel(handleId, dclabel, incoming, pendingData) {
 		var pluginHandle = pluginHandles[handleId];
 		if(pluginHandle === null || pluginHandle === undefined ||
 				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
@@ -1436,9 +1436,10 @@ function Janus(gatewayCallbacks) {
 				if(config.dataChannel[label].pending && config.dataChannel[label].pending.length > 0) {
 					Janus.log("Sending pending messages on <" + label + ">:", config.dataChannel[label].pending.length);
 					for(var i in config.dataChannel[label].pending) {
-						var text = config.dataChannel[label].pending[i];
-						Janus.log("Sending string on data channel <" + label + ">: " + text);
-						config.dataChannel[label].send(text);
+						var data = config.dataChannel[label].pending[i];
+						Janus.log("Sending data on data channel <" + label + ">");
+						Janus.debug(data);
+						config.dataChannel[label].send(data);
 					}
 					config.dataChannel[label].pending = [];
 				}
@@ -1452,7 +1453,7 @@ function Janus(gatewayCallbacks) {
 		}
 		if(!incoming) {
 			// FIXME Add options (ordered, maxRetransmits, etc.)
-			config.dataChannel[dclabel] = config.pc.createDataChannel(dclabel, {ordered:false});
+			config.dataChannel[dclabel] = config.pc.createDataChannel(dclabel, {ordered: true});
 		} else {
 			// The channel was created by Janus
 			config.dataChannel[dclabel] = incoming;
@@ -1462,8 +1463,8 @@ function Janus(gatewayCallbacks) {
 		config.dataChannel[dclabel].onclose = onDataChannelStateChange;
 		config.dataChannel[dclabel].onerror = onDataChannelError;
 		config.dataChannel[dclabel].pending = [];
-		if(pendingText)
-			config.dataChannel[dclabel].pending.push(pendingText);
+		if(pendingData)
+			config.dataChannel[dclabel].pending.push(pendingData);
 	}
 
 	// Private method to send a data channel message
@@ -1479,26 +1480,27 @@ function Janus(gatewayCallbacks) {
 			return;
 		}
 		var config = pluginHandle.webrtcStuff;
-		var text = callbacks.text;
-		if(text === null || text === undefined) {
-			Janus.warn("Invalid text");
-			callbacks.error("Invalid text");
+		var data = callbacks.text || callbacks.data;
+		if(data === null || data === undefined) {
+			Janus.warn("Invalid data");
+			callbacks.error("Invalid data");
 			return;
 		}
 		var label = callbacks.label ? callbacks.label : Janus.dataChanDefaultLabel;
 		if(!config.dataChannel[label]) {
 			// Create new data channel and wait for it to open
-			createDataChannel(handleId, label, false, text);
+			createDataChannel(handleId, label, false, data);
 			callbacks.success();
 			return;
 		}
 		if(config.dataChannel[label].readyState !== "open") {
-			config.dataChannel[label].pending.push(text);
+			config.dataChannel[label].pending.push(data);
 			callbacks.success();
 			return;
 		}
-		Janus.log("Sending string on data channel <" + label + ">: " + text);
-		config.dataChannel[label].send(text);
+		Janus.log("Sending data on data channel <" + label + ">");
+		Janus.debug(data);
+		config.dataChannel[label].send(data);
 		callbacks.success();
 	}
 

--- a/ice.c
+++ b/ice.c
@@ -294,8 +294,9 @@ uint16_t rtp_range_max = 0;
 
 #define JANUS_ICE_PACKET_AUDIO	0
 #define JANUS_ICE_PACKET_VIDEO	1
-#define JANUS_ICE_PACKET_DATA	2
-#define JANUS_ICE_PACKET_SCTP	3
+#define JANUS_ICE_PACKET_TEXT	2
+#define JANUS_ICE_PACKET_BINARY	3
+#define JANUS_ICE_PACKET_SCTP	4
 /* Janus enqueued (S)RTP/(S)RTCP packet to send */
 typedef struct janus_ice_queued_packet {
 	char *data;
@@ -2883,14 +2884,14 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 	}
 }
 
-void janus_ice_incoming_data(janus_ice_handle *handle, char *label, char *buffer, int length) {
+void janus_ice_incoming_data(janus_ice_handle *handle, char *label, gboolean textdata, char *buffer, int length) {
 	if(handle == NULL || buffer == NULL || length <= 0)
 		return;
 	janus_plugin *plugin = (janus_plugin *)handle->app;
 	if(plugin && plugin->incoming_data && handle->app_handle &&
 			!g_atomic_int_get(&handle->app_handle->stopped) &&
 			!g_atomic_int_get(&handle->destroyed))
-		plugin->incoming_data(handle->app_handle, label, buffer, length);
+		plugin->incoming_data(handle->app_handle, label, textdata, buffer, length);
 }
 
 
@@ -4262,7 +4263,7 @@ static gboolean janus_ice_outgoing_traffic_handle(janus_ice_handle *handle, janu
 					}
 				}
 			}
-		} else if(pkt->type == JANUS_ICE_PACKET_DATA) {
+		} else if(pkt->type == JANUS_ICE_PACKET_TEXT || pkt->type == JANUS_ICE_PACKET_BINARY) {
 			/* Data */
 			if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_DATA_CHANNELS)) {
 				janus_ice_free_queued_packet(pkt);
@@ -4278,7 +4279,8 @@ static gboolean janus_ice_outgoing_traffic_handle(janus_ice_handle *handle, janu
 				return G_SOURCE_CONTINUE;
 			}
 			component->noerrorlog = FALSE;
-			janus_dtls_wrap_sctp_data(component->dtls, pkt->label, pkt->data, pkt->length);
+			/* TODO Support binary data */
+			janus_dtls_wrap_sctp_data(component->dtls, pkt->label, pkt->type == JANUS_ICE_PACKET_TEXT, pkt->data, pkt->length);
 #endif
 		} else if(pkt->type == JANUS_ICE_PACKET_SCTP) {
 			/* SCTP data to push */
@@ -4409,7 +4411,7 @@ void janus_ice_relay_rtcp(janus_ice_handle *handle, int video, char *buf, int le
 }
 
 #ifdef HAVE_SCTP
-void janus_ice_relay_data(janus_ice_handle *handle, char *label, char *buf, int len) {
+void janus_ice_relay_data(janus_ice_handle *handle, char *label, gboolean textdata, char *buf, int len) {
 	if(!handle || handle->queued_packets == NULL || buf == NULL || len < 1)
 		return;
 	/* Queue this packet */
@@ -4417,7 +4419,7 @@ void janus_ice_relay_data(janus_ice_handle *handle, char *label, char *buf, int 
 	pkt->data = g_malloc(len);
 	memcpy(pkt->data, buf, len);
 	pkt->length = len;
-	pkt->type = JANUS_ICE_PACKET_DATA;
+	pkt->type = textdata ? JANUS_ICE_PACKET_TEXT : JANUS_ICE_PACKET_BINARY;
 	pkt->control = FALSE;
 	pkt->encrypted = FALSE;
 	pkt->retransmission = FALSE;

--- a/ice.h
+++ b/ice.h
@@ -600,15 +600,17 @@ void janus_ice_relay_rtcp(janus_ice_handle *handle, int video, char *buf, int le
 /*! \brief Core SCTP/DataChannel callback, called when a plugin has data to send to a peer
  * @param[in] handle The Janus ICE handle associated with the peer
  * @param[in] label The label of the data channel to use
+ * @param[in] textdata Whether the buffer is text (domstring) or binary data
  * @param[in] buf The message data (buffer)
  * @param[in] len The buffer lenght */
-void janus_ice_relay_data(janus_ice_handle *handle, char *label, char *buf, int len);
+void janus_ice_relay_data(janus_ice_handle *handle, char *label, gboolean textdata, char *buf, int len);
 /*! \brief Plugin SCTP/DataChannel callback, called by the SCTP stack when when there's data for a plugin
  * @param[in] handle The Janus ICE handle associated with the peer
  * @param[in] label The label of the data channel the message is from
+ * @param[in] textdata Whether the buffer is text (domstring) or binary data
  * @param[in] buffer The message data (buffer)
  * @param[in] length The buffer lenght */
-void janus_ice_incoming_data(janus_ice_handle *handle, char *label, char *buffer, int length);
+void janus_ice_incoming_data(janus_ice_handle *handle, char *label, gboolean textdata, char *buffer, int length);
 /*! \brief Core SCTP/DataChannel callback, called by the SCTP stack when when there's data to send.
  * @param[in] handle The Janus ICE handle associated with the peer
  * @param[in] buffer The message data (buffer)

--- a/janus.c
+++ b/janus.c
@@ -485,7 +485,7 @@ int janus_plugin_push_event(janus_plugin_session *plugin_session, janus_plugin *
 json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plugin *plugin, const char *sdp_type, const char *sdp, gboolean restart);
 void janus_plugin_relay_rtp(janus_plugin_session *plugin_session, int video, char *buf, int len);
 void janus_plugin_relay_rtcp(janus_plugin_session *plugin_session, int video, char *buf, int len);
-void janus_plugin_relay_data(janus_plugin_session *plugin_session, char *label, char *buf, int len);
+void janus_plugin_relay_data(janus_plugin_session *plugin_session, char *label, gboolean textdata, char *buf, int len);
 void janus_plugin_close_pc(janus_plugin_session *plugin_session);
 void janus_plugin_end_session(janus_plugin_session *plugin_session);
 void janus_plugin_notify_event(janus_plugin *plugin, janus_plugin_session *plugin_session, json_t *event);
@@ -3467,7 +3467,7 @@ void janus_plugin_relay_rtcp(janus_plugin_session *plugin_session, int video, ch
 	janus_ice_relay_rtcp(handle, video, buf, len);
 }
 
-void janus_plugin_relay_data(janus_plugin_session *plugin_session, char *label, char *buf, int len) {
+void janus_plugin_relay_data(janus_plugin_session *plugin_session, char *label, gboolean textdata, char *buf, int len) {
 	if((plugin_session < (janus_plugin_session *)0x1000) || g_atomic_int_get(&plugin_session->stopped) || buf == NULL || len < 1)
 		return;
 	janus_ice_handle *handle = (janus_ice_handle *)plugin_session->gateway_handle;
@@ -3475,7 +3475,7 @@ void janus_plugin_relay_data(janus_plugin_session *plugin_session, char *label, 
 			|| janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT))
 		return;
 #ifdef HAVE_SCTP
-	janus_ice_relay_data(handle, label, buf, len);
+	janus_ice_relay_data(handle, label, textdata, buf, len);
 #else
 	JANUS_LOG(LOG_WARN, "Asked to relay data, but Data Channels support has not been compiled...\n");
 #endif

--- a/plugins/duktape/echotest.js
+++ b/plugins/duktape/echotest.js
@@ -173,11 +173,16 @@ function hangupMedia(id) {
 	}
 }
 
-function incomingData(id, buf, len) {
+function incomingTextData(id, buf, len) {
 	// Relaying RTP/RTCP in JavaScript makes no sense, but just for fun
 	// we handle data channel messages ourselves to manipulate them
 	var edit = "[" + name + "] --> " + buf;
-	relayData(id, edit, edit.length);
+	relayTextData(id, edit, edit.length);
+}
+
+function incomingBinaryData(id, buf, len) {
+	// If the data we're getting is binary, send it back as it is
+	relayBinaryData(id, buf, len);
 }
 
 function resumeScheduler() {

--- a/plugins/janus_duktape.c
+++ b/plugins/janus_duktape.c
@@ -53,9 +53,10 @@
  *
  * \note Notice that, along the above mentioned callbacks, JavaScript scripts
  * can also implement functions like \c incomingRtp() \c incomingRtcp()
- * and \c incomingData() to handle those packets directly, instead of
- * letting the C code worry about relaying/processing them. While it might
- * make sense to handle incoming data channel messages with \c incomingData()
+ * \c incomingTextData() and \c incomingBinaryData() to handle those packets
+ * directly, instead of letting the C code worry about relaying/processing
+ * them. While it might make sense to handle incoming data channel messages
+ * with \c incomingTextData() or \c incomingBinaryData
  * though, the performance impact of directly processing and manipulating
  * RTP an RTCP packets is probably too high, and so their usage is currently
  * discouraged. As an additional note, JavaScript scripts can also decide to
@@ -215,7 +216,7 @@ json_t *janus_duktape_handle_admin_message(json_t *message);
 void janus_duktape_setup_media(janus_plugin_session *handle);
 void janus_duktape_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_duktape_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_duktape_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
+void janus_duktape_incoming_data(janus_plugin_session *handle, char *label, gboolean textdata, char *buf, int len);
 void janus_duktape_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_duktape_hangup_media(janus_plugin_session *handle);
 void janus_duktape_destroy_session(janus_plugin_session *handle, int *error);
@@ -285,7 +286,7 @@ static char *duktape_script_package = NULL;
 static gboolean has_handle_admin_message = FALSE;
 static gboolean has_incoming_rtp = FALSE;
 static gboolean has_incoming_rtcp = FALSE;
-static gboolean has_incoming_data = FALSE;
+static gboolean has_incoming_text_data = FALSE, has_incoming_binary_data = FALSE;
 static gboolean has_slow_link = FALSE;
 /* JavaScript C scheduler (for coroutines) */
 static GThread *scheduler_thread = NULL;
@@ -342,9 +343,12 @@ static void janus_duktape_session_free(const janus_refcount *session_ref) {
 typedef struct janus_duktape_rtp_relay_packet {
 	rtp_header *data;
 	gint length;
+	gboolean is_rtp;	/* This may be a data packet and not RTP */
 	gboolean is_video;
 	uint32_t timestamp;
 	uint16_t seq_number;
+	/* The following is only relevant for datachannels */
+	gboolean textdata;
 } janus_duktape_rtp_relay_packet;
 static void janus_duktape_relay_rtp_packet(gpointer data, gpointer user_data);
 static void janus_duktape_relay_data_packet(gpointer data, gpointer user_data);
@@ -1024,7 +1028,7 @@ static duk_ret_t janus_duktape_method_relayrtcp(duk_context *ctx) {
 	return 1;
 }
 
-static duk_ret_t janus_duktape_method_relaydata(duk_context *ctx) {
+static duk_ret_t janus_duktape_method_relaytextdata(duk_context *ctx) {
 	if(duk_get_type(ctx, 0) != DUK_TYPE_NUMBER) {
 		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
 			janus_duktape_type_string(DUK_TYPE_NUMBER), janus_duktape_type_string(duk_get_type(ctx, 0)));
@@ -1059,7 +1063,50 @@ static duk_ret_t janus_duktape_method_relaydata(duk_context *ctx) {
 	janus_refcount_increase(&session->ref);
 	janus_mutex_unlock(&duktape_sessions_mutex);
 	/* Send the RTP packet */
-	janus_core->relay_data(session->handle, NULL, (char *)payload, len);
+	janus_core->relay_data(session->handle, NULL, TRUE, (char *)payload, len);
+	janus_refcount_decrease(&session->ref);
+	duk_push_int(ctx, 0);
+	return 1;
+}
+
+static duk_ret_t janus_duktape_method_relaybinarydata(duk_context *ctx) {
+	if(duk_get_type(ctx, 0) != DUK_TYPE_NUMBER) {
+		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
+			janus_duktape_type_string(DUK_TYPE_NUMBER), janus_duktape_type_string(duk_get_type(ctx, 0)));
+		return duk_throw(ctx);
+	}
+	/* TODO Use a different type for binary data */
+	if(duk_get_type(ctx, 1) != DUK_TYPE_STRING) {
+		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
+			janus_duktape_type_string(DUK_TYPE_STRING), janus_duktape_type_string(duk_get_type(ctx, 1)));
+		return duk_throw(ctx);
+	}
+	if(duk_get_type(ctx, 2) != DUK_TYPE_NUMBER) {
+		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
+			janus_duktape_type_string(DUK_TYPE_NUMBER), janus_duktape_type_string(duk_get_type(ctx, 2)));
+		return duk_throw(ctx);
+	}
+	uint32_t id = (uint32_t)duk_get_number(ctx, 0);
+	/* TODO Use a different type for binary data */
+	const char *payload = duk_get_string(ctx, 1);
+	int len = (int)duk_get_number(ctx, 2);
+	if(payload == NULL || len < 1) {
+		JANUS_LOG(LOG_ERR, "Invalid data\n");
+		duk_push_error_object(ctx, DUK_ERR_ERROR, "Invalid payload of declared size %d", len);
+		return duk_throw(ctx);
+	}
+	/* Find the session */
+	janus_mutex_lock(&duktape_sessions_mutex);
+	janus_duktape_session *session = g_hash_table_lookup(duktape_ids, GUINT_TO_POINTER(id));
+	if(session == NULL || g_atomic_int_get(&session->destroyed)) {
+		janus_mutex_unlock(&duktape_sessions_mutex);
+		duk_push_error_object(ctx, DUK_ERR_ERROR, "Session %"SCNu32" doesn't exist", id);
+		return duk_throw(ctx);
+	}
+	janus_refcount_increase(&session->ref);
+	janus_mutex_unlock(&duktape_sessions_mutex);
+	/* Send the RTP packet */
+	janus_core->relay_data(session->handle, NULL, FALSE, (char *)payload, len);
 	janus_refcount_decrease(&session->ref);
 	duk_push_int(ctx, 0);
 	return 1;
@@ -1308,8 +1355,10 @@ int janus_duktape_init(janus_callbacks *callback, const char *config_path) {
 	duk_put_global_string(duktape_ctx, "relayRtp");
 	duk_push_c_function(duktape_ctx, janus_duktape_method_relayrtcp, 4);
 	duk_put_global_string(duktape_ctx, "relayRtcp");
-	duk_push_c_function(duktape_ctx, janus_duktape_method_relaydata, 3);
-	duk_put_global_string(duktape_ctx, "relayData");
+	duk_push_c_function(duktape_ctx, janus_duktape_method_relaytextdata, 3);
+	duk_put_global_string(duktape_ctx, "relayTextData");
+	duk_push_c_function(duktape_ctx, janus_duktape_method_relaybinarydata, 3);
+	duk_put_global_string(duktape_ctx, "relayBinaryData");
 	duk_push_c_function(duktape_ctx, janus_duktape_method_startrecording, 13);
 	duk_put_global_string(duktape_ctx, "startRecording");
 	duk_push_c_function(duktape_ctx, janus_duktape_method_stoprecording, 4);
@@ -1394,9 +1443,12 @@ int janus_duktape_init(janus_callbacks *callback, const char *config_path) {
 	duk_get_global_string(duktape_ctx, "incomingRtcp");
 	if(duk_is_function(duktape_ctx, duk_get_top(duktape_ctx)-1) != 0)
 		has_incoming_rtcp = TRUE;
-	duk_get_global_string(duktape_ctx, "incomingData");
+	duk_get_global_string(duktape_ctx, "incomingTextData");
 	if(duk_is_function(duktape_ctx, duk_get_top(duktape_ctx)-1) != 0)
-		has_incoming_data = TRUE;
+		has_incoming_text_data = TRUE;
+	duk_get_global_string(duktape_ctx, "incomingBinaryData");
+	if(duk_is_function(duktape_ctx, duk_get_top(duktape_ctx)-1) != 0)
+		has_incoming_binary_data = TRUE;
 	duk_get_global_string(duktape_ctx, "slowLink");
 	if(duk_is_function(duktape_ctx, duk_get_top(duktape_ctx)-1) != 0)
 		has_slow_link = TRUE;
@@ -2161,7 +2213,7 @@ void janus_duktape_incoming_rtcp(janus_plugin_session *handle, int video, char *
 	}
 }
 
-void janus_duktape_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len) {
+void janus_duktape_incoming_data(janus_plugin_session *handle, char *label, gboolean textdata, char *buf, int len) {
 	if(handle == NULL || handle->stopped || g_atomic_int_get(&duktape_stopping) || !g_atomic_int_get(&duktape_initialized))
 		return;
 	janus_duktape_session *session = (janus_duktape_session *)handle->plugin_handle;
@@ -2174,13 +2226,14 @@ void janus_duktape_incoming_data(janus_plugin_session *handle, char *label, char
 	/* Are we recording? */
 	janus_recorder_save_frame(session->drc, buf, len);
 	/* Check if the JS script wants to handle/manipulate data channel packets itself */
-	if(has_incoming_data) {
+	if((textdata && has_incoming_text_data) || (!textdata && has_incoming_binary_data)) {
 		/* Yep, pass the data to the JS script and return */
 		janus_mutex_lock(&duktape_mutex);
 		duk_idx_t thr_idx = duk_push_thread(duktape_ctx);
 		duk_context *t = duk_get_context(duktape_ctx, thr_idx);
-		duk_get_global_string(t, "incomingData");
+		duk_get_global_string(t, textdata ? "incomingTextData" : "incomingBinaryData");
 		duk_push_number(t, session->id);
+		/* We use a string for both text and binary data */
 		duk_push_lstring(t, buf, len);
 		duk_push_number(t, len);
 		int res = duk_pcall(t, 3);
@@ -2196,20 +2249,17 @@ void janus_duktape_incoming_data(janus_plugin_session *handle, char *label, char
 	/* Is this session allowed to send data? */
 	if(!session->send_data)
 		return;
-	/* Get a string out of the data */
-	char *text = g_malloc0(len+1);
-	if(text == NULL) {
-		JANUS_LOG(LOG_FATAL, "Memory error!\n");
-		return;
-	}
-	memcpy(text, buf, len);
-	*(text+len) = '\0';
-	JANUS_LOG(LOG_VERB, "Got a DataChannel message (%zu bytes) to forward: %s\n", strlen(text), text);
+	JANUS_LOG(LOG_VERB, "Got a %s DataChannel message (%d bytes) to forward\n",
+		textdata ? "text" : "binary", len);
 	/* Relay to all recipients */
+	janus_duktape_rtp_relay_packet packet;
+	packet.data = (rtp_header *)buf;
+	packet.length = len;
+	packet.is_rtp = FALSE;
+	packet.textdata = textdata;
 	janus_mutex_lock_nodebug(&session->recipients_mutex);
-	g_slist_foreach(session->recipients, janus_duktape_relay_data_packet, text);
+	g_slist_foreach(session->recipients, janus_duktape_relay_data_packet, &packet);
 	janus_mutex_unlock_nodebug(&session->recipients_mutex);
-	g_free(text);
 }
 
 void janus_duktape_slow_link(janus_plugin_session *handle, int uplink, int video) {
@@ -2341,15 +2391,19 @@ static void janus_duktape_relay_rtp_packet(gpointer data, gpointer user_data) {
 }
 
 static void janus_duktape_relay_data_packet(gpointer data, gpointer user_data) {
+	janus_duktape_rtp_relay_packet *packet = (janus_duktape_rtp_relay_packet *)user_data;
+	if(!packet || packet->is_rtp || !packet->data || packet->length < 1) {
+		JANUS_LOG(LOG_ERR, "Invalid packet...\n");
+		return;
+	}
 	janus_duktape_session *session = (janus_duktape_session *)data;
 	if(!session || !session->handle || !g_atomic_int_get(&session->started) || !session->accept_data) {
 		return;
 	}
-	char *text = (char *)user_data;
-	if(janus_core != NULL && text != NULL) {
-		JANUS_LOG(LOG_VERB, "Forwarding DataChannel message (%zu bytes) to session %"SCNu32": %s\n",
-			strlen(text), session->id, text);
-		janus_core->relay_data(session->handle, NULL, text, strlen(text));
+	if(janus_core != NULL) {
+		JANUS_LOG(LOG_VERB, "Forwarding %s DataChannel message (%d bytes) to session %"SCNu32"\n",
+			packet->textdata ? "text" : "binary", packet->length, session->id);
+		janus_core->relay_data(session->handle, NULL, packet->textdata, (char *)packet->data, packet->length);
 	}
 	return;
 }

--- a/plugins/janus_echotest.c
+++ b/plugins/janus_echotest.c
@@ -144,7 +144,7 @@ json_t *janus_echotest_handle_admin_message(json_t *message);
 void janus_echotest_setup_media(janus_plugin_session *handle);
 void janus_echotest_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_echotest_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_echotest_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
+void janus_echotest_incoming_data(janus_plugin_session *handle, char *label, gboolean textdata, char *buf, int len);
 void janus_echotest_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_echotest_hangup_media(janus_plugin_session *handle);
 void janus_echotest_destroy_session(janus_plugin_session *handle, int *error);
@@ -636,7 +636,7 @@ void janus_echotest_incoming_rtcp(janus_plugin_session *handle, int video, char 
 	}
 }
 
-void janus_echotest_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len) {
+void janus_echotest_incoming_data(janus_plugin_session *handle, char *label, gboolean textdata, char *buf, int len) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	/* Simple echo test */
@@ -650,6 +650,15 @@ void janus_echotest_incoming_data(janus_plugin_session *handle, char *label, cha
 			return;
 		if(buf == NULL || len <= 0)
 			return;
+		if(!textdata) {
+			JANUS_LOG(LOG_VERB, "Got a binary DataChannel message (label=%s, %d bytes) to bounce back\n", label, len);
+			/* Save the frame if we're recording */
+			janus_recorder_save_frame(session->drc, buf, len);
+			/* Binary data, shoot back as it is */
+			gateway->relay_data(handle, label, FALSE, buf, len);
+			return;
+		}
+		/* Text data */
 		char *text = g_malloc(len+1);
 		memcpy(text, buf, len);
 		*(text+len) = '\0';
@@ -661,7 +670,7 @@ void janus_echotest_incoming_data(janus_plugin_session *handle, char *label, cha
 		char *reply = g_malloc(strlen(prefix)+len+1);
 		g_snprintf(reply, strlen(prefix)+len+1, "%s%s", prefix, text);
 		g_free(text);
-		gateway->relay_data(handle, label, reply, strlen(reply));
+		gateway->relay_data(handle, label, TRUE, reply, strlen(reply));
 		g_free(reply);
 	}
 }

--- a/plugins/janus_lua.c
+++ b/plugins/janus_lua.c
@@ -53,9 +53,10 @@
  *
  * \note Notice that, along the above mentioned callbacks, Lua scripts
  * can also implement functions like \c incomingRtp() \c incomingRtcp()
- * and \c incomingData() to handle those packets directly, instead of
- * letting the C code worry about relaying/processing them. While it might
- * make sense to handle incoming data channel messages with \c incomingData()
+ * \c incomingTextData() and \c incomingBinaryData() to handle those packets
+ * directly, instead of letting the C code worry about relaying/processing
+ * them. While it might make sense to handle incoming data channel messages
+ * with \c incomingTextData() or \c incomingBinaryData
  * though, the performance impact of directly processing and manipulating
  * RTP an RTCP packets is probably too high, and so their usage is currently
  * discouraged. As an additional note, Lua scripts can also decide to
@@ -216,7 +217,7 @@ json_t *janus_lua_handle_admin_message(json_t *message);
 void janus_lua_setup_media(janus_plugin_session *handle);
 void janus_lua_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_lua_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_lua_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
+void janus_lua_incoming_data(janus_plugin_session *handle, char *label, gboolean textdata, char *buf, int len);
 void janus_lua_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_lua_hangup_media(janus_plugin_session *handle);
 void janus_lua_destroy_session(janus_plugin_session *handle, int *error);
@@ -285,7 +286,7 @@ static char *lua_script_package = NULL;
 static gboolean has_handle_admin_message = FALSE;
 static gboolean has_incoming_rtp = FALSE;
 static gboolean has_incoming_rtcp = FALSE;
-static gboolean has_incoming_data = FALSE;
+static gboolean has_incoming_text_data = FALSE, has_incoming_binary_data = FALSE;
 static gboolean has_slow_link = FALSE;
 /* Lua C scheduler (for coroutines) */
 static GThread *scheduler_thread = NULL;
@@ -342,9 +343,12 @@ static void janus_lua_session_free(const janus_refcount *session_ref) {
 typedef struct janus_lua_rtp_relay_packet {
 	rtp_header *data;
 	gint length;
+	gboolean is_rtp;	/* This may be a data packet and not RTP */
 	gboolean is_video;
 	uint32_t timestamp;
 	uint16_t seq_number;
+	/* The following is only relevant for datachannels */
+	gboolean textdata;
 } janus_lua_rtp_relay_packet;
 static void janus_lua_relay_rtp_packet(gpointer data, gpointer user_data);
 static void janus_lua_relay_data_packet(gpointer data, gpointer user_data);
@@ -911,11 +915,11 @@ static int janus_lua_method_relayrtcp(lua_State *s) {
 	return 1;
 }
 
-static int janus_lua_method_relaydata(lua_State *s) {
+static int janus_lua_method_relaytextdata(lua_State *s) {
 	/* Get the arguments from the provided state */
 	int n = lua_gettop(s);
 	if(n != 3) {
-		JANUS_LOG(LOG_ERR, "Wrong number of arguments: %d (expected 2)\n", n);
+		JANUS_LOG(LOG_ERR, "Wrong number of arguments: %d (expected 3)\n", n);
 		lua_pushnumber(s, -1);
 		return 1;
 	}
@@ -937,8 +941,42 @@ static int janus_lua_method_relaydata(lua_State *s) {
 	}
 	janus_refcount_increase(&session->ref);
 	janus_mutex_unlock(&lua_sessions_mutex);
-	/* Send the RTP packet */
-	janus_core->relay_data(session->handle, NULL, (char *)payload, len);
+	/* Send the data packet */
+	janus_core->relay_data(session->handle, NULL, TRUE, (char *)payload, len);
+	janus_refcount_decrease(&session->ref);
+	lua_pushnumber(s, 0);
+	return 1;
+}
+
+static int janus_lua_method_relaybinarydata(lua_State *s) {
+	/* Get the arguments from the provided state */
+	int n = lua_gettop(s);
+	if(n != 3) {
+		JANUS_LOG(LOG_ERR, "Wrong number of arguments: %d (expected 3)\n", n);
+		lua_pushnumber(s, -1);
+		return 1;
+	}
+	guint32 id = lua_tonumber(s, 1);
+	/* TODO Use a different type for binary data */
+	const char *payload = lua_tostring(s, 2);
+	int len = lua_tonumber(s, 3);
+	if(!payload || len < 1) {
+		JANUS_LOG(LOG_ERR, "Invalid data\n");
+		lua_pushnumber(s, -1);
+		return 1;
+	}
+	/* Find the session */
+	janus_mutex_lock(&lua_sessions_mutex);
+	janus_lua_session *session = g_hash_table_lookup(lua_ids, GUINT_TO_POINTER(id));
+	if(session == NULL || g_atomic_int_get(&session->destroyed)) {
+		janus_mutex_unlock(&lua_sessions_mutex);
+		lua_pushnumber(s, -1);
+		return 1;
+	}
+	janus_refcount_increase(&session->ref);
+	janus_mutex_unlock(&lua_sessions_mutex);
+	/* Send the data packet */
+	janus_core->relay_data(session->handle, NULL, FALSE, (char *)payload, len);
 	janus_refcount_decrease(&session->ref);
 	lua_pushnumber(s, 0);
 	return 1;
@@ -1176,7 +1214,8 @@ int janus_lua_init(janus_callbacks *callback, const char *config_path) {
 	lua_register(lua_state, "sendPli", janus_lua_method_sendpli);
 	lua_register(lua_state, "relayRtp", janus_lua_method_relayrtp);
 	lua_register(lua_state, "relayRtcp", janus_lua_method_relayrtcp);
-	lua_register(lua_state, "relayData", janus_lua_method_relaydata);
+	lua_register(lua_state, "relayTextData", janus_lua_method_relaytextdata);
+	lua_register(lua_state, "relayBinaryData", janus_lua_method_relaybinarydata);
 	lua_register(lua_state, "startRecording", janus_lua_method_startrecording);
 	lua_register(lua_state, "stopRecording", janus_lua_method_stoprecording);
 	/* Register all extra functions, if any were added */
@@ -1233,9 +1272,12 @@ int janus_lua_init(janus_callbacks *callback, const char *config_path) {
 	lua_getglobal(lua_state, "incomingRtcp");
 	if(lua_isfunction(lua_state, lua_gettop(lua_state)) != 0)
 		has_incoming_rtcp = TRUE;
-	lua_getglobal(lua_state, "incomingData");
+	lua_getglobal(lua_state, "incomingTextData");
 	if(lua_isfunction(lua_state, lua_gettop(lua_state)) != 0)
-		has_incoming_data = TRUE;
+		has_incoming_text_data = TRUE;
+	lua_getglobal(lua_state, "incomingBinaryData");
+	if(lua_isfunction(lua_state, lua_gettop(lua_state)) != 0)
+		has_incoming_binary_data = TRUE;
 	lua_getglobal(lua_state, "slowLink");
 	if(lua_isfunction(lua_state, lua_gettop(lua_state)) != 0)
 		has_slow_link = TRUE;
@@ -1790,6 +1832,7 @@ void janus_lua_incoming_rtp(janus_plugin_session *handle, int video, char *buf, 
 	janus_lua_rtp_relay_packet packet;
 	packet.data = rtp;
 	packet.length = len;
+	packet.is_rtp = TRUE;
 	packet.is_video = video;
 	/* Backup the actual timestamp and sequence number set by the publisher, in case switching is involved */
 	packet.timestamp = ntohl(packet.data->timestamp);
@@ -1864,7 +1907,7 @@ void janus_lua_incoming_rtcp(janus_plugin_session *handle, int video, char *buf,
 	}
 }
 
-void janus_lua_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len) {
+void janus_lua_incoming_data(janus_plugin_session *handle, char *label, gboolean textdata, char *buf, int len) {
 	if(handle == NULL || handle->stopped || g_atomic_int_get(&lua_stopping) || !g_atomic_int_get(&lua_initialized))
 		return;
 	janus_lua_session *session = (janus_lua_session *)handle->plugin_handle;
@@ -1877,12 +1920,13 @@ void janus_lua_incoming_data(janus_plugin_session *handle, char *label, char *bu
 	/* Are we recording? */
 	janus_recorder_save_frame(session->drc, buf, len);
 	/* Check if the Lua script wants to handle/manipulate data channel packets itself */
-	if(has_incoming_data) {
+	if((textdata && has_incoming_text_data) || (!textdata && has_incoming_binary_data)) {
 		/* Yep, pass the data to the Lua script and return */
 		janus_mutex_lock(&lua_mutex);
 		lua_State *t = lua_newthread(lua_state);
-		lua_getglobal(t, "incomingData");
+		lua_getglobal(t, textdata ? "incomingTextData" : "incomingBinaryData");
 		lua_pushnumber(t, session->id);
+		/* We use a string for both text and binary data */
 		lua_pushlstring(t, buf, len);
 		lua_pushnumber(t, len);
 		lua_call(t, 3, 0);
@@ -1893,20 +1937,17 @@ void janus_lua_incoming_data(janus_plugin_session *handle, char *label, char *bu
 	/* Is this session allowed to send data? */
 	if(!session->send_data)
 		return;
-	/* Get a string out of the data */
-	char *text = g_malloc0(len+1);
-	if(text == NULL) {
-		JANUS_LOG(LOG_FATAL, "Memory error!\n");
-		return;
-	}
-	memcpy(text, buf, len);
-	*(text+len) = '\0';
-	JANUS_LOG(LOG_VERB, "Got a DataChannel message (%zu bytes) to forward: %s\n", strlen(text), text);
+	JANUS_LOG(LOG_VERB, "Got a %s DataChannel message (%d bytes) to forward\n",
+		textdata ? "text" : "binary", len);
 	/* Relay to all recipients */
+	janus_lua_rtp_relay_packet packet;
+	packet.data = (rtp_header *)buf;
+	packet.length = len;
+	packet.is_rtp = FALSE;
+	packet.textdata = textdata;
 	janus_mutex_lock_nodebug(&session->recipients_mutex);
-	g_slist_foreach(session->recipients, janus_lua_relay_data_packet, text);
+	g_slist_foreach(session->recipients, janus_lua_relay_data_packet, &packet);
 	janus_mutex_unlock_nodebug(&session->recipients_mutex);
-	g_free(text);
 }
 
 void janus_lua_slow_link(janus_plugin_session *handle, int uplink, int video) {
@@ -2026,15 +2067,19 @@ static void janus_lua_relay_rtp_packet(gpointer data, gpointer user_data) {
 }
 
 static void janus_lua_relay_data_packet(gpointer data, gpointer user_data) {
+	janus_lua_rtp_relay_packet *packet = (janus_lua_rtp_relay_packet *)user_data;
+	if(!packet || packet->is_rtp || !packet->data || packet->length < 1) {
+		JANUS_LOG(LOG_ERR, "Invalid packet...\n");
+		return;
+	}
 	janus_lua_session *session = (janus_lua_session *)data;
 	if(!session || !session->handle || !g_atomic_int_get(&session->started) || !session->accept_data) {
 		return;
 	}
-	char *text = (char *)user_data;
-	if(janus_core != NULL && text != NULL) {
-		JANUS_LOG(LOG_VERB, "Forwarding DataChannel message (%zu bytes) to session %"SCNu32": %s\n",
-			strlen(text), session->id, text);
-		janus_core->relay_data(session->handle, NULL, text, strlen(text));
+	if(janus_core != NULL) {
+		JANUS_LOG(LOG_VERB, "Forwarding %s DataChannel message (%d bytes) to session %"SCNu32"\n",
+			packet->textdata ? "text" : "binary", packet->length, session->id);
+		janus_core->relay_data(session->handle, NULL, packet->textdata, (char *)packet->data, packet->length);
 	}
 	return;
 }

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -107,6 +107,7 @@ collision = in case of collision (more than one SSRC hitting the same port), the
 	passed, which would then change the current SSRC (0=disabled)
 dataport = local port for receiving data messages to relay
 dataiface = network interface or IP address to bind to, if any (binds to all otherwise)
+datatype = text|binary (type of data this mountpoint will relay, default=text)
 databuffermsg = true|false (whether the plugin should store the latest
 	message and send it immediately for new viewers)
 threads = number of threads to assist with the relaying part, which can help
@@ -871,6 +872,7 @@ static struct janus_json_parameter rtp_video_parameters[] = {
 static struct janus_json_parameter rtp_data_parameters[] = {
 	{"dataport", JSON_INTEGER, JANUS_JSON_PARAM_REQUIRED | JANUS_JSON_PARAM_POSITIVE},
 	{"databuffermsg", JANUS_JSON_BOOL, 0},
+	{"datatype", JSON_STRING, 0},
 	{"dataiface", JSON_STRING, 0}
 };
 static struct janus_json_parameter destroy_parameters[] = {
@@ -978,6 +980,8 @@ typedef struct janus_streaming_rtp_relay_packet {
 	/* The following are only relevant for VP9 SVC*/
 	gboolean svc;
 	janus_vp9_svc_info svc_info;
+	/* The following is only relevant for datachannels */
+	gboolean textdata;
 } janus_streaming_rtp_relay_packet;
 static janus_streaming_rtp_relay_packet exit_packet;
 static void janus_streaming_rtp_relay_packet_free(janus_streaming_rtp_relay_packet *pkt) {
@@ -1041,6 +1045,7 @@ typedef struct janus_streaming_rtp_source {
 	janus_mutex rtsp_mutex;
 #endif
 	janus_streaming_rtp_keyframe keyframe;
+	gboolean textdata;
 	gboolean buffermsg;
 	int rtp_collision;
 	void *last_msg;
@@ -1123,7 +1128,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 		gboolean doaudio, char *amcast, const janus_network_address *aiface, uint16_t aport, uint16_t artcpport, uint8_t acodec, char *artpmap, char *afmtp, gboolean doaskew,
 		gboolean dovideo, char *vmcast, const janus_network_address *viface, uint16_t vport, uint16_t vrtcpport, uint8_t vcodec, char *vrtpmap, char *vfmtp, gboolean bufferkf,
 			gboolean simulcast, uint16_t vport2, uint16_t vport3, gboolean svc, gboolean dovskew, int rtp_collision,
-		gboolean dodata, const janus_network_address *diface, uint16_t dport, gboolean buffermsg);
+		gboolean dodata, const janus_network_address *diface, uint16_t dport, gboolean textdata, gboolean buffermsg);
 /* Helper to create a file/ondemand live source */
 janus_streaming_mountpoint *janus_streaming_create_file_source(
 		uint64_t id, char *name, char *desc, char *filename,
@@ -1471,6 +1476,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				janus_config_item *vport3 = janus_config_get(config, cat, janus_config_type_item, "videoport3");
 				janus_config_item *dport = janus_config_get(config, cat, janus_config_type_item, "dataport");
 				janus_config_item *dbm = janus_config_get(config, cat, janus_config_type_item, "databuffermsg");
+				janus_config_item *dt = janus_config_get(config, cat, janus_config_type_item, "datatype");
 				janus_config_item *rtpcollision = janus_config_get(config, cat, janus_config_type_item, "collision");
 				janus_config_item *threads = janus_config_get(config, cat, janus_config_type_item, "threads");
 				janus_config_item *ssuite = janus_config_get(config, cat, janus_config_type_item, "srtpsuite");
@@ -1490,6 +1496,18 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					bufferkf = FALSE;
 				}
 				gboolean buffermsg = data && dbm && dbm->value && janus_is_true(dbm->value);
+				gboolean textdata = TRUE;
+				if(data && dt && dt->value) {
+					if(!strcasecmp(dt->value, "text"))
+						textdata = TRUE;
+					else if(!strcasecmp(dt->value, "binary"))
+						textdata = FALSE;
+					else {
+						JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream '%s', invalid data type '%s'...\n", cat->name, dt->value);
+						cl = cl->next;
+						continue;
+					}
+				}
 				if(!doaudio && !dovideo && !dodata) {
 					JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream '%s', no audio, video or data have to be streamed...\n", cat->name);
 					cl = cl->next;
@@ -1656,7 +1674,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 						dodata,
 						dodata && diface && diface->value ? &data_iface : NULL,
 						(dport && dport->value) ? data_port : 0,
-						buffermsg)) == NULL) {
+						textdata, buffermsg)) == NULL) {
 					JANUS_LOG(LOG_ERR, "Error creating 'rtp' stream '%s'...\n", cat->name);
 					cl = cl->next;
 					continue;
@@ -2461,7 +2479,7 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 				dosvc = vsvc ? json_is_true(vsvc) : FALSE;
 			}
 			uint16_t dport = 0;
-			gboolean buffermsg = FALSE;
+			gboolean textdata = TRUE, buffermsg = FALSE;
 			if(dodata) {
 				JANUS_VALIDATE_JSON_OBJECT(root, rtp_data_parameters,
 					error_code, error_cause, TRUE,
@@ -2473,6 +2491,20 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 				dport = json_integer_value(dataport);
 				json_t *dbm = json_object_get(root, "databuffermsg");
 				buffermsg = dbm ? json_is_true(dbm) : FALSE;
+				json_t *dt = json_object_get(root, "datatype");
+				if(dt) {
+					const char *datatype = (const char *)json_string_value(dt);
+					if(!strcasecmp(datatype, "text"))
+						textdata = TRUE;
+					else if(!strcasecmp(datatype, "binary"))
+						textdata = FALSE;
+					else {
+						JANUS_LOG(LOG_ERR, "Invalid element (datatype can only be text or binary)\n");
+						error_code = JANUS_STREAMING_ERROR_INVALID_ELEMENT;
+						g_snprintf(error_cause, 512, "Invalid element (datatype can only be text or binary)");
+						goto prepare_response;
+					}
+				}
 				json_t *diface = json_object_get(root, "dataiface");
 				if(diface) {
 					const char *miface = (const char *)json_string_value(diface);
@@ -2530,7 +2562,7 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 					dovideo, vmcast, &video_iface, vport, vrtcpport, vcodec, vrtpmap, vfmtp, bufferkf,
 					simulcast, vport2, vport3, dosvc, dovskew,
 					rtpcollision ? json_integer_value(rtpcollision) : 0,
-					dodata, &data_iface, dport, buffermsg);
+					dodata, &data_iface, dport, textdata, buffermsg);
 			janus_mutex_lock(&mountpoints_mutex);
 			g_hash_table_remove(mountpoints_temp, &mpid);
 			janus_mutex_unlock(&mountpoints_mutex);
@@ -4918,7 +4950,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 		gboolean doaudio, char *amcast, const janus_network_address *aiface, uint16_t aport, uint16_t artcpport, uint8_t acodec, char *artpmap, char *afmtp, gboolean doaskew,
 		gboolean dovideo, char *vmcast, const janus_network_address *viface, uint16_t vport, uint16_t vrtcpport, uint8_t vcodec, char *vrtpmap, char *vfmtp, gboolean bufferkf,
 			gboolean simulcast, uint16_t vport2, uint16_t vport3, gboolean svc, gboolean dovskew, int rtp_collision,
-		gboolean dodata, const janus_network_address *diface, uint16_t dport, gboolean buffermsg) {
+		gboolean dodata, const janus_network_address *diface, uint16_t dport, gboolean textdata, gboolean buffermsg) {
 	char tempname[255];
 	if(name == NULL) {
 		JANUS_LOG(LOG_VERB, "Missing name, will generate a random one...\n");
@@ -5229,6 +5261,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 	live_rtp_source->keyframe.temp_ts = 0;
 	janus_mutex_init(&live_rtp_source->keyframe.mutex);
 	live_rtp_source->rtp_collision = rtp_collision;
+	live_rtp_source->textdata = textdata;
 	live_rtp_source->buffermsg = buffermsg;
 	live_rtp_source->last_msg = NULL;
 	janus_mutex_init(&live_rtp_source->buffermsg_mutex);
@@ -7035,25 +7068,25 @@ static void *janus_streaming_relay_thread(void *data) {
 					}
 					if(!mountpoint->enabled && !source->drc)
 						continue;
-					/* Get a string out of the data */
-					char *text = g_malloc(bytes+1);
-					memcpy(text, buffer, bytes);
-					*(text+bytes) = '\0';
+					/* Copy the data */
+					char *data = g_malloc(bytes);
+					memcpy(data, buffer, bytes);
 					/* Relay on all sessions */
-					packet.data = (janus_rtp_header *)text;
-					packet.length = bytes+1;
+					packet.data = (janus_rtp_header *)data;
+					packet.length = bytes;
 					packet.is_rtp = FALSE;
+					packet.textdata = source->textdata;
 					/* Is there a recorder? */
-					janus_recorder_save_frame(source->drc, text, strlen(text));
+					janus_recorder_save_frame(source->drc, data, bytes);
 					if(mountpoint->enabled) {
 						/* Are we keeping track of the last message being relayed? */
 						if(source->buffermsg) {
 							janus_mutex_lock(&source->buffermsg_mutex);
 							janus_streaming_rtp_relay_packet *pkt = g_malloc0(sizeof(janus_streaming_rtp_relay_packet));
-							pkt->data = g_malloc(bytes+1);
-							memcpy(pkt->data, text, bytes+1);
+							pkt->data = g_malloc(bytes);
+							memcpy(pkt->data, data, bytes);
 							packet.is_rtp = FALSE;
-							pkt->length = bytes+1;
+							pkt->length = bytes;
 							janus_mutex_unlock(&source->buffermsg_mutex);
 						}
 						/* Go! */
@@ -7063,8 +7096,8 @@ static void *janus_streaming_relay_thread(void *data) {
 							&packet);
 						janus_mutex_unlock(&mountpoint->mutex);
 					}
+					g_free(packet.data);
 					packet.data = NULL;
-					g_free(text);
 					continue;
 				} else if(audio_rtcp_fd != -1 && fds[i].fd == audio_rtcp_fd) {
 					addrlen = sizeof(remote);
@@ -7419,9 +7452,8 @@ static void janus_streaming_relay_rtp_packet(gpointer data, gpointer user_data) 
 		/* We're broadcasting a data channel message */
 		if(!session->data)
 			return;
-		char *text = (char *)packet->data;
-		if(gateway != NULL && text != NULL)
-			gateway->relay_data(session->handle, NULL, text, strlen(text));
+		if(gateway != NULL)
+			gateway->relay_data(session->handle, NULL, packet->textdata, (char *)packet->data, packet->length);
 	}
 
 	return;

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -290,7 +290,7 @@ struct janus_plugin_result *janus_videocall_handle_message(janus_plugin_session 
 void janus_videocall_setup_media(janus_plugin_session *handle);
 void janus_videocall_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_videocall_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_videocall_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
+void janus_videocall_incoming_data(janus_plugin_session *handle, char *label, gboolean textdata, char *buf, int len);
 void janus_videocall_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_videocall_hangup_media(janus_plugin_session *handle);
 void janus_videocall_destroy_session(janus_plugin_session *handle, int *error);
@@ -812,7 +812,7 @@ void janus_videocall_incoming_rtcp(janus_plugin_session *handle, int video, char
 	}
 }
 
-void janus_videocall_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len) {
+void janus_videocall_incoming_data(janus_plugin_session *handle, char *label, gboolean textdata, char *buf, int len) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
 	if(gateway) {
@@ -830,15 +830,12 @@ void janus_videocall_incoming_data(janus_plugin_session *handle, char *label, ch
 			return;
 		if(buf == NULL || len <= 0)
 			return;
-		char *text = g_malloc(len+1);
-		memcpy(text, buf, len);
-		*(text+len) = '\0';
-		JANUS_LOG(LOG_VERB, "Got a DataChannel message (%zu bytes) to forward: %s\n", strlen(text), text);
+		JANUS_LOG(LOG_VERB, "Got a %s DataChannel message (%d bytes) to forward\n",
+			textdata ? "text" : "binary", len);
 		/* Save the frame if we're recording */
 		janus_recorder_save_frame(session->drc, buf, len);
 		/* Forward the packet to the peer */
-		gateway->relay_data(peer->handle, label, text, strlen(text));
-		g_free(text);
+		gateway->relay_data(peer->handle, label, textdata, buf, len);
 	}
 }
 

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1090,7 +1090,7 @@ json_t *janus_videoroom_handle_admin_message(json_t *message);
 void janus_videoroom_setup_media(janus_plugin_session *handle);
 void janus_videoroom_incoming_rtp(janus_plugin_session *handle, int video, char *buf, int len);
 void janus_videoroom_incoming_rtcp(janus_plugin_session *handle, int video, char *buf, int len);
-void janus_videoroom_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len);
+void janus_videoroom_incoming_data(janus_plugin_session *handle, char *label, gboolean textdata, char *buf, int len);
 void janus_videoroom_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_videoroom_hangup_media(janus_plugin_session *handle);
 void janus_videoroom_destroy_session(janus_plugin_session *handle, int *error);
@@ -1534,6 +1534,7 @@ typedef struct janus_videoroom_subscriber {
 typedef struct janus_videoroom_rtp_relay_packet {
 	janus_rtp_header *data;
 	gint length;
+	gboolean is_rtp;	/* This may be a data packet and not RTP */
 	gboolean is_video;
 	uint32_t ssrc[3];
 	uint32_t timestamp;
@@ -1541,6 +1542,8 @@ typedef struct janus_videoroom_rtp_relay_packet {
 	/* The following are only relevant if we're doing VP9 SVC*/
 	gboolean svc;
 	janus_vp9_svc_info svc_info;
+	/* The following is only relevant for datachannels */
+	gboolean textdata;
 } janus_videoroom_rtp_relay_packet;
 
 
@@ -4503,6 +4506,7 @@ void janus_videoroom_incoming_rtp(janus_plugin_session *handle, int video, char 
 		janus_videoroom_rtp_relay_packet packet;
 		packet.data = rtp;
 		packet.length = len;
+		packet.is_rtp = TRUE;
 		packet.is_video = video;
 		packet.svc = FALSE;
 		if(video && videoroom->do_svc) {
@@ -4635,7 +4639,7 @@ void janus_videoroom_incoming_rtcp(janus_plugin_session *handle, int video, char
 	}
 }
 
-void janus_videoroom_incoming_data(janus_plugin_session *handle, char *label, char *buf, int len) {
+void janus_videoroom_incoming_data(janus_plugin_session *handle, char *label, gboolean textdata, char *buf, int len) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized) || !gateway)
 		return;
 	if(buf == NULL || len <= 0)
@@ -4669,18 +4673,19 @@ void janus_videoroom_incoming_data(janus_plugin_session *handle, char *label, ch
 		}
 	}
 	janus_mutex_unlock(&participant->rtp_forwarders_mutex);
-	/* Get a string out of the data */
-	char *text = g_malloc(len+1);
-	memcpy(text, buf, len);
-	*(text+len) = '\0';
-	JANUS_LOG(LOG_VERB, "Got a DataChannel message (%zu bytes) to forward: %s\n", strlen(text), text);
+	JANUS_LOG(LOG_VERB, "Got a %s DataChannel message (%d bytes) to forward\n",
+		textdata ? "text" : "binary", len);
 	/* Save the message if we're recording */
-	janus_recorder_save_frame(participant->drc, text, strlen(text));
+	janus_recorder_save_frame(participant->drc, buf, len);
 	/* Relay to all subscribers */
+	janus_videoroom_rtp_relay_packet packet;
+	packet.data = (struct rtp_header *)buf;
+	packet.length = len;
+	packet.is_rtp = FALSE;
+	packet.textdata = textdata;
 	janus_mutex_lock_nodebug(&participant->subscribers_mutex);
-	g_slist_foreach(participant->subscribers, janus_videoroom_relay_data_packet, text);
+	g_slist_foreach(participant->subscribers, janus_videoroom_relay_data_packet, &packet);
 	janus_mutex_unlock_nodebug(&participant->subscribers_mutex);
-	g_free(text);
 	janus_videoroom_publisher_dereference_nodebug(participant);
 }
 
@@ -6731,7 +6736,11 @@ static void janus_videoroom_relay_rtp_packet(gpointer data, gpointer user_data) 
 }
 
 static void janus_videoroom_relay_data_packet(gpointer data, gpointer user_data) {
-	char *text = (char *)user_data;
+	janus_videoroom_rtp_relay_packet *packet = (janus_videoroom_rtp_relay_packet *)user_data;
+	if(!packet || packet->is_rtp || !packet->data || packet->length < 1) {
+		JANUS_LOG(LOG_ERR, "Invalid packet...\n");
+		return;
+	}
 	janus_videoroom_subscriber *subscriber = (janus_videoroom_subscriber *)data;
 	if(!subscriber || !subscriber->session || !subscriber->data || subscriber->paused) {
 		return;
@@ -6743,9 +6752,10 @@ static void janus_videoroom_relay_data_packet(gpointer data, gpointer user_data)
 	if(!session->started) {
 		return;
 	}
-	if(gateway != NULL && text != NULL) {
-		JANUS_LOG(LOG_VERB, "Forwarding DataChannel message (%zu bytes) to viewer: %s\n", strlen(text), text);
-		gateway->relay_data(session->handle, NULL, text, strlen(text));
+	if(gateway != NULL) {
+		JANUS_LOG(LOG_VERB, "Forwarding %s DataChannel message (%d bytes) to viewer\n",
+			packet->textdata ? "text" : "binary", packet->length);
+		gateway->relay_data(session->handle, NULL, packet->textdata, (char *)packet->data, packet->length);
 	}
 	return;
 }

--- a/plugins/lua/echotest.lua
+++ b/plugins/lua/echotest.lua
@@ -169,11 +169,16 @@ function hangupMedia(id)
 	end
 end
 
-function incomingData(id, buf, len)
+function incomingTextData(id, buf, len)
 	-- Relaying RTP/RTCP in Lua makes no sense, but just for fun
-	-- we handle data channel messages ourselves to manipulate them
+	-- we handle text data channel messages ourselves to manipulate them
 	local edit = "[" .. name .. "] --> " .. buf
-	relayData(id, edit, string.len(edit));
+	relayTextData(id, edit, string.len(edit));
+end
+
+function incomingBinaryData(id, buf, len)
+	-- If the data we're getting is binary, send it back as it is
+	relayBinaryData(id, buf, len);
 end
 
 function resumeScheduler()

--- a/plugins/plugin.h
+++ b/plugins/plugin.h
@@ -170,7 +170,7 @@ janus_plugin *create(void) {
  * Janus instance or it will crash.
  *
  */
-#define JANUS_PLUGIN_API_VERSION	13
+#define JANUS_PLUGIN_API_VERSION	14
 
 /*! \brief Initialization of all plugin properties to NULL
  *
@@ -304,9 +304,10 @@ struct janus_plugin {
 	 * use them.
 	 * @param[in] handle The plugin/gateway session used for this peer
 	 * @param[in] label The label of the data channel to use
+	 * @param[in] textdata Whether the buffer is text (domstring) or binary data
 	 * @param[in] buf The message data (buffer)
 	 * @param[in] len The buffer lenght */
-	void (* const incoming_data)(janus_plugin_session *handle, char *label, char *buf, int len);
+	void (* const incoming_data)(janus_plugin_session *handle, char *label, gboolean textdata, char *buf, int len);
 	/*! \brief Method to be notified by the core when too many NACKs have
 	 * been received or sent by Janus, and so a slow or potentially
 	 * unreliable network is to be expected for this peer
@@ -368,9 +369,10 @@ struct janus_callbacks {
 	/*! \brief Callback to relay SCTP/DataChannel messages to a peer
 	 * @param[in] handle The plugin/gateway session that will be used for this peer
 	 * @param[in] label The label of the data channel to use
+	 * @param[in] textdata Whether the buffer is text (domstring) or binary data
 	 * @param[in] buf The message data (buffer)
 	 * @param[in] len The buffer lenght */
-	void (* const relay_data)(janus_plugin_session *handle, char *label, char *buf, int len);
+	void (* const relay_data)(janus_plugin_session *handle, char *label, gboolean textdata, char *buf, int len);
 
 	/*! \brief Callback to ask the core to close a WebRTC PeerConnection
 	 * \note A call to this method will result in the core invoking the hangup_media

--- a/sctp.h
+++ b/sctp.h
@@ -203,9 +203,10 @@ void janus_sctp_data_from_dtls(janus_sctp_association *sctp, char *buf, int len)
 /*! \brief Method to send data via SCTP to the peer
  * \param[in] sctp The SCTP association this data is from
  * @param[in] label The label of the data channel to use
+ * @param[in] textdata Whether the buffer is text (domstring) or binary data
  * \param[in] buf The data buffer
  * \param[in] len The buffer length */
-void janus_sctp_send_data(janus_sctp_association *sctp, char *label, char *buf, int len);
+void janus_sctp_send_data(janus_sctp_association *sctp, char *label, gboolean textdata, char *buf, int len);
 
 #endif
 


### PR DESCRIPTION
As the title says, this patch tries to add support for binary data to datachannels in Janus. As you probably know if you've been using datachannels in the past, so far we only supported text, so this should complement that part. Notice that this support is not extended to recordings, where we currently still only support postprocessing to `.srt` files, and so will only work as expected for text.

If you have your own plugin, notice that this introduces a change in both `incoming_data` and `relay_data`, both of which now include a new `textdata` boolean property to specify whether the data is text or binary. Check the diff on "plugin.h" for details: all stock plugins have been updated to take this into account, so you can check their diffs too for more info.

If you're just talking to Janus, instead, it should be pretty much transparent, since both sending and receiving data will depend on the type of data. Nothing changes in janus.js, for instance, where:

    echotest.data({data: "ciao"});

will send text data since the data is a string, while:

    echotest.data({data: new Uint8Array(16)});

will send binary data instead. Same thing for when you receive data: just look at the type of data you got in the `ondata` callback to understand what you just received.

I tested this briefly and it seems to be working as expected, but I'm not a great expert on using data from JavaScript, so not sure if there are shortcomings and pitfalls in our current bnary support. Feedback more than welcome!