### PR TITLE
Fix rare race condition when claiming sessions

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -682,12 +682,19 @@ janus_session *janus_session_find(guint64 session_id) {
 }
 
 void janus_session_notify_event(janus_session *session, json_t *event) {
-	if(session != NULL && !g_atomic_int_get(&session->destroyed) && session->source != NULL && session->source->transport != NULL) {
-		/* Send this to the transport client */
-		JANUS_LOG(LOG_HUGE, "Sending event to %s (%p)\n", session->source->transport->get_package(), session->source->instance);
-		session->source->transport->send_message(session->source->instance, NULL, FALSE, event);
+	if(session != NULL && !g_atomic_int_get(&session->destroyed)) {
+		janus_mutex_lock(&session->mutex);
+		if(session->source != NULL && session->source->transport != NULL) {
+			/* Send this to the transport client */
+			JANUS_LOG(LOG_HUGE, "Sending event to %s (%p)\n", session->source->transport->get_package(), session->source->instance);
+			session->source->transport->send_message(session->source->instance, NULL, FALSE, event);
+		} else {
+			/* No transport, free the event */
+			json_decref(event);
+		}
+		janus_mutex_unlock(&session->mutex);
 	} else {
-		/* No transport, free the event */
+		/* No session, free the event */
 		json_decref(event);
 	}
 }
@@ -1108,9 +1115,10 @@ int janus_process_incoming_request(janus_request *request) {
 		g_hash_table_remove(sessions, &session->session_id);
 		janus_mutex_unlock(&sessions_mutex);
 		/* Notify the source that the session has been destroyed */
-		if(session->source && session->source->transport) {
+		janus_mutex_lock(&session->mutex);
+		if(session->source && session->source->transport)
 			session->source->transport->session_over(session->source->instance, session->session_id, FALSE, FALSE);
-		}
+		janus_mutex_unlock(&session->mutex);
 		/* Schedule the session for deletion */
 		janus_session_destroy(session);
 
@@ -2440,9 +2448,10 @@ int janus_process_incoming_admin_request(janus_request *request) {
 			g_hash_table_remove(sessions, &session->session_id);
 			janus_mutex_unlock(&sessions_mutex);
 			/* Notify the source that the session has been destroyed */
-			if(session->source && session->source->transport) {
+			janus_mutex_lock(&session->mutex);
+			if(session->source && session->source->transport)
 				session->source->transport->session_over(session->source->instance, session->session_id, FALSE, FALSE);
-			}
+			janus_mutex_unlock(&session->mutex);
 			/* Schedule the session for deletion */
 			janus_session_destroy(session);
 
@@ -2565,12 +2574,14 @@ int janus_process_incoming_admin_request(janus_request *request) {
 		/* Check if we should limit the response to the plugin-specific info */
 		gboolean plugin_only = json_is_true(json_object_get(root, "plugin_only"));
 		/* Prepare info */
-		janus_mutex_lock(&handle->mutex);
 		json_t *info = json_object();
 		json_object_set_new(info, "session_id", json_integer(session_id));
 		json_object_set_new(info, "session_last_activity", json_integer(session->last_activity));
+		janus_mutex_lock(&session->mutex);
 		if(session->source && session->source->transport)
 			json_object_set_new(info, "session_transport", json_string(session->source->transport->get_package()));
+		janus_mutex_unlock(&session->mutex);
+		janus_mutex_lock(&handle->mutex);
 		json_object_set_new(info, "handle_id", json_integer(handle_id));
 		if(handle->opaque_id)
 			json_object_set_new(info, "opaque_id", json_string(handle->opaque_id));
@@ -3020,7 +3031,7 @@ void janus_transport_gone(janus_transport *plugin, janus_transport_session *tran
 					janus_session_destroy(session);
 					g_hash_table_iter_remove(&iter);
 				} else {
-					/* Set flag for transport_gone. The Janus sessions watchdog will clean this up if not reclaimed*/
+					/* Set flag for transport_gone. The Janus sessions watchdog will clean this up if not reclaimed */
 					g_atomic_int_set(&session->transport_gone, 1);
 				}
 			}


### PR DESCRIPTION
We've been notified about a rare race condition that can occur when claiming sessions, specifically when a "claim" request for a session happens at the same time as an event pushed by a plugin to a handle belonging to the session itself. The root cause is that the `source` property of `session` (which contains the info to relate a session to a transport instance) is used by different threads concurrently, and only some parts of the code are locking it properly: specifically, the code for "claim" does, while the code that notifies the event doesn't.

Looking at the code, I found other instances where `source` was accessed without a lock, so this patch makes sure they're all fixed. The only place where this doesn't happen is `janus_check_sessions`, as when `source` is accessed there a session has already timed out, meaning no conflicts are likely to take place. The patch also makes "claim" do nothing if you're trying to claim a session you already own (meaning "claim" comes from the same transport instance that is managing the session already): before we were replacing it with itself, which made little sense and made the issue easier to replicate.

I don't expect this to cause issues, as I've followed the core/transports interaction for the calls that are invoked from within the lock, and I didn't find any way transports can go back to the core and try to lock the same mutex. As such, I'm planning to merge soon, but feedback that might prove me wrong is more than welcome.