### PR TITLE
Added option to configure time needed to detect a missing simulcast substream

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -854,6 +854,7 @@ room-<unique room ID>: {
 	"offer_data" : <true|false; whether or not datachannels should be negotiated; true by default if the publisher has datachannels>,
 	"substream" : <substream to receive (0-2), in case simulcasting is enabled; optional>,
 	"temporal" : <temporal layers to receive (0-2), in case simulcasting is enabled; optional>,
+	"fallback" : <How much time (in us, default 250000) without receiving packets will make us drop to the substream below>,
 	"spatial_layer" : <spatial layer to receive (0-2), in case VP9-SVC is enabled; optional>,
 	"temporal_layer" : <temporal layers to receive (0-2), in case VP9-SVC is enabled; optional>
 }
@@ -967,6 +968,7 @@ room-<unique room ID>: {
 	"data" : <true|false, depending on whether datachannel messages should be relayed or not; optional>,
 	"substream" : <substream to receive (0-2), in case simulcasting is enabled; optional>,
 	"temporal" : <temporal layers to receive (0-2), in case simulcasting is enabled; optional>,
+	"fallback" : <How much time (in us, default 250000) without receiving packets will make us drop to the substream below>,
 	"spatial_layer" : <spatial layer to receive (0-2), in case VP9-SVC is enabled; optional>,
 	"temporal_layer" : <temporal layers to receive (0-2), in case VP9-SVC is enabled; optional>
 }
@@ -1281,6 +1283,7 @@ static struct janus_json_parameter configure_parameters[] = {
 	/* For VP8 (or H.264) simulcast */
 	{"substream", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"temporal", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"fallback", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	/* For VP9 SVC */
 	{"spatial_layer", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"temporal_layer", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
@@ -1299,6 +1302,7 @@ static struct janus_json_parameter subscriber_parameters[] = {
 	/* For VP8 (or H.264) simulcast */
 	{"substream", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"temporal", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"fallback", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	/* For VP9 SVC */
 	{"spatial_layer", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"temporal_layer", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
@@ -2649,6 +2653,8 @@ json_t *janus_videoroom_query_session(janus_plugin_session *handle) {
 					json_object_set_new(simulcast, "substream-target", json_integer(participant->sim_context.substream_target));
 					json_object_set_new(simulcast, "temporal-layer", json_integer(participant->sim_context.templayer));
 					json_object_set_new(simulcast, "temporal-layer-target", json_integer(participant->sim_context.templayer_target));
+					if(participant->sim_context.drop_trigger > 0)
+						json_object_set_new(simulcast, "fallback", json_integer(participant->sim_context.drop_trigger));
 					json_object_set_new(info, "simulcast", simulcast);
 				}
 				if(participant->room && participant->room->do_svc) {
@@ -5702,6 +5708,7 @@ static void *janus_videoroom_handler(void *data) {
 					janus_mutex_unlock(&videoroom->mutex);
 					goto error;
 				}
+				json_t *sc_fallback = json_object_get(root, "fallback");
 				janus_videoroom_publisher *owner = NULL;
 				janus_videoroom_publisher *publisher = g_hash_table_lookup(videoroom->participants,
 					string_ids ? (gpointer)feed_id_str : (gpointer)&feed_id);
@@ -5780,6 +5787,7 @@ static void *janus_videoroom_handler(void *data) {
 					subscriber->sim_context.rid_ext_id = publisher->rid_extmap_id;
 					subscriber->sim_context.substream_target = sc_substream ? json_integer_value(sc_substream) : 2;
 					subscriber->sim_context.templayer_target = sc_temporal ? json_integer_value(sc_temporal) : 2;
+					subscriber->sim_context.drop_trigger = sc_fallback ? json_integer_value(sc_fallback) : 0;
 					janus_vp8_simulcast_context_reset(&subscriber->vp8_context);
 					/* Check if a VP9 SVC-related request is involved */
 					if(subscriber->room->do_svc) {
@@ -6195,6 +6203,7 @@ static void *janus_videoroom_handler(void *data) {
 					g_snprintf(error_cause, 512, "Invalid value (temporal/temporal_layer should be 0, 1 or 2)");
 					goto error;
 				}
+				json_t *sc_fallback = json_object_get(root, "fallback");
 				/* Update the audio/video/data flags, if set */
 				janus_videoroom_publisher *publisher = subscriber->feed;
 				if(publisher) {
@@ -6259,6 +6268,9 @@ static void *janus_videoroom_handler(void *data) {
 							/* Send a FIR */
 							janus_videoroom_reqpli(publisher, "Simulcasting temporal layer change");
 						}
+					}
+					if(sc_fallback && (publisher->ssrc[0] != 0 || publisher->rid[0] != NULL)) {
+						subscriber->sim_context.drop_trigger = json_integer_value(sc_fallback);
 					}
 				}
 				if(subscriber->room->do_svc) {

--- a/rtp.c
+++ b/rtp.c
@@ -997,9 +997,9 @@ gboolean janus_rtp_simulcasting_context_process_rtp(janus_rtp_simulcasting_conte
 		/* Let's start slow */
 		context->last_relayed = janus_get_monotonic_time();
 	} else {
-		/* Check if 250ms went by with no packet relayed */
+		/* Check if too much time went by with no packet relayed */
 		gint64 now = janus_get_monotonic_time();
-		if(now-context->last_relayed >= 250000) {
+		if(now-context->last_relayed >= (context->drop_trigger ? context->drop_trigger : 250000)) {
 			context->last_relayed = now;
 			int substream = context->substream-1;
 			if(substream < 0)

--- a/rtp.h
+++ b/rtp.h
@@ -288,6 +288,8 @@ typedef struct janus_rtp_simulcasting_context {
 	int templayer;
 	/*! \brief As above, but to handle transitions (e.g., wait for keyframe) */
 	int templayer_target;
+	/*! \brief How much time (in us, default 250000) without receiving packets will make us drop to the substream below */
+	guint32 drop_trigger;
 	/*! \brief When we relayed the last packet (used to detect when substreams become unavailable) */
 	gint64 last_relayed;
 	/*! \brief Whether the substream has changed after processing a packet */


### PR DESCRIPTION
See [this](https://groups.google.com/forum/#!topic/meetecho-janus/wGRCC8qGYZI) for context.

So far we've had a 250ms hardcoded value for detecting a missing substream: if we don't receive packets for a substream we're subscribed to for more than 250ms, then we consider the substream currently unavailable and drop to a lower substream instead. This works fine in most cases, except apparently when screensharing, as in some cases the framerate there can drop considerably: since 250ms correspond to about 4fps, anything below that would mean packets would be sent with larger intervals, thus triggering false positives.

This patch makes this property configurable in most plugins. For Streaming and VideoRoom plugins, these are per-subscriber configurations, _NOT_ per-publisher ones: each subscriber has their own simulcast context, which means they have their own tweak. I made the syntax pretty much the same in all plugins, so all you need to do is pass a

    fallback: <timer in microseconds>

in whatever request supports it to enforce it. The default if you don't specify it (or if you pass `0`) is `250000` as before.

Tested briefly with large values to see if this was behaving as expected and it looks like it is. I'll let you guys play with it more and shower me with tons of feedback.