### PR TITLE
 Add Python aiortc-based functional testing.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,51 @@
+# Janus testing
+
+The files in this sub-folder are intended to be used for testing Janus.
+
+## aiortc functional testing
+
+We implemented some RTC Python clients based on [aiortc](https://github.com/aiortc/aiortc).
+In order to use them you'll need Python >= 3.4 (Python 3.6 is recommended).
+
+Also you'll need all of the [aiortc requirements](https://github.com/aiortc/aiortc#requirements) and the following python libraries:
+
+```bash
+pip3 install setuptools websockets aiortc
+```
+
+### echo.py
+
+This script does a quick echotest with a specified Janus instance.
+The source code has been largely inspired by the examples on the aiortc repository.
+The program basically initiates a Janus session through a WebSocket connection, then creates a new echotest handle and starts an audio/video negotiation according to the echotest API.
+
+Once everything has been succesfully set up, the client waits for 5 seconds and then checks the following assertions:
+* WebSocket is connected
+* ICE Connection State is completed
+* DTLS state is connected
+* outbound RTP packets are greater or equal than inbound RTP packets
+
+If any of these assertion fails, the client returns a non-zero value.
+No assertion has been made on the RTP packets to check if they contains valid media or not, I guess this is something that might be added in future.
+
+The script is invoked like this:
+
+```bash
+python3 echo.py ws://localhost:8188/ --play-from media_file --verbose
+```
+
+The websocket endpoint default is `ws://localhost:8188/`.
+The media_file is optional and if omitted dummy audio/video tracks will be generated.
+
+### The test_aiortc.sh helper script
+
+We have added a `test_aiortc.sh` helper script in order to easily launch a Janus aiortc-based test.
+The scripts must be invoked like this:
+
+```bash
+./test_aiortc.sh echo.py ws://localhost:8188/
+```
+
+It will start a Janus instance in the background taking the binary files from the parent directory.
+Then it will wait for 3 seconds before invoking the Python script specified in the first parameter.
+Finally it will check the exit status of the Python script and kill the Janus instance.

--- a/test/README.md
+++ b/test/README.md
@@ -46,6 +46,6 @@ The scripts must be invoked like this:
 ./test_aiortc.sh echo.py ws://localhost:8188/
 ```
 
-It will start a Janus instance in the background taking the binary files from the parent directory.
-Then it will wait for 3 seconds before invoking the Python script specified in the first parameter.
+It will start a Janus instance in the background taking the binary files from the Janus sources directory.
+Then it will wait for some seconds before invoking the Python script specified in the first parameter.
 Finally it will check the exit status of the Python script and kill the Janus instance.

--- a/test/echo.py
+++ b/test/echo.py
@@ -1,0 +1,257 @@
+import argparse
+import asyncio
+import logging
+import random
+import string
+import sys
+
+import websockets as ws
+import json
+
+
+from aiortc import RTCPeerConnection, RTCSessionDescription
+from aiortc.mediastreams import AudioStreamTrack, VideoStreamTrack
+from aiortc.contrib.media import MediaPlayer
+
+
+logger = logging.getLogger('echo')
+
+
+class WebSocketClient():
+
+    def __init__(self, url='ws://localhost:8188/'):
+        self._url = url
+        self.connection = None
+        self._transactions = {}
+
+    async def connect(self):
+        self.connection = await ws.connect(self._url,
+                                           subprotocols=['janus-protocol'],
+                                           ping_interval=10,
+                                           ping_timeout=10,
+                                           compression=None)
+        if self.connection.open:
+            asyncio.ensure_future(self.receiveMessage())
+            logger.info('WebSocket connected')
+            return self
+
+    def transaction_id(self):
+        return ''.join(random.choice(string.ascii_letters) for x in range(12))
+
+    async def send(self, message):
+        tx_id = self.transaction_id()
+        message.update({'transaction': tx_id})
+        tx = asyncio.get_event_loop().create_future()
+        self._transactions[tx_id] = tx
+        try:
+            await asyncio.gather(self.connection.send(json.dumps(message)), tx)
+        except Exception as e:
+            tx.set_result(e)
+        return tx.result()
+
+    async def receiveMessage(self):
+        try:
+            async for message in self.connection:
+                data = json.loads(message)
+                tx_id = data.get('transaction')
+                response = data['janus']
+                if tx_id and response == 'ack':
+                    logger.debug(f'Received ACK for transaction {tx_id}')
+                    continue
+                if response not in {'success', 'error'}:
+                    logger.info(f'Janus Event --> {response}')
+                if tx_id and tx_id in self._transactions:
+                    tx = self._transactions[tx_id]
+                    tx.set_result(data)
+                    del self._transactions[tx_id]
+                    logger.debug(f'Closed transaction {tx_id}'
+                                 f' with {response}')
+        except Exception:
+            logger.error('WebSocket failure')
+        logger.info('Connection closed')
+
+    async def close(self):
+        if self.connection:
+            await self.connection.close()
+            self.connection = None
+        self._transactions = {}
+
+
+class JanusPlugin:
+    def __init__(self, session, handle_id):
+        self._session = session
+        self._handle_id = handle_id
+
+    async def sendMessage(self, message):
+        logger.info('Sending message to the plugin')
+        message.update({'janus': 'message', 'handle_id': self._handle_id})
+        response = await self._session.send(message)
+        return response
+
+
+class JanusSession:
+    def __init__(self, url='ws://localhost:8188/'):
+        self._websocket = None
+        self._url = url
+        self._handles = {}
+        self._session_id = None
+
+    async def send(self, message):
+        message.update({'session_id': self._session_id})
+        response = await self._websocket.send(message)
+        return response
+
+    async def create(self):
+        logger.info('Creating session')
+        self._websocket = await WebSocketClient(self._url).connect()
+        message = {'janus': 'create'}
+        response = await self.send(message)
+        assert response['janus'] == 'success'
+        session_id = response['data']['id']
+        self._session_id = session_id
+        logger.info('Session created')
+
+    async def attach(self, plugin):
+        logger.info('Attaching handle')
+        message = {'janus': 'attach', 'plugin': plugin}
+        response = await self.send(message)
+        assert response['janus'] == 'success'
+        handle_id = response['data']['id']
+        handle = JanusPlugin(self, handle_id)
+        self._handles[handle_id] = handle
+        logger.info('Handle attached')
+        return handle
+
+    async def destroy(self):
+        logger.info('Destroying session')
+        if self._session_id:
+            message = {'janus': 'destroy'}
+            await self.send(message)
+            self._session_id = None
+        self._handles = {}
+        logger.info('Session destroyed')
+
+        logger.info('Closing WebSocket')
+        if self._websocket:
+            await self._websocket.close()
+            self._websocket = None
+
+
+async def run(pc, player, session, bitrate=512000, record=False):
+    @pc.on('track')
+    def on_track(track):
+        logger.info(f'Track {track.kind} received')
+        @track.on('ended')
+        def on_ended():
+            print(f'Track {track.kind} ended')
+
+    @pc.on('iceconnectionstatechange')
+    def on_ice_state_change():
+        # logger.info(f'ICE state changed to {pc.iceConnectionState}')
+        pass
+
+    # create session
+    await session.create()
+
+    # configure media
+    media = {'audio': True, 'video': True}
+    if player and player.audio:
+        pc.addTrack(player.audio)
+    else:
+        pc.addTrack(AudioStreamTrack())
+    if player and player.video:
+        pc.addTrack(player.video)
+    else:
+        pc.addTrack(VideoStreamTrack())
+
+    # attach to echotest plugin
+    plugin = await session.attach('janus.plugin.echotest')
+
+    # send offer
+    await pc.setLocalDescription(await pc.createOffer())
+    request = {'record': record, 'bitrate': bitrate}
+    request.update(media)
+    response = await plugin.sendMessage(
+        {
+            'body': request,
+            'jsep': {
+                'sdp': pc.localDescription.sdp,
+                'trickle': False,
+                'type': pc.localDescription.type,
+            },
+        }
+    )
+    assert response['plugindata']['data']['result'] == 'ok'
+
+    # apply answer
+    answer = RTCSessionDescription(
+        sdp=response['jsep']['sdp'],
+        type=response['jsep']['type']
+    )
+    await pc.setRemoteDescription(answer)
+
+    logger.info('Running for a while...')
+    await asyncio.sleep(5)
+
+    # Check WebSocket status
+    assert session._websocket.connection.open
+
+    # Get RTC stats and check the status
+    rtcstats = await pc.getStats()
+    rtp = {'audio': {'in': 0, 'out': 0}, 'video': {'in': 0, 'out': 0}}
+    dtls_state = None
+    for stat in rtcstats.values():
+        if stat.type == 'inbound-rtp':
+            rtp[stat.kind]['in'] = stat.packetsReceived
+        elif stat.type == 'outbound-rtp':
+            rtp[stat.kind]['out'] = stat.packetsSent
+        elif stat.type == 'transport':
+            dtls_state = stat.dtlsState
+    # ICE succeded
+    assert pc.iceConnectionState == 'completed'
+    # DTLS succeded
+    assert dtls_state == 'connected'
+    # Janus echoed the sent packets
+    assert rtp['audio']['out'] >= rtp['audio']['in'] > 0
+    assert rtp['video']['out'] >= rtp['video']['in'] > 0
+
+    logger.info('Ending the test now')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Janus')
+    parser.add_argument('url',
+                        help='Janus root URL, e.g. ws://localhost:8188/')
+    parser.add_argument('--play-from',
+                        help='Read the media from a file and sent it.'),
+    parser.add_argument('--verbose', '-v', action='count')
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    # create signaling and peer connection
+    session = JanusSession(args.url)
+    pc = RTCPeerConnection()
+
+    # create media source
+    if args.play_from:
+        player = MediaPlayer(args.play_from)
+    else:
+        player = None
+
+    loop = asyncio.get_event_loop()
+    try:
+        loop.run_until_complete(
+            run(pc=pc, player=player, session=session)
+        )
+        logger.info('Test Passed')
+        sys.exit(0)
+    except Exception:
+        logger.exception('Test Failed')
+        sys.exit(1)
+    finally:
+        loop.run_until_complete(pc.close())
+        loop.run_until_complete(session.destroy())

--- a/test/echo.py
+++ b/test/echo.py
@@ -168,6 +168,7 @@ class JanusSession:
             logger.info('Keepalive OK')
             await asyncio.sleep(self._ka_interval)
 
+
 async def run(pc, player, session, bitrate=512000, record=False):
     @pc.on('track')
     def on_track(track):

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,2 @@
+websockets==8.1
+aiortc==0.9.26

--- a/test/test_aiortc.sh
+++ b/test/test_aiortc.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+
+TEST=${1-"echo.py"}
+URL=${2-"ws://localhost:8188/"}
+
+echo "Starting Janus ..."
+../janus >/dev/null 2>&1 &
+JANUS_PID=$!
+
+sleep 3
+
+echo "Launching test $TEST ..."
+python3 $TEST $URL
+
+if [ $? -eq 0 ]; then
+    echo "TEST SUCCEDED"
+    kill -9 $JANUS_PID
+    exit 0
+else
+    echo "TEST FAILED"
+    kill -9 $JANUS_PID
+    exit 1
+fi

--- a/test/test_aiortc.sh
+++ b/test/test_aiortc.sh
@@ -1,13 +1,17 @@
 #!/bin/bash -eu
 
-TEST=${1-"echo.py"}
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+JANUS_SRC="$( dirname $SCRIPTPATH )"
+
+TEST=${1-"$SCRIPTPATH/echo.py"}
 URL=${2-"ws://localhost:8188/"}
 
-echo "Starting Janus ..."
-../janus >/dev/null 2>&1 &
+echo "Starting Janus binary from $JANUS_SRC ..."
+$JANUS_SRC/janus >/dev/null 2>&1 &
 JANUS_PID=$!
 
-sleep 3
+echo "Waiting for some seconds before launching the test ..."
+sleep 5
 
 echo "Launching test $TEST ..."
 python3 $TEST $URL


### PR DESCRIPTION
This PR adds a very minimal functional testing for Janus.
The only proposed test, as of now, is a Python script based on [aiortc](https://github.com/aiortc/aiortc) (`echo.py`) that basically implements an echotest session and evaluates some WebRTC related assertions (ICE, DTLS, RTP and so on).
We're also providing a helper script (`test_aiortc.sh`) that you can launch to quickly start a test.
Both `echo.py` and `test_aiortc.sh` return 0 for a successful execution. This should facilitate future integrations with continuous testing frameworks.

In order to test the script you'll need to have working Janus binaries in the parent directory and working Janus configurations installed in the `prefix` path specified in the `configure`.

Example of the output
```
atoppi@atoppi:~/src/janus-gateway$ ./test/test_aiortc.sh
Starting Janus binary from /home/atoppi/src/janus-gateway ...
Waiting for some seconds before launching the test ...
Launching test /home/atoppi/src/janus-gateway/test/echo.py ...
INFO:echo:Creating session
INFO:echo:WebSocket connected
INFO:echo:Session created
INFO:echo:Attaching handle
INFO:echo:Handle attached
INFO:echo:Sending message to the plugin
INFO:echo:Janus Event --> event
INFO:echo:Track audio received
INFO:echo:Track video received
INFO:echo:Running for a while...
INFO:ice:Connection(0) Check CandidatePair(('192.168.1.169', 40934) -> ('192.168.1.169', 36351)) State.FROZEN -> State.WAITING
INFO:ice:Connection(0) Check CandidatePair(('192.168.1.169', 40934) -> ('192.168.1.169', 36351)) State.WAITING -> State.IN_PROGRESS
INFO:ice:Connection(0) Check CandidatePair(('192.168.1.169', 40934) -> ('192.168.1.169', 36351)) State.IN_PROGRESS -> State.SUCCEEDED
INFO:ice:Connection(0) ICE completed
INFO:echo:Janus Event --> webrtcup
INFO:echo:Janus Event --> media
INFO:echo:Janus Event --> media
INFO:echo:Ending the test now
INFO:echo:Test Passed
INFO:echo:Destroying session
INFO:echo:Janus Event --> event
INFO:echo:Session destroyed
INFO:echo:Closing WebSocket
INFO:echo:Connection closed
TEST SUCCEDED
```

For more details please refer to the README file.