### PR TITLE
Several fixes to session management in VideoCall plugin

### DIFF
--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -350,6 +350,7 @@ static gboolean notify_events = TRUE;
 static janus_callbacks *gateway = NULL;
 static GThread *handler_thread;
 static void *janus_videocall_handler(void *data);
+static void janus_videocall_hangup_media_internal(janus_plugin_session *handle);
 
 typedef struct janus_videocall_message {
 	janus_plugin_session *handle;
@@ -387,11 +388,15 @@ typedef struct janus_videocall_session {
 	volatile gint destroyed;
 	janus_refcount ref;
 } janus_videocall_session;
-static GHashTable *sessions;
+static GHashTable *sessions = NULL, *usernames = NULL;
 static janus_mutex sessions_mutex = JANUS_MUTEX_INITIALIZER;
 
 static void janus_videocall_session_destroy(janus_videocall_session *session) {
 	if(session && g_atomic_int_compare_and_exchange(&session->destroyed, 0, 1))
+		janus_refcount_decrease(&session->ref);
+}
+static void janus_videocall_session_unref(janus_videocall_session *session) {
+	if(session)
 		janus_refcount_decrease(&session->ref);
 }
 
@@ -480,7 +485,10 @@ int janus_videocall_init(janus_callbacks *callback, const char *config_path) {
 	janus_config_destroy(config);
 	config = NULL;
 
-	sessions = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, (GDestroyNotify)janus_videocall_session_destroy);
+	sessions = g_hash_table_new_full(g_str_hash, g_str_equal,
+		NULL, (GDestroyNotify)janus_videocall_session_destroy);
+	usernames = g_hash_table_new_full(g_str_hash, g_str_equal,
+		(GDestroyNotify)g_free, (GDestroyNotify)janus_videocall_session_unref);
 	messages = g_async_queue_new_full((GDestroyNotify) janus_videocall_message_free);
 	/* This is the callback we'll need to invoke to contact the Janus core */
 	gateway = callback;
@@ -492,7 +500,8 @@ int janus_videocall_init(janus_callbacks *callback, const char *config_path) {
 	handler_thread = g_thread_try_new("videocall handler", janus_videocall_handler, NULL, &error);
 	if(error != NULL) {
 		g_atomic_int_set(&initialized, 0);
-		JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the VideoCall handler thread...\n", error->code, error->message ? error->message : "??");
+		JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the VideoCall handler thread...\n",
+			error->code, error->message ? error->message : "??");
 		return -1;
 	}
 	JANUS_LOG(LOG_INFO, "%s initialized!\n", JANUS_VIDEOCALL_NAME);
@@ -513,6 +522,8 @@ void janus_videocall_destroy(void) {
 	janus_mutex_lock(&sessions_mutex);
 	g_hash_table_destroy(sessions);
 	sessions = NULL;
+	g_hash_table_destroy(usernames);
+	usernames = NULL;
 	janus_mutex_unlock(&sessions_mutex);
 	g_async_queue_unref(messages);
 	messages = NULL;
@@ -550,6 +561,14 @@ const char *janus_videocall_get_package(void) {
 	return JANUS_VIDEOCALL_PACKAGE;
 }
 
+static janus_videocall_session *janus_videocall_lookup_session(janus_plugin_session *handle) {
+	janus_videocall_session *session = NULL;
+	if(g_hash_table_contains(sessions, handle)) {
+		session = (janus_videocall_session *)handle->plugin_handle;
+	}
+	return session;
+}
+
 void janus_videocall_create_session(janus_plugin_session *handle, int *error) {
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized)) {
 		*error = -1;
@@ -576,6 +595,10 @@ void janus_videocall_create_session(janus_plugin_session *handle, int *error) {
 	handle->plugin_handle = session;
 	janus_refcount_init(&session->ref, janus_videocall_session_free);
 
+	janus_mutex_lock(&sessions_mutex);
+	g_hash_table_insert(sessions, handle, session);
+	janus_mutex_unlock(&sessions_mutex);
+
 	return;
 }
 
@@ -584,21 +607,21 @@ void janus_videocall_destroy_session(janus_plugin_session *handle, int *error) {
 		*error = -1;
 		return;
 	}
-	janus_videocall_session *session = (janus_videocall_session *)handle->plugin_handle;
+	janus_mutex_lock(&sessions_mutex);
+	janus_videocall_session *session = janus_videocall_lookup_session(handle);
 	if(!session) {
-		JANUS_LOG(LOG_ERR, "No VideoCall session associated with this handle...\n");
+		janus_mutex_unlock(&sessions_mutex);
+		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
 		*error = -2;
 		return;
 	}
-	janus_mutex_lock(&sessions_mutex);
 	JANUS_LOG(LOG_VERB, "Removing VideoCall user %s session...\n", session->username ? session->username : "'unknown'");
-	janus_videocall_hangup_media(handle);
+	janus_videocall_hangup_media_internal(handle);
 	if(session->username != NULL) {
-		int res = g_hash_table_remove(sessions, (gpointer)session->username);
+		int res = g_hash_table_remove(usernames, (gpointer)session->username);
 		JANUS_LOG(LOG_VERB, "  -- Removed: %d\n", res);
-	} else {
-		janus_videocall_session_destroy(session);
 	}
+	g_hash_table_remove(sessions, handle);
 	janus_mutex_unlock(&sessions_mutex);
 	return;
 }
@@ -607,12 +630,15 @@ json_t *janus_videocall_query_session(janus_plugin_session *handle) {
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized)) {
 		return NULL;
 	}
