### PR TITLE
Detect libsrtp(2) using pkg-config (fixes #2019)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -144,6 +144,8 @@ janus_SOURCES = \
 janus_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(JANUS_CFLAGS) \
+	$(LIBSRTP_CFLAGS) \
+	$(LIBCURL_CFLAGS) \
 	-DPLUGINDIR=\"$(plugindir)\" \
 	-DTRANSPORTDIR=\"$(transportdir)\" \
 	-DEVENTDIR=\"$(eventdir)\" \
@@ -156,6 +158,8 @@ janus_LDADD = \
 	$(BORINGSSL_LIBS) \
 	$(JANUS_LIBS) \
 	$(JANUS_MANUAL_LIBS) \
+	$(LIBSRTP_LDFLAGS) $(LIBSRTP_LIBS) \
+	$(LIBCURL_LDFLAGS) $(LIBCURL_LIBS) \
 	$(NULL)
 
 dist_man1_MANS = janus.1
@@ -317,9 +321,9 @@ events_libadd = \
 if ENABLE_SAMPLEEVH
 event_LTLIBRARIES += events/libjanus_sampleevh.la
 events_libjanus_sampleevh_la_SOURCES = events/janus_sampleevh.c
-events_libjanus_sampleevh_la_CFLAGS = $(events_cflags)
-events_libjanus_sampleevh_la_LDFLAGS = $(events_ldflags) -lcurl -lm
-events_libjanus_sampleevh_la_LIBADD = $(events_libadd)
+events_libjanus_sampleevh_la_CFLAGS = $(events_cflags) $(LIBCURL_CFLAGS)
+events_libjanus_sampleevh_la_LDFLAGS = $(events_ldflags) $(LIBCURL_LDFLAGS) $(LIBCURL_LIBS) -lm
+events_libjanus_sampleevh_la_LIBADD = $(events_libadd) $(LIBCURL_LIBADD)
 conf_DATA += conf/janus.eventhandler.sampleevh.jcfg.sample
 EXTRA_DIST += conf/janus.eventhandler.sampleevh.jcfg.sample
 endif
@@ -582,11 +586,13 @@ janus_pp_rec_SOURCES = \
 
 janus_pp_rec_CFLAGS = \
 	$(AM_CFLAGS) \
+	$(LIBCURL_CFLAGS) \
 	$(POST_PROCESSING_CFLAGS) \
 	$(NULL)
 
 janus_pp_rec_LDADD = \
 	$(POST_PROCESSING_LIBS) \
+	$(LIBCURL_LDFLAGS) $(LIBCURL_LIBS) \
 	$(NULL)
 
 BUILT_SOURCES += postprocessing/pp-cmdline.c postprocessing/pp-cmdline.h

--- a/configure.ac
+++ b/configure.ac
@@ -387,51 +387,29 @@ AC_CHECK_LIB([dl],
 
 AM_CONDITIONAL([ENABLE_LIBSRTP_2], false)
 AS_IF([test "x$enable_libsrtp2" != "xno"],
-      [AC_CHECK_LIB([srtp2],
-                    [srtp_init],
-                    [
-                      AC_CHECK_HEADER([srtp2/srtp.h],
-                                      [
-                                        AC_DEFINE(HAVE_SRTP_2)
-                                        JANUS_MANUAL_LIBS="${JANUS_MANUAL_LIBS} -lsrtp2"
-                                        enable_libsrtp2=yes
-                                        AM_CONDITIONAL([ENABLE_LIBSRTP_2], true)
-                                        AC_CHECK_LIB([srtp2],
-                                                     [srtp_crypto_policy_set_aes_gcm_256_16_auth],
-                                                     [AC_DEFINE(HAVE_SRTP_AESGCM)],
-                                                     [AC_MSG_NOTICE([libsrtp2 does not have support for AES-GCM profiles])])
-                                      ],
-                                      [
-                                        AS_IF([test "x$enable_libsrtp2" = "xyes"],
-                                              [AC_MSG_ERROR([libsrtp2 headers not found. See README.md for installation instructions or use --disable-libsrtp-2 to try and autodetect libsrtp 1.5.x instead])])
-                                      ])
-                    ],
-                    [
-                      AS_IF([test "x$enable_libsrtp2" = "xyes"],
-                            [AC_MSG_ERROR([libsrtp2 not found. See README.md for installation instructions or use --disable-libsrtp-2 to try and autodetect libsrtp 1.5.x instead])])
-                    ])
+      [PKG_CHECK_MODULES([LIBSRTP],
+                         [libsrtp2],
+                         [
+                          AC_DEFINE(HAVE_SRTP_2)
+                          AC_DEFINE(HAVE_SRTP_AESGCM)
+                          enable_libsrtp2=yes
+                          AM_CONDITIONAL([ENABLE_LIBSRTP_2], true)
+                         ],
+                         [
+                          AS_IF([test "x$enable_libsrtp2" = "xyes"],
+                                [AC_MSG_ERROR([libsrtp2 headers not found. See README.md for installation instructions or use --disable-libsrtp-2 to try and autodetect libsrtp 1.5.x instead])])
+                         ])
       ])
 AM_COND_IF([ENABLE_LIBSRTP_2],
            [],
-           [AC_CHECK_LIB([srtp],
-                         [srtp_init],
-                         [
-                           AC_CHECK_HEADER([srtp/srtp.h],
-                                           [
-                                             JANUS_MANUAL_LIBS="${JANUS_MANUAL_LIBS} -lsrtp"
-                                             enable_libsrtp2=no
-                                             PKG_CHECK_MODULES([SRTP15X],
-                                                               [
-                                                                 libsrtp >= 1.5.0
-                                                               ])
-                                             AC_CHECK_LIB([srtp],
-                                                          [crypto_policy_set_aes_gcm_256_16_auth],
-                                                          [AC_DEFINE(HAVE_SRTP_AESGCM)],
-                                                          [AC_MSG_NOTICE([libsrtp does not have support for AES-GCM profiles])])
-                                           ],
-                                           [AC_MSG_ERROR([libsrtp and libsrtp2 headers not found. See README.md for installation instructions])])
-                         ],
-                         [AC_MSG_ERROR([libsrtp and libsrtp2 not found. See README.md for installation instructions])])
+           [PKG_CHECK_MODULES([LIBSRTP],
+                              [libsrtp >= 1.5.0],
+                              [
+                               AC_DEFINE(HAVE_SRTP_AESGCM)
+                               enable_libsrtp2=no
+                              ],
+                              [AC_MSG_ERROR([libsrtp and libsrtp2 not found. See README.md for installation instructions])
+                              ])
            ])
 
 AC_CHECK_LIB([usrsctp],
@@ -454,7 +432,6 @@ PKG_CHECK_MODULES([LIBCURL],
                   [libcurl],
                   [
                     AC_DEFINE(HAVE_LIBCURL)
-                    JANUS_MANUAL_LIBS="${JANUS_MANUAL_LIBS} -lcurl"
                     AS_IF(
                       [test "x$enable_turn_rest_api" != "xno"],
                       [


### PR DESCRIPTION
This should help address #2019, where a custom installation of libsrtp/libsrtp2 is not found and used properly by Janus.

Notice that this removes the check we had on `srtp_crypto_policy_set_aes_gcm_256_16_auth` (for libsrtp2) and `crypto_policy_set_aes_gcm_256_16_auth` (for libsrtp), and now assumes they're always available since I don't think we can check for the function now that the location for the library stuff is delegated to pkg-config. I can't remember why we had the check in place: it may be it's only implemented if the library has been build with OpenSSL, but not otherwise, but I'm not sure. In case a check is indeed needed, we'll have to find a way to do that (hints welcome).

Please test and ensure this works for you.