### PR TITLE
Swap RR/SR Report Blocks if the first block contains rtx data.

### DIFF
--- a/fuzzers/rtcp_fuzzer.c
+++ b/fuzzers/rtcp_fuzzer.c
@@ -30,11 +30,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	/* Do some copies of input data */
 	uint8_t copy_data0[size], copy_data1[size],
 		copy_data2[size], copy_data3[size],
-			copy_data4[size];
-	uint8_t *copy_data[5] = { copy_data0, copy_data1,
-			copy_data2, copy_data3, copy_data4};
+			copy_data4[size], copy_data5[size];
+	uint8_t *copy_data[6] = { copy_data0, copy_data1,
+			copy_data2, copy_data3,
+				copy_data4, copy_data5 };
 	int idx, newlen;
-	for (idx=0; idx < 5; idx++) {
+	for (idx=0; idx < 6; idx++) {
 		memcpy(copy_data[idx], data, size);
 	}
 	idx = 0;
@@ -53,8 +54,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	janus_rtcp_get_sender_ssrc((char *)data, size);
 	/* Functions that alter input data */
 	janus_rtcp_cap_remb((char *)copy_data[idx++], size, 256000);
-	janus_rtcp_fix_report_data((char *)copy_data[idx++], size, 2000, 1000, 1234, 1234, 1234, TRUE);
-	janus_rtcp_fix_ssrc(&ctx0, (char *)copy_data[idx++], size, 1, 2, 3);
+	janus_rtcp_swap_report_blocks((char *)copy_data[idx++], size, 2);
+	janus_rtcp_fix_report_data((char *)copy_data[idx++], size, 2000, 1000, 2, 2, 2, TRUE);
+	janus_rtcp_fix_ssrc(&ctx0, (char *)copy_data[idx++], size, 1, 2, 2);
 	janus_rtcp_parse(&ctx1, (char *)copy_data[idx++], size);
 	janus_rtcp_remove_nacks((char *)copy_data[idx++], size);
 	/* Functions that allocate new memory */

--- a/ice.c
+++ b/ice.c
@@ -2779,6 +2779,9 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 				}
 				/* Is this audio or video? */
 				int video = 0, vindex = 0;
+				if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX)) {
+					janus_rtcp_swap_report_blocks(buf, buflen, stream->video_ssrc_rtx);
+				}
 				/* Bundled streams, should we check the SSRCs? */
 				if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AUDIO)) {
 					/* No audio has been negotiated, definitely video */

--- a/rtcp.h
+++ b/rtcp.h
@@ -322,6 +322,12 @@ uint32_t janus_rtcp_context_get_out_link_quality(janus_rtcp_context *ctx);
  * @param[in] ctx The RTCP context to query
  * @returns Outbound media link quality estimation */
 uint32_t janus_rtcp_context_get_out_media_link_quality(janus_rtcp_context *ctx);
+/*! \brief Method to swap Report Blocks and move media RB in first position in case rtx SSRC comes first
+ * @param[in] packet The message data
+ * @param[in] len The message data length in bytes
+ * @param[in] rtx_ssrc The rtx SSRC
+ * @returns The receiver SSRC, or 0 in case of error */
+void janus_rtcp_swap_report_blocks(char *packet, int len, uint32_t rtx_ssrc);
 /*! \brief Method to quickly retrieve the sender SSRC (needed for demuxing RTCP in BUNDLE)
  * @param[in] packet The message data
  * @param[in] len The message data length in bytes


### PR DESCRIPTION
**CONTEXT**: Janus RTCP Receiver Reports (RR) / Sender Reports (SR) parsing functions support just 1 Report Block ([rfc](https://tools.ietf.org/html/rfc3550#page-42)). This generally means that only the data contained in the first Report Block will be used for any kind of computation.
In particular:

1) _for connections of which Janus knows the remote SSRC (sendonly, sendrecv)_: 
- Janus reads the sender SSRC through [janus_rtcp_get_sender_ssrc](https://github.com/meetecho/janus-gateway/blob/02dd7da5aa251b4a93a0f1ba0a4c67921b6fb825/rtcp.c#L76)
- this method gets the data straight from the RTCP header
- the first Report Block will be used [to update connection RTCP stats](https://github.com/meetecho/janus-gateway/blob/02dd7da5aa251b4a93a0f1ba0a4c67921b6fb825/rtcp.c#L322)
- plugins will potentially match the SSRC they know in received SR/RR [only in the first report block](https://github.com/meetecho/janus-gateway/blob/02dd7da5aa251b4a93a0f1ba0a4c67921b6fb825/rtcp.c#L972)

2) _for connections of which Janus DOES NOT KNOW the remote SSRC (recvonly)_:  e.g. subscribers of videoroom and streaming, in this case browsers usually set the sender SSRC  to a dummy value (like `0x1`):
- Janus relies on the [janus_rtcp_get_receiver_ssrc](https://github.com/meetecho/janus-gateway/blob/02dd7da5aa251b4a93a0f1ba0a4c67921b6fb825/rtcp.c#L137) to evaluate the SSRC
- This method inspects the first Report Block to understand which RTP stream this report relates to, and if the matched SSRC is not the one concerning media, the packet is simply dropped
- the first Report Block will be used to update connection RTCP stats
- plugins will potentially match the SSRC they know in received SR/RR only in the first report

**ISSUE**: in some circumstances the browser may decide to send a RR containing more than one Report Block. The most common scenario is when rtx has been negotiated. If the the first Report Block is the rtx one:

1) in above case 1, the wrong RTCP data will be used for statistics and the same wrong RTCP data will be passed to plugins

2) in above case 2, the whole RTCP compound packet will be discarded including, if present, the other parts of the message like NACKs or feedbacks. As a consequence Janus **will drop NACKs and feedbacks included in those packets**.
Ignoring NACKs clearly means that re-transmissions are not possible. This has been observed on Chrome when rtx channel is being used due to packet loss. 

**FIX**: We decided to introduce a new method called `janus_rtcp_swap_report_blocks`. In case RTCP has been received and rtx has been negotiated, this method **swaps the first RB with the second one** if the first RB SSRC matches the rtx SSRC. In this way wa have been able to re-use all of the existing RTCP parsers. Changing the code too much might be a risk because multi-stream support would probably need to solve the same challenges.

Credits to @davibe for being [the first to notice the effects](https://github.com/meetecho/janus-gateway/commit/f34a97dd1679e4f0677b1429277e132fc614750e#commitcomment-38608356) of this issue.