### PR TITLE
Fix candidates memory leaks

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -3643,8 +3643,10 @@ void janus_ice_resend_trickles(janus_ice_handle *handle) {
 		handle->handle_id, g_slist_length(candidates), stream->stream_id, component->component_id);
 	for(i = candidates; i; i = i->next) {
 		NiceCandidate *c = (NiceCandidate *) i->data;
-		if(c->type == NICE_CANDIDATE_TYPE_PEER_REFLEXIVE)
+		if(c->type == NICE_CANDIDATE_TYPE_PEER_REFLEXIVE) {
+			nice_candidate_free(c);
 			continue;
+		}
 		if(janus_ice_candidate_to_string(handle, c, buffer, sizeof(buffer), FALSE, FALSE) == 0) {
 			/* Candidate encoded, send a "trickle" event to the browser */
 			janus_ice_notify_trickle(handle, buffer);

--- a/ice.c
+++ b/ice.c
@@ -2039,12 +2039,12 @@ static void janus_ice_cb_new_local_candidate (NiceAgent *agent, NiceCandidate *c
 	while(tmp) {
 		NiceCandidate *c = (NiceCandidate *)tmp->data;
 		/* Check if this is what we're looking for */
-		if(!strcasecmp(c->foundation, foundation)) {
+		if(!candidate && !strcasecmp(c->foundation, foundation)) {
 			/* It is! */
 			candidate = c;
-			break;
+		} else {
+			nice_candidate_free(c);
 		}
-		nice_candidate_free(c);
 		tmp = tmp->next;
 	}
 	g_slist_free(candidates);


### PR DESCRIPTION
- Ignored peer-reflexive candidates were not released.
- All found local candidates after the one that was used were leaking.