### PR TITLE
Fix g_async_queue usage

### DIFF
--- a/events.c
+++ b/events.c
@@ -269,8 +269,6 @@ void *janus_events_thread(void *data) {
 	while(eventsenabled) {
 		/* Any event in queue? */
 		event = g_async_queue_pop(events);
-		if(event == NULL)
-			continue;
 		if(event == &exit_event)
 			break;
 

--- a/events/janus_mqttevh.c
+++ b/events/janus_mqttevh.c
@@ -964,10 +964,6 @@ static void *janus_mqttevh_handler(void *data) {
 	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
 		/* Get event from queue */
 		event = g_async_queue_pop(events);
-		if(event == NULL) {
-			/* There was nothing in the queue */
-			continue;
-		}
 		if(event == &exit_event) {
 			break;
 		}

--- a/events/janus_nanomsgevh.c
+++ b/events/janus_nanomsgevh.c
@@ -397,8 +397,6 @@ static void *janus_nanomsgevh_handler(void *data) {
 	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
 
 		event = g_async_queue_pop(events);
-		if(event == NULL)
-			continue;
 		if(event == &exit_event)
 			break;
 		count = 0;

--- a/events/janus_rabbitmqevh.c
+++ b/events/janus_rabbitmqevh.c
@@ -523,8 +523,6 @@ static void *janus_rabbitmqevh_handler(void *data) {
 	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
 
 		event = g_async_queue_pop(events);
-		if(event == NULL)
-			continue;
 		if(event == &exit_event)
 			break;
 		count = 0;

--- a/events/janus_sampleevh.c
+++ b/events/janus_sampleevh.c
@@ -453,8 +453,6 @@ static void *janus_sampleevh_handler(void *data) {
 	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
 		if(!retransmit) {
 			event = g_async_queue_pop(events);
-			if(event == NULL)
-				continue;
 			if(event == &exit_event)
 				break;
 			count = 0;

--- a/events/janus_wsevh.c
+++ b/events/janus_wsevh.c
@@ -535,8 +535,6 @@ static void *janus_wsevh_handler(void *data) {
 	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
 
 		event = g_async_queue_pop(events);
-		if(event == NULL)
-			continue;
 		if(event == &exit_event)
 			break;
 		count = 0;

--- a/loggers/janus_jsonlog.c
+++ b/loggers/janus_jsonlog.c
@@ -324,8 +324,6 @@ static void *janus_jsonlog_thread(void *data) {
 	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
 		/* Get a log line from the queue */
 		jline = g_async_queue_pop(loglines);
-		if(jline == NULL)
-			continue;
 		if(jline == &exit_line)
 			break;
 

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -981,8 +981,7 @@ static void janus_audiobridge_participant_free(const janus_refcount *participant
 	if(participant->outbuf != NULL) {
 		while(g_async_queue_length(participant->outbuf) > 0) {
 			janus_audiobridge_rtp_relay_packet *pkt = g_async_queue_pop(participant->outbuf);
-			if(pkt)
-				g_free(pkt->data);
+			g_free(pkt->data);
 			g_free(pkt);
 		}
 		g_async_queue_unref(participant->outbuf);

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -7572,8 +7572,6 @@ static void *janus_streaming_helper_thread(void *data) {
 	janus_streaming_rtp_relay_packet *pkt = NULL;
 	while(!g_atomic_int_get(&stopping) && !g_atomic_int_get(&mp->destroyed)) {
 		pkt = g_async_queue_pop(helper->queued_packets);
-		if(pkt == NULL)
-			continue;
 		if(pkt == &exit_packet)
 			break;
 		janus_mutex_lock(&helper->mutex);

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -5364,6 +5364,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 					error->code, error->message ? error->message : "??");
 				janus_refcount_decrease(&live_rtp->ref);	/* This is for the helper thread */
 				janus_streaming_mountpoint_destroy(live_rtp);
+				g_free(helper);
 				return NULL;
 			}
 			live_rtp->threads = g_list_append(live_rtp->threads, helper);

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -976,8 +976,6 @@ static void *janus_videocall_handler(void *data) {
 	json_t *root = NULL;
 	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
 		msg = g_async_queue_pop(messages);
-		if(msg == NULL)
-			continue;
 		if(msg == &exit_message)
 			break;
 		if(msg->handle == NULL) {

--- a/transports/janus_rabbitmq.c
+++ b/transports/janus_rabbitmq.c
@@ -748,8 +748,6 @@ void *janus_rmq_out_thread(void *data) {
 	while(!rmq_client->destroy && !g_atomic_int_get(&stopping)) {
 		/* We send messages from here as well, not only notifications */
 		janus_rabbitmq_response *response = g_async_queue_pop(rmq_client->messages);
-		if(response == NULL)
-			continue;
 		if(response == &exit_message)
 			break;
 		if(!rmq_client->destroy && !g_atomic_int_get(&stopping) && response->payload) {


### PR DESCRIPTION
This PR is a continuation of https://github.com/meetecho/janus-gateway/pull/1121 with the addition that it checks that every queue was allocated beforehand. The deleted `if (popped) continue` are therefore guaranteed to be dead code.

The main rationale for deleting the `if (popped) continue` blocks is that these obscure the fact that calls to `g_async_queue_pop` are in fact blocking.