### PR TITLE
Don't keep session in paused when switching mountpoints

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -5205,7 +5205,7 @@ done:
 				janus_mutex_unlock(&helper->mutex);
 			}
 			session->mountpoint = mp;
-			g_atomic_int_set(&session->paused, 1);
+			g_atomic_int_set(&session->paused, 0);
 			janus_mutex_unlock(&session->mutex);
 			janus_mutex_unlock(&mp->mutex);
 			/* Done */


### PR DESCRIPTION
Don't keep session in paused when switching mountpoints

Caused by typo in this commit in 2a98ec2
```
			- session->paused = FALSE;
			+ g_atomic_int_set(&session->paused, 1);
```