### PR TITLE
Added new tool to convert .pcap captures to .mjr recording

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs/html/
 /janus-cfgconv
 /janus-pp-rec
 /mjr2pcap
+/pcap2mjr
 /plugins/*.so
 /transports/*.so
 /events/*.so
@@ -53,6 +54,8 @@ Makefile.in
 /postprocessing/*.o
 /postprocessing/pp-cmdline.c
 /postprocessing/pp-cmdline.h
+/postprocessing/p2m-cmdline.c
+/postprocessing/p2m-cmdline.h
 /fuzzers/*.a
 /fuzzers/*.o
 /fuzzers/out

--- a/Makefile.am
+++ b/Makefile.am
@@ -560,6 +560,9 @@ endif
 if ENABLE_POST_PROCESSING
 bin_PROGRAMS += janus-pp-rec
 bin_PROGRAMS += mjr2pcap
+if ENABLE_PCAP2MJR
+bin_PROGRAMS += pcap2mjr
+endif
 
 janus_pp_rec_SOURCES = \
 	postprocessing/pp-cmdline.c \
@@ -622,8 +625,44 @@ mjr2pcap_LDADD = \
 	$(POST_PROCESSING_MANUAL_LIBS) \
 	$(NULL)
 
+if ENABLE_PCAP2MJR
+pcap2mjr_SOURCES = \
+	postprocessing/p2m-cmdline.c \
+	postprocessing/p2m-cmdline.h \
+	postprocessing/pp-rtp.h \
+	postprocessing/pcap2mjr.c \
+	log.c \
+	utils.c \
+	$(NULL)
+
+pcap2mjr_CFLAGS = \
+	$(AM_CFLAGS) \
+	$(POST_PROCESSING_CFLAGS) \
+	$(PCAP_CFLAGS) \
+	$(NULL)
+
+pcap2mjr_LDADD = \
+	$(POST_PROCESSING_LIBS) \
+	$(POST_PROCESSING_MANUAL_LIBS) \
+	$(PCAP_LIBS) \
+	$(NULL)
+
+BUILT_SOURCES += postprocessing/p2m-cmdline.c postprocessing/p2m-cmdline.h
+
+postprocessing/p2m-cmdline.h: postprocessing/p2m-cmdline.c
+
+postprocessing/p2m-cmdline.c: postprocessing/pcap2mjr.c
+	gengetopt --set-package="pcap2mjr" --set-version="$(VERSION)" -F postprocessing/p2m-cmdline < postprocessing/pcap2mjr.ggo
+
+EXTRA_DIST += postprocessing/pcap2mjr.ggo
+CLEANFILES += postprocessing/p2m-cmdline.c postprocessing/p2m-cmdline.h
+endif
+
 dist_man1_MANS += postprocessing/janus-pp-rec.1
 dist_man1_MANS += postprocessing/mjr2pcap.1
+if ENABLE_PCAP2MJR
+dist_man1_MANS += postprocessing/pcap2mjr.1
+endif
 
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -903,8 +903,21 @@ AS_IF([test "x$enable_post_processing" = "xyes"],
                          ])
       ])
 
+PKG_CHECK_MODULES([PCAP],
+                  [libpcap],
+                  [
+                   AC_DEFINE(HAVE_LIBPCAP)
+                   enable_pcap2mjr=yes
+                  ],
+                  [
+                   enable_pcap2mjr=no
+                  ])
+AC_SUBST([PCAP_CFLAGS])
+AC_SUBST([PCAP_LIBS])
+
 AM_CONDITIONAL([WITH_SOURCE_DATE_EPOCH], [test "x$SOURCE_DATE_EPOCH" != "x"])
 AM_CONDITIONAL([ENABLE_POST_PROCESSING], [test "x$enable_post_processing" = "xyes"])
+AM_CONDITIONAL([ENABLE_PCAP2MJR], [test "x$enable_pcap2mjr" = "xyes"])
 
 AC_CONFIG_FILES([
   Makefile

--- a/postprocessing/mjr2pcap.1
+++ b/postprocessing/mjr2pcap.1
@@ -7,7 +7,7 @@ mjr2pcap \- Helper tool to convert a Janus recordings to pcap format.
 .IR destination.pcap
 .SH DESCRIPTION
 .B mjr2pcap
-is a simple utility that allows you remove extract RTP packets from Janus recordings and save them to a .pcap file instead. Notice that network levels are simulated, and so are timestamps for when the packets have really been received, since that info is not stored in .mjr files. As such, its main purpose is helping analyze RTP packets, rather than investigate network issues.
+is a simple utility that allows you to extract RTP packets from Janus recordings and save them to a .pcap file instead. Notice that network levels are simulated, and so are timestamps for when the packets have really been received, since that info is not stored in .mjr files. As such, its main purpose is helping analyze RTP packets, rather than investigate network issues.
 .TP
 The tool requires two parameters: the path to the .mjr file to read, and a path to the target .pcap file. Notice that an attempt to process a non-RTP recording will result in an error.
 .SH EXAMPLES

--- a/postprocessing/pcap2mjr.1
+++ b/postprocessing/pcap2mjr.1
@@ -1,0 +1,46 @@
+.TH PCAP2MJR 1
+.SH NAME
+pcap2mjr \- Helper tool to convert a pcap dump to a Janus recordings.
+.SH SYNOPSIS
+.B pcap2mjr [options]
+.IR source.pcap
+.IR destination.mjr
+.SH DESCRIPTION
+.B pcap2mjr
+is a simple utility that allows you take .pcap network captures, extract a specific RTP session via its SSRC, and convert it to an .mjr Janus recording instead. Its main purpose is helping convert .pcap captures to media files, or make it easier to replay them via Janus.
+.TP
+The tool requires a path to the .pcap file to read, and a path to the target .pcap file; besides, it needs info on the codec and the SSRC to filter. Notice that if the tool can't detect any RTP packet with that SSRC, it will result in an error.
+.SH OPTIONS
+.TP
+.BR \-h ", " \-\-help
+Print help and exit
+.TP
+.BR \-V ", " \-\-version
+Print version and exit
+.TP
+.BR \-c ", " \-\-codec=\fIcodec\fR
+Codec the recording will contain (e.g., opus, vp8, etc.)
+.TP
+.BR \-s ", " \-\-ssrc=\fISSRC (numeric)\fR
+SSRC of the packets in the pcap file to save
+.TP
+.BR \-w ", " \-\-warnings
+Show warnings for skipped packets (e.g., not RTP or wrong SSRC)
+.SH EXAMPLES
+\fBpcap2mjr -c opus -s 12345678 rec1234.pcap rec1234.mjr\fR \- Read all RTP packets with SSRC 12345678 from the provided .pcap file, and save them to a new .mjr file as an Opus recording
+.SH BUGS
+.TP
+If you think you found a bug or want to contribute a feature, you can issue or a pull request on https://github.com/meetecho/janus-gateway/issues.
+.TP
+Anyway, before doing that make sure you read the documentation at http://janus.conf.meetecho.com/docs/ and that it has not been discussed already at https://groups.google.com/forum/#!forum/meetecho-janus. We only use Github for code issues, and \fBNOT\fR for configuration or usage issues: use the group for that.
+.SH SEE ALSO
+.TP
+https://github.com/meetecho/janus-gateway \- Official repository
+.TP
+http://janus.conf.meetecho.com \- Demos and documentation
+.TP
+https://groups.google.com/forum/#!forum/meetecho-janus \- Community
+.TP
+http://www.meetecho.com/blog/ \- Tutorials and blog posts on Janus
+.SH AUTHORS
+Lorenzo Miniero (lorenzo@meetecho.com)

--- a/postprocessing/pcap2mjr.c
+++ b/postprocessing/pcap2mjr.c
@@ -1,0 +1,344 @@
+/*! \file    pcap2mjr.c
+ * \author   Lorenzo Miniero <lorenzo@meetecho.com>
+ * \copyright GNU General Public License v3
+ * \brief    Helper tool to convert .pcap files to Janus .mjr recordings
+ * \details  Our Janus WebRTC gateway provides a simple helper (janus_recorder)
+ * to allow plugins to record audio, video and text frames sent by users.
+ * These recordings can then be processed and converted to playable files,
+ * or replayed via WebRTC again. The \c pcap2mjr tool is a simple utility
+ * that allows you take .pcap network captures, extract a specific RTP
+ * session via its SSRC, and convert it to an .mjr Janus recording instead.
+ * Its main purpose is helping convert .pcap captures to media files, or
+ * make it easier to replay them via Janus.
+ *
+ * Using the utility is quite simple. Just pass, as arguments to the tool,
+ * the SSRC to extract, the codec used for the RTP packets originally, the
+ * path to the .pcap source file, and the path to the destination file, e.g.:
+ *
+\verbatim
+./pcap2mjr -c vp8 -s 12345678 /path/to/source.pcap /path/to/destination.mjr
+\endverbatim
+ *
+ * If the tool can't detect any RTP packet with that SSRC, it will result in an error.
+ *
+ * \ingroup postprocessing
+ * \ref postprocessing
+ */
+
+#include <arpa/inet.h>
+#ifdef __MACH__
+#include <machine/endian.h>
+#else
+#include <endian.h>
+#endif
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <sys/time.h>
+#include <errno.h>
+
+#include <glib.h>
+#include <jansson.h>
+#include <pcap.h>
+
+#include "../debug.h"
+#include "p2m-cmdline.h"
+#include "pp-rtp.h"
+
+
+#define htonll(x) ((1==htonl(1)) ? (x) : ((gint64)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
+#define ntohll(x) ((1==ntohl(1)) ? (x) : ((gint64)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
+
+int janus_log_level = 4;
+gboolean janus_log_timestamps = FALSE;
+gboolean janus_log_colors = TRUE;
+char *janus_log_global_prefix = NULL;
+int lock_debug = 0;
+
+int working = 0;
+
+/* Info header in the structured recording */
+static const char *header = "MJR00002";
+/* Frame header in the structured recording */
+static const char *frame_header = "MEET";
+
+/* Ethernet header */
+typedef struct pcap2mjr_ethernet_header {
+	uint8_t dst[6];
+	uint8_t src[6];
+	uint16_t type;
+} pcap2mjr_ethernet_header;
+
+/* IP header */
+typedef struct pcap2mjr_ip_header {
+#if __BYTE_ORDER == __BIG_ENDIAN
+	uint8_t version:4;
+	uint8_t hlen:4;
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+	uint8_t hlen:4;
+	uint8_t version:4;
+#endif
+	uint8_t tos;
+	uint16_t tlen;
+	uint16_t id;
+	uint16_t flags;
+	uint8_t ttl;
+	uint8_t protocol;
+	uint16_t csum;
+	uint8_t src[4];
+	uint8_t dst[4];
+} pcap2mjr_ip_header;
+
+/* UDP header */
+typedef struct pcap2mjr_udp_header {
+	uint16_t srcport;
+	uint16_t dstport;
+	uint16_t len;
+	uint16_t csum;
+} pcap2mjr_udp_header;
+
+
+/* Signal handler */
+static void janus_p2m_handle_signal(int signum) {
+	working = 0;
+}
+
+/* Main Code */
+int main(int argc, char *argv[])
+{
+	struct gengetopt_args_info args_info;
+	/* Let's call our cmdline parser */
+	if(cmdline_parser(argc, argv, &args_info) != 0)
+		exit(1);
+
+	janus_log_init(FALSE, TRUE, NULL);
+	atexit(janus_log_destroy);
+
+	/* Evaluate arguments to find source and target */
+	uint32_t ssrc = args_info.ssrc_arg;
+	const char *codec = args_info.codec_arg;
+	gboolean show_warnings = args_info.warnings_given;
+	gboolean video = FALSE;
+	if(!strcasecmp(codec, "vp8") || !strcasecmp(codec, "vp9") || !strcasecmp(codec, "h264")) {
+		video = TRUE;
+	} else if(!strcasecmp(codec, "opus")
+			|| !strcasecmp(codec, "g711") || !strcasecmp(codec, "pcmu") || !strcasecmp(codec, "pcma")
+			|| !strcasecmp(codec, "g722")) {
+		video = FALSE;
+	} else if(!strcasecmp(codec, "text")) {
+		/* We only do processing for RTP */
+		JANUS_LOG(LOG_ERR, "Data channels not supported by this tool\n");
+		cmdline_parser_free(&args_info);
+		exit(1);
+	} else {
+		JANUS_LOG(LOG_ERR, "Unsupported codec '%s'\n", codec);
+		cmdline_parser_free(&args_info);
+		exit(1);
+	}
+	char *source = NULL, *destination = NULL, *setting = NULL;
+	int i=0;
+	for(i=1; i<argc; i++) {
+		if(argv[i] == NULL || strlen(argv[i]) == 0) {
+			setting = NULL;
+			continue;
+		}
+		if(argv[i][0] == '-') {
+			setting = argv[i];
+			continue;
+		}
+		if(setting == NULL || (
+				(strcmp(setting, "-c")) && (strcmp(setting, "--codec")) &&
+				(strcmp(setting, "-s")) && (strcmp(setting, "--ssrc"))
+		)) {
+			if(source == NULL)
+				source = argv[i];
+			else if(destination == NULL)
+				destination = argv[i];
+		}
+		setting = NULL;
+	}
+	if(source == NULL || destination == NULL) {
+		cmdline_parser_print_help();
+		cmdline_parser_free(&args_info);
+		exit(1);
+	}
+	JANUS_LOG(LOG_INFO, "[%s/%"SCNu32"] %s --> %s\n", codec, ssrc, source, destination);
+
+	/* Open and parse the pcap file */
+	char errbuf[PCAP_ERRBUF_SIZE];
+	pcap_t *pcap = pcap_open_offline(source, errbuf);
+	if(pcap == NULL) {
+		JANUS_LOG(LOG_ERR, "Could not open file %s: %s\n", source, errbuf);
+		cmdline_parser_free(&args_info);
+		exit(1);
+	}
+
+	/* Create the target file */
+	FILE *outfile = fopen(destination, "wb");
+	if(outfile == NULL) {
+		JANUS_LOG(LOG_ERR, "Couldn't open output file\n");
+		cmdline_parser_free(&args_info);
+		pcap_close(pcap);
+		exit(1);
+	}
+	/* Write the first part of the header */
+	size_t res = fwrite(header, sizeof(char), strlen(header), outfile);
+	if(res != strlen(header)) {
+		JANUS_LOG(LOG_ERR, "Couldn't write .mjr header (%zu != %zu, %s)\n",
+			res, strlen(header), strerror(errno));
+		cmdline_parser_free(&args_info);
+		pcap_close(pcap);
+		exit(1);
+	}
+
+	/* Handle SIGINT */
+	working = 1;
+	signal(SIGINT, janus_p2m_handle_signal);
+
+	/* TODO Loop */
+    struct pcap_pkthdr *header = NULL;
+    const u_char *buffer = NULL, *temp = NULL;
+	uint32_t count = 0, written = 0, pssrc = 0;
+    int ret = 0;
+    size_t min_size = sizeof(pcap2mjr_ethernet_header) + sizeof(pcap2mjr_ip_header) +
+		sizeof(pcap2mjr_udp_header) + 12, pkt_size = 0;
+	gboolean header_written = FALSE;
+	gint64 start_ts = 0, pkt_ts = 0;
+    while(working && (ret = pcap_next_ex(pcap, &header, &buffer)) >= 0) {
+		count++;
+		if(header->len != header->caplen) {
+			if(show_warnings) {
+				JANUS_LOG(LOG_WARN, "Packet and capture lengths differ (%d != %d), skipping packet #%"SCNu32"\n",
+					header->len, header->caplen, count);
+			}
+			continue;
+		}
+		if(header->len < min_size) {
+			if(show_warnings) {
+				JANUS_LOG(LOG_WARN, "Packet too small (< %zu), skipping packet #%"SCNu32"\n", min_size, count);
+			}
+			continue;
+		}
+		temp = buffer;
+		pkt_size = header->len;
+		pkt_ts = header->ts.tv_sec*G_USEC_PER_SEC + header->ts.tv_usec;
+		if(start_ts == 0)
+			start_ts = pkt_ts;
+		/* Traverse all the headers */
+		pcap2mjr_ethernet_header *eth = (pcap2mjr_ethernet_header *)temp;
+		if(ntohs(eth->type) != 0x0800) {
+			if(show_warnings) {
+				JANUS_LOG(LOG_WARN, "Not an IPv4 packet, skipping packet #%"SCNu32"\n", count);
+			}
+			continue;
+		}
+		temp += sizeof(pcap2mjr_ethernet_header);
+		pkt_size -= sizeof(pcap2mjr_ethernet_header);
+		pcap2mjr_ip_header *ip = (pcap2mjr_ip_header *)temp;
+		if(ip->protocol != 17) {
+			if(show_warnings) {
+				JANUS_LOG(LOG_WARN, "Not an UDP packet, skipping\n");
+			}
+			continue;
+		}
+		temp += (sizeof(pcap2mjr_ip_header) + sizeof(pcap2mjr_udp_header));
+		pkt_size -= (sizeof(pcap2mjr_ip_header) + sizeof(pcap2mjr_udp_header));
+		/* Make sure this is an RTP packet */
+		janus_pp_rtp_header *rtp = (janus_pp_rtp_header *)temp;
+		if(rtp->version != 2 || (rtp->type >= 64 && rtp->type < 96)) {
+			if(show_warnings) {
+				JANUS_LOG(LOG_WARN, "Not an RTP packet, skipping packet #%"SCNu32"\n", count);
+			}
+			continue;
+		}
+		pssrc = htonl(rtp->ssrc);
+		if(pssrc != ssrc) {
+			if(show_warnings) {
+				JANUS_LOG(LOG_WARN, "Not the SSRC we need (%"SCNu32" != %"SCNu32"), skipping packet #%"SCNu32"\n",
+					pssrc, ssrc, count);
+			}
+			continue;
+		}
+		/* Save the packet, but first check if we've written the .mjr header already */
+		if(!header_written) {
+			/* Write info header as a JSON formatted info */
+			header_written = TRUE;
+			json_t *info = json_object();
+			/* FIXME Codecs should be configurable in the future */
+			const char *type = NULL;
+			if(video)
+				type = "v";
+			else
+				type = "a";
+			json_object_set_new(info, "t", json_string(type));
+			json_object_set_new(info, "c", json_string(codec));
+			json_object_set_new(info, "s", json_integer(pkt_ts));
+			json_object_set_new(info, "u", json_integer(pkt_ts));
+			gchar *info_text = json_dumps(info, JSON_PRESERVE_ORDER);
+			json_decref(info);
+			uint16_t info_bytes = htons(strlen(info_text));
+			size_t res = fwrite(&info_bytes, sizeof(uint16_t), 1, outfile);
+			if(res != 1) {
+				JANUS_LOG(LOG_WARN, "Couldn't write size of JSON header in .mjr file (%zu != %zu, %s), expect issues post-processing\n",
+					res, sizeof(uint16_t), strerror(errno));
+			}
+			res = fwrite(info_text, sizeof(char), strlen(info_text), outfile);
+			if(res != strlen(info_text)) {
+				JANUS_LOG(LOG_WARN, "Couldn't write JSON header in .mjr file (%zu != %zu, %s), expect issues post-processing\n",
+					res, strlen(info_text), strerror(errno));
+			}
+			free(info_text);
+		}
+		/* Write frame header (fixed part[4], timestamp[4], length[2]) */
+		size_t res = fwrite(frame_header, sizeof(char), strlen(frame_header), outfile);
+		if(res != strlen(frame_header)) {
+			JANUS_LOG(LOG_WARN, "Couldn't write frame header in .mjr file (%zu != %zu, %s), expect issues post-processing\n",
+				res, strlen(frame_header), strerror(errno));
+		}
+		uint32_t timestamp = (uint32_t)(pkt_ts > start_ts ? ((pkt_ts - start_ts)/1000) : 0);
+		timestamp = htonl(timestamp);
+		res = fwrite(&timestamp, sizeof(uint32_t), 1, outfile);
+		if(res != 1) {
+			JANUS_LOG(LOG_WARN, "Couldn't write frame timestamp in .mjr file (%zu != %zu, %s), expect issues post-processing\n",
+				res, sizeof(uint32_t), strerror(errno));
+		}
+		uint16_t header_bytes = htons(pkt_size);
+		res = fwrite(&header_bytes, sizeof(uint16_t), 1, outfile);
+		if(res != 1) {
+			JANUS_LOG(LOG_WARN, "Couldn't write size of frame in .mjr file (%zu != %zu, %s), expect issues post-processing\n",
+				res, sizeof(uint16_t), strerror(errno));
+		}
+		/* Save packet on file */
+		written++;
+		int tmp = 0, tot = pkt_size;
+		while(tot > 0) {
+			tmp = fwrite(temp+pkt_size-tot, sizeof(char), tot, outfile);
+			if(tmp <= 0) {
+				JANUS_LOG(LOG_ERR, "Error saving frame, stopping here...\n");
+				goto done;
+			}
+			tot -= tmp;
+		}
+	}
+	JANUS_LOG(LOG_INFO, "Saved %"SCNu32" out of %"SCNu32" packets\n", written, count);
+
+done:
+	/* We're done */
+	pcap_close(pcap);
+	fclose(outfile);
+	outfile = fopen(destination, "rb");
+	if(outfile == NULL) {
+		JANUS_LOG(LOG_WARN, "No destination file %s??\n", destination);
+	} else {
+		fseek(outfile, 0L, SEEK_END);
+		size_t fsize = ftell(outfile);
+		fseek(outfile, 0L, SEEK_SET);
+		JANUS_LOG(LOG_INFO, "%s is %zu bytes\n", destination, fsize);
+		fclose(outfile);
+	}
+
+	cmdline_parser_free(&args_info);
+	JANUS_LOG(LOG_INFO, "Bye!\n");
+	return 0;
+}

