### PR TITLE
Added option to ignore mDNS candidates

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -231,6 +231,14 @@ nat: {
 	#ice_lite = true
 	#ice_tcp = true
 
+	# By default Janus tries to resolve mDNS (.local) candidates: since
+	# this is currently done synchronously and might keep the API busy,
+	# especially in case mDNS resolution takes a long time to timeout,
+	# you can choose to drop all .local candidates instead, which is
+	# helpful in case you know clients will never be in the same private
+	# network as the one the Janus instance is running from.
+	#ignore_mdns = true
+
 	# In case you're deploying Janus on a server which is configured with
 	# a 1:1 NAT (e.g., Amazon EC2), you might want to also specify the public
 	# address of the machine using the setting below. This will result in

--- a/ice.c
+++ b/ice.c
@@ -89,6 +89,12 @@ gboolean janus_ice_is_full_trickle_enabled(void) {
 	return janus_full_trickle_enabled;
 }
 
+/* mDNS resolution support */
+static gboolean janus_mdns_enabled;
+gboolean janus_ice_is_mdns_enabled(void) {
+	return janus_mdns_enabled;
+}
+
 /* IPv6 support (still mostly WIP) */
 static gboolean janus_ipv6_enabled;
 gboolean janus_ice_is_ipv6_enabled(void) {
@@ -784,10 +790,12 @@ void janus_ice_trickle_destroy(janus_ice_trickle *trickle) {
 
 
 /* libnice initialization */
-void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean full_trickle, gboolean ipv6, uint16_t rtp_min_port, uint16_t rtp_max_port) {
+void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean full_trickle, gboolean ignore_mdns,
+		gboolean ipv6, uint16_t rtp_min_port, uint16_t rtp_max_port) {
 	janus_ice_lite_enabled = ice_lite;
 	janus_ice_tcp_enabled = ice_tcp;
 	janus_full_trickle_enabled = full_trickle;
+	janus_mdns_enabled = !ignore_mdns;
 	janus_ipv6_enabled = ipv6;
 	JANUS_LOG(LOG_INFO, "Initializing ICE stuff (%s mode, ICE-TCP candidates %s, %s-trickle, IPv6 support %s)\n",
 		janus_ice_lite_enabled ? "Lite" : "Full",
@@ -822,6 +830,8 @@ void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean full_trickle, 
 		JANUS_LOG(LOG_INFO, "ICE port range: %"SCNu16"-%"SCNu16"\n", rtp_range_min, rtp_range_max);
 #endif
 	}
+	if(!janus_mdns_enabled)
+		JANUS_LOG(LOG_WARN, "mDNS resolution disabled, .local candidates will be ignored\n");
 
 	/* We keep track of plugin sessions to avoid problems */
 	plugin_sessions = g_hash_table_new_full(NULL, NULL, NULL, (GDestroyNotify)janus_plugin_session_dereference);

--- a/ice.h
+++ b/ice.h
@@ -35,10 +35,12 @@
  * @param[in] ice_lite Whether the ICE Lite mode should be enabled or not
  * @param[in] ice_tcp Whether ICE-TCP support should be enabled or not (only libnice >= 0.1.8, currently broken)
  * @param[in] full_trickle Whether full-trickle must be used (instead of half-trickle)
+ * @param[in] ignore_mdns Whether mDNS candidates should be ignored, instead of resolved
  * @param[in] ipv6 Whether IPv6 candidates must be negotiated or not
  * @param[in] rtp_min_port Minimum port to use for RTP/RTCP, if a range is to be used
  * @param[in] rtp_max_port Maximum port to use for RTP/RTCP, if a range is to be used */
-void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean full_trickle, gboolean ipv6, uint16_t rtp_min_port, uint16_t rtp_max_port);
+void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean full_trickle, gboolean ignore_mdns,
+	gboolean ipv6, uint16_t rtp_min_port, uint16_t rtp_max_port);
 /*! \brief ICE stuff de-initialization */
 void janus_ice_deinit(void);
 /*! \brief Method to check whether a STUN server is reachable
@@ -119,6 +121,9 @@ gboolean janus_ice_is_ice_tcp_enabled(void);
 /*! \brief Method to check whether full-trickle support is enabled or not
  * @returns true if full-trickle support is enabled, false otherwise */
 gboolean janus_ice_is_full_trickle_enabled(void);
+/*! \brief Method to check whether mDNS resolution is enabled or not
+ * @returns true if mDNS resolution is enabled, false otherwise */
+gboolean janus_ice_is_mdns_enabled(void);
 /*! \brief Method to check whether IPv6 candidates are enabled/supported or not (still WIP)
  * @returns true if IPv6 candidates are enabled/supported, false otherwise */
 gboolean janus_ice_is_ipv6_enabled(void);

--- a/sdp.c
+++ b/sdp.c
@@ -666,7 +666,12 @@ int janus_sdp_parse_candidate(void *ice_stream, const char *candidate, int trick
 	if(res >= 7) {
 		if(strstr(rip, ".local")) {
 			/* The IP is actually an mDNS address, try to resolve it
-			 * https://tools.ietf.org/html/draft-ietf-rtcweb-mdns-ice-candidates-00 */
+			 * https://tools.ietf.org/html/draft-ietf-rtcweb-mdns-ice-candidates-04 */
+			if(!janus_ice_is_mdns_enabled()) {
+				/* ...unless mDNS resolution is disabled, in which case ignore this candidate */
+				JANUS_LOG(LOG_VERB, "[%"SCNu64"] mDNS candidate ignored\n", handle->handle_id);
+				return 0;
+			}
 			struct addrinfo *info = NULL;
 			janus_network_address addr;
 			janus_network_address_string_buffer addr_buf;
@@ -798,13 +803,11 @@ int janus_sdp_parse_candidate(void *ice_stream, const char *candidate, int trick
 					added = nice_address_set_from_string(&c->base_addr, rrelip);
 					if(added)
 						nice_address_set_port(&c->base_addr, rrelport);
-					
 				} else if(c->type == NICE_CANDIDATE_TYPE_RELAYED) {
 					/* FIXME Do we really need the base address for TURN? */
 					added = nice_address_set_from_string(&c->base_addr, rrelip);
 					if(added)
 						nice_address_set_port(&c->base_addr, rrelport);
-					
 				}
 				if(!added) {
 					JANUS_LOG(LOG_WARN, "[%"SCNu64"]    Invalid base address '%s', skipping %s candidate (%s)\n",


### PR DESCRIPTION
You may be familiar with [mDNS candidates](https://tools.ietf.org/html/draft-ietf-rtcweb-mdns-ice-candidates-04), which we've supported in Janus for a while. We need to resolve them ourselves before passing them to libnice, though, and we currently do that using `getaddrinfo`, which is a blocking method that only returns when the resolution has been either a success or a failure. This usually happens very quickly, but we've seen instances where it can take many seconds for a request to timeout, e.g., because services like Avahi are turned off on the machine: since this happens while the handle mutex is locked, and on the API messages thread, this can cause Janus being unresponsive in the meanwhile.

The first step to address this is this patch, that adds a new property in `janus.jcfg` by which you can tell Janus to ignore mDNS candidates. Of course this should only be used when you know for a fact you won't have any use for mDNS candidates (e.g., all users will always be remote, and not in the Janus network), but that can still help in case this has been an issue for you.

In the next few weeks we'll also work on making the resolution more asynchronous, but in the meanwhile, I'm planning to merge quite soon so feedback welcome!