### PR TITLE
Don't set ICE credentials when parsing remote credentials

### DIFF
--- a/sdp.c
+++ b/sdp.c
@@ -841,8 +841,6 @@ int janus_sdp_parse_candidate(void *ice_stream, const char *candidate, int trick
 					return 0;
 				}
 				nice_address_set_port(&c->addr, rport);
-				c->username = g_strdup(stream->ruser);
-				c->password = g_strdup(stream->rpass);
 				if(c->type == NICE_CANDIDATE_TYPE_SERVER_REFLEXIVE || c->type == NICE_CANDIDATE_TYPE_PEER_REFLEXIVE) {
 					added = nice_address_set_from_string(&c->base_addr, rrelip);
 					if(added)


### PR DESCRIPTION
Came up reviewing #2045: apparently, we're setting the credentials on the `NiceCandidate` instance we create when we call `janus_sdp_parse_candidate`, which shouldn't be needed since libnice already has access to them from a previous call to `nice_agent_set_remote_credentials`.

It seems to still work as expected for me, but even if it's a tiny change I prefer keeping it a PR for now, so that you can make sure everything works for you too.