### PR TITLE
Avoid RTP header memory misalignment in rtx packets

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -2355,10 +2355,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 						 * the whole payload back two bytes, we shift the header forward (less bytes to move) */
 						buflen -= 2;
 						plen -= 2;
-						size_t hsize = payload-buf;
-						memmove(buf+2, buf, hsize);
-						buf += 2;
-						payload +=2;
+						memmove(payload, payload+2, plen);
 						header = (janus_rtp_header *)buf;
 						if(stream->rid_ext_id > 1 && stream->ridrtx_ext_id > 1) {
 							/* Replace the 'repaired' extension ID as well with the 'regular' one */

--- a/ice.c
+++ b/ice.c
@@ -2351,8 +2351,8 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 					header->ssrc = htonl(packet_ssrc);
 					if(plen > 0) {
 						memcpy(&header->seq_number, payload, 2);
-						/* Finally, remove the original sequence number from the payload: rather than moving
-						 * the whole payload back two bytes, we shift the header forward (less bytes to move) */
+						/* Finally, remove the original sequence number from the payload: move the whole
+						 * payload back two bytes rather than shifting the header forward (avoid misaligned access) */
 						buflen -= 2;
 						plen -= 2;
 						memmove(payload, payload+2, plen);


### PR DESCRIPTION
When handling `rtx` packets Janus does [the following](https://github.com/meetecho/janus-gateway/blob/c7a35a9d86edc69b23506bc9f51389a00b45a5b5/ice.c#L2353):

```c
	memcpy(&header->seq_number, payload, 2);
	/* Finally, remove the original sequence number from the payload: rather than moving
 	* the whole payload back two bytes, we shift the header forward (less bytes to move) */
	buflen -= 2;
	plen -= 2;
	size_t hsize = payload-buf;
	memmove(buf+2, buf, hsize);
	buf += 2;
	payload +=2;
	header = (janus_rtp_header *)buf;
```
Since `rtx` packets contain the original sequence number in the first two bytes of the payload, Janus basically copies the original sequence number from the payload to the RTP header and then moves the whole header two bytes to the right.
The issue with this right shifting operation is that it is changing the memory alignment of the `buf` pointer **from (at least) 16** (because it comes from a libnice 64k static buffer, see _System V X86_64 ABI, Aggregate and Unions_) **to 2**.
So any following access to `header` like in `rtp.c`
```c
	janus_rtp_header *rtp = (janus_rtp_header *)buf;
	if (rtp->version != 2) {
		return -2;
	}
```
is leading to a misaligned memory access, as confirmed by the undefined behavior sanitizer:
```
rtp.c:331:19: runtime error: member access within misaligned address 0x7fd2b0696462 for type 'struct janus_rtp_header', which requires 4 byte alignment
0x7fd2b0696462: note: pointer points here
 00 00  90 e0 90 e0 4e d0 dc 32  76 27 92 df de 75 be de  00 02 d0 00 31 00 03 40  31 00 80 80 be f3
              ^ 
```
This should not be a big deal on modern x86 processors, but I don't think that deliberately changing a pointer alignment is the right thing to do here.
It's true that the current implementation just moves a couple dozen of bytes, but we are trading the performance gain (still to estimate) with a potential undefined behavior. In addition to this, any misaligned access also has a performance hit (again, still to estimate) on architectures that permit it.