### PR TITLE
Add G.711 support to the AudioBridge plugin

### DIFF
--- a/conf/janus.plugin.audiobridge.jcfg.sample
+++ b/conf/janus.plugin.audiobridge.jcfg.sample
@@ -21,7 +21,8 @@
 # rtp_forward_host_family = "<ipv4|ipv6; by default, first family returned by DNS request>"
 # rtp_forward_port = port to forward RTP packets of mixed audio to
 # rtp_forward_ssrc = SSRC to use to use when streaming (optional: stream_id used if missing)
-# rtp_forward_ptype = payload type to use when streaming (optional: 100 used if missing)
+# rtp_forward_codec = opus (default), pcma (A-Law) or pcmu (mu-Law)
+# rtp_forward_ptype = payload type to use when streaming (optional: only read for Opus, 100 used if missing)
 # rtp_forward_srtp_suite = length of authentication tag (32 or 80)
 # rtp_forward_srtp_crypto = "<key to use as crypto (base64 encoded key as in SDES)>"
 # rtp_forward_always_on = true|false, whether silence should be forwarded when the room is empty (optional: false used if missing)

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -672,8 +672,8 @@ room-<unique room ID>: {
 
 
 /* Plugin information */
-#define JANUS_AUDIOBRIDGE_VERSION			10
-#define JANUS_AUDIOBRIDGE_VERSION_STRING	"0.0.10"
+#define JANUS_AUDIOBRIDGE_VERSION			11
+#define JANUS_AUDIOBRIDGE_VERSION_STRING	"0.0.11"
 #define JANUS_AUDIOBRIDGE_DESCRIPTION		"This is a plugin implementing an audio conference bridge for Janus, mixing Opus streams."
 #define JANUS_AUDIOBRIDGE_NAME				"JANUS AudioBridge plugin"
 #define JANUS_AUDIOBRIDGE_AUTHOR			"Meetecho s.r.l."

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -498,6 +498,7 @@ room-<unique room ID>: {
 	"display" : "<display name to have in the room; optional>",
 	"token" : "<invitation token, in case the room has an ACL; optional>",
 	"muted" : <true|false, whether to start unmuted or muted>,
+	"codec" : "<codec to use, among opus (default), pcma (A-Law) or pcmu (mu-Law)>",
 	"quality" : <0-10, Opus-related complexity to use, the higher the value, the better the quality (but more CPU); optional, default is 4>,
 	"volume" : <percent value, <100 reduces volume, >100 increases volume; optional, default is 100 (no volume change)>
 }
@@ -803,6 +804,7 @@ static struct janus_json_parameter join_parameters[] = {
 	{"display", JSON_STRING, 0},
 	{"token", JSON_STRING, 0},
 	{"muted", JANUS_JSON_BOOL, 0},
+	{"codec", JSON_STRING, 0},
 	{"quality", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"volume", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE}
 };


### PR DESCRIPTION
This was asked a few times in the past, and I had some time to work on it, so here it is. The AudioBridge now supports G.711 as well as a codec, not just Opus: this means that, whenever the sampling rate is not 8000 (te only rate G.711 supports), resampling will take place for G.711 participants to make sure their contribution can be mixed with the others', and they can receive a mix made on a higher sampling rate instead.

You can force G.711 for a participant by adding a `codec` property to the `join` request, and set it to `pcma` (a-Law) or `pcmu` (mu-Law): the default, if the property is missing, is still Opus. As a result, the SDP answer will match the provided codec instead. It's important to set the `codec` property, because if the SDP offer from a new participant _only_ contains G.711, but the `codec` property is not `pcmu` or `pcma`, the negotiation will _fail_, because the plugin will try to negotiate Opus instead.

The new G.711 support is available in the AudioBridge RTP forwarding functionality as well, and the way to configure a G.711 forwarder is via a `codec` property (same values as before) in the `rtp_forward` request. If you're creating the forwarder statically, the property to set in the configuration file is `rtp_forwarder_codec`.

Feedback welcome!