### PR TITLE
AudioBridge: The target should also recevied latest status

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -2521,9 +2521,6 @@ static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_s
 			g_hash_table_iter_init(&iter, audiobridge->participants);
 			while (g_hash_table_iter_next(&iter, NULL, &value)) {
 				janus_audiobridge_participant *p = value;
-				if(p == participant) {
-					continue;	/* Skip the new participant itself */
-				}
 				JANUS_LOG(LOG_VERB, "Notifying participant %"SCNu64" (%s)\n", p->user_id, p->display ? p->display : "??");
 				int ret = gateway->push_event(p->session->handle, &janus_audiobridge_plugin, NULL, pub, NULL);
 				JANUS_LOG(LOG_VERB, "  >> %d (%s)\n", ret, janus_get_api_error(ret));
@@ -2534,7 +2531,7 @@ static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_s
 		/* Also notify event handlers */
 		if(notify_events && gateway->events_is_enabled()) {
 			json_t *info = json_object();
-			json_object_set_new(info, "event", json_string("muted"));
+			json_object_set_new(info, "event", json_string(request_text));
 			json_object_set_new(info, "room", json_integer(room_id));
 			json_object_set_new(info, "id", json_integer(user_id));
 			gateway->notify_event(&janus_audiobridge_plugin, session ? session->handle : NULL, info);


### PR DESCRIPTION
The target of participant should also acknowledge the latest mute/unmute status which has been made by administrator.