### PR TITLE
Rnnoise, neural network noise canceling - AudioBridge

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -152,6 +152,7 @@ janus_CFLAGS = \
 	-DLOGGERDIR=\"$(loggerdir)\" \
 	-DCONFDIR=\"$(confdir)\" \
 	$(BORINGSSL_CFLAGS) \
+	$(RNNOISE_CFLAGS) \
 	$(NULL)
 
 janus_LDADD = \
@@ -160,6 +161,7 @@ janus_LDADD = \
 	$(JANUS_MANUAL_LIBS) \
 	$(LIBSRTP_LDFLAGS) $(LIBSRTP_LIBS) \
 	$(LIBCURL_LDFLAGS) $(LIBCURL_LIBS) \
+	$(RNNOISE_LIBS) \
 	$(NULL)
 
 dist_man1_MANS = janus.1

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ A couple of plugins depend on a few more libraries:
 * [libogg](http://xiph.org/ogg/) (needed for the VoiceMail plugin and/or post-processor, and optionally AudioBridge and Streaming plugins)
 * [libcurl](https://curl.haxx.se/libcurl/) (only needed if you are interested in RTSP support in the Streaming plugin or in the sample Event Handler plugin)
 * [Lua](https://www.lua.org/download.html) (only needed for the Lua plugin)
+* [Rnnoise](https://github.com/xiph/rnnoise) (only needed for noise suppression based on a recurrent neural network in audiobridge plugin)
+
 
 Additionally, you'll need the following libraries and tools:
 
@@ -164,6 +166,16 @@ Finally, the same can be said for rabbitmq-c as well, which is needed for the op
 	make && sudo make install
 
 * *Note:* you may need to pass `--libdir=/usr/lib64` to the configure script if you're installing on a x86_64 distribution.
+
+In case you want to use neural network noise supression library in AudioBridge audio mix you will need to compile Rnnoise lib and pass --enable-rnnoise when compiling Janus lib. Installation:
+
+	git clone https://github.com/xiph/rnnoise.git
+	cd rnnoise
+	./autogen.sh
+	./configure --prefix=/usr
+	make && sudo make install
+
+* *Note:* for audio rooom configuration refer to https://github.com/meetecho/janus-gateway/blob/master/conf/janus.plugin.audiobridge.jcfg.sample
 
 To conclude, should you be interested in building the Janus documentation as well, you'll need some additional tools too:
 

--- a/configure.ac
+++ b/configure.ac
@@ -120,6 +120,18 @@ AC_ARG_ENABLE([boringssl],
               ],
               [boringssl_dir=])
 
+AC_ARG_ENABLE([rnnoise],
+              [AS_HELP_STRING([--enable-rnnoise],
+                              [Enable Rnnoise noise cancellation])],
+              [
+                case "${enableval}" in
+                  yes) rnnoise_dir=/opt/rnnoise ;;
+                  no)  rnnoise_dir= ;;
+                  *) rnnoise_dir=${enableval} ;;
+                esac
+              ],
+              [rnnoise_dir=])
+
 AC_ARG_ENABLE([libsrtp2],
               [AS_HELP_STRING([--enable-libsrtp2],
                               [Use libsrtp 2.0.x instead of libsrtp 1.5.x])],
@@ -377,6 +389,20 @@ AS_IF([test "x$enable_pthread_mutex" = "xyes"],
       AC_MSG_NOTICE([Will use pthread_mutex instead of GMutex])
       ])
 AM_CONDITIONAL([ENABLE_PTHREAD_MUTEX], [test "x$enable_pthread_mutex" = "xyes"])
