### PR TITLE
Fix deadlock during dynamic mountpoint creation

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2994,6 +2994,8 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 					goto prepare_response;
 				}
 			}
+			janus_mutex_unlock(&mountpoints_mutex);
+			
 			mp = janus_streaming_create_rtp_source(
 				mpid,
 				name ? (char *)json_string_value(name) : NULL,


### PR DESCRIPTION
Fixes #1955.
Before calling function _janus_streaming_create_rtp_source_ the _mountpoints_mutex_ has to been unlocked.