### PR TITLE
Travis libnice clang flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ addons:
 before_script:
   - if [ $LIBCURL = YES ]; then sudo apt-get -y install libcurl4-openssl-dev; fi
   - travis_retry git clone -b master https://gitlab.freedesktop.org/libnice/libnice.git libnice
-  - if [ $CC = clang ]; then LNICE_CFLAGS="-Wnocast-align"; fi; pushd libnice && ./autogen.sh && ./configure CFLAGS=$LNICE_CFLAGS --prefix=/usr --disable-gtk-doc --disable-gtk-doc-html --disable-gupnp && make -j$(nproc) && sudo make install && popd
+  - if [ $CC = clang ]; then LNICE_CFLAGS="-Wno-cast-align"; fi; pushd libnice && ./autogen.sh && ./configure CFLAGS=$LNICE_CFLAGS --prefix=/usr --disable-gtk-doc --disable-gtk-doc-html --disable-gupnp && make -j$(nproc) && sudo make install && popd
   - travis_retry git clone -b v2.3.0 https://github.com/cisco/libsrtp.git libsrtp
   - pushd libsrtp && ./configure --prefix=/usr --enable-openssl && make -j$(nproc) shared_library && sudo make install && popd
   - if [ $DATACHANNELS = YES ]; then git clone -b master https://github.com/sctplab/usrsctp usrsctp; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ addons:
 before_script:
   - if [ $LIBCURL = YES ]; then sudo apt-get -y install libcurl4-openssl-dev; fi
   - travis_retry git clone -b master https://gitlab.freedesktop.org/libnice/libnice.git libnice
-  - pushd libnice && ./autogen.sh && ./configure --prefix=/usr --disable-gtk-doc --disable-gtk-doc-html --disable-gupnp && make -j$(nproc) && sudo make install && popd
+  - if [ $CC = clang ]; then LNICE_CFLAGS="-Wnocast-align"; fi; pushd libnice && ./autogen.sh && ./configure CFLAGS=$LNICE_CFLAGS --prefix=/usr --disable-gtk-doc --disable-gtk-doc-html --disable-gupnp && make -j$(nproc) && sudo make install && popd
   - travis_retry git clone -b v2.3.0 https://github.com/cisco/libsrtp.git libsrtp
   - pushd libsrtp && ./configure --prefix=/usr --enable-openssl && make -j$(nproc) shared_library && sudo make install && popd
   - if [ $DATACHANNELS = YES ]; then git clone -b master https://github.com/sctplab/usrsctp usrsctp; fi


### PR DESCRIPTION
Add `-Wno-cast-align` when building `libnice` with clang on Travis.