### PR TITLE
Reference count janus_request instances

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -575,6 +575,24 @@ static void janus_session_free(const janus_refcount *session_ref) {
 	g_free(session);
 }
 
+static janus_request *janus_session_get_request(janus_session *session) {
+	if(session == NULL)
+		return NULL;
+	janus_mutex_lock(&session->mutex);
+	janus_request *source = session->source;
+	if(source != NULL && !g_atomic_int_get(&source->destroyed)) {
+		janus_refcount_increase(&source->ref);
+	} else {
+		source = NULL;
+	}
+	janus_mutex_unlock(&session->mutex);
+	return source;
+}
+static void janus_request_unref(janus_request *request) {
+	if(request)
+		janus_refcount_decrease(&request->ref);
+}
+
 static gboolean janus_check_sessions(gpointer user_data) {
 	if(session_timeout < 1)		/* Session timeouts are disabled */
 		return G_SOURCE_CONTINUE;
@@ -597,12 +615,14 @@ static gboolean janus_check_sessions(gpointer user_data) {
 				/* Mark the session as over, we'll deal with it later */
 				janus_session_handles_clear(session);
 				/* Notify the transport */
-				if(session->source) {
+				janus_request *source = janus_session_get_request(session);
+				if(source) {
 					json_t *event = janus_create_message("timeout", session->session_id, NULL);
 					/* Send this to the transport client and notify the session's over */
-					session->source->transport->send_message(session->source->instance, NULL, FALSE, event);
-					session->source->transport->session_over(session->source->instance, session->session_id, TRUE, FALSE);
+					source->transport->send_message(source->instance, NULL, FALSE, event);
+					source->transport->session_over(source->instance, session->session_id, TRUE, FALSE);
 				}
+				janus_request_unref(source);
 				/* Notify event handlers as well */
 				if(janus_events_is_enabled())
 					janus_events_notify_handlers(JANUS_EVENT_TYPE_SESSION, JANUS_EVENT_SUBTYPE_NONE,
@@ -684,16 +704,16 @@ janus_session *janus_session_find(guint64 session_id) {
 
 void janus_session_notify_event(janus_session *session, json_t *event) {
 	if(session != NULL && !g_atomic_int_get(&session->destroyed)) {
-		janus_mutex_lock(&session->mutex);
-		if(session->source != NULL && session->source->transport != NULL) {
+		janus_request *source = janus_session_get_request(session);
+		if(source != NULL && source->transport != NULL) {
 			/* Send this to the transport client */
-			JANUS_LOG(LOG_HUGE, "Sending event to %s (%p)\n", session->source->transport->get_package(), session->source->instance);
-			session->source->transport->send_message(session->source->instance, NULL, FALSE, event);
+			JANUS_LOG(LOG_HUGE, "Sending event to %s (%p)\n", source->transport->get_package(), source->instance);
+			source->transport->send_message(source->instance, NULL, FALSE, event);
 		} else {
 			/* No transport, free the event */
 			json_decref(event);
 		}
-		janus_mutex_unlock(&session->mutex);
+		janus_request_unref(source);
 	} else {
 		/* No session, free the event */
 		json_decref(event);
@@ -782,6 +802,20 @@ json_t *janus_session_handles_list_json(janus_session *session) {
 }
 
 /* Requests management */
+static void janus_request_free(const janus_refcount *request_ref) {
+	janus_request *request = janus_refcount_containerof(request_ref, janus_request, ref);
+	/* This request can be destroyed, free all the resources */
+	request->transport = NULL;
+	if(request->instance)
+		janus_refcount_decrease(&request->instance->ref);
+	request->instance = NULL;
+	request->request_id = NULL;
+	if(request->message)
+		json_decref(request->message);
+	request->message = NULL;
+	g_free(request);
+}
+
 janus_request *janus_request_new(janus_transport *transport, janus_transport_session *instance, void *request_id, gboolean admin, json_t *message) {
 	janus_request *request = g_malloc(sizeof(janus_request));
 	request->transport = transport;
@@ -790,20 +824,15 @@ janus_request *janus_request_new(janus_transport *transport, janus_transport_ses
 	request->request_id = request_id;
 	request->admin = admin;
 	request->message = message;
+	g_atomic_int_set(&request->destroyed, 0);
+	janus_refcount_init(&request->ref, janus_request_free);
 	return request;
 }
 
 void janus_request_destroy(janus_request *request) {
-	if(request == NULL || request == &exit_message)
+	if(request == NULL || request == &exit_message || !g_atomic_int_compare_and_exchange(&request->destroyed, 0, 1))
 		return;
-	request->transport = NULL;
-	janus_refcount_decrease(&request->instance->ref);
-	request->instance = NULL;
-	request->request_id = NULL;
-	if(request->message)
-		json_decref(request->message);
-	request->message = NULL;
-	g_free(request);
+	janus_refcount_decrease(&request->ref);
 }
 
 static int janus_request_check_secret(janus_request *request, guint64 session_id, const gchar *transaction_text) {
@@ -1116,10 +1145,11 @@ int janus_process_incoming_request(janus_request *request) {
 		g_hash_table_remove(sessions, &session->session_id);
 		janus_mutex_unlock(&sessions_mutex);
 		/* Notify the source that the session has been destroyed */
-		janus_mutex_lock(&session->mutex);
-		if(session->source && session->source->transport)
-			session->source->transport->session_over(session->source->instance, session->session_id, FALSE, FALSE);
-		janus_mutex_unlock(&session->mutex);
+		janus_request *source = janus_session_get_request(session);
+		if(source && source->transport)
+			source->transport->session_over(source->instance, session->session_id, FALSE, FALSE);
+		janus_request_unref(source);
+
 		/* Schedule the session for deletion */
 		janus_session_destroy(session);
 
@@ -2461,10 +2491,10 @@ int janus_process_incoming_admin_request(janus_request *request) {
 			g_hash_table_remove(sessions, &session->session_id);
 			janus_mutex_unlock(&sessions_mutex);
 			/* Notify the source that the session has been destroyed */
-			janus_mutex_lock(&session->mutex);
-			if(session->source && session->source->transport)
-				session->source->transport->session_over(session->source->instance, session->session_id, FALSE, FALSE);
-			janus_mutex_unlock(&session->mutex);
+			janus_request *source = janus_session_get_request(session);
+			if(source && source->transport)
+				source->transport->session_over(source->instance, session->session_id, FALSE, FALSE);
+			janus_request_unref(source);
 			/* Schedule the session for deletion */
 			janus_session_destroy(session);
 
@@ -4716,7 +4746,7 @@ gint main(int argc, char *argv[])
 		exit(1);
 	}
 	/* Start the thread that will dispatch incoming requests */
-	requests = g_async_queue_new_full((GDestroyNotify) janus_request_destroy);
+	requests = g_async_queue_new_full((GDestroyNotify)janus_request_destroy);
 	GThread *requests_thread = g_thread_try_new("sessions requests", &janus_transport_requests, NULL, &error);
 	if(error != NULL) {
 		JANUS_LOG(LOG_FATAL, "Got error %d (%s) trying to start requests thread...\n", error->code, error->message ? error->message : "??");

--- a/janus.h
+++ b/janus.h
@@ -127,6 +127,10 @@ struct janus_request {
 	gboolean admin;
 	/*! \brief Pointer to the original request, if available */
 	json_t *message;
+	/*! \brief Atomic flag to check if this instance has been destroyed */
+	volatile gint destroyed;
+	/*! \brief Reference counter for this instance */
+	janus_refcount ref;
 };
 /*! \brief Helper to allocate a janus_request instance
  * @param[in] transport Pointer to the transport

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -127,20 +127,29 @@ typedef struct janus_http_msg {
 	char *response;						/* The response from the core as a string */
 	size_t resplen;						/* Length of the response in octets */
 	GSource *timeout;					/* Timeout monitor, if any */
+	volatile gint destroyed;			/* Whether this session has been destroyed */
+	janus_refcount ref;					/* Reference counter for this message */
 } janus_http_msg;
 static GHashTable *messages = NULL;
 static janus_mutex messages_mutex = JANUS_MUTEX_INITIALIZER;
 
-static void janus_http_msg_destroy(void *msg) {
-	if(!msg)
+static void janus_http_msg_free(const janus_refcount *msg_ref) {
+	janus_http_msg *request = janus_refcount_containerof(msg_ref, janus_http_msg, ref);
+	/* This message can be destroyed, free all the resources */
+	if(!request)
 		return;
-	janus_http_msg *request = (janus_http_msg *)msg;
 	g_free(request->payload);
 	g_free(request->contenttype);
 	g_free(request->acrh);
 	g_free(request->acrm);
 	g_free(request->response);
 	g_free(request);
+}
+
+static void janus_http_msg_destroy(void *msg) {
+	janus_http_msg *request = (janus_http_msg *)msg;
+	if(request && g_atomic_int_compare_and_exchange(&request->destroyed, 0, 1))
+		janus_refcount_decrease(&request->ref);
 }
 
 
@@ -487,8 +496,9 @@ static struct MHD_Daemon *janus_http_create_daemon(gboolean admin, char *path,
 
 /* Static helper method to fill in the CORS headers */
 static void janus_http_add_cors_headers(janus_http_msg *msg, struct MHD_Response *response) {
-	if(msg == NULL || response == NULL)
+	if(msg == NULL || g_atomic_int_get(&msg->destroyed) || response == NULL)
 		return;
+	janus_refcount_increase(&msg->ref);
 	MHD_add_response_header(response, "Access-Control-Allow-Origin", allow_origin ? allow_origin : "*");
 	if(allow_origin) {
 		/* We need these two headers as well, in case Access-Control-Allow-Origin is custom */
@@ -500,6 +510,7 @@ static void janus_http_add_cors_headers(janus_http_msg *msg, struct MHD_Response
 		MHD_add_response_header(response, "Access-Control-Allow-Methods", msg->acrm);
 	if(msg->acrh)
 		MHD_add_response_header(response, "Access-Control-Allow-Headers", msg->acrh);
+	janus_refcount_decrease(&msg->ref);
 }
 
 /* Static callback that we register to */
@@ -828,7 +839,9 @@ void janus_http_destroy(void) {
 	while(g_hash_table_iter_next(&iter, NULL, &value)) {
 		janus_transport_session *transport = value;
 		janus_http_msg *msg = (janus_http_msg *)transport->transport_p;
-		MHD_resume_connection(msg->connection);
+		if(msg != NULL && !g_atomic_int_get(&msg->destroyed)) {
+			MHD_resume_connection(msg->connection);
+		}
 	}
 	janus_mutex_unlock(&messages_mutex);
 
@@ -937,6 +950,7 @@ int janus_http_send_message(janus_transport_session *transport, void *request_id
 			msg = (janus_http_msg *)(transport ? transport->transport_p : NULL);
 			/* Is this connection ready to send a response back? */
 			if(msg && g_atomic_pointer_compare_and_exchange(&msg->longpoll, session, NULL)) {
+				janus_refcount_increase(&msg->ref);
 				/* Send the events back */
 				if(msg->timeout != NULL) {
 					g_source_destroy(msg->timeout);
@@ -945,6 +959,7 @@ int janus_http_send_message(janus_transport_session *transport, void *request_id
 				}
 				msg->timeout = NULL;
 				janus_http_notifier(msg);
+				janus_refcount_decrease(&msg->ref);
 			}
 			session->longpolls = g_list_remove(session->longpolls, transport);
 		}
@@ -972,10 +987,12 @@ int janus_http_send_message(janus_transport_session *transport, void *request_id
 			return -1;
 		}
 		janus_http_msg *msg = (janus_http_msg *)transport->transport_p;
+		janus_refcount_increase(&msg->ref);
 		janus_mutex_unlock(&messages_mutex);
 		if(!msg->connection) {
 			JANUS_LOG(LOG_ERR, "Invalid HTTP connection...\n");
 			json_decref(message);
+			janus_refcount_decrease(&msg->ref);
 			return -1;
 		}
 		if(msg->timeout != NULL) {
@@ -988,6 +1005,7 @@ int janus_http_send_message(janus_transport_session *transport, void *request_id
 		msg->response = response_text;
 		msg->resplen = strlen(response_text);
 		MHD_resume_connection(msg->connection);
+		janus_refcount_decrease(&msg->ref);
 	}
 	return 0;
 }
@@ -1051,6 +1069,7 @@ void janus_http_session_claimed(janus_transport_session *transport, guint64 sess
 		transport = (janus_transport_session *)old_session->longpolls->data;
 		msg = (janus_http_msg *)(transport ? transport->transport_p : NULL);
 		if(msg != NULL) {
+			janus_refcount_increase(&msg->ref);
 			if(msg->timeout != NULL) {
 				g_source_destroy(msg->timeout);
 				janus_refcount_decrease(&old_session->ref);
@@ -1064,6 +1083,7 @@ void janus_http_session_claimed(janus_transport_session *transport, guint64 sess
 				g_source_set_callback(msg->timeout, janus_http_timeout, transport, NULL);
 				g_source_attach(msg->timeout, httpctx);
 			}
+			janus_refcount_decrease(&msg->ref);
 		}
 		session->longpolls = g_list_remove(old_session->longpolls, transport);
 	}
@@ -1135,6 +1155,7 @@ static int janus_http_handler(void *cls, struct MHD_Connection *connection,
 		JANUS_LOG(LOG_DBG, " ... Just parsing headers for now...\n");
 		msg = g_malloc0(sizeof(janus_http_msg));
 		msg->connection = connection;
+		janus_refcount_init(&msg->ref, janus_http_msg_free);
 		ts = janus_transport_session_create(msg, janus_http_msg_destroy);
 		janus_mutex_lock(&messages_mutex);
 		g_hash_table_insert(messages, ts, ts);
@@ -1741,6 +1762,7 @@ done:
 
 static int janus_http_headers(void *cls, enum MHD_ValueKind kind, const char *key, const char *value) {
 	janus_http_msg *request = (janus_http_msg *)cls;
+	janus_refcount_increase(&request->ref);
 	JANUS_LOG(LOG_DBG, "%s: %s\n", key, value);
 	if(!strcasecmp(key, MHD_HTTP_HEADER_CONTENT_TYPE)) {
 		if(request)
@@ -1752,6 +1774,7 @@ static int janus_http_headers(void *cls, enum MHD_ValueKind kind, const char *ke
 		if(request)
 			request->acrh = g_strdup(value);
 	}
+	janus_refcount_decrease(&request->ref);
 	return MHD_YES;
 }
 
@@ -1763,6 +1786,7 @@ static void janus_http_request_completed(void *cls, struct MHD_Connection *conne
 		return;
 	janus_http_msg *request = (janus_http_msg *)ts->transport_p;
 	if(request != NULL) {
+		janus_refcount_increase(&request->ref);
 		janus_http_session *session = (janus_http_session *)g_atomic_pointer_get(&request->longpoll);
 		if(session != NULL)
 			janus_refcount_increase(&session->ref);
@@ -1779,6 +1803,7 @@ static void janus_http_request_completed(void *cls, struct MHD_Connection *conne
 			janus_mutex_unlock(&session->mutex);
 			janus_refcount_decrease(&session->ref);
 		}
+		janus_refcount_decrease(&request->ref);
 	}
 	janus_mutex_lock(&messages_mutex);
 	g_hash_table_remove(messages, ts);
@@ -1792,10 +1817,12 @@ static ssize_t janus_http_response_callback(void *cls, uint64_t pos, char *buf, 
 		return MHD_CONTENT_READER_END_WITH_ERROR;
 	if(pos >= request->resplen)
 		return MHD_CONTENT_READER_END_OF_STREAM;
+	janus_refcount_increase(&request->ref);
 	size_t bytes = request->resplen - pos;
 	if(bytes > max)
 		bytes = max;
 	memcpy(buf, request->response + pos, bytes);
+	janus_refcount_decrease(&request->ref);
 	return bytes;
 }
 
@@ -1881,6 +1908,7 @@ static int janus_http_return_success(janus_transport_session *ts, char *payload)
 			free(payload);
 		return MHD_NO;
 	}
+	janus_refcount_increase(&msg->ref);
 	struct MHD_Response *response = MHD_create_response_from_buffer(
 		payload ? strlen(payload) : 0,
 		(void*)payload,
@@ -1889,6 +1917,7 @@ static int janus_http_return_success(janus_transport_session *ts, char *payload)
 	janus_http_add_cors_headers(msg, response);
 	int ret = MHD_queue_response(msg->connection, MHD_HTTP_OK, response);
 	MHD_destroy_response(response);
+	janus_refcount_decrease(&msg->ref);
 	return ret;
 }
 


### PR DESCRIPTION
While investigating #2005, and while @atoppi tried to replicate the issue, we found out that for some reason `janus_request` was one of the few structures still not using our reference counter mechanism. This `janus_request` structure contains a reference to the transport instance that originated it, and is actually used in two different ways:

1. any time we receive a request from a transport, we create an instance of `janus_request` and we destroy it when the request has been served (or acked, if it's an asynchronous plugin message);
2. when a session is created, we create an instance as well, in order to keep track of the transport instance we should send events to.

The latter in particular seems to be the root cause of issues like #2005: since this request object contains a reference to the transport instance, if that request is destroyed while it's used (e.g., in a `send_message` on the transport) it can cause a crash. The fact that this is not refcounted makes it of course much harder to track and protect accordingly.

As such, this patch adds refcount support to that struct, and adds a way to (try and) ensure it's not destroyed while it's used. Specifically, now each attempt to mess with `session->source` (which is the pointer the `janus_request` the session owns) is protected by the session mutex: rather than just wrap any attempt to use that request and its transport (e.g., to interact with transport plugins), I added a new method that, using the mutex, copies the pointer and increases the refcount, while we work on the copy for what we need to do. Basically, you'll find something like this:

	janus_request *source = janus_session_get_request(session);
	if(source && source->transport)
		source->transport->session_over(source->instance, session->session_id, FALSE, FALSE);
	janus_request_unref(source);

where `janus_session_get_request` returns a pointer to `session->source` with an additional reference (hence the `janus_request_unref` after we've used it) which has been obtained locking the session mutex. This way, even if something else unrefs the session request, it will not be destroyed until we're actually done with it.

This should also mitigate some risk of deadlock we had before, where we were invoking transport methods with the session mutex locked: while none of the transports invoked a core callback from those method, thus risking a new session mutex lock, new or third party transports might, and so this now avoids it, as we only use the mutex to get a reference to the request we need, *before* invoking the transport method.

I only did some brief tests here, and it doesn't seem to introduce leaks, but of course we'll need some more extensive testing to be sure this does indeed fix the HTTP issue mentioned in #2005, and if it does that it doesn't introduce regressions in HTTP or other transports.