### PR TITLE
Update janus.js

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -909,7 +909,7 @@ function Janus(gatewayCallbacks) {
 				Janus.debug(json);
 				if(json["janus"] !== "success") {
 					Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
-					callbacks.error(json["error"].reason);
+					callbacks.error(json["error"]);
 					return;
 				}
 				connected = true;


### PR DESCRIPTION
Little fix. for send back to error callback detailed info (reason, +code). Without this modification, users only listen to string for example, Unauthorized request (wrong or missing secret/token)