### PR TITLE
Fix broken EchoTest demo for Firefox if datachannels are not supported

### DIFF
--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -1504,7 +1504,6 @@ janus_sdp *janus_sdp_generate_answer(janus_sdp *offer, ...) {
 					char *fmt_str = (char *)fmt->data;
 					if(fmt_str)
 						am->fmts = g_list_append(am->fmts, g_strdup(fmt_str));
-					JANUS_LOG(LOG_FATAL, "[answer] %p, %p\n", am, am->fmts);
 				}
 				temp = temp->next;
 				continue;

--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -430,7 +430,7 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen) {
 						m->proto = g_strdup(proto);
 						m->direction = JANUS_SDP_SENDRECV;
 						m->c_ipv4 = TRUE;
-						if(m->port > 0) {
+						if(m->port > 0 || m->type == JANUS_SDP_APPLICATION) {
 							/* Now let's check the payload types/formats */
 							gchar **mline_parts = g_strsplit(line+2, " ", -1);
 							if(!mline_parts) {
@@ -934,7 +934,7 @@ char *janus_sdp_write(janus_sdp *imported) {
 		janus_sdp_mline *m = (janus_sdp_mline *)temp->data;
 		g_snprintf(buffer, sizeof(buffer), "m=%s %d %s", m->type_str, m->port, m->proto);
 		g_strlcat(sdp, buffer, JANUS_BUFSIZE);
-		if(m->port == 0) {
+		if(m->port == 0 && m->type != JANUS_SDP_APPLICATION) {
 			/* Remove all payload types/formats if we're rejecting the media */
 			g_list_free_full(m->fmts, (GDestroyNotify)g_free);
 			m->fmts = NULL;
@@ -1498,6 +1498,14 @@ janus_sdp *janus_sdp_generate_answer(janus_sdp *offer, ...) {
 			if(!do_data || data > 1) {
 				/* Reject */
 				am->port = 0;
+				/* Add the format anyway, to keep Firefox happy */
+				GList *fmt = m->fmts;
+				if(fmt) {
+					char *fmt_str = (char *)fmt->data;
+					if(fmt_str)
+						am->fmts = g_list_append(am->fmts, g_strdup(fmt_str));
+					JANUS_LOG(LOG_FATAL, "[answer] %p, %p\n", am, am->fmts);
+				}
 				temp = temp->next;
 				continue;
 			}


### PR DESCRIPTION
I was recently made aware that if you try to open the EchoTest demo with Firefox on a Janus that has been build without support for datachannels, the PeerConnection setup fails. I'm just mentioning the EchoTest here and in the commit/title for the sake of simplicity, but this actually is true for all PeerConnections where Firefox offers data channels and Janus doesn't support them (e.g., VideoRoom publishers sending data too). The cause is how we create the m-line to reject the media:

    m=application 0 UDP/DTLS/SCTP 0

which causes this error to appear on the Firefox JS console:

    WebRTC error: DOMException: SIPCC Failed to parse SDP: SDP Parse Error on line 53:  No webrtc-datachannel token in m= media line, parse failed.

It all works as expected in Chrome instead (haven't tried Safari, Edge, or mobile browsers).

This patch tries to address that, by ensuring that we always add the `webrtc-datachannel` format to the m-line even when we're rejecting the SDP, i.e.:

    m=application 0 UDP/DTLS/SCTP webrtc-datachannel

This seems to fix the broken PeerConnection in Firefox, and still works in Chrome, so I consider the issue fixed. I decided to push this as a pull request just in case you can find cases where this actually breaks something it shouldn't (as I mentioned, I didn't test extensively, also because I don't have access to some browsers at all). I plan to merge soon, though, so please notice I won't wait forever.