### PR TITLE
Valgrind fixes for sockaddr structs

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -858,8 +858,8 @@ int janus_ice_test_stun_server(janus_network_address *addr, uint16_t port,
 		return -1;
 	}
 	struct sockaddr *address = NULL, *remote = NULL;
-	struct sockaddr_in address4, remote4;
-	struct sockaddr_in6 address6, remote6;
+	struct sockaddr_in address4 = { 0 }, remote4 = { 0 };
+	struct sockaddr_in6 address6 = { 0 }, remote6 = { 0 };
 	socklen_t addrlen = 0;
 	if(addr->family == AF_INET) {
 		memset(&address4, 0, sizeof(address4));

--- a/ip-utils.c
+++ b/ip-utils.c
@@ -267,7 +267,7 @@ int janus_network_detect_local_ip(janus_network_query_options addr_type, janus_n
 	int fd = -1;
 	if(addr_type == janus_network_query_options_ipv4 || addr_type == janus_network_query_options_any_ip) {
 		/* Let's try IPv4 (FIXME Should probably use other internal methods) */
-		struct sockaddr_in addr;
+		struct sockaddr_in addr = { 0 };
 		socklen_t len;
 		fd = socket(AF_INET, SOCK_DGRAM, 0);
 		if(fd > -1) {
@@ -290,7 +290,7 @@ int janus_network_detect_local_ip(janus_network_query_options addr_type, janus_n
 	fd = -1;
 	if(!found && (addr_type == janus_network_query_options_ipv6 || addr_type == janus_network_query_options_any_ip)) {
 		/* Let's try IPv6 (FIXME Should probably use other internal methods) */
-		struct sockaddr_in6 addr;
+		struct sockaddr_in6 addr = { 0 };
 		socklen_t len;
 		fd = socket(AF_INET6, SOCK_DGRAM, 0);
 		if(fd > -1) {

--- a/plugins/janus_nosip.c
+++ b/plugins/janus_nosip.c
@@ -1871,7 +1871,7 @@ char *janus_nosip_sdp_manipulate(janus_nosip_session *session, janus_sdp *sdp, g
 }
 
 static int janus_nosip_bind_socket(int fd, int port) {
-	struct sockaddr_in rtp_address;
+	struct sockaddr_in rtp_address = { 0 };
 	rtp_address.sin_family = AF_INET;
 	rtp_address.sin_port = htons(port);
 	inet_pton(AF_INET, local_ip, &rtp_address.sin_addr.s_addr);
@@ -2139,7 +2139,7 @@ static void *janus_nosip_relay_thread(void *data) {
 
 	/* File descriptors */
 	socklen_t addrlen;
-	struct sockaddr_in remote;
+	struct sockaddr_in remote = { 0 };
 	int resfd = 0, bytes = 0, pollerrs = 0;
 	struct pollfd fds[5];
 	int pipe_fd = session->media.pipefd[0];
@@ -2163,12 +2163,12 @@ static void *janus_nosip_relay_thread(void *data) {
 			session->media.updated = FALSE;
 
 			have_audio_server_ip = session->media.remote_audio_ip != NULL;
-			struct sockaddr_in audio_server_addr;
+			struct sockaddr_in audio_server_addr = { 0 };
 			memset(&audio_server_addr, 0, sizeof(struct sockaddr_in));
 			audio_server_addr.sin_family = AF_INET;
 
 			have_video_server_ip = session->media.remote_video_ip != NULL;
-			struct sockaddr_in video_server_addr;
+			struct sockaddr_in video_server_addr = { 0 };
 			memset(&video_server_addr, 0, sizeof(struct sockaddr_in));
 			video_server_addr.sin_family = AF_INET;
 

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -4725,8 +4725,8 @@ error:
 static int janus_streaming_create_fd(int port, in_addr_t mcast, const janus_network_address *iface,
 		const char *listenername, const char *medianame, const char *mountpointname, gboolean quiet) {
 	janus_mutex_lock(&fd_mutex);
-	struct sockaddr_in address;
-	struct sockaddr_in6 address6;
+	struct sockaddr_in address = { 0 };
+	struct sockaddr_in6 address6 = { 0 };
 	janus_network_address_string_buffer address_representation;
 
 	uint16_t rtp_port_next = rtp_range_slider; 					/* Read global slider */
@@ -4909,7 +4909,7 @@ static int janus_streaming_allocate_port_pair(const char *name, const char *medi
 
 /* Helper to return fd port */
 static int janus_streaming_get_fd_port(int fd) {
-	struct sockaddr_in6 server;
+	struct sockaddr_in6 server = { 0 };
 	socklen_t len = sizeof(server);
 	if(getsockname(fd, &server, &len) == -1) {
 		return -1;
@@ -6070,8 +6070,8 @@ static void janus_streaming_rtsp_latch(int fd, char *host, int port, struct sock
 	} else {
 		freeaddrinfo(res);
 		/* Prepare the recipient */
-		struct sockaddr_in remote4;
-		struct sockaddr_in6 remote6;
+		struct sockaddr_in remote4 = { 0 };
+		struct sockaddr_in6 remote6 = { 0 };
 		socklen_t addrlen = 0;
 		if(addr.family == AF_INET) {
 			memset(&remote4, 0, sizeof(remote4));
@@ -6104,7 +6104,7 @@ static int janus_streaming_rtsp_play(janus_streaming_rtp_source *source) {
 	if(source == NULL || source->curldata == NULL)
 		return -1;
 	/* First of all, send a latching packet to the RTSP server port(s) */
-	struct sockaddr_in6 remote;
+	struct sockaddr_in6 remote = { 0 };
 	if(source->remote_audio_port > 0 && source->audio_fd >= 0) {
 		JANUS_LOG(LOG_VERB, "RTSP audio latching: %s:%d\n", source->rtsp_ahost, source->remote_audio_port);
 		janus_streaming_rtsp_latch(source->audio_fd, source->rtsp_ahost,

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1779,7 +1779,7 @@ static guint32 janus_videoroom_rtp_forwarder_add_helper(janus_videoroom_publishe
 				errno, strerror(errno));
 			return 0;
 		}
-		struct sockaddr_in6 address;
+		struct sockaddr_in6 address = { 0 };
 		socklen_t len = sizeof(address);
 		memset(&address, 0, sizeof(address));
 		address.sin6_family = AF_INET6;

--- a/sctp.c
+++ b/sctp.c
@@ -151,7 +151,7 @@ janus_sctp_association *janus_sctp_association_create(janus_dtls_srtp *dtls, jan
 
 	struct socket *sock = NULL;
 	unsigned int i = 0;
-	struct sockaddr_conn sconn;
+	struct sockaddr_conn sconn = { 0 };
 
 	/* Now go on with SCTP */
 	janus_sctp_channel *channel = NULL;
@@ -257,7 +257,7 @@ janus_sctp_association *janus_sctp_association_create(janus_dtls_srtp *dtls, jan
 
 	/* Operating as client */
 	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Connecting the SCTP association\n", sctp->handle_id);
-	struct sockaddr_conn rconn;
+	struct sockaddr_conn rconn = { 0 };
 	memset(&rconn, 0, sizeof(struct sockaddr_conn));
 	rconn.sconn_family = AF_CONN;
 	rconn.sconn_port = htons(sctp->remote_port);

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -288,8 +288,8 @@ static struct MHD_Daemon *janus_http_create_daemon(gboolean admin, char *path,
 	/* Any interface or IP address we need to limit ourselves to?
 	 * NOTE WELL: specifying an interface does NOT bind to all IPs associated
 	 * with that interface, but only to the first one that's detected */
-	static struct sockaddr_in addr;
-	struct sockaddr_in6 addr6;
+	static struct sockaddr_in addr = { 0 };
+	struct sockaddr_in6 addr6 = { 0 };
 	gboolean ipv6 = FALSE;
 	if(ip && strstr(ip, ":"))
 		ipv6 = TRUE;


### PR DESCRIPTION
Should fix valgrind errors of the form:
```
==12== Syscall param socketcall.bind(my_addr.sin6_scope_id) points to uninitialised byte(s)
==12==    at 0x55C538B: bind (syscall-template.S:78)
==12==    by 0x113A788C: janus_streaming_create_fd (janus_streaming.c:4844)
==12==    by 0x113715D3: janus_streaming_create_rtp_source (janus_streaming.c:5072)
==12==    by 0x1136BDBB: janus_streaming_init (janus_streaming.c:1650)
==12==    by 0x480715: main (janus.c:4931)
==12==  Address 0x1ffefef250 is on thread 1's stack
==12==  in frame #1, created by janus_streaming_create_fd (janus_streaming.c:4726)
==12==  Uninitialised value was created by a stack allocation
==12==    at 0x113A5D70: janus_streaming_create_fd (janus_streaming.c:4726)
```