### PR TITLE
Fix sscanf-related security issues

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -5831,7 +5831,7 @@ char *janus_sip_sdp_manipulate(janus_sip_session *session, janus_sdp *sdp, gbool
 			while(ma) {
 				janus_sdp_attribute *a = (janus_sdp_attribute *)ma->data;
 				if(a->name != NULL && a->value != NULL && !strcasecmp(a->name, "rtpmap")) {
-					if(sscanf(a->value, "%3d %s", &pt, codec) == 2) {
+					if(sscanf(a->value, "%3d %49s", &pt, codec) == 2) {
 						if(g_hash_table_lookup(codecs, codec) != NULL) {
 							/* We already have a version of this codec, remove the payload type */
 							pts_to_remove = g_list_append(pts_to_remove, GINT_TO_POINTER(pt));

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -6280,7 +6280,7 @@ static int janus_streaming_rtsp_parse_sdp(const char *buffer, const char *name, 
 	char ip[256];
 	in_addr_t mcast = INADDR_ANY;
 	if(c != NULL) {
-		if(sscanf(c, "c=IN IP4 %[^/]", ip) != 0) {
+		if(sscanf(c, "c=IN IP4 %255[^/]", ip) != 0) {
 			memcpy(host, ip, sizeof(ip));
 			c = strstr(host, "\r\n");
 			if(c)

--- a/rtp.c
+++ b/rtp.c
@@ -91,7 +91,7 @@ const char *janus_rtp_header_extension_get_from_id(const char *sdp, int id) {
 			if(strstr(line, extmap)) {
 				/* Gotcha! */
 				char extension[100];
-				if(sscanf(line, "a=extmap:%d %s", &id, extension) == 2) {
+				if(sscanf(line, "a=extmap:%d %99s", &id, extension) == 2) {
 					*next = '\n';
 					if(strstr(extension, JANUS_RTP_EXTMAP_AUDIO_LEVEL))
 						return JANUS_RTP_EXTMAP_AUDIO_LEVEL;

--- a/utils.c
+++ b/utils.c
@@ -406,7 +406,7 @@ const char *janus_get_codec_from_pt(const char *sdp, int pt) {
 			if(strstr(line, rtpmap)) {
 				/* Gotcha! */
 				char name[100];
-				if(sscanf(line, "a=rtpmap:%d %s", &pt, name) == 2) {
+				if(sscanf(line, "a=rtpmap:%d %99s", &pt, name) == 2) {
 					*next = '\n';
 					if(strstr(name, "vp8") || strstr(name, "VP8"))
 						return "vp8";


### PR DESCRIPTION
We've been notified about a couple of security issues related to a broken usage of sscanf (reserved IDs: CVE-2020-14033, CVE-2020-14034). Using that information, we extended the fix to a couple of other locations where the issue was present but not reported.

Merging right away, considering these are important fixes and I can't replicate them anymore.