### PR TITLE
Send websocket message in multiple fragments when needed.

### DIFF
--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -165,9 +165,9 @@ typedef struct janus_websockets_client {
 	GAsyncQueue *messages;					/* Queue of outgoing messages to push */
 	char *incoming;							/* Buffer containing the incoming message to process (in case there are fragments) */
 	unsigned char *buffer;					/* Buffer containing the message to send */
-	int buflen;								/* Length of the buffer (may be resized after re-allocations) */
-	int bufpending;							/* Data an interrupted previous write couldn't send */
-	int bufoffset;							/* Offset from where the interrupted previous write should resume */
+	size_t buflen;								/* Length of the buffer (may be resized after re-allocations) */
+	size_t bufpending;							/* Data an interrupted previous write couldn't send */
+	size_t bufoffset;							/* Offset from where the interrupted previous write should resume */
 	volatile gint destroyed;				/* Whether this libwebsockets client instance has been closed */
 	janus_transport_session *ts;			/* Janus core-transport session */
 } janus_websockets_client;
@@ -1057,6 +1057,9 @@ static int janus_websockets_callback_https(
 	return janus_websockets_callback_http(wsi, reason, user, in, len);
 }
 
+/* Use ~ 2xMTU as chunk size */
+#define MESSAGE_CHUNK_SIZE 2800
+
 /* This callback handles Janus API requests */
 static int janus_websockets_common_callback(
 		struct lws *wsi,
@@ -1184,7 +1187,7 @@ static int janus_websockets_common_callback(
 				/* Check if Websockets send pipe is choked */
 				if(lws_send_pipe_choked(wsi)) {
 					if(ws_client->buffer && ws_client->bufpending > 0 && ws_client->bufoffset > 0) {
-						JANUS_LOG(LOG_WARN, "Websockets choked with buffer: %d, trying again\n", ws_client->bufpending);
+						JANUS_LOG(LOG_WARN, "Websockets choked with buffer: %zu, trying again\n", ws_client->bufpending);
 						lws_callback_on_writable(wsi);
 					} else {
 						gint qlen = g_async_queue_length(ws_client->messages);
@@ -1198,56 +1201,63 @@ static int janus_websockets_common_callback(
 				}
 
 				/* Check if we have a pending/partial write to complete first */
-				if(ws_client->buffer && ws_client->bufpending > 0 && ws_client->bufoffset > 0
-						&& !g_atomic_int_get(&ws_client->destroyed) && !g_atomic_int_get(&stopping)) {
-					JANUS_LOG(LOG_HUGE, "[%s-%p] Completing pending WebSocket write (still need to write last %d bytes)...\n",
+				if(ws_client->bufpending > 0 && ws_client->bufoffset > 0) {
+					JANUS_LOG(LOG_HUGE, "[%s-%p] Completing pending WebSocket write (still need to write last %zu bytes)...\n",
 						log_prefix, wsi, ws_client->bufpending);
-					int sent = lws_write(wsi, ws_client->buffer + ws_client->bufoffset, ws_client->bufpending, LWS_WRITE_TEXT);
-					JANUS_LOG(LOG_HUGE, "[%s-%p]   -- Sent %d/%d bytes\n", log_prefix, wsi, sent, ws_client->bufpending);
-					if(sent > -1 && sent < ws_client->bufpending) {
-						/* We still couldn't send everything that was left, we'll try and complete this in the next round */
-						ws_client->bufpending -= sent;
-						ws_client->bufoffset += sent;
-					} else {
-						/* Clear the pending/partial write queue */
-						ws_client->bufpending = 0;
-						ws_client->bufoffset = 0;
-					}
-					/* Done for this round, check the next response/notification later */
-					lws_callback_on_writable(wsi);
-					janus_mutex_unlock(&ws_client->ts->mutex);
-					return 0;
 				}
-				/* Shoot all the pending messages */
-				char *response = g_async_queue_try_pop(ws_client->messages);
-				if(response && !g_atomic_int_get(&ws_client->destroyed) && !g_atomic_int_get(&stopping)) {
+				else {
+					/* Shoot all the pending messages */
+					char* response = g_async_queue_try_pop(ws_client->messages);
+					if (!response) {
+						/* No messages found */
+						janus_mutex_unlock(&ws_client->ts->mutex);
+						return 0;
+					}
 					/* Gotcha! */
-					int buflen = LWS_PRE + strlen(response);
+					JANUS_LOG(LOG_HUGE, "[%s-%p] Sending WebSocket message (%zu bytes)...\n", log_prefix, wsi, strlen(response));
+					size_t buflen = LWS_PRE + strlen(response);
 					if (buflen > ws_client->buflen) {
 						/* We need a larger shared buffer */
-						JANUS_LOG(LOG_HUGE, "[%s-%p] Re-allocating to %d bytes (was %d, response is %zu bytes)\n", log_prefix, wsi, buflen, ws_client->buflen, strlen(response));
+						JANUS_LOG(LOG_HUGE, "[%s-%p] Re-allocating to %zu bytes (was %zu, response is %zu bytes)\n", log_prefix, wsi, buflen, ws_client->buflen, strlen(response));
 						ws_client->buflen = buflen;
 						ws_client->buffer = g_realloc(ws_client->buffer, buflen);
 					}
 					memcpy(ws_client->buffer + LWS_PRE, response, strlen(response));
-					JANUS_LOG(LOG_HUGE, "[%s-%p] Sending WebSocket message (%zu bytes)...\n", log_prefix, wsi, strlen(response));
-					int sent = lws_write(wsi, ws_client->buffer + LWS_PRE, strlen(response), LWS_WRITE_TEXT);
-					JANUS_LOG(LOG_HUGE, "[%s-%p]   -- Sent %d/%zu bytes\n", log_prefix, wsi, sent, strlen(response));
-					if(sent > -1 && sent < (int)strlen(response)) {
-						/* We couldn't send everything in a single write, we'll complete this in the next round */
-						ws_client->bufpending = strlen(response) - sent;
-						ws_client->bufoffset = LWS_PRE + sent;
-						JANUS_LOG(LOG_HUGE, "[%s-%p]   -- Couldn't write all bytes (%d missing), setting offset %d\n",
-							log_prefix, wsi, ws_client->bufpending, ws_client->bufoffset);
-					}
+					/* Initialize pending bytes count and buffer offset */
+					ws_client->bufpending = strlen(response);
+					ws_client->bufoffset = LWS_PRE;
 					/* We can get rid of the message */
 					free(response);
-					/* Done for this round, check the next response/notification later */
-					lws_callback_on_writable(wsi);
-					janus_mutex_unlock(&ws_client->ts->mutex);
-					return 0;
 				}
+
+				/* Evaluate amount of data to send according to MESSAGE_CHUNK_SIZE */
+				int amount = ws_client->bufpending <= MESSAGE_CHUNK_SIZE ? ws_client->bufpending : MESSAGE_CHUNK_SIZE;
+				/* Set fragment flags */
+				int flags = lws_write_ws_flags(LWS_WRITE_TEXT, ws_client->bufoffset <= LWS_PRE, ws_client->bufpending <= (size_t)amount);
+				/* Send the fragment with proper flags */
+				int sent = lws_write(wsi, ws_client->buffer + ws_client->bufoffset, (size_t)amount, flags);
+				JANUS_LOG(LOG_HUGE, "[%s-%p]   -- First=%d, Last=%d, Requested=%d bytes, Sent=%d bytes, Missing=%zu bytes\n", log_prefix, wsi, ws_client->bufoffset <= LWS_PRE, ws_client->bufpending <= (size_t)amount, amount, sent, ws_client->bufpending - amount);
+				if(sent < amount) {
+					/* Error on sending, abort operation */
+					JANUS_LOG(LOG_ERR, "Websocket sent only %d bytes (expected %d)\n", sent, amount);
+					ws_client->bufpending = 0;
+					ws_client->bufoffset = 0;
+				}
+				else {
+					/* Fragment successfully sent, update status */
+					ws_client->bufpending -= amount;
+					ws_client->bufoffset += amount;
+					if(ws_client->bufpending > 0) {
+						/* We still couldn't send everything that was left, we'll try and complete this in the next round */
+						/* We couldn't send everything in a single write, we'll complete this in the next round */
+						JANUS_LOG(LOG_HUGE, "[%s-%p]   -- Couldn't write all bytes (%zu missing), setting offset %zu\n",
+							log_prefix, wsi, ws_client->bufpending, ws_client->bufoffset);
+					}
+				}
+				/* Done for this round, check the next response/notification later */
+				lws_callback_on_writable(wsi);
 				janus_mutex_unlock(&ws_client->ts->mutex);
+				return 0;
 			}
 			return 0;
 		}


### PR DESCRIPTION
This PR adds the support to WebSocket fragmentation ([RFC 6455](https://tools.ietf.org/html/rfc6455#section-5.4)) when sending large messages to Janus clients and fixes #2349.

The effort started after the issue #2349 where it has been proved that in particular scenarios that involved the encapsulation of websocket in h2 Janus would crash due to a buffer overflow in the underlying libraries.
We decided to follow @lws-team suggestion (thanks again!) to implement message fragmentation in order to avoid this crash.
The size of each fragment (aka message chunk ) has been set as suggested to about 2 MTU (so 2800 bytes) and it is defined in the `MESSAGE_CHUNK_SIZE` macro.

While working on this PR we have also refactored the event loop in order to avoid duplicate source and make the code cleaner and more readable.

Clients **should not** take any action as their websocket libraries are expected to take care of message fragmentation.

**Notable changes (for reviewers)**:
- we do not use anymore the `sent` integer returned by `lws_write` to move the buffer pointer `bufoffset`. We just check that `sent` bytes are not lesser than requested `amount` (that would mean an error occurred) and then increment the pointer by `amount`
- `bufoffset` is now initialized to `LWS_PRE` (IMHO it does more sense, given that the buffer has size equals to `LWS_PRE` + `message size`
- the `response` string (that is the message to be sent) is now being freed as soon as it has been copied into the buffer and not just before quitting a loop iteration as before
- we fixed some potential overflows by transforming _bufsize_-like variables from `int` type to `size_t`