### PR TITLE
Janus Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,13 @@ env:
   global:
     - JANUS_COMMON_OPTS="--prefix=/opt/janus --disable-docs --enable-post-processing --enable-plugin-lua --enable-plugin-duktape --enable-json-logger"
   jobs:
-    - JANUS_CONFIG_OPTS="" LIBCURL=YES
-    - JANUS_CONFIG_OPTS="--disable-data-channels" LIBCURL=YES
-    - JANUS_CONFIG_OPTS="--disable-turn-rest-api --disable-sample-event-handler" LIBCURL=NO
+    - JANUS_CONFIG_OPTS="" LIBCURL=YES DATACHANNELS=YES
+    - JANUS_CONFIG_OPTS="--disable-data-channels" LIBCURL=YES DATACHANNELS=NO
+    - JANUS_CONFIG_OPTS="--disable-turn-rest-api --disable-sample-event-handler" LIBCURL=NO DATACHANNELS=YES
 
 git:
   quiet: true
+  depth: 1
 
 addons:
   apt:
@@ -53,12 +54,12 @@ before_script:
   - pushd libnice && ./autogen.sh && ./configure --prefix=/usr --disable-gtk-doc --disable-gtk-doc-html --disable-gupnp && make -j$(nproc) && sudo make install && popd
   - git clone -b 2_2_x_throttle https://github.com/cisco/libsrtp.git libsrtp
   - pushd libsrtp && ./configure --prefix=/usr --enable-openssl && make -j$(nproc) shared_library && sudo make install && popd
-  - git clone -b master https://github.com/sctplab/usrsctp usrsctp
-  - pushd usrsctp && ./bootstrap && ./configure --prefix=/usr --disable-static --disable-debug --disable-programs && make -j$(nproc) && sudo make install && popd
+  - if [ $DATACHANNELS = YES ]; then git clone -b master https://github.com/sctplab/usrsctp usrsctp; fi
+  - if [ $DATACHANNELS = YES ]; pushd usrsctp && ./bootstrap && ./configure --prefix=/usr --disable-static --disable-debug --disable-programs && make -j$(nproc) && sudo make install && popd; fi
   - git clone -b v3.2-stable https://github.com/warmcat/libwebsockets.git libwebsockets
   - pushd libwebsockets && mkdir -p build && pushd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DLWS_WITH_STATIC=OFF -DLWS_WITHOUT_CLIENT=ON -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON -DLWS_WITH_HTTP2=OFF .. && make -j$(nproc) && sudo make install && popd && popd
   - git clone -b master https://github.com/alanxz/rabbitmq-c rabbitmq-c
-  - pushd rabbitmq-c && git submodule update --init && mkdir build && pushd build && cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_TOOLS=OFF .. && sudo cmake --build . --target install -- -j$(nproc) && popd && popd
+  - pushd rabbitmq-c && mkdir build && pushd build && cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_TOOLS=OFF .. && sudo cmake --build . --target install -- -j$(nproc) && popd && popd
   - git clone -b master https://github.com/eclipse/paho.mqtt.c.git paho.mqtt.c
   - pushd paho.mqtt.c && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_SAMPLES=FALSE -DPAHO_BUILD_DOCUMENTATION=FALSE && make -j$(nproc) && sudo make install && popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,15 +52,15 @@ before_script:
   - if [ $LIBCURL = YES ]; then sudo apt-get -y install libcurl4-openssl-dev; fi
   - git clone -b master https://gitlab.freedesktop.org/libnice/libnice.git libnice
   - pushd libnice && ./autogen.sh && ./configure --prefix=/usr --disable-gtk-doc --disable-gtk-doc-html --disable-gupnp && make -j$(nproc) && sudo make install && popd
-  - git clone -b 2_2_x_throttle https://github.com/cisco/libsrtp.git libsrtp
+  - git clone -b v2.3.0 https://github.com/cisco/libsrtp.git libsrtp
   - pushd libsrtp && ./configure --prefix=/usr --enable-openssl && make -j$(nproc) shared_library && sudo make install && popd
   - if [ $DATACHANNELS = YES ]; then git clone -b master https://github.com/sctplab/usrsctp usrsctp; fi
   - if [ $DATACHANNELS = YES ]; then pushd usrsctp && ./bootstrap && ./configure --prefix=/usr --disable-static --disable-debug --disable-programs && make -j$(nproc) && sudo make install && popd; fi
