### PR TITLE
Fixed validation of subscriber_parameters with string_ids true in vid…

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1670,7 +1670,6 @@ static struct janus_json_parameter subscriber_parameters[] = {
 	{"temporal_layer", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 };
 static struct janus_json_parameter subscriber_stream_parameters[] = {
-	{"feed", JANUS_JSON_INTEGER, JANUS_JSON_PARAM_REQUIRED | JANUS_JSON_PARAM_POSITIVE},
 	{"mid", JANUS_JSON_STRING, 0},
 	/* For VP8 (or H.264) simulcast */
 	{"substream", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -7233,6 +7233,13 @@ static void *janus_videoroom_handler(void *data) {
 					}
 					if(error_code != 0) {
 						janus_mutex_unlock(&videoroom->mutex);
+						/* Unref publishers we may have taken note of so far */
+						while(publishers) {
+							janus_videoroom_publisher *publisher = (janus_videoroom_publisher *)publishers->data;
+							janus_refcount_decrease(&publisher->ref);
+							janus_refcount_decrease(&publisher->session->ref);
+							publishers = g_list_remove(publishers, publisher);
+						}
 						janus_refcount_decrease(&videoroom->ref);
 						goto error;
 					}


### PR DESCRIPTION
It seems the field "feed" inside stream is always validated as a integer, while it could also be a string.
