### PR TITLE
Remove duplicated codecs when answering SIP call

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -5512,6 +5512,8 @@ void janus_sip_sdp_process(janus_sip_session *session, janus_sdp *sdp, gboolean 
 char *janus_sip_sdp_manipulate(janus_sip_session *session, janus_sdp *sdp, gboolean answer) {
 	if(!session || !session->stack || !sdp)
 		return NULL;
+	GHashTable *codecs = NULL;
+	GList *pts_to_remove = NULL;
 	/* Start replacing stuff */
 	JANUS_LOG(LOG_VERB, "Setting protocol to %s\n", session->media.require_srtp ? "RTP/SAVP" : "RTP/AVP");
 	if(sdp->c_addr) {
@@ -5561,7 +5563,44 @@ char *janus_sip_sdp_manipulate(janus_sip_session *session, janus_sdp *sdp, gbool
 				}
 			}
 		}
+		/* If this is an answer, get rid of multiple versions of the same
+		 * codec as well (e.g., video profiles), as that confuses the hell
+		 * out of SOATAG_RTP_SELECT(SOA_RTP_SELECT_COMMON) in nua_respond() */
+		if(answer) {
+			if(codecs == NULL)
+				codecs = g_hash_table_new_full(g_str_hash, g_str_equal, (GDestroyNotify)g_free, NULL);
+			/* Check all rtpmap attributes */
+			int pt = -1;
+			char codec[50];
+			GList *ma = m->attributes;
+			while(ma) {
+				janus_sdp_attribute *a = (janus_sdp_attribute *)ma->data;
+				if(a->name != NULL && a->value != NULL && !strcasecmp(a->name, "rtpmap")) {
+					if(sscanf(a->value, "%3d %s", &pt, codec) == 2) {
+						if(g_hash_table_lookup(codecs, codec) != NULL) {
+							/* We already have a version of this codec, remove the payload type */
+							pts_to_remove = g_list_append(pts_to_remove, GINT_TO_POINTER(pt));
+							JANUS_LOG(LOG_HUGE, "Removing %d (%s)\n", pt, codec);
+						} else {
+							/* Keep track of this codec */
+							g_hash_table_insert(codecs, g_strdup(codec), GINT_TO_POINTER(pt));
+						}
+					}
+				}
+				ma = ma->next;
+			}
+		}
 		temp = temp->next;
+	}
+	/* If we need to remove some payload types from the SDP, do it now */
+	if(pts_to_remove != NULL) {
+		GList *temp = pts_to_remove;
+		while(temp) {
+			int pt = GPOINTER_TO_INT(temp->data);
+			janus_sdp_remove_payload_type(sdp, pt);
+			temp = temp->next;
+		}
+		g_list_free(pts_to_remove);
 	}
 	/* Generate a SDP string out of our changes */
 	return janus_sdp_write(sdp);


### PR DESCRIPTION
When two WebRTC users are establishing a media session through the SIP plugin, and video is used, the SIP plugin messes up the SDP if multiple versions (e.g., video profiles) of the same codecs are used in the 200 OK. For instance:

```
m=video 25120 RTP/AVP 96 98 100 102 127 125 108
c=IN IP4 192.168.1.218
a=rtpmap:96 VP8/90000
a=rtpmap:98 VP9/90000
a=fmtp:98 profile-id=0
a=rtpmap:100 VP9/90000
a=fmtp:100 profile-id=2
[..]
```

becomes:

```
m=video 32206 RTP/AVP 96 98 98 102 102 102 102
c=IN IP4 192.168.1.218
a=rtpmap:96 VP8/90000
a=rtpmap:98 VP9/90000
a=fmtp:98 profile-id=0
a=rtpmap:98 VP9/90000
a=fmtp:98 profile-id=2
[..]
```

In this example, all instances of VP9 in the SDP are assigned the same payload type (98), and the same thing happens to H.264 (102), in both cases because they're the only codecs for which different profiles are negotiated with different payload types. Obviously, this results in the browser rejecting the SDP which breaks the session.

Sofia SIP is to blame here, in particular the way we create a response when an SDP is provided as `"answer"` is called:

	nua_respond(session->stack->s_nh_i,
		200, sip_status_phrase(200),
		SOATAG_USER_SDP_STR(sdp),
		SOATAG_RTP_SELECT(SOA_RTP_SELECT_COMMON),
		NUTAG_AUTOANSWER(0),
		TAG_IF(strlen(custom_headers) > 0, SIPTAG_HEADER_STR(custom_headers)),
		TAG_END());

`SOA_RTP_SELECT_COMMON` instructs the stack to only keep the codecs in common with the offer, but also is what messes up the answer. The alternative there would be to either use `SOA_RTP_SELECT_ALL`, which keeps all codecs there, or `SOA_RTP_SELECT_SINGLE`, which only keeps the "best" codec, but both causes other issues: specifically, `SOA_RTP_SELECT_ALL` has exactly the same issue as `SOA_RTP_SELECT_COMMON` (nothing changes), while `SOA_RTP_SELECT_SINGLE` drops `telephone-event` from the audio m-line, so no DTMF, and keeps the `rtcp-fb` attributes there after removing payload types (which breaks browsers).

As such, the solution this patch provides is to keep `SOA_RTP_SELECT_COMMON` in place (which we added some time ago to fix other issues), and remove codec duplicates when manipulating an SDP answer we got from the browser, before passing it to Sofia: this way, when we find, e.g., different profiles of the same codec, we just drop them. This shouldn't cause issues because we only drop duplicates *after* the first one, which means the one we keep is a preference for the answerer anyway.

Planning to merge soon, but feedback welcome in the meanwhile.