### PR TITLE
Fix volume-related functions in janus.js

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2897,8 +2897,10 @@ function Janus(gatewayCallbacks) {
 		var config = pluginHandle.webrtcStuff;
 		if(!config.volume[stream])
 			config.volume[stream] = { value: 0 };
-		// Start getting the volume, if getStats is supported
-		if(config.pc.getStats && Janus.webRTCAdapter.browserDetails.browser === "chrome") {
+		// Start getting the volume, if audioLevel in getStats is supported (apparently
+		// they're only available in Chrome/Safari right now: https://webrtc-stats.callstats.io/)
+		if(config.pc.getStats && (Janus.webRTCAdapter.browserDetails.browser === "chrome" ||
+				Janus.webRTCAdapter.browserDetails.browser === "safari")) {
 			if(remote && !config.remoteStream) {
 				Janus.warn("Remote stream unavailable");
 				return 0;
@@ -2911,16 +2913,13 @@ function Janus(gatewayCallbacks) {
 				config.volume[stream].timer = setInterval(function() {
 					config.pc.getStats()
 						.then(function(stats) {
-							var results = stats.result();
-							for(var i=0; i<results.length; i++) {
-								var res = results[i];
-								if(res.type == 'ssrc') {
-									if(remote && res.stat('audioOutputLevel'))
-										config.volume[stream].value = parseInt(res.stat('audioOutputLevel'));
-									else if(!remote && res.stat('audioInputLevel'))
-										config.volume[stream].value = parseInt(res.stat('audioInputLevel'));
-								}
-							}
+							stats.forEach(function (res) {
+								if(!res || res.kind !== "audio")
+									return;
+								if((remote && !res.remoteSource) || (!remote && res.type !== "media-source"))
+									return;
+								config.volume[stream].value = (res.audioLevel ? res.audioLevel : 0);
+							});
 						});
 				}, 200);
 				return 0;	// We don't have a volume to return yet


### PR DESCRIPTION
Apparently the volume-related functions in `janus.js` (`getLocalVolume()`, `getRemoteVolume()` and its alias `getVolume()`) all stopped working recently, showing a ton of exceptions on the JavaScript console. The cause were on one side the fact we were still using a legacy syntax for `getStats` (while it was up-to-date for bitrates, instead, so an oversight I guess), and on the other end a change in the way `getStats` are presented by browsers. This patch tries to fix that.

Looking at the (Callstats.io implementation status comparison)[https://webrtc-stats.callstats.io/], this should be supported bu both Chrome and Safari: previously we had a fence to only use this feature on Chrome, so I decided to extend the check to allow Safari as well. That said, I could only verify this seems to be working as expected on my Chrome (and that it's indeed not there in Firefox), as I don't have access to a Mac OSX machine right now: if you have ways to double check this on more versions of Chrome (possibly other OSs too) and Safari, that would help merge this sooner.

Thanks, looking forward to your feedback.