### PR TITLE
Added option to enforce validation on DTLS certificates

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -167,11 +167,14 @@ general: {
 # want to enforce the DTLS stack in Janus to enforce valid certificates
 # from peers, though, you can do that setting 'dtls_accept_selfsigned' to
 # 'false' below: DO NOT TOUCH THAT IF YOU DO NOT KNOW WHAT YOU'RE DOING!
+# Finally, you can configure the DTLS ciphers to offer: the default if
+# not specified is "HIGH:!aNULL:!MD5:!RC4" (what Janus used so far).
 certificates: {
 	#cert_pem = "/path/to/certificate.pem"
 	#cert_key = "/path/to/key.pem"
 	#cert_pwd = "secretpassphrase"
 	#dtls_accept_selfsigned = false
+	#dtls_ciphers = "DEFAULT:!NULL:!aNULL:!SHA256:!SHA384:!aECDH:!AESGCM+AES256:!aPSK"
 }
 
 # Media-related stuff: you can configure whether if you want

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -163,11 +163,15 @@ general: {
 # Janus will autogenerate a self-signed certificate to use. Notice that
 # self-signed certificates are fine for the purpose of WebRTC DTLS
 # connectivity, for the time being, at least until Identity Providers
-# are standardized and implemented in browsers.
+# are standardized and implemented in browsers. If for some reason you
+# want to enforce the DTLS stack in Janus to enforce valid certificates
+# from peers, though, you can do that setting 'dtls_accept_selfsigned' to
+# 'false' below: DO NOT TOUCH THAT IF YOU DO NOT KNOW WHAT YOU'RE DOING!
 certificates: {
 	#cert_pem = "/path/to/certificate.pem"
 	#cert_key = "/path/to/key.pem"
 	#cert_pwd = "secretpassphrase"
+	#dtls_accept_selfsigned = false
 }
 
 # Media-related stuff: you can configure whether if you want

--- a/dtls.h
+++ b/dtls.h
@@ -32,11 +32,12 @@ const char *janus_get_ssl_version(void);
  * @param[in] server_pem Path to the certificate to use
  * @param[in] server_key Path to the key to use
  * @param[in] password Password needed to use the key, if any
+ * @param[in] ciphers DTLS ciphers to use (will use hardcoded defaults, if NULL)
  * @param[in] timeout DTLS timeout base, in ms, to use for retransmissions (ignored if not using BoringSSL)
  * @param[in] accept_selfsigned Whether to accept self-signed certificates (default) or enforce validation
  * @returns 0 in case of success, a negative integer on errors */
 gint janus_dtls_srtp_init(const char *server_pem, const char *server_key, const char *password,
-	guint16 timeout, gboolean accept_selfsigned);
+	const char *ciphers, guint16 timeout, gboolean accept_selfsigned);
 /*! \brief Method to cleanup DTLS stuff before exiting */
 void janus_dtls_srtp_cleanup(void);
 /*! \brief Method to return a string representation (SHA-256) of the certificate fingerprint */

--- a/dtls.h
+++ b/dtls.h
@@ -33,12 +33,16 @@ const char *janus_get_ssl_version(void);
  * @param[in] server_key Path to the key to use
  * @param[in] password Password needed to use the key, if any
  * @param[in] timeout DTLS timeout base, in ms, to use for retransmissions (ignored if not using BoringSSL)
+ * @param[in] accept_selfsigned Whether to accept self-signed certificates (default) or enforce validation
  * @returns 0 in case of success, a negative integer on errors */
-gint janus_dtls_srtp_init(const char *server_pem, const char *server_key, const char *password, guint16 timeout);
+gint janus_dtls_srtp_init(const char *server_pem, const char *server_key, const char *password,
+	guint16 timeout, gboolean accept_selfsigned);
 /*! \brief Method to cleanup DTLS stuff before exiting */
 void janus_dtls_srtp_cleanup(void);
 /*! \brief Method to return a string representation (SHA-256) of the certificate fingerprint */
 gchar *janus_dtls_get_local_fingerprint(void);
+/*! \brief Method to check whether DTLS self-signed certificates are ok (default) or not */
+gboolean janus_dtls_are_selfsigned_certs_ok(void);
 
 
 /*! \brief DTLS roles */

--- a/janus.c
+++ b/janus.c
@@ -4635,6 +4635,10 @@ gint main(int argc, char *argv[])
 		password = item->value;
 	}
 	JANUS_LOG(LOG_VERB, "Using certificates:\n\t%s\n\t%s\n", server_pem, server_key);
