### PR TITLE
fix #1967: HTTP error not call callbacks.error when attaching plugin

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1262,7 +1262,11 @@ function Janus(gatewayCallbacks) {
 				callbacks.success(pluginHandle);
 			},
 			error: function(textStatus, errorThrown) {
-				Janus.error(textStatus + ":", errorThrown);	// FIXME
+				Janus.error(textStatus + ":", errorThrown);	// FIXME				
+				if(errorThrown === "")
+					callbacks.error(textStatus + ": Is the server down?");
+				else
+					callbacks.error(textStatus + ": " + errorThrown);
 			}
 		});
 	}


### PR DESCRIPTION
HTTP error not call error callback when attaching plugin