### PR TITLE
[WIP] Fixed segfault when json_decref in sample event handler

### DIFF
--- a/events/janus_sampleevh.c
+++ b/events/janus_sampleevh.c
@@ -778,8 +778,10 @@ done:
 			g_free(event_text);
 
 		/* Done, let's unref the event */
-		json_decref(output);
-		output = NULL;
+		if (output) {
+			json_decref(output);
+			output = NULL;
+		}
 	}
 	JANUS_LOG(LOG_VERB, "Leaving SampleEventHandler handler thread\n");
 	return NULL;


### PR DESCRIPTION
Fixed segfault when calling `json_decref` with `NULL` `output`.

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f09a60eb3f0 in ?? () from /usr/lib/x86_64-linux-gnu/libjansson.so.4
[Current thread is 1 (Thread 0x7f09990bd700 (LWP 58))]
(gdb) bt
#0  0x00007f09a60eb3f0 in ?? () from /usr/lib/x86_64-linux-gnu/libjansson.so.4
#1  0x00007f09a60eb4c9 in ?? () from /usr/lib/x86_64-linux-gnu/libjansson.so.4
#2  0x00007f09a60f0f91 in json_delete () from /usr/lib/x86_64-linux-gnu/libjansson.so.4
#3  0x00007f09a60eb41e in ?? () from /usr/lib/x86_64-linux-gnu/libjansson.so.4
#4  0x00007f09a60eb4c9 in ?? () from /usr/lib/x86_64-linux-gnu/libjansson.so.4
#5  0x00007f09a60f0f91 in json_delete () from /usr/lib/x86_64-linux-gnu/libjansson.so.4
#6  0x00007f09990c0000 in json_decref (json=0x7f0958176d80) at /usr/include/jansson.h:129
#7  0x00007f09990c4ff8 in janus_sampleevh_handler (data=0x0) at events/janus_sampleevh.c:781
#8  0x00007f09a636a175 in ?? () from /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#9  0x00007f09a4b226db in start_thread (arg=0x7f09990bd700) at pthread_create.c:463
#10 0x00007f09a484b88f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
(gdb) print(*(0x7f0958176d80))
$1 = 0
(gdb) 
```
