### PR TITLE
NoSIP plugin: Fixed SRTP-SDES for "process" request and session update

### DIFF
--- a/html/nosiptest.html
+++ b/html/nosiptest.html
@@ -73,7 +73,11 @@
 					<div class="col-md-6">
 						<div class="panel panel-default">
 							<div class="panel-heading">
-								<h3 class="panel-title">Caller</h3>
+								<h3 class="panel-title">Caller
+									<div class="btn-group btn-group-xs pull-right">
+										<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
+									</div>
+								</h3>
 							</div>
 							<div class="panel-body" id="videoleft"></div>
 						</div>

--- a/html/nosiptest.js
+++ b/html/nosiptest.js
@@ -57,7 +57,7 @@ var opaqueId = Janus.randomString(12);
 var spinner = null;
 
 var videoenabled = true;
-var srtp = undefined ; // use "sdes_mandatory" to test SRTP_SDES
+var srtp = undefined ; // use "sdes_mandatory" to test SRTP-SDES
 
 $(document).ready(function() {
 	// Initialize the library (all console debuggers enabled)

--- a/html/nosiptest.js
+++ b/html/nosiptest.js
@@ -56,6 +56,9 @@ var opaqueId = Janus.randomString(12);
 
 var spinner = null;
 
+var videoenabled = true;
+var srtp = undefined ; // use "sdes_mandatory" to test SRTP_SDES
+
 $(document).ready(function() {
 	// Initialize the library (all console debuggers enabled)
 	Janus.init({debug: "all", callback: function() {
@@ -91,7 +94,7 @@ $(document).ready(function() {
 										Janus.debug("[caller] Trying a createOffer too (audio/video sendrecv)");
 										caller.createOffer(
 											{
-												// No media provided: by default, it's sendrecv for audio and video
+												media: {audio: true, video: videoenabled},
 												success: function(jsep) {
 													Janus.debug("[caller] Got SDP!", jsep);
 													// We now have a WebRTC SDP: to get a barebone SDP legacy
@@ -101,7 +104,8 @@ $(document).ready(function() {
 													// the SIP plugin uses (mandatory vs. optional). We'll
 													// get the result in an event called "generated" here.
 													var body = {
-														request: "generate"
+														request: "generate",
+														srtp: srtp
 													};
 													caller.send({ message: body, jsep: jsep });
 												},
@@ -172,7 +176,8 @@ $(document).ready(function() {
 												request: "process",
 												type: result["type"],
 												sdp: result["sdp"],
-												update: result["update"]
+												update: result["update"],
+												srtp: srtp
 											}
 											callee.send({ message: processOffer });
 										} else if(event === "processed") {
@@ -273,6 +278,43 @@ $(document).ready(function() {
 										$('#videoright .no-video-container').remove();
 										$('#peervideo').removeClass('hide').show();
 									}
+
+									if(videoenabled) {
+										$('#togglevideo').html("Disable video").removeClass("btn-success").addClass("btn-danger");
+									} else {
+										$('#togglevideo').html("Enable video").removeClass("btn-danger").addClass("btn-success");
+									}
+
+									$('#togglevideo').unbind('click').removeAttr('disabled').click(
+										function() {
+											videoenabled = !videoenabled;
+											var media;
+											if(videoenabled) {
+												$('#togglevideo').html("Disable video").removeClass("btn-success").addClass("btn-danger");
+												media = {addVideo: true};
+											} else {
+												$('#togglevideo').html("Enable video").removeClass("btn-danger").addClass("btn-success");
+												media = {removeVideo: true};
+											}
+											caller.createOffer(
+												{
+													media: media,
+													success: function(jsep) {
+														Janus.debug("[caller] Got UPDATE SDP!");
+														Janus.debug(jsep);
+														var body = {
+															request: "generate",
+															update: true,
+															srtp: srtp
+														};
+														caller.send({message: body, jsep: jsep});
+													},
+													error: function(error) {
+														Janus.error("WebRTC error:", error);
+														bootbox.alert("WebRTC error... " + JSON.stringify(error));
+													}
+												});
+										});
 								},
 								oncleanup: function() {
 									Janus.log("[caller]  ::: Got a cleanup notification :::");
@@ -363,7 +405,8 @@ $(document).ready(function() {
 														// We'll get the result in an event called "generated" here.
 														var body = {
 															request: "generate",
-															update: update
+															update: update,
+															srtp: srtp
 														};
 														callee.send({ message: body, jsep: jsep });
 													},
@@ -385,7 +428,8 @@ $(document).ready(function() {
 												request: "process",
 												type: result["type"],
 												sdp: result["sdp"],
-												update: result["update"]
+												update: result["update"],
+												srtp: srtp
 											}
 											caller.send({ message: processAnswer });
 										}

--- a/plugins/janus_nosip.c
+++ b/plugins/janus_nosip.c
@@ -1504,9 +1504,9 @@ static void *janus_nosip_handler(void *data) {
 					goto error;
 				}
 				if(session->media.require_srtp && !session->media.has_srtp_remote) {
-					JANUS_LOG(LOG_ERR, "Can't generate answer: SDES-SRTP required, but caller didn't offer it\n");
+					JANUS_LOG(LOG_ERR, "Can't process request: SDES-SRTP required, but caller didn't offer it\n");
 					error_code = JANUS_NOSIP_ERROR_TOO_STRICT;
-					g_snprintf(error_cause, 512, "Can't generate answer: SDES-SRTP required, but caller didn't offer it");
+					g_snprintf(error_cause, 512, "Can't process request: SDES-SRTP required, but caller didn't offer it");
 					goto error;
 				}
 				/* Take note of the SDP (may be useful for UPDATEs or re-INVITEs) */

--- a/plugins/janus_nosip.c
+++ b/plugins/janus_nosip.c
@@ -2226,8 +2226,6 @@ static void *janus_nosip_relay_thread(void *data) {
 	/* Loop */
 	int num = 0;
 	gboolean goon = TRUE;
-	int astep = 0, vstep = 0;
-	guint32 ats = 0, vts = 0;
 
 	session->media.updated = TRUE; /* Connect UDP sockets upon loop entry */
 	gboolean have_audio_server_ip = TRUE;
@@ -2427,25 +2425,6 @@ static void *janus_nosip_relay_thread(void *data) {
 					/* Check if the SSRC changed (e.g., after a re-INVITE or UPDATE) */
 					guint32 timestamp = ntohl(header->timestamp);
 					janus_rtp_header_update(header, &session->media.context, video, 0);
-					if(video) {
-						if(vts == 0) {
-							vts = timestamp;
-						} else if(vstep == 0) {
-							vstep = timestamp-vts;
-							if(vstep < 0) {
-								vstep = 0;
-							}
-						}
-					} else {
-						if(ats == 0) {
-							ats = timestamp;
-						} else if(astep == 0) {
-							astep = timestamp-ats;
-							if(astep < 0) {
-								astep = 0;
-							}
-						}
-					}
 					/* Save the frame if we're recording */
 					janus_recorder_save_frame(video ? session->vrc_peer : session->arc_peer, buffer, bytes);
 					/* Relay to browser */


### PR DESCRIPTION
Hi,
As I promised in my previous pull request here is the fix for SRTP-SDES in the NoSIP plugin.

Two issues are fixed:
- SRTP-SDES for session update. It's the same fix applied in the SIP plugin.
- "srtp" property was ignored for "process" requests. For example, if you send a "process" request with "srtp" set to “sdes_mandatory” and SDP that doesn’t contain any crypto attributes, although it should fail, it would be processed.

Also, I updated the demo page for NoSIP plugin for easier testing session update and SRTP-SDES.

p.s. I hope I will not promise a new fix in this pull request :)