### PR TITLE
stop all tracks when streamsDone fails

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -86,6 +86,20 @@ var defaultExtension = {
 	}
 };
 
+function stopAllTracks (stream) {
+	try {
+		// Try a MediaStreamTrack.stop() for each track
+		var tracks = stream.getTracks();
+		for(var mst of tracks) {
+			Janus.log(mst);
+			if(mst)
+				mst.stop();
+		}
+	} catch(e) {
+		// Do nothing if this fails
+	}
+}
+
 Janus.useDefaultDependencies = function (deps) {
 	var f = (deps && deps.fetch) || fetch;
 	var p = (deps && deps.Promise) || Promise;
@@ -276,13 +290,7 @@ Janus.init = function(options) {
 						Janus.debug(devices);
 						callback(devices);
 						// Get rid of the now useless stream
-						try {
-							var tracks = stream.getTracks();
-							for(var mst of tracks) {
-								if(mst)
-									mst.stop();
-							}
-						} catch(e) {}
+						stopAllTracks(stream);
 					});
 				})
 				.catch(function(err) {
@@ -2088,17 +2096,7 @@ function Janus(gatewayCallbacks) {
 			if(media.update) {
 				if(config.myStream && config.myStream !== callbacks.stream && !config.streamExternal) {
 					// We're replacing a stream we captured ourselves with an external one
-					try {
-						// Try a MediaStreamTrack.stop() for each track
-						var tracks = config.myStream.getTracks();
-						for(var mst of tracks) {
-							Janus.log(mst);
-							if(mst)
-								mst.stop();
-						}
-					} catch(e) {
-						// Do nothing if this fails
-					}
+					stopAllTracks(config.myStream);
 					config.myStream = null;
 				}
 			}
@@ -3083,20 +3081,6 @@ function Janus(gatewayCallbacks) {
 
 	function webrtcError(error) {
 		Janus.error("WebRTC error:", error);
-	}
-
-	function stopAllTracks(stream) {
-		try {
-			// Try a MediaStreamTrack.stop() for each track
-			var tracks = stream.getTracks();
-			for(var mst of tracks) {
-				Janus.log(mst);
-				if(mst)
-					mst.stop();
-			}
-		} catch(e) {
-			// Do nothing if this fails
-		}
 	}
 
 	function cleanupWebrtc(handleId, hangupRequest) {

--- a/html/janus.js
+++ b/html/janus.js
@@ -202,6 +202,22 @@ Janus.dataChanDefaultLabel = "JanusDataChannel";
 // attempted in https://github.com/meetecho/janus-gateway/issues/1670
 Janus.endOfCandidates = null;
 
+// Stop all tracks from a given stream
+Janus.stopAllTracks  = function(stream) {
+	try {
+		// Try a MediaStreamTrack.stop() for each track
+		var tracks = stream.getTracks();
+		for(var mst of tracks) {
+			Janus.log(mst);
+			if(mst) {
+				mst.stop();
+			}
+		}
+	} catch(e) {
+		// Do nothing if this fails
+	}
+}
+
 // Initialization
 Janus.init = function(options) {
 	options = options || {};
@@ -276,13 +292,7 @@ Janus.init = function(options) {
 						Janus.debug(devices);
 						callback(devices);
 						// Get rid of the now useless stream
-						try {
-							var tracks = stream.getTracks();
-							for(var mst of tracks) {
-								if(mst)
-									mst.stop();
-							}
-						} catch(e) {}
+						Janus.stopAllTracks(stream)
 					});
 				})
 				.catch(function(err) {
@@ -1624,27 +1634,15 @@ function Janus(gatewayCallbacks) {
 		});
 	}
 
-	function stopAllTracks (stream) {
-		try {
-			// Try a MediaStreamTrack.stop() for each track
-			var tracks = stream.getTracks();
-			for(var mst of tracks) {
-				Janus.log(mst);
-				if(mst)
-					mst.stop();
-			}
-		} catch(e) {
-			// Do nothing if this fails
-		}
-	}
-
 	// WebRTC stuff
 	function streamsDone(handleId, jsep, media, callbacks, stream) {
 		var pluginHandle = pluginHandles[handleId];
 		if(!pluginHandle || !pluginHandle.webrtcStuff) {
 			Janus.warn("Invalid handle");
-			// close all tracks if the given stream has been created internally
-			if (!callbacks.stream) stopAllTracks(stream);
+			// Close all tracks if the given stream has been created internally
+			if(!callbacks.stream) {
+				Janus.stopAllTracks(stream);
+			}
 			callbacks.error("Invalid handle");
 			return;
 		}
@@ -2102,7 +2100,7 @@ function Janus(gatewayCallbacks) {
 			if(media.update) {
 				if(config.myStream && config.myStream !== callbacks.stream && !config.streamExternal) {
 					// We're replacing a stream we captured ourselves with an external one
-					stopAllTracks(config.myStream);
+					Janus.stopAllTracks(config.myStream);
 					config.myStream = null;
 				}
 			}
@@ -3138,7 +3136,7 @@ function Janus(gatewayCallbacks) {
 			config.bitrate.value = null;
 			if(!config.streamExternal && config.myStream) {
 				Janus.log("Stopping local stream tracks");
-				stopAllTracks(config.myStream);
+				Janus.stopAllTracks(config.myStream);
 			}
 			config.streamExternal = false;
 			config.myStream = null;

--- a/html/janus.js
+++ b/html/janus.js
@@ -86,20 +86,6 @@ var defaultExtension = {
 	}
 };
 
-function stopAllTracks (stream) {
-	try {
-		// Try a MediaStreamTrack.stop() for each track
-		var tracks = stream.getTracks();
-		for(var mst of tracks) {
-			Janus.log(mst);
-			if(mst)
-				mst.stop();
-		}
-	} catch(e) {
-		// Do nothing if this fails
-	}
-}
-
 Janus.useDefaultDependencies = function (deps) {
 	var f = (deps && deps.fetch) || fetch;
 	var p = (deps && deps.Promise) || Promise;
@@ -290,7 +276,13 @@ Janus.init = function(options) {
 						Janus.debug(devices);
 						callback(devices);
 						// Get rid of the now useless stream
-						stopAllTracks(stream);
+						try {
+							var tracks = stream.getTracks();
+							for(var mst of tracks) {
+								if(mst)
+									mst.stop();
+							}
+						} catch(e) {}
 					});
 				})
 				.catch(function(err) {
@@ -1630,6 +1622,20 @@ function Janus(gatewayCallbacks) {
 				callbacks.success();
 			}
 		});
+	}
+
+	function stopAllTracks (stream) {
+		try {
+			// Try a MediaStreamTrack.stop() for each track
+			var tracks = stream.getTracks();
+			for(var mst of tracks) {
+				Janus.log(mst);
+				if(mst)
+					mst.stop();
+			}
+		} catch(e) {
+			// Do nothing if this fails
+		}
 	}
 
 	// WebRTC stuff

--- a/html/janus.js
+++ b/html/janus.js
@@ -1864,29 +1864,6 @@ function Janus(gatewayCallbacks) {
 		callbacks = callbacks || {};
 		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
 		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : webrtcError;
-
-		function stopTracksOnError(stream, callbacks) {
-			var originalErrorCallback = callbacks.error;
-			callbacks.error = function (err) {
-				try {
-					// Try a MediaStreamTrack.stop() for each track
-					var tracks = stream.getTracks();
-					for(var mst of tracks) {
-						Janus.log(mst);
-						if(mst)
-							mst.stop();
-					}
-				} catch(e) {
-					// Do nothing if this fails
-				}
-				if (typeof callbacks.error == "function") {
-					originalErrorCallback(err)
-				}
-			}
-
-			return callbacks;
-		}
-
 		var jsep = callbacks.jsep;
 		if(offer && jsep) {
 			Janus.error("Provided a JSEP to a createOffer");
@@ -2222,10 +2199,10 @@ function Janus(gatewayCallbacks) {
 									navigator.mediaDevices.getUserMedia({ audio: true, video: false })
 									.then(function (audioStream) {
 										stream.addTrack(audioStream.getAudioTracks()[0]);
-										streamsDone(handleId, jsep, media, stopTracksOnError(stream, callbacks), stream);
+										streamsDone(handleId, jsep, media, callbacks, stream);
 									})
 								} else {
-									streamsDone(handleId, jsep, media, stopTracksOnError(stream, callbacks), stream);
+									streamsDone(handleId, jsep, media, callbacks, stream);
 								}
 							}, function (error) {
 								pluginHandle.consentDialog(false);
@@ -2240,7 +2217,7 @@ function Janus(gatewayCallbacks) {
 						if(error) {
 							callbacks.error(error);
 						} else {
-							streamsDone(handleId, jsep, media, stopTracksOnError(stream, callbacks), stream);
+							streamsDone(handleId, jsep, media, callbacks, stream);
 						}
 					}
 					function getScreenMedia(constraints, gsmCallback, useAudio) {
@@ -2396,7 +2373,7 @@ function Janus(gatewayCallbacks) {
 						navigator.mediaDevices.getUserMedia(gumConstraints)
 							.then(function(stream) {
 								pluginHandle.consentDialog(false);
-								streamsDone(handleId, jsep, media, stopTracksOnError(stream, callbacks), stream);
+								streamsDone(handleId, jsep, media, callbacks, stream);
 							}).catch(function(error) {
 								pluginHandle.consentDialog(false);
 								callbacks.error({code: error.code, name: error.name, message: error.message});


### PR DESCRIPTION
This fixes https://github.com/meetecho/janus-gateway/issues/2126

The goal of this PR is to stop tracks only in cases where Janus initially created the stream (e.g. `getUserMedia()` or `getDisplayMedia()`). Another option would be to stop all tracks within `streamsDone()` itself, but this might stop tracks in cases where it is not desired (e.g. externally passed streams).

This PR needs to be properly reviewed as I don't exactly know in which cases tracks should or should not be stopped. 

I am not happy the way I solved it (overriding `callbacks.error()`), maybe there is a cleaner way, feedback is highly appreciated.