### PR TITLE
Edit callback.error returning

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2454,7 +2454,7 @@ function Janus(gatewayCallbacks) {
 				})
 				.catch(function(error) {
 					pluginHandle.consentDialog(false);
-					callbacks.error('enumerateDevices error', error);
+					callbacks.error(error);
 				});
 			}
 		} else {


### PR DESCRIPTION
There are many places where callbacks.error return `string` and many where return `Error`. And  the only place, where callbacks.error return `string, Error`. That's why it needed to write redundancy conditions for right handling errors from createOffer(). But we can return only `Error` object like for `getUserMedia()` to avoid this