### PR TITLE
Update Webpack exports-loader module config example

### DIFF
--- a/mainpage.dox
+++ b/mainpage.dox
@@ -903,7 +903,10 @@ echotest.createOffer({
        // Let's use 'exports-loader' to simulate it uses 'export'.
        {
          test: require.resolve('janus-gateway'),
-         use: 'exports-loader?Janus=Janus'
+         loader: 'exports-loader',
+          options: {
+            exports: 'Janus',
+          },
        }
      ]
    }


### PR DESCRIPTION
Previous config example leads to throw next exception:
```
 ERROR  Failed to compile with 1 errors                                                                                                             11:24:16 PM

 error  in ./node_modules/janus-gateway/html/janus.js

Module build failed (from ./node_modules/exports-loader/dist/cjs.js):
ValidationError: Invalid options object. Exports Loader has been initialized using an options object that does not match the API schema.
 - options misses the property 'exports'. Should be:
   non-empty string | object { name, syntax?, alias? } | [non-empty string | object { name, syntax?, alias? }, ...] (should not have fewer than 1 item)
    at validate (/Users/y/p/w/src/w_d/node_modules/exports-loader/node_modules/schema-utils/dist/validate.js:96:11)
    at Object.loader (/Users/y/p/w/src/w_d/node_modules/exports-loader/dist/index.js:28:28)

 @ ./node_modules/cache-loader/dist/cjs.js??ref--12-0!./node_modules/babel-loader/lib!./node_modules/vuetify-loader/lib/loader.js??ref--19-0!./node_modules/cache-loader/dist/cjs.js??ref--0-0!./node_modules/vue-loader/lib??vue-loader-options!./src/components/DialogCall.vue?vue&type=script&lang=js& 60:0-38 122:8-13 126:42-47 127:2-7 133:11-16 136:26-31 262:16-21 266:16-21 344:6-11
 @ ./src/components/DialogCall.vue?vue&type=script&lang=js&
 @ ./src/components/DialogCall.vue
 @ ./node_modules/cache-loader/dist/cjs.js??ref--12-0!./node_modules/babel-loader/lib!./node_modules/vuetify-loader/lib/loader.js??ref--19-0!./node_modules/cache-loader/dist/cjs.js??ref--0-0!./node_modules/vue-loader/lib??vue-loader-options!./src/App.vue?vue&type=script&lang=js&
 @ ./src/App.vue?vue&type=script&lang=js&
 @ ./src/App.vue
 @ ./src/main.js
 @ multi (webpack)-dev-server/client?http://192.168.0.10:8080/sockjs-node (webpack)/hot/dev-server.js ./src/main.js


Process finished with exit code 0
```