### PR TITLE
Configurable global prefix for log lines

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -18,6 +18,11 @@ general: {
 	#debug_timestamps = true				# Whether to show a timestamp for each log line
 	#debug_colors = false					# Whether colors should be disabled in the log
 	#debug_locks = true						# Whether to enable debugging of locks (very verbose!)
+	#log_prefix = "[janus] "				# In case you want log lines to be prefixed by some
+											# custom text, you can use the 'log_prefix' property.
+											# It supports terminal colors, meaning something like
+											# "[\x1b[32mjanus\x1b[0m] " would show a green "janus"
+											# string in square brackets (assuming debug_colors=true).
 
 		# This is what you configure if you want to launch Janus as a daemon
 	#daemonize = true						# Whether Janus should run as a daemon

--- a/debug.h
+++ b/debug.h
@@ -18,6 +18,7 @@
 extern int janus_log_level;
 extern gboolean janus_log_timestamps;
 extern gboolean janus_log_colors;
+extern char *janus_log_global_prefix;
 
 /** @name Janus log colors
  */
@@ -100,7 +101,8 @@ do { \
 			snprintf(janus_log_src, sizeof(janus_log_src), \
 			         "[%s:%s:%d] ", __FILE__, __FUNCTION__, __LINE__); \
 		} \
-		JANUS_PRINT("%s%s%s" format, \
+		JANUS_PRINT("%s%s%s%s" format, \
+			janus_log_global_prefix ? janus_log_global_prefix : "", \
 			janus_log_ts, \
 			janus_log_prefix[level | ((int)janus_log_colors << 3)], \
 			janus_log_src, \

--- a/fuzzers/rtcp_fuzzer.c
+++ b/fuzzers/rtcp_fuzzer.c
@@ -10,6 +10,7 @@
 int janus_log_level = LOG_NONE;
 gboolean janus_log_timestamps = FALSE;
 gboolean janus_log_colors = FALSE;
+char *janus_log_global_prefix = NULL;
 int lock_debug = 0;
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {

--- a/fuzzers/rtp_fuzzer.c
+++ b/fuzzers/rtp_fuzzer.c
@@ -10,6 +10,7 @@
 int janus_log_level = LOG_NONE;
 gboolean janus_log_timestamps = FALSE;
 gboolean janus_log_colors = FALSE;
+char *janus_log_global_prefix = NULL;
 int lock_debug = 0;
 
 /* This is to avoid linking with openSSL */

--- a/fuzzers/sdp_fuzzer.c
+++ b/fuzzers/sdp_fuzzer.c
@@ -10,6 +10,7 @@
 int janus_log_level = LOG_NONE;
 gboolean janus_log_timestamps = FALSE;
 gboolean janus_log_colors = FALSE;
+char *janus_log_global_prefix = NULL;
 int lock_debug = 0;
 int refcount_debug = 0;
 

--- a/janus-cfgconv.c
+++ b/janus-cfgconv.c
@@ -34,6 +34,7 @@
 int janus_log_level = 4;
 gboolean janus_log_timestamps = FALSE;
 gboolean janus_log_colors = TRUE;
+char *janus_log_global_prefix = NULL;
 int lock_debug = 0;
 
 /* Main Code */

--- a/janus.c
+++ b/janus.c
@@ -425,6 +425,7 @@ static json_t *janus_info(const char *transaction) {
 int janus_log_level = LOG_INFO;
 gboolean janus_log_timestamps = FALSE;
 gboolean janus_log_colors = FALSE;
+char *janus_log_global_prefix = NULL;
 int lock_debug = 0;
 #ifdef REFCOUNT_DEBUG
 int refcount_debug = 1;
@@ -3810,6 +3811,11 @@ gint main(int argc, char *argv[])
 	janus_config_category *config_events = janus_config_get_create(config, NULL, janus_config_type_category, "events");
 	janus_config_category *config_loggers = janus_config_get_create(config, NULL, janus_config_type_category, "loggers");
 
+	/* Any log prefix? */
+	janus_config_array *lp = janus_config_get(config, config_general, janus_config_type_item, "log_prefix");
+	if(lp && lp->value)
+		janus_log_global_prefix = g_strdup(lp->value);
+
 	/* Check if there are folders to protect */
 	janus_config_array *pfs = janus_config_get(config, config_general, janus_config_type_array, "protected_folders");
 	if(pfs && pfs->list) {
@@ -5203,6 +5209,7 @@ gint main(int argc, char *argv[])
 	}
 	janus_mutex_unlock(&counters_mutex);
 #endif
+	g_clear_pointer(&janus_log_global_prefix, g_free);
 
 	JANUS_PRINT("Bye!\n");
 

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -113,6 +113,7 @@ Usage: janus-pp-rec [OPTIONS] source.mjr [destination.[opus|wav|webm|mp4|srt]]
 int janus_log_level = 4;
 gboolean janus_log_timestamps = FALSE;
 gboolean janus_log_colors = TRUE;
+char *janus_log_global_prefix = NULL;
 int lock_debug = 0;
 
 gboolean janus_faststart = FALSE;

--- a/postprocessing/mjr2pcap.c
+++ b/postprocessing/mjr2pcap.c
@@ -49,6 +49,7 @@
 int janus_log_level = 4;
 gboolean janus_log_timestamps = FALSE;
 gboolean janus_log_colors = TRUE;
+char *janus_log_global_prefix = NULL;
 int lock_debug = 0;
 
 int working = 0;


### PR DESCRIPTION
A simple patch that adds a new configuration property, to specify a prefix that should appear in all log lines. For instance, setting

    log_prefix = "[janus] "

in `janus.jcfg` will result in something like this:

```
Janus commit: 77b710c8efd1a93ecff82ba3c444ffc4d39622ec
Compiled on:  Thu  6 Feb 18:05:19 CET 2020

[janus] Logger plugins folder: /home/lminiero/test/logs/lib/janus/loggers
[janus] Loading logger plugin 'libjanus_jsonlog.so'...
[janus] [WARN] JSON logger disabled
```

Terminal colors are supported, so something like this:

    log_prefix = "[\x1b[32mjanus\x1b[0m] "

will do the same thing, but with "janus" in green.

This is probably not very useful, and maybe redundant considering that this kind of flexibility can be better achieved with a custom logger, but it might be helpful in some cases anyway. Will merge soon, unless I'm told something's very wrong.