### PR TITLE
Small fixes for TypeScript declaration file

### DIFF
--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -23,7 +23,7 @@ declare namespace JanusJS {
 		dependencies?: Dependencies;
 	}
 
-	interface ConstuctorOptions {
+	interface ConstructorOptions {
 		server: string | string[];
 		iceServers?: RTCIceServer[];
 		ipv6?: boolean;
@@ -138,7 +138,7 @@ declare namespace JanusJS {
 		static error(...args: any[]): void;
 		static randomString(length: number): string;
 
-		constructor(options: ConstuctorOptions);
+		constructor(options: ConstructorOptions);
 
 		getServer(): string;
 		isConnected(): boolean;

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -25,7 +25,7 @@ declare namespace JanusJS {
 
 	interface ConstuctorOptions {
 		server: string | string[];
-		iceServers?: string[];
+		iceServers?: RTCIceServer[];
 		ipv6?: boolean;
 		withCredentials?: boolean;
 		max_poll_events?: number;


### PR DESCRIPTION
Fixed a typo and an issue with the typing of iceServers.

Based on the usage in the js library and the RTCPeerConnection's constructor spec (https://w3c.github.io/webrtc-pc/#dom-rtcconfiguration), it seems like it should be an array of RTCIceServer instead of string. TypeScript provides this definition (https://github.com/Microsoft/TypeScript/blob/master/lib/lib.dom.d.ts)