### PR TITLE
Pass MQTT buffer settings to Paho

### DIFF
--- a/conf/janus.eventhandler.mqttevh.jcfg.sample
+++ b/conf/janus.eventhandler.mqttevh.jcfg.sample
@@ -23,6 +23,7 @@ general: {
 	#retain = 0						# Default MQTT retain flag for published events
 	#qos = 1						# Default MQTT QoS for published events
 	#max_inflight = 10				# Maximum number of inflight messages
+	#max_buffered = 100				# Maximum number of buffered messages
 	#disconnect_timeout = 100		# Seconds to wait before destroying client
 	#username = "guest"				# Username for authentication (default: no authentication)
 	#password = "guest"				# Password for authentication (default: no authentication)

--- a/conf/janus.eventhandler.mqttevh.jcfg.sample
+++ b/conf/janus.eventhandler.mqttevh.jcfg.sample
@@ -22,6 +22,7 @@ general: {
 	#cleansession = 0				# Clean session flag (default: off)
 	#retain = 0						# Default MQTT retain flag for published events
 	#qos = 1						# Default MQTT QoS for published events
+	#max_inflight = 10				# Maximum number of inflight messages
 	#disconnect_timeout = 100		# Seconds to wait before destroying client
 	#username = "guest"				# Username for authentication (default: no authentication)
 	#password = "guest"				# Password for authentication (default: no authentication)

--- a/conf/janus.transport.mqtt.jcfg.sample
+++ b/conf/janus.transport.mqtt.jcfg.sample
@@ -15,6 +15,7 @@ general: {
 	#keep_alive_interval = 20			# Keep connection for N seconds
 	#cleansession = 0					# Clean session flag
 	#max_inflight = 10					# Maximum number of inflight messages
+	#max_buffered = 100					# Maximum number of buffered messages
 	#disconnect_timeout = 100			# Milliseconds to wait before destroying client
 	subscribe_topic = "to-janus"		# Topic for incoming messages
 	#subscribe_qos = 1					# QoS for incoming messages

--- a/conf/janus.transport.mqtt.jcfg.sample
+++ b/conf/janus.transport.mqtt.jcfg.sample
@@ -14,6 +14,7 @@ general: {
 	#password = "guest"					# Password to use to authenticate, if needed
 	#keep_alive_interval = 20			# Keep connection for N seconds
 	#cleansession = 0					# Clean session flag
+	#max_inflight = 10					# Maximum number of inflight messages
 	#disconnect_timeout = 100			# Milliseconds to wait before destroying client
 	subscribe_topic = "to-janus"		# Topic for incoming messages
 	#subscribe_qos = 1					# QoS for incoming messages
@@ -52,6 +53,6 @@ status: {
 	#disconnect_message = "{\"online\": false}"
 
 	#topic = "status"			# Status topic (default: "status")
-	#qos = 1			      	# QoS for status messages (default: 1)
-	#retain = false		    # Whether status messages should be retained (default: false)
+	#qos = 1				  	# QoS for status messages (default: 1)
+	#retain = false				# Whether status messages should be retained (default: false)
 }

--- a/events/janus_mqttevh.c
+++ b/events/janus_mqttevh.c
@@ -95,6 +95,7 @@ static volatile gint initialized = 0, stopping = 0;
 #define	JANUS_MQTTEVH_DEFAULT_ADDEVENT				1
 #define	JANUS_MQTTEVH_DEFAULT_KEEPALIVE				30
 #define	JANUS_MQTTEVH_DEFAULT_CLEANSESSION			0	/* Off */
+#define JANUS_MQTTEVH_DEFAULT_MAX_INFLIGHT			10
 #define JANUS_MQTTEVH_DEFAULT_TIMEOUT				30
 #define JANUS_MQTTEVH_DEFAULT_DISCONNECT_TIMEOUT	100
 #define JANUS_MQTTEVH_DEFAULT_QOS					0
@@ -148,6 +149,7 @@ typedef struct janus_mqttevh_context {
 		int mqtt_version;
 		int keep_alive_interval;
 		int cleansession;
+		int max_inflight;
 		char *client_id;
 		char *username;
 		char *password;
@@ -373,6 +375,7 @@ static int janus_mqttevh_client_connect(janus_mqttevh_context *ctx) {
 	options.password = ctx->connect.password;
 	options.automaticReconnect = TRUE;
 	options.keepAliveInterval = ctx->connect.keep_alive_interval;
+	options.maxInflight = ctx->connect.max_inflight;
 
 	MQTTAsync_willOptions willOptions = MQTTAsync_willOptions_initializer;
 	if(ctx->will.enabled) {
@@ -653,7 +656,7 @@ static int janus_mqttevh_init(const char *config_path) {
 	int res = 0;
 	janus_config_item *url_item;
 	janus_config_item *username_item, *password_item, *topic_item, *addevent_item;
-	janus_config_item *keep_alive_interval_item, *cleansession_item, *disconnect_timeout_item, *qos_item, *retain_item, *connect_status_item, *disconnect_status_item;
+	janus_config_item *keep_alive_interval_item, *cleansession_item, *max_inflight_item, *disconnect_timeout_item, *qos_item, *retain_item, *connect_status_item, *disconnect_status_item;
 	janus_config_item *will_retain_item, *will_qos_item, *will_enabled_item;
 
 	if(g_atomic_int_get(&stopping)) {
@@ -794,6 +797,14 @@ static int janus_mqttevh_init(const char *config_path) {
 	if(ctx->connect.cleansession < 0) {
 		JANUS_LOG(LOG_ERR, "Invalid clean-session value: %s (falling back to default)\n", cleansession_item->value);
 		ctx->connect.cleansession = JANUS_MQTTEVH_DEFAULT_CLEANSESSION;
+	}
+
+	max_inflight_item = janus_config_get(config, config_general, janus_config_type_item, "max_inflight");
+	ctx->connect.max_inflight = (max_inflight_item && max_inflight_item->value) ?
+		atoi(max_inflight_item->value) : JANUS_MQTTEVH_DEFAULT_MAX_INFLIGHT;
+	if(ctx->connect.max_inflight < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid max-inflight value: %s (falling back to default)\n", max_inflight_item->value);
+		ctx->connect.max_inflight = JANUS_MQTTEVH_DEFAULT_MAX_INFLIGHT;
 	}
 
 	/* Disconnect configuration */

--- a/events/janus_mqttevh.c
+++ b/events/janus_mqttevh.c
@@ -96,6 +96,7 @@ static volatile gint initialized = 0, stopping = 0;
 #define	JANUS_MQTTEVH_DEFAULT_KEEPALIVE				30
 #define	JANUS_MQTTEVH_DEFAULT_CLEANSESSION			0	/* Off */
 #define JANUS_MQTTEVH_DEFAULT_MAX_INFLIGHT			10
+#define JANUS_MQTTEVH_DEFAULT_MAX_BUFFERED			100
 #define JANUS_MQTTEVH_DEFAULT_TIMEOUT				30
 #define JANUS_MQTTEVH_DEFAULT_DISCONNECT_TIMEOUT	100
 #define JANUS_MQTTEVH_DEFAULT_QOS					0
@@ -150,6 +151,7 @@ typedef struct janus_mqttevh_context {
 		int keep_alive_interval;
 		int cleansession;
 		int max_inflight;
+		int max_buffered;
 		char *client_id;
 		char *username;
 		char *password;
@@ -656,7 +658,7 @@ static int janus_mqttevh_init(const char *config_path) {
 	int res = 0;
 	janus_config_item *url_item;
 	janus_config_item *username_item, *password_item, *topic_item, *addevent_item;
-	janus_config_item *keep_alive_interval_item, *cleansession_item, *max_inflight_item, *disconnect_timeout_item, *qos_item, *retain_item, *connect_status_item, *disconnect_status_item;
+	janus_config_item *keep_alive_interval_item, *cleansession_item, *max_inflight_item, *max_buffered_item, *disconnect_timeout_item, *qos_item, *retain_item, *connect_status_item, *disconnect_status_item;
 	janus_config_item *will_retain_item, *will_qos_item, *will_enabled_item;
 
 	if(g_atomic_int_get(&stopping)) {
@@ -805,6 +807,14 @@ static int janus_mqttevh_init(const char *config_path) {
 	if(ctx->connect.max_inflight < 0) {
 		JANUS_LOG(LOG_ERR, "Invalid max-inflight value: %s (falling back to default)\n", max_inflight_item->value);
 		ctx->connect.max_inflight = JANUS_MQTTEVH_DEFAULT_MAX_INFLIGHT;
+	}
+
+	max_buffered_item = janus_config_get(config, config_general, janus_config_type_item, "max_buffered");
+	ctx->connect.max_buffered = (max_buffered_item && max_buffered_item->value) ?
+		atoi(max_buffered_item->value) : JANUS_MQTTEVH_DEFAULT_MAX_BUFFERED;
+	if(ctx->connect.max_buffered < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid max-buffered value: %s (falling back to default)\n", max_buffered_item->value);
+		ctx->connect.max_buffered = JANUS_MQTTEVH_DEFAULT_MAX_BUFFERED;
 	}
 
 	/* Disconnect configuration */
@@ -970,6 +980,8 @@ static int janus_mqttevh_init(const char *config_path) {
 		create_options.MQTTVersion = MQTTVERSION_5;
 	}
 #endif
+
+	create_options.maxBufferedMessages = ctx->connect.max_buffered;
 
 	res = MQTTAsync_createWithOptions(
 		&ctx->client,

--- a/transports/janus_mqtt.c
+++ b/transports/janus_mqtt.c
@@ -116,6 +116,7 @@ typedef struct janus_mqtt_context {
 		int cleansession;
 		char *username;
 		char *password;
+		int max_inflight;
 	} connect;
 	struct {
 		int timeout;
@@ -420,6 +421,15 @@ int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path
 	if(ctx->connect.cleansession < 0) {
 		JANUS_LOG(LOG_ERR, "Invalid clean-session value: %s (falling back to default)\n", cleansession_item->value);
 		ctx->connect.cleansession = 0;
+	}
+
+	janus_config_item *max_inflight_item = janus_config_get(config, config_general, janus_config_type_item, "max_inflight");
+	max_inflight_item = janus_config_get(config, config_general, janus_config_type_item, "max_inflight");
+	ctx->connect.max_inflight = (max_inflight_item && max_inflight_item->value) ?
+		atoi(max_inflight_item->value) : 10;
+	if(ctx->connect.max_inflight < 0) {
+		JANUS_LOG(LOG_ERR, "Invalid max-inflight value: %s (falling back to default)\n", max_inflight_item->value);
+		ctx->connect.max_inflight = 10;
 	}
 
 	janus_config_item *enabled_item = janus_config_get(config, config_general, janus_config_type_item, "enabled");
@@ -1068,6 +1078,7 @@ int janus_mqtt_client_connect(janus_mqtt_context *ctx) {
 	options.password = ctx->connect.password;
 	options.automaticReconnect = TRUE;
 	options.keepAliveInterval = ctx->connect.keep_alive_interval;
+	options.maxInflight = ctx->connect.max_inflight;
 
 	MQTTAsync_SSLOptions ssl_opts = MQTTAsync_SSLOptions_initializer;
 	if(ctx->ssl_enabled) {


### PR DESCRIPTION
This is out of scope of the [previous](https://github.com/meetecho/janus-gateway/pull/2273) PR so here is a separate one.

This feature allows passing a couple of options to Paho MQTT client through transport & evh configs: max inflight messages and max buffered messages. By default Paho sets the first one to 10 and the second one to 100 which may be insufficient for high load. So here're options to configure them.