### PR TITLE
Fix use after free in janus_videoroom_handler with events

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -5857,9 +5857,6 @@ static void *janus_videoroom_handler(void *data) {
 						gint64 start = janus_get_monotonic_time();
 						int res = gateway->push_event(msg->handle, &janus_videoroom_plugin, msg->transaction, event, jsep);
 						JANUS_LOG(LOG_VERB, "  >> Pushing event: %d (took %"SCNu64" us)\n", res, janus_get_monotonic_time()-start);
-						json_decref(event);
-						json_decref(jsep);
-						janus_videoroom_message_free(msg);
 						/* Also notify event handlers */
 						if(notify_events && gateway->events_is_enabled()) {
 							json_t *info = json_object();
@@ -5869,6 +5866,9 @@ static void *janus_videoroom_handler(void *data) {
 							json_object_set_new(info, "private_id", json_integer(pvt_id));
 							gateway->notify_event(&janus_videoroom_plugin, session->handle, info);
 						}
+						json_decref(event);
+						json_decref(jsep);
+						janus_videoroom_message_free(msg);
 						continue;
 					}
 					janus_mutex_unlock(&publisher->subscribers_mutex);


### PR DESCRIPTION
When trying to get janus up and running with asan for #2087, it would report a heap-user-after-free error ([cleaned up output](https://pastebin.com/2ZBkztXN), [full output](https://pastebin.com/SJ3q6VRp))

It looks like `feed_id_str` was being destroyed by a `json_decref` / `janus_videoroom_message_free` before being used to send the event off. One solution which fixed the problem for me was to simply decref and free after processing the event.