### PR TITLE
Prepare RTCP Sender Reports by considering the last RTP timestamp sent.

### DIFF
--- a/ice.h
+++ b/ice.h
@@ -403,10 +403,14 @@ struct janus_ice_stream {
 	gint64 video_first_ntp_ts[3];
 	/*! \brief First received video NTP RTP timestamp (for all simulcast video streams) */
 	guint32 video_first_rtp_ts[3];
+	/*! \brief Last sent audio NTP timestamp */
+	gint64 audio_last_ntp_ts;
 	/*! \brief Last sent audio RTP timestamp */
-	guint32 audio_last_ts;
+	guint32 audio_last_rtp_ts;
+	/*! \brief Last sent video NTP timestamp */
+	gint64 video_last_ntp_ts;
 	/*! \brief Last sent video RTP timestamp */
-	guint32 video_last_ts;
+	guint32 video_last_rtp_ts;
 	/*! \brief SDES mid RTP extension ID */
 	gint mid_ext_id;
 	/*! \brief RTP Stream extension ID, and the related rtx one */


### PR DESCRIPTION
**CONTEXT**
Janus periodically sends a RTCP Sender Report every 1 second.
When calculating the RTP timestamp to include in that report it does the following:
```c
gettimeofday(&tv, NULL);
int64_t ntp = tv.tv_sec*G_USEC_PER_SEC + tv.tv_usec;
uint32_t rtp_ts = ((ntp-stream->audio_first_ntp_ts)*(rtcp_ctx->tb))/1000000 + stream->audio_first_rtp_ts;
```
`stream->audio_first_ntp_ts`  and `stream->audio_first_rtp_ts` are respectively:
- the NTP timestamp of the **first** sent packet
- the RTP timestamp of the **first** sent packet

So basically Janus keeps memory of the first packet sent to an endpoint, then every 1 second calculates how much time has passed since that moment and it converts that time difference in a RTP timestamp difference. That value is the final SR timestamp.

**PROBLEM**
The first sample pair (`stream->audio_first_ntp_ts`  and `stream->audio_first_rtp_ts`) that Janus uses to calculate future RTCP SR may be affected by an error due to a very large number of reasons (like unexpected network delay, temporary RTP encoder issue on the sender's side and so on).
Once Janus has stored a wrong _starting point_, it will basically introduce a constant error in the future SR, confusing the RTP decoders that will try to compensate the associated media track.
In addition to this constant error, another worse issue might happen: in scenarios where the RTP clock of a sender is not honouring the nominal value (e.g. very high CPU load, clock drift etc.) and the SR sent by the sender itself would be affected by the same problem, Janus will continue to send RTCP SR to the receiver according to its own clock, again confusing the RTP decoder on the playout time of the media.
This described behavior **may explain some of the lipsync problems** that we have recently observed, including the still open #1653 . 

**RATIONALE**
The core concept here is that Janus, being a SFU, will never be a media source and so it should not  generate the RTCP by itself with its own local clock. Instead it should strictly follow the RTP timestamps that it is delivering, so that any clock issue on the sender's side would be acknowledged and compensated by the recipient. Trying to "fix" the RTCP SR clock, leaving the RTP clock as it is, will just confuse the RTP decoder and potentially lead to the aforementioned issues.

**FIX**
The proposed fix is to generate the RTCP SR timestamps by **evaluating the elapsed time since the last sending**, converting that elapsed time in RTP timestamp units and then add the difference to the last RTP timestamp sent.

```c
gettimeofday(&tv, NULL);
int64_t ntp = tv.tv_sec*G_USEC_PER_SEC + tv.tv_usec;
uint32_t rtp_ts = ((ntp-stream->video_last_ntp_ts)*(rtcp_ctx->tb))/1000000 + stream->video_last_rtp_ts;
```

Incidentally, it looks like mediasoup is [taking the same approach](https://github.com/versatica/mediasoup/blob/v3/worker/src/RTC/RtpStreamSend.cpp#L197). I'd like to hear what @ibc thinks about this.