--- a/postprocessing/pcap2mjr.ggo
+++ b/postprocessing/pcap2mjr.ggo
@@ -1,0 +1,5 @@
+#pcap2mjr 0.9.4 gengetopt file
+usage "pcap2mjr [OPTIONS] source.pcap destination.mjr"
+option "codec" c "Codec the recording will contain (e.g., opus, vp8, etc.)" string typestr="codec" required
+option "ssrc" s "SSRC of the packets in the pcap file to save" int typestr="ssrc" required
+option "warnings" w "Show warnings for skipped packets (e.g., not RTP or wrong SSRC)" flag off

--- a/postprocessing/pcap2mjr.ggo
+++ b/postprocessing/pcap2mjr.ggo
@@ -1,4 +1,4 @@
-#pcap2mjr 0.9.4 gengetopt file
+#pcap2mjr 0.9.5 gengetopt file
 usage "pcap2mjr [OPTIONS] source.pcap destination.mjr"
 option "codec" c "Codec the recording will contain (e.g., opus, vp8, etc.)" string typestr="codec" required
 option "ssrc" s "SSRC of the packets in the pcap file to save" int typestr="ssrc" required


### PR DESCRIPTION
What the title says. It's basically the reverse of the `mjr2pcap` we added in #1718, that I implemented since I needed it for some internal use cases, but can actually be useful in other scenarios as well. It depends on `libpcap`, so if the library is unavailable the tool will not be built. It's currently hardcoded to IPv4/UDP parsing, so if the pcap capture contains something else (e.g., RTP packet on IPv6) at the moment those packets will simply be ignored. In the future we can make it more flexible, but for the time being this should cover most of the typical captures.

Unlike `mjr2pcap`, `pcap2mjr` expects two additional command line arguments:

1. the codec to write in the .mjr header (e.g., `opus`)
2. the SSRC to filter (since a .pcap file may contain several RTP sessions and we only need one)

Example:

    pcap2mjr -c opus -s 12345678 file.pcap file.mjr

Planning to merge soon, so feedback welcome.