+
+AS_IF([test "x${rnnoise_dir}" != "x"],
+	  [echo "Checking for rnnoise lib";
+	   AC_MSG_NOTICE([Rnnoise directory is ${rnnoise_dir}])
+	   CFLAGS="$CFLAGS -I${rnnoise_dir}/include";
+	   RNNOISE_CFLAGS=" -I${rnnoise_dir}/include";  
+       AC_SUBST(RNNOISE_CFLAGS)
+	   RNNOISE_LIBS=" -L${rnnoise_dir}/lib";
+       AC_SUBST(RNNOISE_LIBS)
+	   AC_CHECK_HEADERS([${rnnoise_dir}/include/rnnoise.h],
+	                    [AC_DEFINE(HAVE_RNNOISE)],
+	                    [AC_MSG_ERROR([Rnnoise headers not found in ${rnnoise_dir}, use --disable-rnnoise])])
+      ])
+AM_CONDITIONAL([ENABLE_RNNOISE], [test "x${rnnoise_dir}" != "x"])
 
 AC_SEARCH_LIBS([tls_config_set_ca_mem],[tls],
              [AM_CONDITIONAL([LIBRESSL_DETECTED], true)],
@@ -975,6 +1001,9 @@ AM_COND_IF([ENABLE_POST_PROCESSING],
 AM_COND_IF([ENABLE_TURN_REST_API],
 	[echo "TURN REST API client:      yes"],
 	[echo "TURN REST API client:      no"])
+AM_COND_IF([ENABLE_RNNOISE],
+	[echo "Rnnoise support:           yes"],
+	[echo "Rnnoise support:           no"])
 AM_COND_IF([ENABLE_DOCS],
 	[echo "Doxygen documentation:     yes"],
 	[echo "Doxygen documentation:     no"])

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -6768,7 +6768,6 @@ static void *janus_audiobridge_participant_thread(void *data) {
 				janus_audiobridge_relay_rtp_packet(participant->session, outpkt);
 			} else if(g_atomic_int_get(&participant->active) && participant->encoder &&
 					g_atomic_int_compare_and_exchange(&participant->encoding, 0, 1)) {
-
 				/* Encode raw frame to Opus */
 				opus_int16 *outBuffer = (opus_int16 *)mixedpkt->data;
 				outpkt->length = opus_encode(participant->encoder, outBuffer, mixedpkt->length, payload+12, 1500-12);
@@ -6838,4 +6837,3 @@ static void janus_audiobridge_relay_rtp_packet(gpointer data, gpointer user_data
 	packet->data->timestamp = htonl(packet->timestamp);
 	packet->data->seq_number = htons(packet->seq_number);
 }
-

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -6535,12 +6535,12 @@ static void *janus_audiobridge_mixer_thread(void *data) {
 			janus_audiobridge_rtp_relay_packet *mixedpkt = g_malloc(sizeof(janus_audiobridge_rtp_relay_packet));
 			mixedpkt->data = g_malloc(samples*2);
 #ifdef HAVE_RNNOISE
-			if (denoiseState && audiobridge->rnnoise_complexity) {
+			if(denoiseState && audiobridge->rnnoise_complexity) {
 				/* after 3 frames denoised, there is no point skiping them anymore, effect will be barelly noticable*/ 
 				if(denoise_again >= 3 || denoise_again < audiobridge->rnnoise_complexity) {
 					size_t i;
 					float denoiseFrames[OPUS_SAMPLES*2];
-					if(audiobridge->sampling_rate != 16000){
+					if(audiobridge->sampling_rate != 16000) {
 						float inFrames[OPUS_SAMPLES], outFrames[OPUS_SAMPLES];
 						int n = janus_audiobridge_resample((int16_t *)outBuffer, samples, audiobridge->sampling_rate, (int16_t *)sumBuffer, 16000);
 						if(n == 0) {
@@ -6551,7 +6551,7 @@ static void *janus_audiobridge_mixer_thread(void *data) {
 						}
 					}
 
-					for (i = 0; i < OPUS_SAMPLES*2; i++) {
+					for(i = 0; i < OPUS_SAMPLES*2; i++) {
 						denoiseFrames[i] = outBuffer[i];
 					}
 					
@@ -6561,10 +6561,10 @@ static void *janus_audiobridge_mixer_thread(void *data) {
 						denoise_again++;
 					}
 
-					for (i = 0; i < OPUS_SAMPLES*2; i++) {
+					for(i = 0; i < OPUS_SAMPLES*2; i++) {
 						outBuffer[i] = denoiseFrames[i];
 					}
-					if(audiobridge->sampling_rate != 16000){
+					if(audiobridge->sampling_rate != 16000) {
 						int n = janus_audiobridge_resample((int16_t *)outBuffer, samples, 16000, (int16_t *)outBuffer, audiobridge->sampling_rate);
 						if(n == 0) {
 							JANUS_LOG(LOG_WARN, "[Rnnoise] Error re-sampling from 16000 to %d\n", audiobridge->sampling_rate);


### PR DESCRIPTION
Based upon [rnnoise](https://github.com/xiph/rnnoise) library, and only as a poc, to see if it makes sense to use it or not.
Instalation instructions are updated in README.md and also audiobridge usage.

`rnnoise_complexity` room parameter is actually how often frames should go trough rnnoise.
0 - disabled
1 - every second frame will be denoised
2 - 2 frames will be denoised, third skipped
3 - every frame will be denoised
This is an option since denoising will decrees audio quality (add a bit robotic flavor or even sometimes cut end of words, recognizing them as noise)

The rnnoise readme states `It operates on RAW 16-bit (machine endian) mono PCM files sampled at 48 kHz` and from code example I see it does read from a file into frames and process them one by one. I only managed to get clear audio on 16000 sampling rate room.

It would be nice to get some feedback on how good it is, or even better if it can be made better in any way, since my understanding of sampling is very limited :+1: )
