### PR TITLE
Remove odd respond to automatically responded OPTIONS request

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4762,8 +4762,8 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 		}
 		case nua_i_options:
 			JANUS_LOG(LOG_VERB, "[%s][%s]: %d %s\n", session->account.username, nua_event_name(event), status, phrase ? phrase : "??");
-			/* FIXME Should we handle this message? for now we reply with a 405 Method Not Implemented */
-			nua_respond(nh, 405, sip_status_phrase(405), TAG_END());
+			/* Stack responds automatically to OPTIONS request unless OPTIONS is 
+			   included in the set of application methods, set by NUTAG_APPL_METHOD(). */
 			break;
 	/* Responses */
 		case nua_r_get_params:

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4763,7 +4763,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 		case nua_i_options:
 			JANUS_LOG(LOG_VERB, "[%s][%s]: %d %s\n", session->account.username, nua_event_name(event), status, phrase ? phrase : "??");
 			/* Stack responds automatically to OPTIONS request unless OPTIONS is 
-			   included in the set of application methods, set by NUTAG_APPL_METHOD(). */
+			 * included in the set of application methods, set by NUTAG_APPL_METHOD(). */
 			break;
 	/* Responses */
 		case nua_r_get_params:


### PR DESCRIPTION
I got a lot of next messages in logs:
```
[Thu Jan 23 16:11:39 2020] [1208963210][nua_i_options]: 200 OK
[Thu Jan 23 16:11:39 2020] [WARN] [1208963210][nua_i_error]: 500 Responding to a Non-Existing Request
[Thu Jan 23 16:11:44 2020] [1208963210][nua_i_options]: 200 OK
[Thu Jan 23 16:11:44 2020] [WARN] [1208963210][nua_i_error]: 500 Responding to a Non-Existing Request
[Thu Jan 23 16:11:49 2020] [1208963210][nua_i_options]: 200 OK
[Thu Jan 23 16:11:49 2020] [WARN] [1208963210][nua_i_error]: 500 Responding to a Non-Existing Request
```

After some investigation, I can say that the reason for this WARNs is an attempt to respond to the automatically responded OPTIONS request ([nua_i_options](http://sofia-sip.sourceforge.net/refdocs/nua/nua_8h.html#abca36033336ce16e538a279413d2ca51a9333c2fe86eae2a33d472e0e84445303)).

So the eases way to prevent this WARNs is to remove this attempt to respond.
But if the plugin needs it then it must declare that OPTIONS request handled by application with [NUTAG_APPL_METHOD](http://sofia-sip.sourceforge.net/refdocs/nua/nua__tag_8h.html#aa556061c2b7306080669012a49e1aca0).