### PR TITLE
added gtk-doc-tools package for ubuntu/debian deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ On Ubuntu or Debian, it would require something like this:
 	aptitude install libmicrohttpd-dev libjansson-dev \
 		libssl-dev libsrtp-dev libsofia-sip-ua-dev libglib2.0-dev \
 		libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev \
-		libconfig-dev pkg-config gengetopt libtool automake
+		libconfig-dev pkg-config gengetopt libtool automake gtk-doc-tools
 
 * *Note:* please notice that libopus may not be available out of the box on Ubuntu or Debian, unless you're using a recent version (e.g., Ubuntu 14.04 LTS). In that case, you'll have to [install it manually](http://www.opus-codec.org).
 


### PR DESCRIPTION
libnice required `gtk-doc-tools`

see: 

```
./autogen.sh: 26: ./autogen.sh: gtkdocize: not found
```