### PR TITLE
Allow simulcast ports to be picked randomly in Streaming mountpoints

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -1824,13 +1824,13 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				}
 				gboolean dovideortcp = (vrtcpport != NULL && vrtcpport->value != NULL);
 				if(dovideo && vport2 != NULL && vport2->value != NULL &&
-						(janus_string_to_uint16(vport2->value, &video_port2) < 0 || video_port2 == 0)) {
+						(janus_string_to_uint16(vport2->value, &video_port2) < 0)) {
 					JANUS_LOG(LOG_ERR, "Can't add 'rtp' mountpoint '%s', invalid simulcast port...\n", cat->name);
 					cl = cl->next;
 					continue;
 				}
 				if(dovideo && vport3 != NULL && vport3->value != NULL &&
-						(janus_string_to_uint16(vport3->value, &video_port3) < 0 || video_port3 == 0)) {
+						(janus_string_to_uint16(vport3->value, &video_port3) < 0)) {
 					JANUS_LOG(LOG_ERR, "Can't add 'rtp' mountpoint '%s', invalid simulcast port...\n", cat->name);
 					cl = cl->next;
 					continue;
@@ -5776,48 +5776,44 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 			vrtcpport = janus_streaming_get_fd_port(video_rtcp_fd);
 		}
 		if(simulcast) {
-			if(vport2 > 0) {
-				video_fd[1] = janus_streaming_create_fd(vport2, vmcast ? inet_addr(vmcast) : INADDR_ANY, viface,
-					NULL, 0, "Video", "video", name ? name : tempname, FALSE);
-				if(video_fd[1] < 0) {
-					JANUS_LOG(LOG_ERR, "Can't bind to port %d for video (2nd port)...\n", vport2);
-					if(audio_fd > -1)
-						close(audio_fd);
-					if(audio_rtcp_fd > -1)
-						close(audio_rtcp_fd);
-					if(video_fd[0] > -1)
-						close(video_fd[0]);
-					if(video_rtcp_fd > -1)
-						close(video_rtcp_fd);
-					janus_mutex_lock(&mountpoints_mutex);
-					g_hash_table_remove(mountpoints_temp, &id);
-					janus_mutex_unlock(&mountpoints_mutex);
-					return NULL;
-				}
-				vport2 = janus_streaming_get_fd_port(video_fd[1]);
+			video_fd[1] = janus_streaming_create_fd(vport2, vmcast ? inet_addr(vmcast) : INADDR_ANY, viface,
+				NULL, 0, "Video", "video", name ? name : tempname, FALSE);
+			if(video_fd[1] < 0) {
+				JANUS_LOG(LOG_ERR, "Can't bind to port %d for video (2nd port)...\n", vport2);
+				if(audio_fd > -1)
+					close(audio_fd);
+				if(audio_rtcp_fd > -1)
+					close(audio_rtcp_fd);
+				if(video_fd[0] > -1)
+					close(video_fd[0]);
+				if(video_rtcp_fd > -1)
+					close(video_rtcp_fd);
+				janus_mutex_lock(&mountpoints_mutex);
+				g_hash_table_remove(mountpoints_temp, &id);
+				janus_mutex_unlock(&mountpoints_mutex);
+				return NULL;
 			}
-			if(vport3 > 0) {
-				video_fd[2] = janus_streaming_create_fd(vport3, vmcast ? inet_addr(vmcast) : INADDR_ANY, viface,
-					NULL, 0, "Video", "video", name ? name : tempname, FALSE);
-				if(video_fd[2] < 0) {
-					JANUS_LOG(LOG_ERR, "Can't bind to port %d for video (3rd port)...\n", vport3);
-					if(audio_fd > -1)
-						close(audio_fd);
-					if(audio_rtcp_fd > -1)
-						close(audio_rtcp_fd);
-					if(video_rtcp_fd > -1)
-						close(video_rtcp_fd);
-					if(video_fd[0] > -1)
-						close(video_fd[0]);
-					if(video_fd[1] > -1)
-						close(video_fd[1]);
-					janus_mutex_lock(&mountpoints_mutex);
-					g_hash_table_remove(mountpoints_temp, &id);
-					janus_mutex_unlock(&mountpoints_mutex);
-					return NULL;
-				}
-				vport3 = janus_streaming_get_fd_port(video_fd[2]);
+			vport2 = janus_streaming_get_fd_port(video_fd[1]);
+			video_fd[2] = janus_streaming_create_fd(vport3, vmcast ? inet_addr(vmcast) : INADDR_ANY, viface,
+				NULL, 0, "Video", "video", name ? name : tempname, FALSE);
+			if(video_fd[2] < 0) {
+				JANUS_LOG(LOG_ERR, "Can't bind to port %d for video (3rd port)...\n", vport3);
+				if(audio_fd > -1)
+					close(audio_fd);
+				if(audio_rtcp_fd > -1)
+					close(audio_rtcp_fd);
+				if(video_rtcp_fd > -1)
+					close(video_rtcp_fd);
+				if(video_fd[0] > -1)
+					close(video_fd[0]);
+				if(video_fd[1] > -1)
+					close(video_fd[1]);
+				janus_mutex_lock(&mountpoints_mutex);
+				g_hash_table_remove(mountpoints_temp, &id);
+				janus_mutex_unlock(&mountpoints_mutex);
+				return NULL;
 			}
+			vport3 = janus_streaming_get_fd_port(video_fd[2]);
 		}
 	}
 	int data_fd = -1;


### PR DESCRIPTION
Normally, when you pass `0` as a port to create a Streaming plugin mountpoint, this means a random port will be picked in the configured RTP range (the plugin's rane, not the core's). This is currently not true for the simulcast ports, though, that is `videoport2` and `videoport3`, which are considered to be disabled instead when you pass `0`. This patch changes that, and uses random ports for them when `videosimulcast=true` and they're not provided or set to 0.

This means you can't create a simulcast mountpoints with just two substreams anymore, but I don't think it's that big of a deal (not sure anyone was doing that anyway). I don't think this is controversial, so I plan to merge soon.