### PR TITLE
Assign an address family when no interface is specified.

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -5343,6 +5343,7 @@ static int janus_streaming_create_fd(int port, in_addr_t mcast, const janus_netw
 				return -1;
 			}
 			/* TODO IPv6 */
+			family = AF_INET;
 			address.sin_addr.s_addr = mcast;
 		} else {
 			if(!IN_MULTICAST(ntohl(mcast)) && !janus_network_address_is_null(iface)) {


### PR DESCRIPTION
There is a code path in the janus_streaming plugin/janus_streaming_create_fd() where a multicast mount point (mcast and port) is specified but no interface (iface) is specified that leaves the family set to zero. This causes the bind() call to fail because the incomplete address6 structure is passed when an IPv4 multicast address is the target.