### PR TITLE
plugins/janus_audiobridge.c: fix build without libogg

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -1334,7 +1334,9 @@ static void janus_audiobridge_participant_free(const janus_refcount *participant
 		}
 		g_async_queue_unref(participant->outbuf);
 	}
+#ifdef HAVE_LIBOGG
 	janus_audiobridge_file_free(participant->annc);
+#endif
 	g_free(participant);
 }
 
@@ -6385,6 +6387,7 @@ static void *janus_audiobridge_mixer_thread(void *data) {
 			janus_mutex_unlock(&p->qmutex);
 			ps = ps->next;
 		}
+#ifdef HAVE_LIBOGG
 		/* If there are announcements playing, mix those too */
 		GList *anncs_list = g_hash_table_get_values(audiobridge->anncs);
 		if(anncs_list != NULL) {
@@ -6458,6 +6461,7 @@ static void *janus_audiobridge_mixer_thread(void *data) {
 				ps = ps->next;
 			}
 		}
+#endif
 		/* Are we recording the mix? (only do it if there's someone in, though...) */
 		if(audiobridge->recording != NULL && g_list_length(participants_list) > 0) {
 			for(i=0; i<samples; i++) {


### PR DESCRIPTION
Build without libogg is broken since commit 53761d07c5456424d368c708fda2757e6606a4bf:

```
plugins/janus_audiobridge.c:1337:41: error: 'janus_audiobridge_participant' {aka 'struct janus_audiobridge_participant'} has no member named 'annc'
 1337 |  janus_audiobridge_file_free(participant->annc);
      |                                         ^~
  CC       plugins/plugins_libjanus_nosip_la-janus_nosip.lo
plugins/janus_audiobridge.c: In function 'janus_audiobridge_mixer_thread':
plugins/janus_audiobridge.c:6394:9: error: 'janus_audiobridge_participant' {aka 'struct janus_audiobridge_participant'} has no member named 'annc'
 6394 |     if(p->annc == NULL || g_atomic_int_get(&p->destroyed)) {
      |         ^~
plugins/janus_audiobridge.c:6398:16: warning: implicit declaration of function 'janus_audiobridge_file_read'; did you mean 'janus_audiobridge_mixer_thread'? [-Wimplicit-function-declaration]
 6398 |     int read = janus_audiobridge_file_read(p->annc, p->decoder, resampled, sizeof(resampled));
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                janus_audiobridge_mixer_thread
plugins/janus_audiobridge.c:6398:16: warning: nested extern declaration of 'janus_audiobridge_file_read' [-Wnested-externs]
plugins/janus_audiobridge.c:6398:45: error: 'janus_audiobridge_participant' {aka 'struct janus_audiobridge_participant'} has no member named 'annc'
 6398 |     int read = janus_audiobridge_file_read(p->annc, p->decoder, resampled, sizeof(resampled));
      |                                             ^~
plugins/janus_audiobridge.c:6401:10: error: 'janus_audiobridge_participant' {aka 'struct janus_audiobridge_participant'} has no member named 'annc'
 6401 |      if(p->annc->started) {
      |          ^~
plugins/janus_audiobridge.c:6428:10: error: 'janus_audiobridge_participant' {aka 'struct janus_audiobridge_participant'} has no member named 'annc'
 6428 |     if(!p->annc->started) {
      |          ^~
plugins/janus_audiobridge.c:6430:7: error: 'janus_audiobridge_participant' {aka 'struct janus_audiobridge_participant'} has no member named 'annc'
 6430 |      p->annc->started = TRUE;
      |       ^~
  CC       plugins/plugins_libjanus_streaming_la-janus_streaming.lo
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>