### PR TITLE
Fixed typo in querylogger_parameters (copy/paste error)

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -148,7 +148,7 @@ static struct janus_json_parameter queryhandler_parameters[] = {
 	{"request", JSON_OBJECT, 0}
 };
 static struct janus_json_parameter querylogger_parameters[] = {
-	{"handler", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
+	{"logger", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
 	{"request", JSON_OBJECT, 0}
 };
 static struct janus_json_parameter messageplugin_parameters[] = {


### PR DESCRIPTION
We've been notified about a typo in the JSON validation of the "query_logger" Admin API request, that could lead to trying to use a string that doesn't actually exist. This was quite clearly a copy paste error, when duplicating the existing "query_handler" to support loggers as well, and this patch fixes it for good.

I verified this fixes the issue for me, and so I'm planning to merge (very) soon, but feedback is welcome.