### PR TITLE
Detect H264 key frames with smaller SPS units

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -742,7 +742,7 @@ gboolean janus_vp9_is_keyframe(const char *buffer, int len) {
 }
 
 gboolean janus_h264_is_keyframe(const char *buffer, int len) {
-	if(!buffer || len < 16)
+	if(!buffer || len < 6)
 		return FALSE;
 	/* Parse H264 header now */
 	uint8_t fragment = *buffer & 0x1F;


### PR DESCRIPTION
Reduces the H264 keyframe length check from 16 to 6 bytes.
6 bytes seems to be the lower bound of any possibly valid SPS NAL unit,
based on Section 7.3 of the H264 specification.

For reference, we have been observing Chrome 80 producing SPS units
of 12 bytes or less.