### PR TITLE
http_transport: add NULL checks

### DIFF
--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -933,9 +933,9 @@ int janus_http_send_message(janus_transport_session *transport, void *request_id
 		janus_http_msg *msg = NULL;
 		while(session->longpolls) {
 			transport = (janus_transport_session *)session->longpolls->data;
-			msg = (janus_http_msg *)transport->transport_p;
+			msg = (janus_http_msg *)(transport ? transport->transport_p : NULL);
 			/* Is this connection ready to send a response back? */
-			if(g_atomic_pointer_compare_and_exchange(&msg->longpoll, session, NULL)) {
+			if(msg && g_atomic_pointer_compare_and_exchange(&msg->longpoll, session, NULL)) {
 				/* Send the events back */
 				if(msg->timeout != NULL) {
 					g_source_destroy(msg->timeout);


### PR DESCRIPTION
Refs #2005

I don't have enough info from that ticket to confirm that this is really a fix, but it does seem suspicious that these guards are present here https://github.com/meetecho/janus-gateway/blob/360fbc13367f782cd9ccd85a3e06c8981d60c750/transports/janus_http.c#L958

but not in this earlier branch.