-	janus_videocall_session *session = (janus_videocall_session *)handle->plugin_handle;
+	janus_mutex_lock(&sessions_mutex);
+	janus_videocall_session *session = janus_videocall_lookup_session(handle);
 	if(!session) {
+		janus_mutex_unlock(&sessions_mutex);
 		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
 		return NULL;
 	}
 	janus_refcount_increase(&session->ref);
+	janus_mutex_unlock(&sessions_mutex);
 	/* Provide some generic info, e.g., if we're in a call and with whom */
 	janus_videocall_session *peer = session->peer;
 	json_t *info = json_object();
@@ -661,14 +687,18 @@ json_t *janus_videocall_query_session(janus_plugin_session *handle) {
 struct janus_plugin_result *janus_videocall_handle_message(janus_plugin_session *handle, char *transaction, json_t *message, json_t *jsep) {
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, g_atomic_int_get(&stopping) ? "Shutting down" : "Plugin not initialized", NULL);
-	janus_videocall_session *session = (janus_videocall_session *)handle->plugin_handle;
-	if(!session)
-		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, "No session associated with this handle", NULL);
 
-	janus_videocall_message *msg = g_malloc(sizeof(janus_videocall_message));
+	janus_mutex_lock(&sessions_mutex);
+	janus_videocall_session *session = janus_videocall_lookup_session(handle);
+	if(!session) {
+		janus_mutex_unlock(&sessions_mutex);
+		return janus_plugin_result_new(JANUS_PLUGIN_ERROR, "No session associated with this handle", NULL);
+	}
 	/* Increase the reference counter for this session: we'll decrease it after we handle the message */
 	janus_refcount_increase(&session->ref);
+	janus_mutex_unlock(&sessions_mutex);
 
+	janus_videocall_message *msg = g_malloc(sizeof(janus_videocall_message));
 	msg->handle = handle;
 	msg->transaction = transaction;
 	msg->message = message;
@@ -683,14 +713,19 @@ void janus_videocall_setup_media(janus_plugin_session *handle) {
 	JANUS_LOG(LOG_INFO, "[%s-%p] WebRTC media is now available\n", JANUS_VIDEOCALL_PACKAGE, handle);
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
-	janus_videocall_session *session = (janus_videocall_session *)handle->plugin_handle;
+	janus_mutex_lock(&sessions_mutex);
+	janus_videocall_session *session = janus_videocall_lookup_session(handle);
 	if(!session) {
+		janus_mutex_unlock(&sessions_mutex);
 		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
 		return;
 	}
-	if(g_atomic_int_get(&session->destroyed))
+	if(g_atomic_int_get(&session->destroyed)) {
+		janus_mutex_unlock(&sessions_mutex);
 		return;
+	}
 	g_atomic_int_set(&session->hangingup, 0);
+	janus_mutex_unlock(&sessions_mutex);
 	/* We really don't care, as we only relay RTP/RTCP we get in the first place anyway */
 }
 
