### PR TITLE
Add new configuration property to add protected folders not to save to

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -138,7 +138,6 @@ general: {
 		"/sbin",
 		"/sys",
 		"/usr",
-		"/usr/sbin",
 		"/var",
 			# We add what is usually the folders Janus is installed too
 			# as well: we don't just put "/opt/janus" because that would

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -124,6 +124,8 @@ general: {
 		# you can configure an array of folders that Janus should prevent
 		# creating files in. By default no folder is protected, unless the
 		# 'protected_folder' property below is uncommented and configured.
+		# Notice that at the moment this only covers attempts to start
+		# an .mjr recording and pcap/text2pcap packet captures.
 	protected_folders = [
 		"/bin",
 		"/boot",
@@ -139,7 +141,7 @@ general: {
 		"/sys",
 		"/usr",
 		"/var",
-			# We add what is usually the folders Janus is installed too
+			# We add what are usually the folders Janus is installed to
 			# as well: we don't just put "/opt/janus" because that would
 			# include folders like "/opt/janus/share" that is where
 			# recordings might be saved to by some plugins

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -117,6 +117,41 @@ general: {
 		# e.g., to look at unencrypted live traffic with a browser. By
 		# default it is obviously disabled, as WebRTC mandates encryption.
 	#no_webrtc_encryption = true
+
+		# Janus provides ways via its API to specify custom paths to save
+		# files to (e.g., recordings, pcap captures and the like). In order
+		# to avoid people can mess with folders they're not supposed to,
+		# you can configure an array of folders that Janus should prevent
+		# creating files in. By default no folder is protected, unless the
+		# 'protected_folder' property below is uncommented and configured.
+	protected_folders = [
+		"/bin",
+		"/boot",
+		"/dev",
+		"/etc",
+		"/initrd",
+		"/lib",
+		"/lib32",
+		"/lib64",
+		"/proc",
+		"/root",
+		"/sbin",
+		"/sys",
+		"/usr",
+		"/usr/sbin",
+		"/var",
+			# We add what is usually the folders Janus is installed too
+			# as well: we don't just put "/opt/janus" because that would
+			# include folders like "/opt/janus/share" that is where
+			# recordings might be saved to by some plugins
+		"/opt/janus/bin",
+		"/opt/janus/etc",
+		"/opt/janus/include",
+		"/opt/janus/lib",
+		"/opt/janus/lib32",
+		"/opt/janus/lib64",
+		"/opt/janus/sbin",
+	]
 }
 
 # Certificate and key to use for DTLS (and passphrase if needed). If missing,

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -149,7 +149,7 @@ general: {
 		"/opt/janus/lib",
 		"/opt/janus/lib32",
 		"/opt/janus/lib64",
-		"/opt/janus/sbin",
+		"/opt/janus/sbin"
 	]
 }
 

--- a/janus-cfgconv.c
+++ b/janus-cfgconv.c
@@ -34,6 +34,7 @@
 int janus_log_level = 4;
 gboolean janus_log_timestamps = FALSE;
 gboolean janus_log_colors = TRUE;
+int lock_debug = 0;
 
 /* Main Code */
 int main(int argc, char *argv[])

--- a/janus.c
+++ b/janus.c
@@ -3747,6 +3747,18 @@ gint main(int argc, char *argv[])
 	janus_config_category *config_events = janus_config_get_create(config, NULL, janus_config_type_category, "events");
 	janus_config_category *config_loggers = janus_config_get_create(config, NULL, janus_config_type_category, "loggers");
 
+	/* Check if there are folders to protect */
+	janus_config_array *pfs = janus_config_get(config, config_general, janus_config_type_array, "protected_folders");
+	if(pfs && pfs->list) {
+		GList *item = pfs->list;
+		while(item) {
+			janus_config_item *pf = (janus_config_item *)item->data;
+			if(pf && pf->type == janus_config_type_item && pf->name == NULL && pf->value != NULL)
+				janus_protected_folder_add(pf->value);
+			item = item->next;
+		}
+	}
+
 	/* Check if we need to log to console and/or file */
 	gboolean use_stdout = TRUE;
 	if(args_info.disable_stdout_given) {
@@ -5111,6 +5123,8 @@ gint main(int argc, char *argv[])
 
 	if(janus_ice_get_static_event_loops() > 0)
 		janus_ice_stop_static_event_loops();
+
+	janus_protected_folders_clear();
 
 #ifdef REFCOUNT_DEBUG
 	/* Any reference counters that are still up while we're leaving? (debug-mode only) */

--- a/record.c
+++ b/record.c
@@ -70,7 +70,8 @@ static void janus_recorder_free(const janus_refcount *recorder_ref) {
 	recorder->dir = NULL;
 	g_free(recorder->filename);
 	recorder->filename = NULL;
-	fclose(recorder->file);
+	if(recorder->file != NULL)
+		fclose(recorder->file);
 	recorder->file = NULL;
 	g_free(recorder->codec);
 	recorder->codec = NULL;
@@ -99,6 +100,7 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	}
 	/* Create the recorder */
 	janus_recorder *rc = g_malloc0(sizeof(janus_recorder));
+	janus_refcount_init(&rc->ref, janus_recorder_free);
 	rc->dir = NULL;
 	rc->filename = NULL;
 	rc->file = NULL;
@@ -109,7 +111,7 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	char *copy_for_parent = NULL;
 	char *copy_for_base = NULL;
 	/* Check dir and filename values */
-	if (filename != NULL) {
+	if(filename != NULL) {
 		/* Helper copies to avoid overwriting */
 		copy_for_parent = g_strdup(filename);
 		copy_for_base = g_strdup(filename);
@@ -117,7 +119,7 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 		const char *filename_parent = dirname(copy_for_parent);
 		/* Get filename base file */
 		const char *filename_base = basename(copy_for_base);
-		if (!dir) {
+		if(!dir) {
 			/* If dir is NULL we have to create filename_parent and filename_base */
 			rec_dir = filename_parent;
 			rec_file = filename_base;
@@ -125,7 +127,7 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 			/* If dir is valid we have to create dir and filename*/
 			rec_dir = dir;
 			rec_file = filename;
-			if (strcasecmp(filename_parent, ".") || strcasecmp(filename_base, filename)) {
+			if(strcasecmp(filename_parent, ".") || strcasecmp(filename_base, filename)) {
 				JANUS_LOG(LOG_WARN, "Unsupported combination of dir and filename %s %s\n", dir, filename);
 			}
 		}
@@ -138,11 +140,17 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 			if(ENOENT == errno) {
 				/* Directory does not exist, try creating it */
 				if(janus_mkdir(rec_dir, 0755) < 0) {
-					JANUS_LOG(LOG_ERR, "mkdir error: %d\n", errno);
+					JANUS_LOG(LOG_ERR, "mkdir (%s) error: %d (%s)\n", rec_dir, errno, strerror(errno));
+					janus_recorder_destroy(rc);
+					g_free(copy_for_parent);
+					g_free(copy_for_base);
 					return NULL;
 				}
 			} else {
-				JANUS_LOG(LOG_ERR, "stat error: %d\n", errno);
+				JANUS_LOG(LOG_ERR, "stat (%s) error: %d (%s)\n", rec_dir, errno, strerror(errno));
+				janus_recorder_destroy(rc);
+				g_free(copy_for_parent);
+				g_free(copy_for_base);
 				return NULL;
 			}
 		} else {
@@ -152,6 +160,9 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 			} else {
 				/* File exists but it's not a directory? */
 				JANUS_LOG(LOG_ERR, "Not a directory? %s\n", rec_dir);
+				janus_recorder_destroy(rc);
+				g_free(copy_for_parent);
+				g_free(copy_for_base);
 				return NULL;
 			}
 		}
@@ -179,15 +190,34 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	}
 	/* Try opening the file now */
 	if(rec_dir == NULL) {
+		/* Make sure folder to save to is not protected */
+		if(janus_is_folder_protected(newname)) {
+			JANUS_LOG(LOG_ERR, "Target recording path '%s' is in protected folder...\n", newname);
+			janus_recorder_destroy(rc);
+			g_free(copy_for_parent);
+			g_free(copy_for_base);
+			return NULL;
+		}
 		rc->file = fopen(newname, "wb");
 	} else {
 		char path[1024];
 		memset(path, 0, 1024);
 		g_snprintf(path, 1024, "%s/%s", rec_dir, newname);
+		/* Make sure folder to save to is not protected */
+		if(janus_is_folder_protected(path)) {
+			JANUS_LOG(LOG_ERR, "Target recording path '%s' is in protected folder...\n", path);
+			janus_recorder_destroy(rc);
+			g_free(copy_for_parent);
+			g_free(copy_for_base);
+			return NULL;
+		}
 		rc->file = fopen(path, "wb");
 	}
 	if(rc->file == NULL) {
 		JANUS_LOG(LOG_ERR, "fopen error: %d\n", errno);
+		janus_recorder_destroy(rc);
+		g_free(copy_for_parent);
+		g_free(copy_for_base);
 		return NULL;
 	}
 	if(rec_dir)
@@ -199,10 +229,9 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	if(res != strlen(header)) {
 		JANUS_LOG(LOG_ERR, "Couldn't write .mjr header (%zu != %zu, %s)\n",
 			res, strlen(header), strerror(errno));
-		g_free(rc->dir);
-		g_free(rc->filename);
-		fclose(rc->file);
-		g_free(rc);
+		janus_recorder_destroy(rc);
+		g_free(copy_for_parent);
+		g_free(copy_for_base);
 		return NULL;
 	}
 	g_atomic_int_set(&rc->writable, 1);
@@ -211,7 +240,6 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
 	janus_mutex_init(&rc->mutex);
 	/* Done */
 	g_atomic_int_set(&rc->destroyed, 0);
-	janus_refcount_init(&rc->ref, janus_recorder_free);
 	g_free(copy_for_parent);
 	g_free(copy_for_base);
 	return rc;

--- a/utils.h
+++ b/utils.h
@@ -154,6 +154,19 @@ int janus_pidfile_create(const char *file);
  * @returns 0 if successful, a negative integer otherwise */
 int janus_pidfile_remove(void);
 
+/*! \brief Add a folder to the protected list (meaning we won't create
+ * files there, like recordings or pcap dumps)
+ * @param folder Folder to protect */
+void janus_protected_folder_add(const char *folder);
+
+/*! \brief Check if the path points to a protected folder
+ * @param path Path we need to check
+ * @returns TRUE if the folder is protected, and FALSE otherwise */
+gboolean janus_is_folder_protected(const char *path);
+
+/*! \brief Cleanup the list of protected folder */
+void janus_protected_folders_clear(void);
+
 /*! \brief Creates a string describing the JSON type and constraint
  * @param jtype The JSON type, e.g., JSON_STRING
  * @param flags Indicates constraints for the described type


### PR DESCRIPTION
This PR tries to address a feature we've been missing so far, that is the configuration of a list of folders we shouldn't write to, at least when it comes to files that may be written as a consequence of an API call. To make a simple example, you might ask for a .mjr recording or a .pcap capture, and saved to, e.g., `/usr/bin/`, at the risk of causing problems to the instance. This patch adds a new property you can add to `janus.jcfg`, an array called `protected_folders`, which contains the base folders you don't want Janus to write to, e.g.:

	protected_folders = [
		"/bin",
		"/boot",
		"/dev",
		"/etc",
		"/initrd",
		"/lib",
		"/lib32",
		"/lib64",
		"/proc",
		"/root",
		"/sbin",
		"/sys",
		"/usr",
		"/var",
		"/opt/janus/bin",
		"/opt/janus/etc",
		"/opt/janus/include",
		"/opt/janus/lib",
		"/opt/janus/lib32",
		"/opt/janus/lib64",
		"/opt/janus/sbin",
	]

With such a list in effect, trying to save an .mjr file in `/usr/bin` would fail since the `/usr` exception would be triggered. At the moment, this is only enforced on attempts to start a new recorder and new pcap/text2pcap captures, that is what you can usually ask for via API: as such, it does NOT include, for instance, configuration files, or files that plugins open themselves using folders specified in their configuration files (although plugins may of course be modified to use that check too). This is because configuration files are supposed to be only accessible to who manages the Janus instance, and so if you write a wrong folder there, you're basically shooting your own foot, while API calls are outside of your control.

By default, no folder is protected, Janus only relies on what is written in `janus.jcfg`: since by default, even after updates, the existing `janus.jcfg` is not touched, existing deployments would need an update to their configuration file to start taking advantage of this. New instances instead should be able to use it right away, as the value of `protected_folders` is uncommented in the sample configuration file. Not sure whether we should have a hardcoded list to fallback to when such a value is missing in the code itself: on one side it would start protecting deployments, but on the other end it might break existing applications that for one reason or another are using those folders.

The underlying implementation uses [realpath](http://man7.org/linux/man-pages/man3/realpath.3.html) under the curtains, meaning it's supposed to be smart enough to take into account relative paths and symbolic links. That said, it might not be perfect, so any improvement here would be welcome, as well as generic feedback on whether you think this is useful/effective or not as it is.