### PR TITLE
Only process mute events if a timer fired to avoid video flashing.

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1784,7 +1784,7 @@ function Janus(gatewayCallbacks) {
 				};
 				event.track.onmute = function(ev) {
 					Janus.log("Remote track muted:", ev);
-					if(config.remoteStream) {
+					if(config.remoteStream && trackMutedTimeoutId == null) {
 						trackMutedTimeoutId = setTimeout(function() {
 							Janus.log("Removing remote track");
 							config.remoteStream.removeTrack(ev.target);
@@ -1799,6 +1799,7 @@ function Janus(gatewayCallbacks) {
 					Janus.log("Remote track flowing again:", ev);
 					if(trackMutedTimeoutId != null) {
 						clearTimeout(trackMutedTimeoutId);
+						trackMutedTimeoutId = null;
 					} else {
 						try {
 							config.remoteStream.addTrack(ev.target);

--- a/html/janus.js
+++ b/html/janus.js
@@ -1775,21 +1775,26 @@ function Janus(gatewayCallbacks) {
 				var trackMutedTimeoutId = null;
 				Janus.log("Adding onended callback to track:", event.track);
 				event.track.onended = function(ev) {
-					Janus.log("Remote track muted/removed:", ev);
+					Janus.log("Remote track removed:", ev);
 					if(config.remoteStream) {
 						clearTimeout(trackMutedTimeoutId);
+						config.remoteStream.removeTrack(ev.target);
+						pluginHandle.onremotestream(config.remoteStream);
+					}
+				};
+				event.track.onmute = function(ev) {
+					Janus.log("Remote track muted:", ev);
+					if(config.remoteStream) {
 						trackMutedTimeoutId = setTimeout(function() {
 							Janus.log("Removing remote track");
 							config.remoteStream.removeTrack(ev.target);
-							pluginHandle.onremotestream(config.remoteStream, ev);
+							pluginHandle.onremotestream(config.remoteStream);
 							trackMutedTimeoutId = null;
 						// Chrome seems to raise mute events only at multiples of 834ms;
 						// we set the timeout to three times this value (rounded to 840ms)
 						}, 3 * 840);
 					}
 				};
-
-				event.track.onmute = event.track.onended;
 				event.track.onunmute = function(ev) {
 					Janus.log("Remote track flowing again:", ev);
 					if(trackMutedTimeoutId != null) {
@@ -1797,7 +1802,7 @@ function Janus(gatewayCallbacks) {
 					} else {
 						try {
 							config.remoteStream.addTrack(ev.target);
-							pluginHandle.onremotestream(config.remoteStream, ev);
+							pluginHandle.onremotestream(config.remoteStream);
 						} catch(e) {
 							Janus.error(e);
 						};


### PR DESCRIPTION
In the last couple of days I happened to have a crappy network as my ISP is having troubles, so I tried to better study the video flashing issue described in #2145. 

By printing the time passed between `mute` and `unmute` events raised by Chrome and plotting them into a graph, I found out that this is always a multiple of 834 ms:
![timing](https://user-images.githubusercontent.com/10725159/81484954-12457b00-924a-11ea-8380-6acb94bca66f.png)
I have no idea where this value comes from, but it's important to take it into account when setting the timeout @schoolcoder suggested. I rounded that value to 840 ms and set the timeout to three times that value (~2.5 seconds) which seems acceptable to me. This made most video flashing disappear in my crappy network.

I suck pretty bad at JavaScript, but it seemed easy enough to arrange a Pull Request.

Fixes #2145.