### PR TITLE
Add configurable DSCP ToS for PeerConnections

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -205,6 +205,16 @@ media: {
 	#slowlink_threshold = 4
 	#twcc_period = 100
 	#dtls_timeout = 500
+
+	# If you need DSCP packet marking and prioritization, you can configure
+	# the 'dscp_tos' property to a specific values, and Janus will try to
+	# set it on all outgoing packets using libnice. Normally, the specs
+	# suggest to use different values depending on whether audio, video
+	# or data are used, but since all PeerConnections in Janus are bundled,
+	# we can only use one. You can refer to this document for more info:
+	# https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18#page-6
+	# That said, DON'T TOUCH THIS IF YOU DON'T KNOW WHAT IT MEANS!
+	#dscp_tos = 46
 }
 
 # NAT-related stuff: specifically, you can configure the STUN/TURN
@@ -311,7 +321,7 @@ nat: {
 	# your machine is ready. Note that Linux distributions offer such directives.
 	# You could use the following directive in systemd: 'After=network-online.target'
 	# https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Before=
-	# ignore_unreachable_ice_server = true
+	#ignore_unreachable_ice_server = true
 }
 
 # You can choose which of the available plugins should be

--- a/ice.c
+++ b/ice.c
@@ -447,6 +447,18 @@ uint janus_get_twcc_period(void) {
 	return twcc_period;
 }
 
+/* DSCP Type of Service, which we can set via libnice: it's disabled by default */
+static int dscp_tos = 0;
+void janus_set_dscp_tos(int tos) {
+	dscp_tos = tos;
+	if(dscp_tos > 0) {
+		JANUS_LOG(LOG_VERB, "Setting DSCP Type of Service to %ds\n", dscp_tos);
+	}
+}
+int janus_get_dscp_tos(void) {
+	return dscp_tos;
+}
+
 
 static inline void janus_ice_free_rtp_packet(janus_rtp_packet *pkt) {
 	if(pkt == NULL) {
@@ -3417,6 +3429,10 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 	}
 	/* Now create an ICE stream for all the media we'll handle */
 	handle->stream_id = nice_agent_add_stream(handle->agent, 1);
+	if(dscp_tos > 0) {
+		/* A DSCP Type of Service was configured, pass it to libnice */
+		nice_agent_set_stream_tos(handle->agent, handle->stream_id, dscp_tos);
+	}
 	janus_ice_stream *stream = g_malloc0(sizeof(janus_ice_stream));
 	janus_refcount_init(&stream->ref, janus_ice_stream_free);
 	janus_refcount_increase(&handle->ref);

--- a/ice.h
+++ b/ice.h
@@ -151,6 +151,12 @@ void janus_set_twcc_period(uint period);
 /*! \brief Method to get the current TWCC period (see above)
  * @returns The current TWCC period */
 uint janus_get_twcc_period(void);
+/*! \brief Method to modify the DSCP Type of Service (TOS), which is disabled by default
+ * @param[in] tos The new TOS value (0 to disable) */
+void janus_set_dscp_tos(int period);
+/*! \brief Method to get the current DSCP Type of Service (see above)
+ * @returns The current TOS value (0 if disabled) */
+int janus_get_dscp_tos(void);
 /*! \brief Method to modify the event handler statistics period (i.e., the number of seconds that should pass before Janus notifies event handlers about media statistics for a PeerConnection)
  * @param[in] period The new period value, in seconds */
 void janus_ice_set_event_stats_period(int period);

--- a/janus.c
+++ b/janus.c
@@ -300,6 +300,8 @@ static json_t *janus_info(const char *transaction) {
 	json_object_set_new(info, "mdns-enabled", janus_ice_is_mdns_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "min-nack-queue", json_integer(janus_get_min_nack_queue()));
 	json_object_set_new(info, "twcc-period", json_integer(janus_get_twcc_period()));
+	if(janus_get_dscp_tos() > 0)
+		json_object_set_new(info, "dscp-tos", json_integer(janus_get_dscp_tos()));
 	if(janus_ice_get_stun_server() != NULL) {
 		char server[255];
 		g_snprintf(server, 255, "%s:%"SCNu16, janus_ice_get_stun_server(), janus_ice_get_stun_port());
@@ -4632,6 +4634,18 @@ gint main(int argc, char *argv[])
 			                    " Expect trouble if this is supposed to work over the internet and not just in a LAN...\n", test_ip);
 		}
 	}
+
+	/* Is there any DSCP TOS to apply? */
+	item = janus_config_get(config, config_media, janus_config_type_item, "dscp_tos");
+	if(item && item->value) {
+		int tos = atoi(item->value);
+		if(tos < 0) {
+			JANUS_LOG(LOG_WARN, "Ignoring dscp_tos value as it's not a positive integer\n");
+		} else {
+			janus_set_dscp_tos(tos);
+		}
+	}
+
 	/* NACK related stuff */
 	item = janus_config_get(config, config_media, janus_config_type_item, "min_nack_queue");
 	if(item && item->value) {


### PR DESCRIPTION
See [this thread](https://groups.google.com/forum/#!topic/meetecho-janus/B10hy9hsJ6E) for context. This PR adds a new property called `dscp_tos` to the `media` section of `janus.jcfg`: if you put something there, then it's set as the DSCP Type of Service (ToS) in all media packets we send, using the `nice_agent_set_stream_tos` method in libnice.

Apparently the [specification](https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18#page-6) suggests using different values for different media, but in Janus we bundle everything on the same ICE stream, and libnice only allows configuring it per stream (which makes sense), so you only get a single value you can set. By default it's 0 meaning that we don't set anything: choosing the right value is up to you.

Right now this is a global property, meaning it's set on all WebRTC PeerConnections we create. In the future we might want to make this configurable (e.g., per-session or even per-handle), so that people have more control over the priority they want to give to different connections. That said, nothing I plan to do in the near future: test this first, let's see if this works, and then we can talk about improving it.