### PR TITLE
Fix streaming plugin demo page when string_ids is true

### DIFF
--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -339,7 +339,7 @@ function getStreamInfo() {
 	if(!selectedStream)
 		return;
 	// Send a request for more info on the mountpoint we subscribed to
-	var body = { request: "info", id: parseInt(selectedStream) };
+	var body = { request: "info", id: parseInt(selectedStream) || selectedStream };
 	streaming.send({ message: body, success: function(result) {
 		if(result && result.info && result.info.metadata) {
 			$('#metadata').html(result.info.metadata);
@@ -357,7 +357,7 @@ function startStream() {
 	$('#streamset').attr('disabled', true);
 	$('#streamslist').attr('disabled', true);
 	$('#watch').attr('disabled', true).unbind('click');
-	var body = { request: "watch", id: parseInt(selectedStream) };
+	var body = { request: "watch", id: parseInt(selectedStream) || selectedStream};
 	streaming.send({ message: body });
 	// No remote video yet
 	$('#stream').append('<video class="rounded centered" id="waitingvideo" width=320 height=240 />');


### PR DESCRIPTION
When `string_ids` is set to `true` in streaming plugin configuration, watching a stream from the janus demos webpage fails with:

```
Invalid element type (id should be a string)
```

This commit makes the browser fallback to string instead of sending `null`.