-  - git clone -b v3.2-stable https://github.com/warmcat/libwebsockets.git libwebsockets
+  - git clone -b v3.2.2 https://github.com/warmcat/libwebsockets.git libwebsockets
   - pushd libwebsockets && mkdir -p build && pushd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DLWS_WITH_STATIC=OFF -DLWS_WITHOUT_CLIENT=ON -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON -DLWS_WITH_HTTP2=OFF .. && make -j$(nproc) && sudo make install && popd && popd
-  - git clone -b master https://github.com/alanxz/rabbitmq-c rabbitmq-c
+  - git clone -b v0.10.0 https://github.com/alanxz/rabbitmq-c rabbitmq-c
   - pushd rabbitmq-c && mkdir build && pushd build && cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_TOOLS=OFF .. && sudo cmake --build . --target install -- -j$(nproc) && popd && popd
-  - git clone -b master https://github.com/eclipse/paho.mqtt.c.git paho.mqtt.c
+  - git clone -b v1.3.1 https://github.com/eclipse/paho.mqtt.c.git paho.mqtt.c
   - pushd paho.mqtt.c && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_SAMPLES=FALSE -DPAHO_BUILD_DOCUMENTATION=FALSE && make -j$(nproc) && sudo make install && popd
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ dist: bionic
 
 env:
   global:
-    - JANUS_COMMON_OPTS="--prefix=/opt/janus --disable-docs --enable-post-processing --enable-plugin-lua --enable-plugin-duktape --enable-json-logger"
+    - JANUS_COMMON_OPTS="--disable-docs --enable-post-processing --enable-plugin-lua --enable-plugin-duktape --enable-json-logger"
   jobs:
     - JANUS_CONFIG_OPTS="" LIBCURL=YES DATACHANNELS=YES
     - JANUS_CONFIG_OPTS="--disable-data-channels" LIBCURL=YES DATACHANNELS=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,70 @@
+language: c
+compiler:
+  - gcc
+  - clang
+
+arch: amd64
+os: linux
+dist: bionic
+
+env:
+  global:
+    - JANUS_COMMON_OPTS="--prefix=/opt/janus --disable-docs --enable-post-processing --enable-plugin-lua --enable-plugin-duktape --enable-json-logger"
+  jobs:
+    - JANUS_CONFIG_OPTS="" LIBCURL=YES
+    - JANUS_CONFIG_OPTS="--disable-data-channels" LIBCURL=YES
+    - JANUS_CONFIG_OPTS="--disable-turn-rest-api --disable-sample-event-handler" LIBCURL=NO
+
+git:
+  quiet: true
+
+addons:
+  apt:
+    update: true
+    packages:
+      - autoconf
+      - automake
+      - cmake
+      - gengetopt
+      - gtk-doc-tools
+      - libavcodec-dev
+      - libavformat-dev
+      - libavutil-dev
+      - libcollection-dev
+      - libconfig-dev
+      - libevent-dev
+      - libglib2.0-dev
+      - libgnutls28-dev
+      - libini-config-dev
+      - liblua5.3-dev
+      - libjansson-dev
+      - libmicrohttpd-dev
+      - libmount-dev
+      - libnanomsg-dev
+      - libogg-dev
+      - libopus-dev
+      - libsofia-sip-ua-dev
+      - libssl-dev
+      - libtool
+      - libvorbis-dev
+      - openssl
+      - pkg-config
+
+before_script:
+  - if [ $LIBCURL = YES ]; then sudo apt-get -y install libcurl4-openssl-dev; fi
+  - git clone -b master https://gitlab.freedesktop.org/libnice/libnice.git libnice
+  - pushd libnice && ./autogen.sh && ./configure --prefix=/usr --disable-gtk-doc --disable-gtk-doc-html --disable-gupnp && make -j$(nproc) && sudo make install && popd
+  - git clone -b 2_2_x_throttle https://github.com/cisco/libsrtp.git libsrtp
+  - pushd libsrtp && ./configure --prefix=/usr --enable-openssl && make -j$(nproc) shared_library && sudo make install && popd
+  - git clone -b master https://github.com/sctplab/usrsctp usrsctp
+  - pushd usrsctp && ./bootstrap && ./configure --prefix=/usr --disable-static --disable-debug --disable-programs && make -j$(nproc) && sudo make install && popd
+  - git clone -b v3.2-stable https://github.com/warmcat/libwebsockets.git libwebsockets
+  - pushd libwebsockets && mkdir -p build && pushd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DLWS_WITH_STATIC=OFF -DLWS_WITHOUT_CLIENT=ON -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON -DLWS_WITH_HTTP2=OFF .. && make -j$(nproc) && sudo make install && popd && popd
+  - git clone -b master https://github.com/alanxz/rabbitmq-c rabbitmq-c
+  - pushd rabbitmq-c && git submodule update --init && mkdir build && pushd build && cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_TOOLS=OFF .. && sudo cmake --build . --target install -- -j$(nproc) && popd && popd
+  - git clone -b master https://github.com/eclipse/paho.mqtt.c.git paho.mqtt.c
+  - pushd paho.mqtt.c && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_SAMPLES=FALSE -DPAHO_BUILD_DOCUMENTATION=FALSE && make -j$(nproc) && sudo make install && popd
+
+script:
+  - ./autogen.sh && ./configure $JANUS_COMMON_OPTS $JANUS_CONFIG_OPTS && make -j$(nproc)
+  - make check-fuzzers

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ addons:
     update: true
     packages:
       - autoconf
