### PR TITLE
Update media direction in SIP plugin if remote address is 0.0.0.0

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -5955,6 +5955,12 @@ static void *janus_sip_relay_thread(void *data) {
 					JANUS_LOG(LOG_ERR, "[SIP-%p] Couldn't update session details: video remote IP address (%s) is invalid\n",
 						session->account.username, session->media.remote_video_ip);
 			}
+
+			/* In case we're on hold (remote address is 0.0.0.0) set the send properties to FALSE */
+			if(have_audio_server_ip && !strcmp(session->media.remote_audio_ip, "0.0.0.0"))
+				session->media.audio_send = FALSE;
+			if(have_video_server_ip && !strcmp(session->media.remote_video_ip, "0.0.0.0"))
+				session->media.video_send = FALSE;
 		}
 
 		/* Prepare poll */


### PR DESCRIPTION
Pretty short patch, that is aimed at fixing an issue we sometimes apparently encounter when putting calls on hold. When we put a call on hold, we set the media direction to `sendonly`, as we don't want to receive anything until the call is resumed: apparently, though, this can sometimes cause issues when the remote party answers with a `0.0.0.0` c-address, that might result in the inability to send packets, ICMP errors, and as a result the call being torn down after a couple of seconds.

This patch adds a further check on the media address when (re)connecting sockets, updating the media direction to false for audio and/or video if their remote address is, indeed, `0.0.0.0`.

Feedback welcome!