### PR TITLE
Fixed bug about parsing RTSP response

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -5713,11 +5713,6 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 			header = strstr(curldata->buffer, "transport:");
 		if(header != NULL) {
 			char *end = strchr(header, '\r');
-			if(end != NULL)
-				*end = '\0';
-			end = strchr(header, '\n');
-			if(end != NULL)
-				*end = '\0';
 			/* Iterate on all params */
 			char *p = header, param[100], *pi = NULL;
 			int read = 0;
@@ -5753,7 +5748,7 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 				}
 				/* Move to the next param */
 				p += read;
-				if(*p != ';')
+				if(p >= end)
 					break;
 				while(*p == ';')
 					p++;
@@ -5765,11 +5760,6 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 			header = strstr(curldata->buffer, "session:");
 		if(header != NULL) {
 			char *end = strchr(header, '\r');
-			if(end != NULL)
-				*end = '\0';
-			end = strchr(header, '\n');
-			if(end != NULL)
-				*end = '\0';
 			/* Iterate on all params */
 			char *p = header, param[100], *pi = NULL;
 			int read = 0;
@@ -5793,7 +5783,7 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 				}
 				/* Move to the next param */
 				p += read;
-				if(*p != ';')
+				if(p >= end)
 					break;
 				while(*p == ';')
 					p++;


### PR DESCRIPTION
'Session:' point was newer reached after 'Transport:' processing because of changed \n to 0 character in 'Transport:' line