### PR TITLE
Fix memory leak in sdp-utils.c

### DIFF
--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -1599,6 +1599,7 @@ int janus_sdp_generate_offer_mline(janus_sdp *offer, ...) {
 				}
 				iter = iter->next;
 			}
+			g_list_free(ids);
 		}
 		/* Check if there's a custom fmtp line to add */
 		if(type == JANUS_SDP_AUDIO && fmtp != NULL) {


### PR DESCRIPTION
GList returned from g_hash_table_get_keys() was never freed.