### PR TITLE
Add DSCP on RTP audio packets in SIP plugin

### DIFF
--- a/conf/janus.plugin.sip.jcfg.sample
+++ b/conf/janus.plugin.sip.jcfg.sample
@@ -32,4 +32,11 @@ general: {
 
 	# Whether events should be sent to event handlers (default=true)
 	#events = false
+   
+	# If you need DSCP packet marking and prioritization, you can configure
+	# the 'dscp_audio_rtp' property to specific values, and Janus SIP plugin
+	# will set it on all outgoing audio RTP packets.
+	# No packet marking is done if this parameter is undefined or equal to 0
+	#dscp_audio_rtp = 46
+	
 }

--- a/conf/janus.plugin.sip.jcfg.sample
+++ b/conf/janus.plugin.sip.jcfg.sample
@@ -34,9 +34,10 @@ general: {
 	#events = false
    
 	# If you need DSCP packet marking and prioritization, you can configure
-	# the 'dscp_audio_rtp' property to specific values, and Janus SIP plugin
-	# will set it on all outgoing audio RTP packets.
+	# the 'dscp_audio_rtp' and/or 'dscp_video_rtp' property to specific values,
+	# and Janus SIP plugin will set it on all outgoing audio/video RTP packets.
 	# No packet marking is done if this parameter is undefined or equal to 0
 	#dscp_audio_rtp = 46
+	#dscp_video_rtp = 26
 	
 }

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -780,6 +780,7 @@ static int register_ttl = JANUS_DEFAULT_REGISTER_TTL;
 static uint16_t rtp_range_min = 10000;
 static uint16_t rtp_range_max = 60000;
 static int dscp_audio_rtp = 0;
+static int dscp_video_rtp = 0;
 
 static GThread *handler_thread;
 static void *janus_sip_handler(void *data);
@@ -1763,6 +1764,15 @@ int janus_sip_init(janus_callbacks *callback, const char *config_path) {
 				JANUS_LOG(LOG_WARN, "Ignoring dscp_audio_rtp value as it's not a positive integer\n");
 			} else {
 				dscp_audio_rtp = val;
+			}
+		}
+		item = janus_config_get(config, config_general, janus_config_type_item, "dscp_video_rtp");
+		if(item && item->value) {
+			int val = atoi(item->value);
+			if(val < 0) {
+				JANUS_LOG(LOG_WARN, "Ignoring dscp_video_rtp value as it's not a positive integer\n");
+			} else {
+				dscp_video_rtp = val;
 			}
 		}
 
@@ -5700,7 +5710,10 @@ static int janus_sip_allocate_local_ports(janus_sip_session *session) {
 				/* Set the DSCP value if set in the config file */ 
 				if (dscp_audio_rtp > 0) {
 					int optval = dscp_audio_rtp << 2;
-					setsockopt(session->media.audio_rtp_fd, IPPROTO_IP, IP_TOS, &optval, sizeof(optval));
+					int ret = setsockopt(session->media.audio_rtp_fd, IPPROTO_IP, IP_TOS, &optval, sizeof(optval));
+					if (ret < 0) {
+						JANUS_LOG(LOG_WARN, "Error setting IP_TOS option on audio RTP socket, value=%d, error=%s\n",optval, strerror(errno));
+					}
 				}
 			}
 			if(session->media.audio_rtcp_fd == -1) {
@@ -5751,6 +5764,14 @@ static int janus_sip_allocate_local_ports(janus_sip_session *session) {
 				return -1;
 			if(session->media.video_rtp_fd == -1) {
 				session->media.video_rtp_fd = socket(AF_INET, SOCK_DGRAM, 0);
+				/* Set the DSCP value if set in the config file */ 
+				if (dscp_video_rtp > 0) {
+					int optval = dscp_video_rtp << 2;
+					int ret = setsockopt(session->media.video_rtp_fd, IPPROTO_IP, IP_TOS, &optval, sizeof(optval));
+					if (ret < 0) {
+						JANUS_LOG(LOG_WARN, "Error setting IP_TOS option on video RTP socket, value=%d, error=%s\n",optval, strerror(errno));
+					}
+				}
 			}
 			if(session->media.video_rtcp_fd == -1) {
 				session->media.video_rtcp_fd = socket(AF_INET, SOCK_DGRAM, 0);


### PR DESCRIPTION
To complete #2055, I propose to do the same thing in the RTP audio packets sent by the SIP plugin.
Tested OK on my implementation of Janus server.