### PR TITLE
Implement ECDSA Certificate generation

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -195,6 +195,7 @@ media: {
 	#slowlink_threshold = 4
 	#twcc_period = 100
 	#dtls_timeout = 500
+	#dtls_generate_rsa_private_key = false
 }
 
 # NAT-related stuff: specifically, you can configure the STUN/TURN

--- a/dtls.h
+++ b/dtls.h
@@ -34,7 +34,7 @@ const char *janus_get_ssl_version(void);
  * @param[in] password Password needed to use the key, if any
  * @param[in] timeout DTLS timeout base, in ms, to use for retransmissions (ignored if not using BoringSSL)
  * @returns 0 in case of success, a negative integer on errors */
-gint janus_dtls_srtp_init(const char *server_pem, const char *server_key, const char *password, guint16 timeout);
+gint janus_dtls_srtp_init(const char *server_pem, const char *server_key, const char *password, guint16 timeout, gboolean dtls_generate_rsa_private_key);
 /*! \brief Method to cleanup DTLS stuff before exiting */
 void janus_dtls_srtp_cleanup(void);
 /*! \brief Method to return a string representation (SHA-256) of the certificate fingerprint */

--- a/janus.c
+++ b/janus.c
@@ -4646,7 +4646,12 @@ gint main(int argc, char *argv[])
 		JANUS_LOG(LOG_WARN, "Invalid DTLS timeout: %s (falling back to default)\n", item->value);
 		dtls_timeout = 1000;
 	}
-	if(janus_dtls_srtp_init(server_pem, server_key, password, dtls_timeout) < 0) {
+	gboolean dtls_generate_rsa_private_key = FALSE;
+	item = janus_config_get(config, config_media, janus_config_type_item, "dtls_generate_rsa_private_key");
+	if(item && item->value) {
+		dtls_generate_rsa_private_key = janus_is_true(item->value);
+	}
+	if(janus_dtls_srtp_init(server_pem, server_key, password, dtls_timeout, dtls_generate_rsa_private_key) < 0) {
 		exit(1);
 	}
 	/* Check if there's any custom value for the starting MTU to use in the BIO filter */


### PR DESCRIPTION
By default generate certificates with NIST P-256. Allow
RSA to still be used by with dtls_generate_rsa_private_key
config option.

Resolves #1978