### PR TITLE
Increase reference to session when handling SIP calls (see #2188)

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4603,9 +4603,8 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 					/* Bind the call to the helper and handle it there */
 					JANUS_LOG(LOG_VERB, "Passing INVITE to helper %p\n", helper);
 					nua_handle_bind(nh, helper);
-					/* Pass the reference for this call to this helper */
+					/* This session won't need the reference anymore, the helper will */
 					janus_refcount_decrease(&session->ref);
-					janus_refcount_increase(&helper->ref);
 					janus_sip_sofia_callback(event, status, phrase, nua, magic, nh, helper, sip, tags);
 					break;
 				}

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1658,11 +1658,12 @@ static void janus_sip_sofia_logger(void *stream, char const *fmt, va_list ap) {
 static void janus_sip_ref_active_call(janus_sip_session *session) {
 	if(session == NULL)
 		return;
-	if(session->master) {
-		janus_mutex_lock(&session->master->mutex);
-		session->master->active_calls = g_list_append(session->master->active_calls, session);
+	janus_sip_session *master = session->master;
+	if(master) {
+		janus_mutex_lock(&master->mutex);
+		master->active_calls = g_list_append(master->active_calls, session);
 		janus_refcount_increase(&session->ref);
-		janus_mutex_unlock(&session->master->mutex);
+		janus_mutex_unlock(&master->mutex);
 	} else {
 		janus_mutex_lock(&session->mutex);
 		session->active_calls = g_list_append(session->active_calls, session);
@@ -1673,13 +1674,14 @@ static void janus_sip_ref_active_call(janus_sip_session *session) {
 static void janus_sip_unref_active_call(janus_sip_session *session) {
 	if(session == NULL)
 		return;
-	if(session->master) {
-		janus_mutex_lock(&session->master->mutex);
-		if(g_list_find(session->master->active_calls, session) != NULL) {
-			session->master->active_calls = g_list_remove(session->master->active_calls, session);
+	janus_sip_session *master = session->master;
+	if(master) {
+		janus_mutex_lock(&master->mutex);
+		if(g_list_find(master->active_calls, session) != NULL) {
+			master->active_calls = g_list_remove(master->active_calls, session);
 			janus_refcount_decrease(&session->ref);
 		}
-		janus_mutex_unlock(&session->master->mutex);
+		janus_mutex_unlock(&master->mutex);
 	} else {
 		janus_mutex_lock(&session->mutex);
 		if(g_list_find(session->active_calls, session) != NULL) {


### PR DESCRIPTION
This is supposed to help with the occasional crashes happening in the SIP plugin when using helpers, described in #2188.

The root cause there is that the `janus_sip_session` associated to a helper may be freed (helper closed), but it still "lives" in the Sofia SIP loop thread, e.g., because there are still events associated to it. This happens when we a call is originated via `nua_invite` on a helper, or when we pass an incoming call to a helper and so bind it to the helper session using `nua_bind_handle`: this causes all events associated to that call to include a pointer to that session, as the `hmagic`. What seems to be happening is that the call still has some state that can trigger events: since the Sofia loop belongs to the master session, it still runs, and so can still ship those events; trying to dereference the now freed helper session causes the crash.

This patch tries to address that by using reference counters to ensure the session is not destroyed until the calls it handles are gone. Specifically, we add a new reference when starting a new call, and when getting a new one: when helpers are involved, we make sure it's their reference that is updated. The reference is then only decreased when we get the `nua_i_terminated` callback, which means the call is definitely over as far as the Sofia SIP stack is concerned.

I tested briefly and it seems to be working. That said, I didn't test intensively: no time for that. As such, if you use the SIP plugin, make sure to test this properly. Notice that you should not only make sure it doesn't crash where it did before, but ideally also check whether this introduces leaks: to do that, please build with libasan support, which will print a summary of the leaked memory when you shut Janus down cleanly. You can also uncomment `REFCOUNT_DEBUG` in `refcount.h` to more specifically track if there is any reference still dangling when Janus is shut down cleanly.

The sooner you can provide me feedback on that (and why not, fixes if you find anything broken), the sooner we can fix this.