### PR TITLE
Start message processing after requesting candidate gathering

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -3562,6 +3562,7 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 #else
 		g_async_queue_push(handle->queued_packets, &janus_ice_start_gathering);
 #endif
+		g_main_context_wakeup(handle->mainctx);
 	}
 	return 0;
 }


### PR DESCRIPTION
Processing stalls after requesting candidate gathering.