### PR TITLE
Small improvements in the documentation of videoroom

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -842,17 +842,21 @@ room-<unique room ID>: {
 }
 \endverbatim
  *
- * Other participants will receive a different event depending on whether
- * you were currently an active publisher ("unpublished") or simply
- * lurking ("leaving"):
+ * Other participants will receive a "leaving" event to notify them the
+ * circumstance:
  *
 \verbatim
 {
 	"videoroom" : "event",
 	"room" : <room ID>,
-	"leaving|unpublished" : <unique ID of the publisher who left>
+	"leaving : <unique ID of the participant who left>
 }
 \endverbatim
+ *
+ * If you were an active publisher, other users will also receive the
+ * corresponding "unpublished" event to notify them the stream is not longer
+ * available, as explained above. If you were simply lurking and not
+ * publishing, the other participants will only receive the "leaving" event.
  *
  * \subsection vroomsub VideoRoom Subscribers
  *

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -871,7 +871,8 @@ room-<unique room ID>: {
  * publisher goes away, the subscriber handle is removed as well. As such,
  * these subscriber sessions are dependent on feedback obtained by
  * publishers, and can't exist on their own, unless you feed them the
- * right info out of band.
+ * right info out of band (which is impossible in rooms configured with
+ * \c require_pvtid).
  *
  * To specify a handle will be associated with a subscriber, you must use
  * the \c join request with \c ptype set to \c subscriber and specify which


### PR DESCRIPTION
The first commit fixes what, in my opinion, is an error in the documentation. With the current implementation (which is more convenient than the documented one) you receive two events when a publisher leaves and only one when a lurker leaves.

The second one adds no new information (the same is implicitly said in other parts of the document), but I think it would be a useful note/reminder for those looking for a way to secure their connections.