### PR TITLE
Bugfix: make audio/video recording in videocall working again

### DIFF
--- a/plugins/janus_videocall.c
+++ b/plugins/janus_videocall.c
@@ -1557,8 +1557,8 @@ static void *janus_videocall_handler(void *data) {
 						if(recording_base) {
 							/* Use the filename and path we have been provided */
 							g_snprintf(filename, 255, "%s-audio", recording_base);
-							session->arc = janus_recorder_create(NULL, janus_audiocodec_name(session->acodec), filename);
-							if(session->arc == NULL) {
+							rc = janus_recorder_create(NULL, janus_audiocodec_name(session->acodec), filename);
+							if(rc == NULL) {
 								/* FIXME We should notify the fact the recorder could not be created */
 								JANUS_LOG(LOG_ERR, "Couldn't open an audio recording file for this VideoCall user!\n");
 							}
@@ -1568,8 +1568,8 @@ static void *janus_videocall_handler(void *data) {
 								session->username ? session->username : "unknown",
 								(peer && peer->username) ? peer->username : "unknown",
 								now);
-							session->arc = janus_recorder_create(NULL, janus_audiocodec_name(session->acodec), filename);
-							if(session->arc == NULL) {
+							rc = janus_recorder_create(NULL, janus_audiocodec_name(session->acodec), filename);
+							if(rc == NULL) {
 								/* FIXME We should notify the fact the recorder could not be created */
 								JANUS_LOG(LOG_ERR, "Couldn't open an audio recording file for this VideoCall user!\n");
 							}
@@ -1586,8 +1586,8 @@ static void *janus_videocall_handler(void *data) {
 						if(recording_base) {
 							/* Use the filename and path we have been provided */
 							g_snprintf(filename, 255, "%s-video", recording_base);
-							session->vrc = janus_recorder_create(NULL, janus_videocodec_name(session->vcodec), filename);
-							if(session->vrc == NULL) {
+							rc = janus_recorder_create(NULL, janus_videocodec_name(session->vcodec), filename);
+							if(rc == NULL) {
 								/* FIXME We should notify the fact the recorder could not be created */
 								JANUS_LOG(LOG_ERR, "Couldn't open an video recording file for this VideoCall user!\n");
 							}
@@ -1597,8 +1597,8 @@ static void *janus_videocall_handler(void *data) {
 								session->username ? session->username : "unknown",
 								(peer && peer->username) ? peer->username : "unknown",
 								now);
-							session->vrc = janus_recorder_create(NULL, janus_videocodec_name(session->vcodec), filename);
-							if(session->vrc == NULL) {
+							rc = janus_recorder_create(NULL, janus_videocodec_name(session->vcodec), filename);
+							if(rc == NULL) {
 								/* FIXME We should notify the fact the recorder could not be created */
 								JANUS_LOG(LOG_ERR, "Couldn't open an video recording file for this VideoCall user!\n");
 							}


### PR DESCRIPTION
MJR audio/video files are created but stay empty forever

does not work since v0.10.1 stable version
regressed at commit 0d32ff377b7f366805ba1083bea6a895630d40e9