### PR TITLE
startup: only close the logger directory if it was opened

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -3965,8 +3965,8 @@ gint main(int argc, char *argv[])
 				g_hash_table_insert(loggers_so, (gpointer)janus_logger->get_package(), event);
 			}
 		}
+		closedir(dir);
 	}
-	closedir(dir);
 	if(disabled_loggers != NULL)
 		g_strfreev(disabled_loggers);
 	disabled_loggers = NULL;


### PR DESCRIPTION
Janus opens the `loggers` directory on startup to scan for logger plugins, but in the case that the `loggers` directory does not exist janus will still try to close the directory, leading to a segfault.
```
DIR * dir = opendir();
if (!dir){
   ...
} else {
   ...
}
closedir(dir);
```
This simply moves the closedir() call to the else branch where the dir is known to be open.