### PR TITLE
Fix out of bounds array access for last_spatial_layer

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -1169,7 +1169,7 @@ typedef struct janus_streaming_session {
 	/* The following are only relevant the mountpoint is VP9-SVC, and are not to be confused with VP8
 	 * simulcast, which has similar info (substream/templayer) but in a completely different context */
 	int spatial_layer, target_spatial_layer;
-	gint64 last_spatial_layer[2];
+	gint64 last_spatial_layer[3];
 	int temporal_layer, target_temporal_layer;
 	gboolean stopping;
 	volatile gint renegotiating;

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1525,7 +1525,7 @@ typedef struct janus_videoroom_subscriber {
 	/* The following are only relevant if we're doing VP9 SVC, and are not to be confused with plain
 	 * simulcast, which has similar info (substream/templayer) but in a completely different context */
 	int spatial_layer, target_spatial_layer;
-	gint64 last_spatial_layer[2];
+	gint64 last_spatial_layer[3];
 	int temporal_layer, target_temporal_layer;
 	volatile gint destroyed;
 	janus_refcount ref;


### PR DESCRIPTION
Caught by clang:
```
plugins/janus_streaming.c:3981:2: warning: array index 2 is past the end of the array (which contains 2 elements) [-Warray-bounds]
        session->last_spatial_layer[2] = 0;
```