### PR TITLE
Feature/allow ice tcp without ice lite

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -170,8 +170,8 @@ media: {
 # users) rather than the default half-trickle (Janus supports trickle
 # candidates from users, but sends its own within the SDP), and whether
 # it should work in ICE-Lite mode (by default it doesn't). Finally,
-# you can also enable ICE-TCP support (beware that it currently *only*
-# works if you enable ICE Lite as well), choose which interfaces should
+# you can also enable ICE-TCP support (beware that this may lead to problems
+# if you do not enable ICE Lite as well), choose which interfaces should
 # be used for gathering candidates, and enable or disable the
 # internal libnice debugging, if needed.
 nat: {

--- a/ice.c
+++ b/ice.c
@@ -806,8 +806,7 @@ void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean full_trickle, 
 		janus_ice_tcp_enabled = FALSE;
 #else
 		if(!janus_ice_lite_enabled) {
-			JANUS_LOG(LOG_WARN, "ICE-TCP only works in libnice if you enable ICE Lite too: disabling ICE-TCP support\n");
-			janus_ice_tcp_enabled = FALSE;
+			JANUS_LOG(LOG_WARN, "You may experience problems when having ICE-TCP enabled without having ICE Lite enabled too in libnice\n");
 		}
 #endif
 	}


### PR DESCRIPTION
We should allow to have ICE-TCP enabled without ICE Lite. Recent versions of libnice allow this combination and gather tcp passive candidates etc. in this setup. Let's keep a warning there if there are known problems in specific version. However, both settings (ICE-TCP and ICE Lite) are disabled by default - and it is still up to the configurator which combination should be used.