### PR TITLE
Added support for static Opus files to Streaming plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -460,9 +460,9 @@ endif
 if ENABLE_PLUGIN_STREAMING
 plugin_LTLIBRARIES += plugins/libjanus_streaming.la
 plugins_libjanus_streaming_la_SOURCES = plugins/janus_streaming.c
-plugins_libjanus_streaming_la_CFLAGS = $(plugins_cflags) $(LIBCURL_CFLAGS)
-plugins_libjanus_streaming_la_LDFLAGS = $(plugins_ldflags) $(LIBCURL_LDFLAGS) $(LIBCURL_LIBS)
-plugins_libjanus_streaming_la_LIBADD = $(plugins_libadd) $(LIBCURL_LIBADD)
+plugins_libjanus_streaming_la_CFLAGS = $(plugins_cflags) $(LIBCURL_CFLAGS) $(OGG_CFLAGS)
+plugins_libjanus_streaming_la_LDFLAGS = $(plugins_ldflags) $(LIBCURL_LDFLAGS) $(LIBCURL_LIBS) $(OGG_LDFLAGS) $(OGG_LIBS)
+plugins_libjanus_streaming_la_LIBADD = $(plugins_libadd) $(LIBCURL_LIBADD) $(OGG_LIBADD)
 conf_DATA += conf/janus.plugin.streaming.jcfg.sample
 stream_DATA += \
 	plugins/streams/music.mulaw \

--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -94,10 +94,19 @@ general: {
 	#string_ids = true
 }
 
