### PR TITLE
Use unique IDs and internal hashtable to map SCTP associations with usrsctp

### DIFF
--- a/sctp.h
+++ b/sctp.h
@@ -99,6 +99,8 @@ typedef struct janus_sctp_channel {
 } janus_sctp_channel;
 
 typedef struct janus_sctp_association {
+	/*! \brief Unique (local) ID of this association (needed for an internal map) */
+	uint32_t map_id;
 	/*! \brief Pointer to the DTLS instance related to this SCTP association */
 	struct janus_dtls_srtp *dtls;
 	/*! \brief Pointer to the ICE handle related to this SCTP association */


### PR DESCRIPTION
This patch aims at addressing a vulnerability that apparently still affects usrsctp, and so you should test this if you use datachannels in your application. You can learn more about the vulnerability (and the workaround we implemented) by reading [this thread on Twitter](https://twitter.com/juberti/status/1288218310941773824).

Basically, with usrsctp almost everyone (including us, libwebrtc developers, and others) passed our custom structures/classes as opaque pointers when creating associations, as this way usrsctp would provide the same pointer back in callbacks, making it easier to address, e.g., incoming messages and events and relate them to the right instance. Apparently, though, usrsctp is actually putting the address of that pointer in SCTP messages (as part of the cookie), which creates an obvious vulnerability. I was made aware of this issue some time ago, but at the same time the notice said this had been fixed in usrsctp itself about a year ago: since we always recommend installing the latest version, I assumed we were fine, but apparently that's not the case. As such, I'm implementing the same workaround the libwebrtc developers implemented, that is an internal map with unique IDs: we pass these harmless IDs to usrsctp, and then look for the right SCTP instance when we get an ID in one of the callbacks.

While it seems to be working as expected in the few tests I made, you're encouraged to test this more thoroughly yourself, especially if you rely on datachannels in your applications. This new map I added also adds a new mutex, and as such there's always the risk of deadlocks in unexpected circumstances (which should happen, but you never know).