### PR TITLE
Easy support for one-to-many scenarios in videoroomtest

### DIFF
--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -64,7 +64,7 @@ var bitrateTimer = [];
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
 var doSimulcast2 = (getQueryStringValue("simulcast2") === "yes" || getQueryStringValue("simulcast2") === "true");
-var subscriber_mode = (getQueryStringValue("subscriber-mode") === "yes")
+var subscriber_mode = (getQueryStringValue("subscriber-mode") === "yes")  || getQueryStringValue("subscriber-mode") === "true");
 
 $(document).ready(function() {
 	// Initialize the library (all console debuggers enabled)
@@ -163,12 +163,13 @@ $(document).ready(function() {
 											myid = msg["id"];
 											mypvtid = msg["private_id"];
 											Janus.log("Successfully joined room " + msg["room"] + " with ID " + myid);
-											if (subscriber_mode) {
+											if(subscriber_mode) {
                                                 						$('#videojoin').hide();
                                                 						$('#videos').removeClass('hide').show();
                                             						}
-                                            						else
+                                            						else {
                                                 						publishOwnFeed(true);
+											}
 
 											// Any new feed to attach to?
 											if(msg["publishers"]) {

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -166,8 +166,7 @@ $(document).ready(function() {
 											if(subscriber_mode) {
                                                 						$('#videojoin').hide();
                                                 						$('#videos').removeClass('hide').show();
-                                            						}
-                                            						else {
+                                            						} else {
                                                 						publishOwnFeed(true);
 											}
 


### PR DESCRIPTION
A small patch to `videoroomtest` for quick and dirty test of one-to-many scenarios. If you specify the query parameter `subscriber-mode=yes` the local instance will neither touch nor send local media, but instead display the media other publishers provide. Doesn't harm and change anything for the default configuration.