### PR TITLE
Track pending nack cleanup tasks and cancel them when freeing a stream.

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -324,6 +324,7 @@ typedef struct janus_ice_nacked_packet {
 	janus_ice_handle *handle;
 	int vindex;
 	guint16 seq_number;
+	guint source_id;
 } janus_ice_nacked_packet;
 static gboolean janus_ice_nacked_packet_cleanup(gpointer user_data) {
 	janus_ice_nacked_packet *pkt = (janus_ice_nacked_packet *)user_data;
@@ -332,6 +333,7 @@ static gboolean janus_ice_nacked_packet_cleanup(gpointer user_data) {
 		JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Cleaning up NACKed packet %"SCNu16" (SSRC %"SCNu32", vindex %d)...\n",
 			pkt->handle->handle_id, pkt->seq_number, pkt->handle->stream->video_ssrc_peer[pkt->vindex], pkt->vindex);
 		g_hash_table_remove(pkt->handle->stream->rtx_nacked[pkt->vindex], GUINT_TO_POINTER(pkt->seq_number));
+		g_hash_table_remove(pkt->handle->stream->pending_nacked_cleanup, GUINT_TO_POINTER(pkt->source_id));
 	}
 
 	return G_SOURCE_REMOVE;
@@ -1434,6 +1436,18 @@ void janus_ice_stream_destroy(janus_ice_stream *stream) {
 		janus_ice_component_destroy(stream->component);
 		stream->component = NULL;
 	}
+	if(stream->pending_nacked_cleanup && g_hash_table_size(stream->pending_nacked_cleanup) > 0) {
+		GHashTableIter iter;
+		gpointer val;
+		g_hash_table_iter_init(&iter, stream->pending_nacked_cleanup);
+		while(g_hash_table_iter_next(&iter, NULL, &val)) {
+			GSource *source = val;
+			g_source_destroy(source);
+			g_source_unref(source);
+		}
+		g_hash_table_destroy(stream->pending_nacked_cleanup);
+	}
+	stream->pending_nacked_cleanup = NULL;
 	janus_ice_handle *handle = stream->handle;
 	if(handle != NULL) {
 		janus_refcount_decrease(&handle->ref);
@@ -2642,9 +2656,12 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 								np->handle = handle;
 								np->seq_number = cur_seq->seq;
 								np->vindex = vindex;
+								if(stream->pending_nacked_cleanup == NULL)
+									stream->pending_nacked_cleanup = g_hash_table_new(NULL, NULL);
 								GSource *timeout_source = g_timeout_source_new_seconds(5);
 								g_source_set_callback(timeout_source, janus_ice_nacked_packet_cleanup, np, (GDestroyNotify)g_free);
-								g_source_attach(timeout_source, handle->mainctx);
+								np->source_id = g_source_attach(timeout_source, handle->mainctx);
+								g_hash_table_insert(stream->pending_nacked_cleanup, GUINT_TO_POINTER(np->source_id), timeout_source);
 								g_source_unref(timeout_source);
 							}
 						} else if(cur_seq->state == SEQ_NACKED  && now - cur_seq->ts > SEQ_NACKED_WAIT) {

--- a/ice.h
+++ b/ice.h
@@ -395,6 +395,8 @@ struct janus_ice_stream {
 	uint16_t nack_queue_ms;
 	/*! \brief Map(s) of the NACKed packets (to track retransmissions and avoid duplicates) */
 	GHashTable *rtx_nacked[3];
+	/*! \brief Map of the pending NACKed cleanup callback */
+	GHashTable *pending_nacked_cleanup;
 	/*! \brief First received audio NTP timestamp */
 	gint64 audio_first_ntp_ts;
 	/*! \brief First received audio RTP timestamp */


### PR DESCRIPTION
This PR aims at fixing (again) #1453 .

This time we are tracking the pending cleanup tasks in a map. When destroying a stream the map is traversed and all pending tasks get cancelled.
I've made a couple of tests and everything seems to work (e.g. no leaks, no crashes) however we'll definitely need more feedback before merging and marking this as solved.