### PR TITLE
Fixed broken simulcast behaviour

### DIFF
--- a/rtp.h
+++ b/rtp.h
@@ -286,7 +286,7 @@ typedef struct janus_rtp_simulcasting_context {
 	/*! \brief Which simulcast substream we should forward back */
 	int substream;
 	/*! \brief As above, but to handle transitions (e.g., wait for keyframe, or get this if available) */
-	int substream_target;
+	int substream_target, substream_target_temp;
 	/*! \brief Which simulcast temporal layer we should forward back */
 	int templayer;
 	/*! \brief As above, but to handle transitions (e.g., wait for keyframe) */

--- a/utils.c
+++ b/utils.c
@@ -676,31 +676,31 @@ gboolean janus_vp8_is_keyframe(const char *buffer, int len) {
 			buffer++;
 			vp8pd = *buffer;
 		}
-		buffer++;	/* Now we're in the payload */
-		if(sbit) {
-			JANUS_LOG(LOG_HUGE, "  -- S bit is set!\n");
-			unsigned long int vp8ph = 0;
-			memcpy(&vp8ph, buffer, 4);
-			vp8ph = ntohl(vp8ph);
-			uint8_t pbit = ((vp8ph & 0x01000000) >> 24);
-			if(!pbit) {
-				JANUS_LOG(LOG_HUGE, "  -- P bit is NOT set!\n");
-				/* It is a key frame! Get resolution for debugging */
-				unsigned char *c = (unsigned char *)buffer+3;
-				/* vet via sync code */
-				if(c[0]!=0x9d||c[1]!=0x01||c[2]!=0x2a) {
-					JANUS_LOG(LOG_HUGE, "First 3-bytes after header not what they're supposed to be?\n");
-				} else {
-					unsigned short val3, val5;
-					memcpy(&val3,c+3,sizeof(short));
-					int vp8w = swap2(val3)&0x3fff;
-					int vp8ws = swap2(val3)>>14;
-					memcpy(&val5,c+5,sizeof(short));
-					int vp8h = swap2(val5)&0x3fff;
-					int vp8hs = swap2(val5)>>14;
-					JANUS_LOG(LOG_HUGE, "Got a VP8 key frame: %dx%d (scale=%dx%d)\n", vp8w, vp8h, vp8ws, vp8hs);
-					return TRUE;
-				}
+	}
+	buffer++;	/* Now we're in the payload */
+	if(sbit) {
+		JANUS_LOG(LOG_HUGE, "  -- S bit is set!\n");
+		unsigned long int vp8ph = 0;
+		memcpy(&vp8ph, buffer, 4);
+		vp8ph = ntohl(vp8ph);
+		uint8_t pbit = ((vp8ph & 0x01000000) >> 24);
+		if(!pbit) {
+			JANUS_LOG(LOG_HUGE, "  -- P bit is NOT set!\n");
+			/* It is a key frame! Get resolution for debugging */
+			unsigned char *c = (unsigned char *)buffer+3;
+			/* vet via sync code */
+			if(c[0]!=0x9d||c[1]!=0x01||c[2]!=0x2a) {
+				JANUS_LOG(LOG_HUGE, "First 3-bytes after header not what they're supposed to be?\n");
+			} else {
+				unsigned short val3, val5;
+				memcpy(&val3,c+3,sizeof(short));
+				int vp8w = swap2(val3)&0x3fff;
+				int vp8ws = swap2(val3)>>14;
+				memcpy(&val5,c+5,sizeof(short));
+				int vp8h = swap2(val5)&0x3fff;
+				int vp8hs = swap2(val5)>>14;
+				JANUS_LOG(LOG_HUGE, "Got a VP8 key frame: %dx%d (scale=%dx%d)\n", vp8w, vp8h, vp8ws, vp8hs);
+				return TRUE;
 			}
 		}
 	}


### PR DESCRIPTION
While simulcast works mostly fine in plugins that support it, it was broken in some particular cases, in particular:

1. if only substreams 2 and 0 are sent, and 2 suddently goes away, it should fallback to 0 since 1 is missing; instead, it stays in the 1 limbo forever;
2. if simulcast drops to a lower layer (e.g., 1) because the target (e.g., 2) is unavailable, it doesn't go back to the target layer when it becomes available again (drop actually becomes the new target).

This PR tries to fix both those issues, making the code smarter when it comes to transitions. All the changes are in the core, so they should be used automatically by all plugins. There's also a fix on keyframe detection for VP8, which was broken in some cases (something we fixed in the postprocessor already, but not here). I could replicate both issues easily with the Streaming plugin, but I can't now, so I consider this fixed.

Planning to merge soon, so please let me know if you have feedback before that.