### PR TITLE
Fixed double unlock when listing private rooms in AudioBridge

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -2647,7 +2647,6 @@ static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_s
 			janus_refcount_increase(&room->ref);
 			if(room->is_private) {
 				/* Skip private room */
-				janus_mutex_unlock(&room->mutex);
 				JANUS_LOG(LOG_VERB, "Skipping private room '%s'\n", room->room_name);
 				janus_refcount_decrease(&room->ref);
 				continue;


### PR DESCRIPTION
We've been notified about a double unlock that could happen when sending a "list" request to a AudioBridge instance hosting private rooms. Indeed, while iterating on all the rooms, there was an unlock for the room mutex in case a room was private. This was very likely a leftover from a previous refactoring, where we relied on mutexes to ensure a room instance was valid: this seems confirmed by how the TextRoom plugin implements "list", for instance, where the locking is still in place. This is not needed in the AudioBridge anymore (and likely not in the TextRoom either), since we increase the reference to the room and decrease it when we're done; besides, the whole process is wrapped in `rooms_mutex`.

As such, this patch simply removes the leftover unlock. I verified this fixes the issue for me, and so I'm planning to merge (very) soon, but feedback is welcome.