### PR TITLE
Resolve mDNS candidates asynchronously with GResolver (see #1998)

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -231,12 +231,13 @@ nat: {
 	#ice_lite = true
 	#ice_tcp = true
 
-	# By default Janus tries to resolve mDNS (.local) candidates: since
-	# this is currently done synchronously and might keep the API busy,
-	# especially in case mDNS resolution takes a long time to timeout,
+	# By default Janus tries to resolve mDNS (.local) candidates: even
+	# though this is now done asynchronously and shouldn't keep the API
+	# busy, even in case mDNS resolution takes a long time to timeout,
 	# you can choose to drop all .local candidates instead, which is
 	# helpful in case you know clients will never be in the same private
-	# network as the one the Janus instance is running from.
+	# network as the one the Janus instance is running from. Notice that
+	# this will cause ICE to fail if mDNS is the only way to connect!
 	#ignore_mdns = true
 
 	# In case you're deploying Janus on a server which is configured with

--- a/configure.ac
+++ b/configure.ac
@@ -324,7 +324,8 @@ AC_ARG_ENABLE([systemd-sockets],
 PKG_CHECK_MODULES([JANUS],
                   [
                     glib-2.0 >= $glib_version
-					libconfig
+                    gio-2.0 >= $glib_version
+                    libconfig
                     nice
                     jansson >= $jansson_version
                     libssl >= $ssl_version

--- a/janus.c
+++ b/janus.c
@@ -453,7 +453,7 @@ static void janus_handle_signal(int signum) {
 	g_atomic_int_inc(&stop);
 	if(g_atomic_int_get(&stop) > 2)
 		exit(1);
-	if(mainloop)
+	if(mainloop && g_main_loop_is_running(mainloop))
 		g_main_loop_quit(mainloop);
 }
 

--- a/janus.c
+++ b/janus.c
@@ -206,6 +206,7 @@ static gint stop_signal = 0;
 gint janus_is_stopping(void) {
 	return g_atomic_int_get(&stop);
 }
+static GMainLoop *mainloop = NULL;
 
 
 /* Public instance name */
@@ -452,6 +453,8 @@ static void janus_handle_signal(int signum) {
 	g_atomic_int_inc(&stop);
 	if(g_atomic_int_get(&stop) > 2)
 		exit(1);
+	if(mainloop)
+		g_main_loop_quit(mainloop);
 }
 
 /*! \brief Termination handler (atexit) */
@@ -5154,10 +5157,9 @@ gint main(int argc, char *argv[])
 		janus_events_notify_handlers(JANUS_EVENT_TYPE_CORE, JANUS_EVENT_SUBTYPE_CORE_STARTUP, 0, info);
 	}
 
-	while(!g_atomic_int_get(&stop)) {
-		/* Loop until we have to stop */
-		usleep(250000); /* A signal will cancel usleep() but not g_usleep() */
-	}
+	/* Loop until we have to stop */
+	mainloop = g_main_loop_new (NULL, TRUE);
+	g_main_loop_run(mainloop);
 
 	/* If the Event Handlers mechanism is enabled, notify handlers that Janus is hanging up */
 	if(janus_events_is_enabled()) {

--- a/sdp.c
+++ b/sdp.c
@@ -727,9 +727,9 @@ int janus_sdp_parse_candidate(void *ice_stream, const char *candidate, int trick
 			mc->handle = handle;
 			mc->candidate = g_strdup(candidate);
 			mc->local = g_strdup(rip);
-			mc->cancellable = g_cancellable_new();
+			mc->cancellable = NULL;
 			GResolver *resolver = g_resolver_get_default();
-			g_resolver_lookup_by_name_async(resolver, rip, mc->cancellable,
+			g_resolver_lookup_by_name_async(resolver, rip, NULL,
 				(GAsyncReadyCallback)janus_sdp_mdns_resolved, mc);
 			return 0;
 		}


### PR DESCRIPTION
I've explained in #1998 how resolving mDNS candidates is done synchronously at the moment (using `getaddrinfo` that is a blocking request), and how this can cause the API to be unresponsive when that resolution takes a long time to timeout. That PR added a way to ignore mDNS candidates entirely, but was not an actual solution (especially in cases where you DO need to be able to resolve them).

This patch tries to address that, using [GResolver](https://developer.gnome.org/gio/stable/GResolver.html) to resolve mDNS candidates asynchronously: when a `.local` address is detected, and mDNS candidates are not ignored (default), we ask for an asynchronous resolution of the address and then return a success right away, thus keeping the API lean. When the address is resolved, we update the candidate we received originally and parse it as usual; if the handle went away in the meanwhile, we just drop it.

This adds a new dependency to `gio`, but to my knowledge it is always automatically installed when you install `glib`, so you should actually not need to do anything at all to use it (the installations instructions haven't been updated). I did make a small change in the core, though: since we needed a main loop to get `GResolver` to work, I got rid of the ugly `usleep(250000)` we had before, and turned that into a `GMainLoop` we run indefinitely there instead. This still works, because when we hit CTRL+C we just call `g_main_loop_quit()` and leave as expected.

I tested this briefly and it seems to be working as expected, but due to the asynchronous nature of the functionality, and the fact it may try to use stuff that has gone (e.g., answer to resolution arrived after the related handle was detached), I'm interested to figure out if it can cause issue, so feedback (and tests) welcome!