### PR TITLE
Updates to mutex unlocking in textroom and videoroom plugins

### DIFF
--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -1453,8 +1453,8 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 			g_snprintf(error_cause, 512, "No such room (%s)", room_id_str);
 			goto msg_response;
 		}
-		janus_mutex_unlock(&rooms_mutex);
 		janus_refcount_increase(&textroom->ref);
+		janus_mutex_unlock(&rooms_mutex);
 		janus_mutex_lock(&textroom->mutex);
 		janus_textroom_participant *participant = g_hash_table_lookup(session->rooms,
 			string_ids ? (gpointer)room_id_str : (gpointer)&room_id);
@@ -1634,8 +1634,8 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 			g_snprintf(error_cause, 512, "No such room (%s)", room_id_str);
 			goto msg_response;
 		}
-		janus_mutex_unlock(&rooms_mutex);
 		janus_refcount_increase(&textroom->ref);
+		janus_mutex_unlock(&rooms_mutex);
 		janus_mutex_lock(&textroom->mutex);
 		/* A PIN may be required for this action */
 		JANUS_CHECK_SECRET(textroom->room_pin, root, "pin", error_code, error_cause,
@@ -1771,8 +1771,8 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 			g_snprintf(error_cause, 512, "No such room (%s)", room_id_str);
 			goto msg_response;
 		}
-		janus_mutex_unlock(&rooms_mutex);
 		janus_refcount_increase(&textroom->ref);
+		janus_mutex_unlock(&rooms_mutex);
 		janus_mutex_lock(&textroom->mutex);
 		janus_mutex_lock(&session->mutex);
 		janus_textroom_participant *participant = g_hash_table_lookup(session->rooms,
@@ -2190,8 +2190,8 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 			g_snprintf(error_cause, 512, "No such room (%s)", room_id_str);
 			goto msg_response;
 		}
-		janus_mutex_unlock(&rooms_mutex);
 		janus_refcount_increase(&textroom->ref);
+		janus_mutex_unlock(&rooms_mutex);
 		janus_mutex_lock(&textroom->mutex);
 		/* A secret may be required for this action */
 		JANUS_CHECK_SECRET(textroom->room_secret, root, "secret", error_code, error_cause,

--- a/plugins/janus_textroom.c
+++ b/plugins/janus_textroom.c
@@ -1453,9 +1453,9 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 			g_snprintf(error_cause, 512, "No such room (%s)", room_id_str);
 			goto msg_response;
 		}
+		janus_mutex_unlock(&rooms_mutex);
 		janus_refcount_increase(&textroom->ref);
 		janus_mutex_lock(&textroom->mutex);
-		janus_mutex_unlock(&rooms_mutex);
 		janus_textroom_participant *participant = g_hash_table_lookup(session->rooms,
 			string_ids ? (gpointer)room_id_str : (gpointer)&room_id);
 		if(participant == NULL) {
@@ -1634,9 +1634,9 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 			g_snprintf(error_cause, 512, "No such room (%s)", room_id_str);
 			goto msg_response;
 		}
+		janus_mutex_unlock(&rooms_mutex);
 		janus_refcount_increase(&textroom->ref);
 		janus_mutex_lock(&textroom->mutex);
-		janus_mutex_unlock(&rooms_mutex);
 		/* A PIN may be required for this action */
 		JANUS_CHECK_SECRET(textroom->room_pin, root, "pin", error_code, error_cause,
 			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT, JANUS_TEXTROOM_ERROR_UNAUTHORIZED);
@@ -1771,9 +1771,9 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 			g_snprintf(error_cause, 512, "No such room (%s)", room_id_str);
 			goto msg_response;
 		}
+		janus_mutex_unlock(&rooms_mutex);
 		janus_refcount_increase(&textroom->ref);
 		janus_mutex_lock(&textroom->mutex);
-		janus_mutex_unlock(&rooms_mutex);
 		janus_mutex_lock(&session->mutex);
 		janus_textroom_participant *participant = g_hash_table_lookup(session->rooms,
 			string_ids ? (gpointer)room_id_str : (gpointer)&room_id);
@@ -2190,9 +2190,9 @@ janus_plugin_result *janus_textroom_handle_incoming_request(janus_plugin_session
 			g_snprintf(error_cause, 512, "No such room (%s)", room_id_str);
 			goto msg_response;
 		}
+		janus_mutex_unlock(&rooms_mutex);
 		janus_refcount_increase(&textroom->ref);
 		janus_mutex_lock(&textroom->mutex);
-		janus_mutex_unlock(&rooms_mutex);
 		/* A secret may be required for this action */
 		JANUS_CHECK_SECRET(textroom->room_secret, root, "secret", error_code, error_cause,
 			JANUS_TEXTROOM_ERROR_MISSING_ELEMENT, JANUS_TEXTROOM_ERROR_INVALID_ELEMENT, JANUS_TEXTROOM_ERROR_UNAUTHORIZED);

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -4127,8 +4127,8 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 			janus_mutex_unlock(&rooms_mutex);
 			goto prepare_response;
 		}
-		janus_mutex_unlock(&rooms_mutex);
 		janus_refcount_increase(&videoroom->ref);
+		janus_mutex_unlock(&rooms_mutex);
 		janus_mutex_lock(&videoroom->mutex);
 		/* A secret may be required for this action */
 		JANUS_CHECK_SECRET(videoroom->room_secret, root, "secret", error_code, error_cause,
@@ -5354,8 +5354,8 @@ static void *janus_videoroom_handler(void *data) {
 				janus_mutex_unlock(&rooms_mutex);
 				goto error;
 			}
-			janus_mutex_unlock(&rooms_mutex);
 			janus_refcount_increase(&videoroom->ref);
+			janus_mutex_unlock(&rooms_mutex);
 			janus_mutex_lock(&videoroom->mutex);
 			json_t *ptype = json_object_get(root, "ptype");
 			const char *ptype_text = json_string_value(ptype);
@@ -5378,8 +5378,7 @@ static void *janus_videoroom_handler(void *data) {
 						error_code, error_cause, TRUE,
 						JANUS_VIDEOROOM_ERROR_MISSING_ELEMENT, JANUS_VIDEOROOM_ERROR_INVALID_ELEMENT);
 				}
-				if(error_code != 0)
-				{
+				if(error_code != 0) {
 					janus_mutex_unlock(&videoroom->mutex);
 					janus_refcount_decrease(&videoroom->ref);
 					goto error;
@@ -5643,8 +5642,7 @@ static void *janus_videoroom_handler(void *data) {
 						error_code, error_cause, TRUE,
 						JANUS_VIDEOROOM_ERROR_MISSING_ELEMENT, JANUS_VIDEOROOM_ERROR_INVALID_ELEMENT);
 				}
-				if(error_code != 0)
-				{
+				if(error_code != 0) {
 					janus_mutex_unlock(&videoroom->mutex);
 					goto error;
 				}


### PR DESCRIPTION
We've found a few locations in the textroom and videoroom plugins that benefit from ensuring the rooms mutex is unlocked before locking a specific room mutex, as well as a couple of places in videoroom where an unlock was necessary and one place where a refcount_decrease was needed. It appears that one of the changes we made is also in PR #1996.