### PR TITLE
Fixed experimental feature videobufferkf

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -7704,9 +7704,9 @@ static void *janus_streaming_relay_thread(void *data) {
 							memcpy(pkt->data, buffer, bytes);
 							pkt->data->ssrc = htons(1);
 							pkt->data->type = mountpoint->codecs.video_pt;
-							packet.is_rtp = TRUE;
-							packet.is_video = TRUE;
-							packet.is_keyframe = TRUE;
+							pkt->is_rtp = TRUE;
+							pkt->is_video = TRUE;
+							pkt->is_keyframe = TRUE;
 							pkt->length = bytes;
 							pkt->timestamp = source->keyframe.temp_ts;
 							pkt->seq_number = ntohs(rtp->seq_number);
@@ -7746,9 +7746,9 @@ static void *janus_streaming_relay_thread(void *data) {
 									memcpy(pkt->data, buffer, bytes);
 									pkt->data->ssrc = htons(1);
 									pkt->data->type = mountpoint->codecs.video_pt;
-									packet.is_rtp = TRUE;
-									packet.is_video = TRUE;
-									packet.is_keyframe = TRUE;
+									pkt->is_rtp = TRUE;
+									pkt->is_video = TRUE;
+									pkt->is_keyframe = TRUE;
 									pkt->length = bytes;
 									pkt->timestamp = source->keyframe.temp_ts;
 									pkt->seq_number = ntohs(rtp->seq_number);


### PR DESCRIPTION
I guess it are some copy/paste errors from this commit 25d3a827976bb3776be99f01aedd3411e71644a6

With these changes the videobufferkf is working again, otherwise the packets will block in `janus_streaming_relay_rtp_packet`