@@ -913,9 +948,15 @@ static void janus_videocall_recorder_close(janus_videocall_session *session) {
 
 void janus_videocall_hangup_media(janus_plugin_session *handle) {
 	JANUS_LOG(LOG_INFO, "[%s-%p] No WebRTC media anymore\n", JANUS_VIDEOCALL_PACKAGE, handle);
+	janus_mutex_lock(&sessions_mutex);
+	janus_videocall_hangup_media_internal(handle);
+	janus_mutex_unlock(&sessions_mutex);
+}
+
+static void janus_videocall_hangup_media_internal(janus_plugin_session *handle) {
 	if(g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
-	janus_videocall_session *session = (janus_videocall_session *)handle->plugin_handle;
+	janus_videocall_session *session = janus_videocall_lookup_session(handle);
 	if(!session) {
 		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
 		return;
@@ -992,16 +1033,20 @@ static void *janus_videocall_handler(void *data) {
 			janus_videocall_message_free(msg);
 			continue;
 		}
-		janus_videocall_session *session = (janus_videocall_session *)msg->handle->plugin_handle;
+		janus_mutex_lock(&sessions_mutex);
+		janus_videocall_session *session = janus_videocall_lookup_session(msg->handle);
 		if(!session) {
+			janus_mutex_unlock(&sessions_mutex);
 			JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
 			janus_videocall_message_free(msg);
 			continue;
 		}
 		if(g_atomic_int_get(&session->destroyed)) {
+			janus_mutex_unlock(&sessions_mutex);
 			janus_videocall_message_free(msg);
 			continue;
 		}
+		janus_mutex_unlock(&sessions_mutex);
 		/* Handle request */
 		error_code = 0;
 		root = msg->message;
@@ -1066,17 +1111,16 @@ static void *janus_videocall_handler(void *data) {
 			json_t *username = json_object_get(root, "username");
 			const char *username_text = json_string_value(username);
 			janus_mutex_lock(&sessions_mutex);
-			if(g_hash_table_lookup(sessions, username_text) != NULL) {
+			if(g_hash_table_lookup(usernames, username_text) != NULL) {
 				janus_mutex_unlock(&sessions_mutex);
 				JANUS_LOG(LOG_ERR, "Username '%s' already taken\n", username_text);
 				error_code = JANUS_VIDEOCALL_ERROR_USERNAME_TAKEN;
 				g_snprintf(error_cause, 512, "Username '%s' already taken", username_text);
 				goto error;
 			}
-			janus_mutex_unlock(&sessions_mutex);
 			session->username = g_strdup(username_text);
-			janus_mutex_lock(&sessions_mutex);
-			g_hash_table_insert(sessions, (gpointer)session->username, session);
+			janus_refcount_increase(&session->ref);
+			g_hash_table_insert(usernames, (gpointer)g_strdup(session->username), session);
 			janus_mutex_unlock(&sessions_mutex);
 			result = json_object();
 			json_object_set_new(result, "event", json_string("registered"));
@@ -1135,7 +1179,7 @@ static void *janus_videocall_handler(void *data) {
 				goto error;
 			}
 			janus_mutex_lock(&sessions_mutex);
-			janus_videocall_session *peer = g_hash_table_lookup(sessions, username_text);
+			janus_videocall_session *peer = g_hash_table_lookup(usernames, username_text);
 			if(peer == NULL || g_atomic_int_get(&peer->destroyed)) {
 				g_atomic_int_set(&session->incall, 0);
 				janus_mutex_unlock(&sessions_mutex);

--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -485,8 +485,7 @@ int janus_videocall_init(janus_callbacks *callback, const char *config_path) {
 	janus_config_destroy(config);
 	config = NULL;
 
-	sessions = g_hash_table_new_full(g_str_hash, g_str_equal,
-		NULL, (GDestroyNotify)janus_videocall_session_destroy);
+	sessions = g_hash_table_new_full(NULL, NULL, NULL, (GDestroyNotify)janus_videocall_session_destroy);
 	usernames = g_hash_table_new_full(g_str_hash, g_str_equal,
 		(GDestroyNotify)g_free, (GDestroyNotify)janus_videocall_session_unref);
 	messages = g_async_queue_new_full((GDestroyNotify) janus_videocall_message_free);


### PR DESCRIPTION
We've been notified about some issues in the VideoCall plugin, specifically some race conditions that could lead to crashes in Janus. After some investigations, this seems to be caused by a broken management of sessions in the plugin, that are tied to the usernames that are registered: this can lead to weird states, where some references may be freed too early or too many times, causing trouble. Checking the code, this is also because the VideoCall was possibly the only plugin that didn't benefit from some fixes we did a long time ago, due exactly to the different session management: this patch addresses that, and should make the plugin much more stable.

This seems to be working as expected for me, and we're doing some more tests in the meanwhile. Should these tests confirm the issue is fixed, I'll merge soon. Feedback welcome!