+	gboolean dtls_accept_selfsigned = TRUE;
+	item = janus_config_get(config, config_certs, janus_config_type_item, "dtls_accept_selfsigned");
+	if(item && item->value)
+		dtls_accept_selfsigned = janus_is_true(item->value);
 
 	SSL_library_init();
 	SSL_load_error_strings();
@@ -4646,7 +4650,7 @@ gint main(int argc, char *argv[])
 		JANUS_LOG(LOG_WARN, "Invalid DTLS timeout: %s (falling back to default)\n", item->value);
 		dtls_timeout = 1000;
 	}
-	if(janus_dtls_srtp_init(server_pem, server_key, password, dtls_timeout) < 0) {
+	if(janus_dtls_srtp_init(server_pem, server_key, password, dtls_timeout, dtls_accept_selfsigned) < 0) {
 		exit(1);
 	}
 	/* Check if there's any custom value for the starting MTU to use in the BIO filter */

--- a/janus.c
+++ b/janus.c
@@ -4635,22 +4635,26 @@ gint main(int argc, char *argv[])
 		password = item->value;
 	}
 	JANUS_LOG(LOG_VERB, "Using certificates:\n\t%s\n\t%s\n", server_pem, server_key);
-	gboolean dtls_accept_selfsigned = TRUE;
-	item = janus_config_get(config, config_certs, janus_config_type_item, "dtls_accept_selfsigned");
-	if(item && item->value)
-		dtls_accept_selfsigned = janus_is_true(item->value);
 
 	SSL_library_init();
 	SSL_load_error_strings();
 	OpenSSL_add_all_algorithms();
 	/* ... and DTLS-SRTP in particular */
+	const char *dtls_ciphers = NULL;
+	item = janus_config_get(config, config_certs, janus_config_type_item, "dtls_ciphers");
+	if(item && item->value)
+		dtls_ciphers = item->value;
 	guint16 dtls_timeout = 1000;
 	item = janus_config_get(config, config_media, janus_config_type_item, "dtls_timeout");
 	if(item && item->value && janus_string_to_uint16(item->value, &dtls_timeout) < 0) {
 		JANUS_LOG(LOG_WARN, "Invalid DTLS timeout: %s (falling back to default)\n", item->value);
 		dtls_timeout = 1000;
 	}
-	if(janus_dtls_srtp_init(server_pem, server_key, password, dtls_timeout, dtls_accept_selfsigned) < 0) {
+	gboolean dtls_accept_selfsigned = TRUE;
+	item = janus_config_get(config, config_certs, janus_config_type_item, "dtls_accept_selfsigned");
+	if(item && item->value)
+		dtls_accept_selfsigned = janus_is_true(item->value);
+	if(janus_dtls_srtp_init(server_pem, server_key, password, dtls_ciphers, dtls_timeout, dtls_accept_selfsigned) < 0) {
 		exit(1);
 	}
 	/* Check if there's any custom value for the starting MTU to use in the BIO filter */


### PR DESCRIPTION
As you probably know already, all (or almost all) of the certificates exchanged via DTLS to establish PeerConnections are self-signed, meaning there's no need for validating them (which would actually failed if you tried). For those that have complete control over their client side, including on the certificates they generate and use, it might nevertheless be helpful to have a way to enforce Janus to enforce such a validation instead, in order to ensure the certificate being presented is valid.

This is exactly what this patch does. By default, we still accept self-signed certificates, so nothing changes. If you set

    dtls_accept_selfsigned = false

in the `[certs]` section of `janus.jcfg`, though, Janus will be instructed to only accept valid certificates, and you should see this line at startup:

    [WARN] WebRTC PeerConnections with self-signed certificates will NOT be accepted

Of course, needless to say **ONLY USE THIS FEATURE IF YOU KNOW WHAT YOU'RE DOING**.

As a side note, when I say that nothing changes for existing PeerConnections, that's only partly true: the DTLS stack in Janus will now also reject certificates that have expired, even when self-signed. This shouldn't be an issue when talking to browsers, but you may want to double check what your endpoints are sending, to make sure you're not using expired certificates somewhere.

Feedback welcome!