-      - automake
       - cmake
       - gengetopt
       - gtk-doc-tools
@@ -45,10 +44,8 @@ addons:
       - libopus-dev
       - libsofia-sip-ua-dev
       - libssl-dev
-      - libtool
       - libvorbis-dev
       - openssl
-      - pkg-config
 
 before_script:
   - if [ $LIBCURL = YES ]; then sudo apt-get -y install libcurl4-openssl-dev; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
   - git clone -b 2_2_x_throttle https://github.com/cisco/libsrtp.git libsrtp
   - pushd libsrtp && ./configure --prefix=/usr --enable-openssl && make -j$(nproc) shared_library && sudo make install && popd
   - if [ $DATACHANNELS = YES ]; then git clone -b master https://github.com/sctplab/usrsctp usrsctp; fi
-  - if [ $DATACHANNELS = YES ]; pushd usrsctp && ./bootstrap && ./configure --prefix=/usr --disable-static --disable-debug --disable-programs && make -j$(nproc) && sudo make install && popd; fi
+  - if [ $DATACHANNELS = YES ]; then pushd usrsctp && ./bootstrap && ./configure --prefix=/usr --disable-static --disable-debug --disable-programs && make -j$(nproc) && sudo make install && popd; fi
   - git clone -b v3.2-stable https://github.com/warmcat/libwebsockets.git libwebsockets
   - pushd libwebsockets && mkdir -p build && pushd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DLWS_WITH_STATIC=OFF -DLWS_WITHOUT_CLIENT=ON -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON -DLWS_WITH_HTTP2=OFF .. && make -j$(nproc) && sudo make install && popd && popd
   - git clone -b master https://github.com/alanxz/rabbitmq-c rabbitmq-c

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-[![Build Status](https://travis-ci.org/meetecho/janus-gateway.svg?branch=master)](https://travis-ci.org/meetecho/janus-gateway)
-
 Janus WebRTC Server
 ===================
+[![Build Status](https://travis-ci.org/meetecho/janus-gateway.svg?branch=master)](https://travis-ci.org/meetecho/janus-gateway)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/13265/badge.svg)](https://scan.coverity.com/projects/meetecho-janus-gateway)
 
 Janus is an open source, general purpose, WebRTC server designed and developed by [Meetecho](http://www.meetecho.com). This version of the server is tailored for Linux systems, although it can be compiled for, and installed on, MacOS machines as well. Windows is not supported, but if that's a requirement, Janus is known to work in the "Windows Subsystem for Linux" on Windows 10.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/meetecho/janus-gateway.svg?branch=master)](https://travis-ci.org/meetecho/janus-gateway)
+
 Janus WebRTC Server
 ===================
 


### PR DESCRIPTION
This PR integrates Travis CI in Janus and basically resumes and extends the #955 by @fippo.

We're checking three different Janus builds:
- complete setup (w/ data channels, all plugins, all transports, all event handlers, all loggers etc.)
- complete setup w/o data channels
- complete setup w/o libcurl

All of these are compiled with Linux amd64 on both gcc and clang.

