### PR TITLE
List private rooms if valid admin_key was provided.

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -3551,12 +3551,33 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 			if(!room)
 				continue;
 			janus_refcount_increase(&room->ref);
-			if(room->is_private) {
-				/* Skip private room */
-				JANUS_LOG(LOG_VERB, "Skipping private room '%s'\n", room->room_name);
-				janus_refcount_decrease(&room->ref);
-				continue;
-			}
+      if(room->is_private) {
+        /* only if admin_key isset */
+        if(admin_key != NULL) {
+          json_t *admin_key_json = json_object_get(root, "admin_key");
+          /* verify admin_key was provided */
+          if(admin_key_json != NULL && strlen(json_string_value(admin_key_json)) > 0) {
+            JANUS_CHECK_SECRET(admin_key, root, "admin_key", error_code, error_cause,
+            JANUS_VIDEOROOM_ERROR_MISSING_ELEMENT, JANUS_VIDEOROOM_ERROR_INVALID_ELEMENT, JANUS_VIDEOROOM_ERROR_UNAUTHORIZED);
+            if(error_code != 0) {
+              JANUS_LOG(LOG_VERB, "No room list, wrong admin_key provided\n");
+              goto end_loop;
+            }
+          }
+          else {
+            /* Skip private room */
+            JANUS_LOG(LOG_VERB, "Skipping private room '%s'\n", room->room_name);
+            janus_refcount_decrease(&room->ref);
+            continue;
+          }
+        }
+        else {
+          /* Skip private room */
+          JANUS_LOG(LOG_VERB, "Skipping private room '%s'\n", room->room_name);
+          janus_refcount_decrease(&room->ref);
+          continue;
+        }
+      }
 			if(!g_atomic_int_get(&room->destroyed)) {
 				json_t *rl = json_object();
 				json_object_set_new(rl, "room", string_ids ? json_string(room->room_id_str) : json_integer(room->room_id));
@@ -3596,6 +3617,7 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 			}
 			janus_refcount_decrease(&room->ref);
 		}
+    end_loop:
 		janus_mutex_unlock(&rooms_mutex);
 		response = json_object();
 		json_object_set_new(response, "videoroom", json_string("success"));

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -3550,14 +3550,13 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 		if(admin_key != NULL) {
 			json_t *admin_key_json = json_object_get(root, "admin_key");
 			/* Verify admin_key if it was provided */
-			if(admin_key_json != NULL && strlen(json_string_value(admin_key_json)) > 0) {
+			if(admin_key_json != NULL && json_is_string(admin_key_json) && strlen(json_string_value(admin_key_json)) > 0) {
 				JANUS_CHECK_SECRET(admin_key, root, "admin_key", error_code, error_cause,
 					JANUS_VIDEOROOM_ERROR_MISSING_ELEMENT, JANUS_VIDEOROOM_ERROR_INVALID_ELEMENT, JANUS_VIDEOROOM_ERROR_UNAUTHORIZED);
 				if(error_code != 0) {
 					janus_mutex_unlock(&rooms_mutex);
 					goto prepare_response;
-				}
-				else {
+				} else {
 					lock_room_list = FALSE;
 				}
 			}
@@ -3568,10 +3567,10 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 				continue;
 			janus_refcount_increase(&room->ref);
 			if(room->is_private && lock_room_list) {
-					/* Skip private room if no valid admin_key was provided */
-					JANUS_LOG(LOG_VERB, "Skipping private room '%s'\n", room->room_name);
-					janus_refcount_decrease(&room->ref);
-					continue;
+				/* Skip private room if no valid admin_key was provided */
+				JANUS_LOG(LOG_VERB, "Skipping private room '%s'\n", room->room_name);
+				janus_refcount_decrease(&room->ref);
+				continue;
 			}
 			if(!g_atomic_int_get(&room->destroyed)) {
 				json_t *rl = json_object();


### PR DESCRIPTION
This simple enhancement allows admins to list private rooms as well using the existing "list" request.
To make this fully backwards compatible, if no "admin_key" is provided the list gets returned like before (without the private rooms).

The same solution could be applied to other plugins like the audiobrige too.