-gstreamer-sample: {
+#
+# This is an example of an RTP source stream, which is what you'll need
+# in the vast majority of cases: here, the Streaming plugin will bind to
+# some ports, and expect media to be sent by an external source (e.g.,
+# FFmpeg or Gstreamer). This sample listens on 5002 for audio (Opus) and
+# 5004 for video (VP8), which is what the sample gstreamer script in the
+# plugins/streams folder sends to. Whatever is sent to those ports will
+# be the source of a WebRTC broadcast users can subscribe to.
+#
+rtp-sample: {
 	type = "rtp"
 	id = 1
-	description = "Opus/VP8 live stream coming from gstreamer"
+	description = "Opus/VP8 live stream coming from external source"
 	audio = true
 	video = true
 	audioport = 5002
@@ -109,6 +118,13 @@ gstreamer-sample: {
 	secret = "adminpwd"
 }
 
+#
+# This is a sample of the file-based streaming support. Specifically,
+# this simulates a radio broadcast by streaming (in a loop) raw a-Law
+# (that is, G.711) frames. Since type is "live", anyone subscribing to
+# this mountpoint will listen to the same broadcast as if it were live.
+# Notice that file-based streaming supports Opus files too, but no video.
+#
 file-live-sample: {
 	type = "live"
 	id = 2
@@ -119,6 +135,14 @@ file-live-sample: {
 	secret = "adminpwd"
 }
 
+#
+# This is another sample of the file-based streaming support, but using
+# the "ondemand" type instead. In this case, the file we're streaming
+# contains raw mu-Law (still G.711) frames. Since this is "ondemand",
+# anyone subscribing to this mountpoint will listen to their own version
+# of the stream, meaning that it will start from the beginning and then
+# loop when it's over. On-demand streaming supports Opus files as well.
+#
 file-ondemand-sample: {
 	type = "ondemand"
 	id = 3
@@ -171,10 +195,11 @@ file-ondemand-sample: {
 #}
 
 #
-# This is a sample configuration for Opus/VP8 multicast streams. You
+# This is a variation of the rtp-sample configuration for Opus/VP8 shown
+# before, where multicast support is used to receive the streams. You
 # need an external script to feed data on those ports, of course.
 #
-#gstreamer-multicast: {
+#rtp-multicast: {
 	#type = "rtp"
 	#id = 20
 	#description = "Opus/VP8 live multicast stream sample"
@@ -197,7 +222,7 @@ file-ondemand-sample: {
 # authentication will only work if you installed libcurl >= 7.45.0)
 # NOTE WELL: the plugin does NOT transcode, so the RTSP stream MUST be
 # in a format the browser can digest (e.g., VP8 or H.264 baseline for video)
-# Again, you can override payload type, rtpmap and/or fmtp, if needed
+# Again, you can override payload type, rtpmap and/or fmtp, if needed.
 #
 #rtsp-test: {
 	#type = "rtsp"

--- a/configure.ac
+++ b/configure.ac
@@ -781,6 +781,7 @@ AC_SUBST([OPUS_LIBS])
 PKG_CHECK_MODULES([OGG],
                   [ogg],
                   [
+                    AC_DEFINE(HAVE_LIBOGG)
                     AS_IF([test "x$enable_plugin_voicemail" = "xmaybe"],
                           [enable_plugin_voicemail=yes])
                   ],

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -305,6 +305,15 @@ function updateStreamsList() {
 			$('#watch').attr('disabled', true).unbind('click');
 			var list = result["list"];
 			Janus.log("Got a list of available streams");
+			if(list && Array.isArray(list)) {
+				list.sort(function(a, b) {
+					if(!a || a.id < (b ? b.id : 0))
+						return -1;
+					if(!b || b.id < (a ? a.id : 0))
+						return 1;
+					return 0;
+				});
+			}
 			Janus.debug(list);
 			for(var mp in list) {
 				Janus.debug("  >> [" + list[mp]["id"] + "] " + list[mp]["description"] + " (" + list[mp]["type"] + ")");

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -147,12 +147,19 @@ $(document).ready(function() {
 									if(jsep !== undefined && jsep !== null) {
 										Janus.debug("Handling SDP as well...");
 										Janus.debug(jsep);
+										var stereo = (jsep.sdp.indexOf("stereo=1") !== -1);
 										// Offer from the plugin, let's answer
 										streaming.createAnswer(
 											{
 												jsep: jsep,
 												// We want recvonly audio/video and, if negotiated, datachannels
 												media: { audioSend: false, videoSend: false, data: true },
+												customizeSdp: function(jsep) {
+													if(stereo && jsep.sdp.indexOf("stereo=1") == -1) {
+														// Make sure that our offer contains stereo too
+														jsep.sdp = jsep.sdp.replace("useinbandfec=1", "useinbandfec=1;stereo=1");
+													}
+												},
 												success: function(jsep) {
 													Janus.debug("Got SDP!");
 													Janus.debug(jsep);


### PR DESCRIPTION
This patch adds support for static Opus files to the Streaming plugin, meaning the plugin can now read Opus files and stream them via RTP, pretty much as we've only supported so far for raw a-Law and mu-Law recordings. This support is available both in pseudo-live mountpoints (when you create a mountpoint, the plugin loops on the specificed file, and when people attach they start listening from where the playout thread is), and in on-demand mountpoints (each person attaching to the mountpoint starts listening to the Opus stream from the beginning, and that loops until the PeerConnection is closed). This feature is only available if `libogg` and its headers are installed (which is already a requirement for the VoiceMail plugin and the post-processor, so you probably already have it).

In the future, we may want to extend this functionality to the AudioBridge as well, e.g., to play pre-recorded announcements, but for the moment in this PR I'd rather keep this to the Streaming and ensure it works as expected. As part of the process, to test stereo Opus files I also modified the Streaming plugin demo so that it negotiates stereo support if stereo is offered (the `stereo=1` property must be both in the SDP offer and answer audio `fmtp` attribute, otherwise the stream falls back to mono).

Before merging, I'll probably also add a couple of Opus streams that can be used with some sample mountpoints, but in the meanwhile it should be easy enough for you to find existing Opus files and test how they work. Here's an example of an on-demand (each user gets their own playout) Opus mountpoint:

```
opus-ondemand-sample: {
	type = "ondemand"
	id = 4
	description = "Opus file source (on-demand)"
	filename = "/path/to/file.opus"
	audio = true
	audiopt = 100
	audiortpmap = "opus/48000/2"
	audiofmtp = "stereo=1"
	video = false
	secret = "adminpwd"
}
```

This is what a pseudolive stream looks like instead:

```
opus-live-sample: {
        type = "live"
        id = 5
        description = "Opus file source (live)"
	filename = "/path/to/file.opus"
        audio = true
        audiopt = 100
        audiortpmap = "opus/48000/2"
	audiofmtp = "stereo=1"
        video = false
        secret = "adminpwd"
}
```

Of course, you won't need the `audiofmtp` property if the file is not stereo.

Feedback welcome.