### PR TITLE
Enable / disable recording while conference is in progress

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -4413,7 +4413,7 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 		if(error_code != 0)
 			goto prepare_response;
 		json_t *record = json_object_get(root, "record");
-		int recording_active = json_is_true(record);
+		gboolean recording_active = json_is_true(record);
 		JANUS_LOG(LOG_VERB, "Enable Recording : %d \n", (recording_active ? 1 : 0));
 		/* Lookup room */
 		janus_mutex_lock(&rooms_mutex);
@@ -4427,7 +4427,7 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 		janus_mutex_lock(&videoroom->mutex);
 		janus_mutex_unlock(&rooms_mutex);
 		/* Set recording status */
-		gboolean room_prev_recording_active = recording_active ? TRUE : FALSE;
+		gboolean room_prev_recording_active = recording_active;
 		if (room_prev_recording_active != videoroom->record) {
 			/* Room recording state has changed */
 			videoroom->record = room_prev_recording_active;

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -797,7 +797,6 @@ room-<unique room ID>: {
 	"room" : <unique numeric ID of the room>,
 	"secret" : "<room secret; mandatory if configured>"
 	"record" : <true|false, whether this room should be recorded or not>,
-	"filename" : "<if recording, the base path/file to use for the recording files; optional>",
 }
 \endverbatim *
  *
@@ -1263,8 +1262,7 @@ static struct janus_json_parameter publish_parameters[] = {
 	{"restart", JANUS_JSON_BOOL, 0}
 };
 static struct janus_json_parameter record_parameters[] = {
-	{"record", JANUS_JSON_BOOL, JANUS_JSON_PARAM_REQUIRED},
-	{"filename", JSON_STRING, 0}
+	{"record", JANUS_JSON_BOOL, JANUS_JSON_PARAM_REQUIRED}
 };
 static struct janus_json_parameter rtp_forward_parameters[] = {
 	{"video_port", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
@@ -4415,7 +4413,6 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 		if(error_code != 0)
 			goto prepare_response;
 		json_t *record = json_object_get(root, "record");
-		json_t *recfile = json_object_get(root, "filename");
 		int recording_active = json_is_true(record);
 		JANUS_LOG(LOG_VERB, "Enable Recording : %d \n", (recording_active ? 1 : 0));
 		/* Lookup room */
@@ -4442,10 +4439,6 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 				gboolean prev_recording_active = participant->recording_active;
 				participant->recording_active = recording_active;
 				JANUS_LOG(LOG_VERB, "Setting record property: %s (room %"SCNu64", user %"SCNu64")\n", participant->recording_active ? "true" : "false", participant->room_id, participant->user_id);
-				if(recfile) {
-					participant->recording_base = g_strdup(json_string_value(recfile));
-					JANUS_LOG(LOG_VERB, "Setting recording basename: %s (room %"SCNu64", user %"SCNu64")\n", participant->recording_base, participant->room_id, participant->user_id);
-				}
 				/* Do we need to do something with the recordings right now? */
 				if(participant->recording_active != prev_recording_active) {
 					/* Something changed */

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -796,7 +796,7 @@ room-<unique room ID>: {
 	"request" : "enable_recording",
 	"room" : <unique numeric ID of the room>,
 	"secret" : "<room secret; mandatory if configured>"
-	"record" : <true|false, whether this publisher should be recorded or not; optional>,
+	"record" : <true|false, whether this room should be recorded or not>,
 	"filename" : "<if recording, the base path/file to use for the recording files; optional>",
 }
 \endverbatim *

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -787,6 +787,20 @@ room-<unique room ID>: {
 }
 \endverbatim *
  *
+ * To enable or disable recording while the conference is in progress,
+ * you can make use of the \c enable_recording request, which has to be
+ * formatted as follows:
+ *
+\verbatim
+{
+	"request" : "enable_recording",
+	"room" : <unique numeric ID of the room>,
+	"secret" : "<room secret; mandatory if configured>"
+	"record" : <true|false, whether this publisher should be recorded or not; optional>,
+	"filename" : "<if recording, the base path/file to use for the recording files; optional>",
+}
+\endverbatim *
+ *
  * To conclude, you can leave a room you previously joined as publisher
  * using the \c leave request. This will also implicitly unpublish you
  * if you were an active publisher in the room. The \c leave request
@@ -1248,6 +1262,10 @@ static struct janus_json_parameter publish_parameters[] = {
 	{"update", JANUS_JSON_BOOL, 0},
 	{"restart", JANUS_JSON_BOOL, 0}
 };
+static struct janus_json_parameter record_parameters[] = {
+	{"record", JANUS_JSON_BOOL, JANUS_JSON_PARAM_REQUIRED},
+	{"filename", JSON_STRING, 0}
+};
 static struct janus_json_parameter rtp_forward_parameters[] = {
 	{"video_port", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"video_rtcp_port", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
@@ -1577,6 +1595,9 @@ typedef struct janus_videoroom_rtp_relay_packet {
 	gboolean textdata;
 } janus_videoroom_rtp_relay_packet;
 
+/* Start / stop recording */
+static void janus_videoroom_recorder_create(janus_videoroom_publisher *participant, gboolean audio, gboolean video, gboolean data);
+static void janus_videoroom_recorder_close(janus_videoroom_publisher *participant);
 
 /* Freeing stuff */
 static void janus_videoroom_subscriber_destroy(janus_videoroom_subscriber *s) {
@@ -4386,6 +4407,70 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 		json_object_set_new(response, "videoroom", json_string("forwarders"));
 		json_object_set_new(response, "room", string_ids ? json_string(room_id_str) : json_integer(room_id));
 		json_object_set_new(response, "rtp_forwarders", list);
+		goto prepare_response;
+	} else if(!strcasecmp(request_text, "enable_recording")) {
+		JANUS_VALIDATE_JSON_OBJECT(root, record_parameters,
+			error_code, error_cause, TRUE,
+			JANUS_VIDEOROOM_ERROR_MISSING_ELEMENT, JANUS_VIDEOROOM_ERROR_INVALID_ELEMENT);
+		if(error_code != 0)
+			goto prepare_response;
+		json_t *record = json_object_get(root, "record");
+		json_t *recfile = json_object_get(root, "filename");
+		int recording_active = json_is_true(record);
+		JANUS_LOG(LOG_VERB, "Enable Recording : %d \n", (recording_active ? 1 : 0));
+		/* Lookup room */
+		janus_mutex_lock(&rooms_mutex);
+		janus_videoroom *videoroom = NULL;
+		error_code = janus_videoroom_access_room(root, FALSE, TRUE, &videoroom, error_cause, sizeof(error_cause));
+		if(error_code != 0) {
+			JANUS_LOG(LOG_ERR, "Failed to access videoroom\n");
+			janus_mutex_unlock(&rooms_mutex);
+			goto prepare_response;
+		}
+		janus_mutex_lock(&videoroom->mutex);
+		janus_mutex_unlock(&rooms_mutex);
+		/* Set recording status */
+		videoroom->record = recording_active ? TRUE : FALSE;
+		/* Iterate over all participants */
+		gpointer value;
+		GHashTableIter iter;
+		g_hash_table_iter_init(&iter, videoroom->participants);
+		while (g_hash_table_iter_next(&iter, NULL, &value)) {
+			janus_videoroom_publisher *participant = value;
+			if(participant && participant->session) {
+				janus_mutex_lock(&participant->rec_mutex);
+				gboolean prev_recording_active = participant->recording_active;
+				participant->recording_active = recording_active;
+				JANUS_LOG(LOG_VERB, "Setting record property: %s (room %"SCNu64", user %"SCNu64")\n", participant->recording_active ? "true" : "false", participant->room_id, participant->user_id);
+				if(recfile) {
+					participant->recording_base = g_strdup(json_string_value(recfile));
+					JANUS_LOG(LOG_VERB, "Setting recording basename: %s (room %"SCNu64", user %"SCNu64")\n", participant->recording_base, participant->room_id, participant->user_id);
+				}
+				/* Do we need to do something with the recordings right now? */
+				if(participant->recording_active != prev_recording_active) {
+					/* Something changed */
+					if(!participant->recording_active) {
+						/* Not recording (anymore?) */
+						janus_videoroom_recorder_close(participant);
+					} else if(participant->recording_active && participant->sdp) {
+						/* We've started recording, send a PLI/FIR and go on */
+						janus_videoroom_recorder_create(
+							participant, strstr(participant->sdp, "m=audio") != NULL,
+							strstr(participant->sdp, "m=video") != NULL,
+							strstr(participant->sdp, "m=application") != NULL);
+						if(strstr(participant->sdp, "m=video")) {
+							/* Send a FIR */
+							janus_videoroom_reqpli(participant, "Recording video");
+						}
+					}
+				}
+				janus_mutex_unlock(&participant->rec_mutex);
+			}
+		}
+		janus_mutex_unlock(&videoroom->mutex);
+		response = json_object();
+		json_object_set_new(response, "videoroom", json_string("success"));
+		json_object_set_new(response, "record", json_boolean(recording_active));
 		goto prepare_response;
 	} else {
 		/* Not a request we recognize, don't do anything */

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -787,16 +787,16 @@ room-<unique room ID>: {
 }
 \endverbatim *
  *
- * To enable or disable recording while the conference is in progress,
- * you can make use of the \c enable_recording request, which has to be
- * formatted as follows:
+ * To enable or disable recording on all participants while the conference 
+ * is in progress, you can make use of the \c enable_recording request, 
+ * which has to be formatted as follows:
  *
 \verbatim
 {
 	"request" : "enable_recording",
 	"room" : <unique numeric ID of the room>,
 	"secret" : "<room secret; mandatory if configured>"
-	"record" : <true|false, whether this room should be recorded or not>,
+	"record" : <true|false, whether participants in this room should be automatically recorded or not>,
 }
 \endverbatim *
  *


### PR DESCRIPTION
This PR adds a command to the video room plugin to enable / disable recording while a conference is in progress.  The command is formatted as follows.

> {
>     "request" : "enable_recording",
>     "room" : < unique numeric ID of the room >,
>     "secret" : "< room secret; mandatory if configured >"
>     "record" : < true|false, whether this publisher should be recorded or not; optional >,
>     "filename" : "< if recording, the base path/file to use for the recording files; optional >",
> }
