### PR TITLE
Prevent generating huge opus files when received timestamp is 0

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -6378,8 +6378,16 @@ static void *janus_sip_relay_thread(void *data) {
 						}
 						bytes = buflen;
 					}
+					if(header->markerbit) {
+						JANUS_LOG(LOG_ERR, "[SIP-%s] 0 RTP packet (seq=%"SCNu16", ssrc=%"SCNu32" ts=%"SCNu32")\n",
+							  session->account.username, ntohs(header->seq_number), ntohl(header->ssrc), ntohl(header->timestamp));
+					}
 					/* Check if the SSRC changed (e.g., after a re-INVITE or UPDATE) */
 					janus_rtp_header_update(header, &session->media.context, FALSE, 0);
+					if(header->markerbit) {
+						JANUS_LOG(LOG_ERR, "[SIP-%s] 1 RTP packet (seq=%"SCNu16", ssrc=%"SCNu32" ts=%"SCNu32")\n",
+							  session->account.username, ntohs(header->seq_number), ntohl(header->ssrc), ntohl(header->timestamp));
+					}
 					/* Save the frame if we're recording */
 					janus_recorder_save_frame(session->arc_peer, buffer, bytes);
 					/* Relay to application */

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -6378,16 +6378,8 @@ static void *janus_sip_relay_thread(void *data) {
 						}
 						bytes = buflen;
 					}
-					if(header->markerbit) {
-						JANUS_LOG(LOG_ERR, "[SIP-%s] 0 RTP packet (seq=%"SCNu16", ssrc=%"SCNu32" ts=%"SCNu32")\n",
-							  session->account.username, ntohs(header->seq_number), ntohl(header->ssrc), ntohl(header->timestamp));
-					}
 					/* Check if the SSRC changed (e.g., after a re-INVITE or UPDATE) */
 					janus_rtp_header_update(header, &session->media.context, FALSE, 0);
-					if(header->markerbit) {
-						JANUS_LOG(LOG_ERR, "[SIP-%s] 1 RTP packet (seq=%"SCNu16", ssrc=%"SCNu32" ts=%"SCNu32")\n",
-							  session->account.username, ntohs(header->seq_number), ntohl(header->ssrc), ntohl(header->timestamp));
-					}
 					/* Save the frame if we're recording */
 					janus_recorder_save_frame(session->arc_peer, buffer, bytes);
 					/* Relay to application */

--- a/rtp.c
+++ b/rtp.c
@@ -605,7 +605,7 @@ int janus_rtp_skew_compensate_video(janus_rtp_header *header, janus_rtp_switchin
 	return exit_status;
 }
 
-gint64 janus_get_audio_time_diff(uint16_t codec_type, gint64 a_last_time) {
+static gint64 janus_get_audio_time_diff(uint16_t codec_type, gint64 a_last_time) {
 	gint64 time_diff = janus_get_monotonic_time() - a_last_time;
 	int akhz = 48;
 	if(codec_type == 0 || codec_type == 8 || codec_type == 9)

--- a/rtp.c
+++ b/rtp.c
@@ -677,7 +677,7 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 			context->a_base_seq = seq;
 			/* How much time since the last audio RTP packet? We compute an offset accordingly */
 			if(context->a_last_time > 0) {
-				gint64 time_diff = janus_get_audio_time_diff(header->type, context->a_last_ts);
+				gint64 time_diff = janus_get_audio_time_diff(header->type, context->a_last_time);
 				context->a_base_ts_prev += (guint32)time_diff;
 				context->a_prev_ts += (guint32)time_diff;
 				context->a_last_ts += (guint32)time_diff;
@@ -697,7 +697,7 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 		if(timestamp >= context->a_base_ts) {
 			context->a_last_ts = (timestamp - context->a_base_ts) + context->a_base_ts_prev;
 		} else {
-			gint64 time_diff = janus_get_audio_time_diff(header->type, context->a_last_ts);
+			gint64 time_diff = janus_get_audio_time_diff(header->type, context->a_last_time);
 			context->a_last_ts += time_diff;
 		}
 		context->a_prev_seq = context->a_last_seq;


### PR DESCRIPTION
Hi Meetecho,

Recently we noticed that janus-pp-rec tool generates huge opus files(20GB, 30GB...) for some SIP calls. 
We use the latest Janus version, so bugfix introduced in PR https://github.com/meetecho/janus-gateway/pull/2250 didn't resolve our issue.

We converted the problematic mjr files to pcap and found some packets with very large timestamps(almost max uint32). 
But packets before and after the problematic packet were fine. Here is an example: 

![image](https://user-images.githubusercontent.com/11505022/90752095-444d8b00-e2d7-11ea-85c3-35d2d1cfa22a.png)

Then we captured RTP packets on the network and found out that those problematic packets are received with a timestamp set to 0 and Janus converts them to large integer due to negative subtraction of timestamp and base_ts values.

Here is an example from the network trace:

![image](https://user-images.githubusercontent.com/11505022/90752508-c5a51d80-e2d7-11ea-96d9-17efc8666a83.png)

I couldn't find any RFC how this packet with timestamp=0 and marker=1 should be handled so I decided to calculate timestamp based on the time when the previous packet is received (the same solution was used for an SSRC change). If you have another idea or any suggestion let me know.

We have tested this fix last few days and it's working fine for us. 

@neilkinnish can you also please take a look at this? Maybe this might resolve your issue, too.
