### PR TITLE
ice: ensure that stream is non-NULL

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -4379,7 +4379,7 @@ static void janus_ice_queue_packet(janus_ice_handle *handle, janus_ice_queued_pa
 }
 
 void janus_ice_relay_rtp(janus_ice_handle *handle, janus_plugin_rtp *packet) {
-	if(!handle || handle->queued_packets == NULL || packet == NULL || packet->buffer == NULL ||
+	if(!handle || !handle->stream || handle->queued_packets == NULL || packet == NULL || packet->buffer == NULL ||
 			!janus_is_rtp(packet->buffer, packet->length))
 		return;
 	if((!packet->video && !janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AUDIO))


### PR DESCRIPTION
This fixes a crash on later stream checks (e.g., transport_wide_cc et al).