### PR TITLE
Use custom GSource to handle HTTP request timeouts (see #2062 and #2066)

### DIFF
--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -196,7 +196,7 @@ typedef struct janus_http_request_timeout {
 static void janus_http_timeout(janus_transport_session *ts, janus_http_session *session);
 /* GSource Functions */
 static gboolean janus_http_request_timeout_dispatch(GSource *source, GSourceFunc callback, gpointer user_data) {
-	JANUS_LOG(LOG_WARN, "[%p] dispatch\n", source);
+	JANUS_LOG(LOG_DBG, "[%p] dispatch\n", source);
 	janus_http_request_timeout *t = (janus_http_request_timeout *)source;
 	/* Timeout fired, invoke the function */
 	janus_http_timeout(t->ts, t->session);
@@ -206,7 +206,7 @@ static gboolean janus_http_request_timeout_dispatch(GSource *source, GSourceFunc
 	return G_SOURCE_REMOVE;
 }
 static void janus_http_request_timeout_finalize(GSource *source) {
-	JANUS_LOG(LOG_WARN, "[%p] finalize\n", source);
+	JANUS_LOG(LOG_DBG, "[%p] finalize\n", source);
 	janus_http_request_timeout *timeout = (janus_http_request_timeout *)source;
 	if(timeout) {
 		if(timeout->session)
@@ -227,7 +227,7 @@ static GSource *janus_http_request_timeout_create(janus_transport_session *ts, j
 	t->ts = ts;
 	t->session = session;
 	g_source_set_ready_time(source, janus_get_monotonic_time() + timeout*G_USEC_PER_SEC);
-	JANUS_LOG(LOG_WARN, "[%p] create (%d)\n", source, timeout);
+	JANUS_LOG(LOG_DBG, "[%p] create (%d)\n", source, timeout);
 	return source;
 }
 


### PR DESCRIPTION
We've seen a few issues related to HTTP, lately (#2062 and #2066, plus the #2071 duplicate). They mostly seem to be caused by race conditions, and one in particular (which may be the root cause of the other issues too) is apparently caused by an attempt to send an event on a long poll while at the same time the long poll expired and we're sending an empty response back. This race condition can lead to a double unref of the `janus_transport_session` instance that acts as a glue between core and transport, thus causing havoc.

The race condition can happen when:

1. we send an event, notice a timeout timer is still active, and so we destroy it and clean the resources (unref the transport and session related to it)
2. the timeout fires at the same time, which uses/unrefs the same data.

This patch tries to solve it by changing the stock glib timeout source we were using with a custom one: this custom source behaves pretty much as the existing timeout source (we use the same way to trigger it), but keeps track of the transport and session itself: both are only unreffed when the source is finalized, however that happens (whether it's because 1. happened, or because the timeout fired because indeed there was no event to send in 30s).

I tested this briefly but I can't check if this really solves the issue myself, since I never managed to replicate the issue that have been reported. If this patch doesn't solve the problem and you have simple ways to consistently replicate, please let me know.