### PR TITLE
Fix js client Chrome unified plan check

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -389,9 +389,9 @@ Janus.init = function(options) {
 			// Firefox definitely does, starting from version 59
 			Janus.unifiedPlan = true;
 		} else if(Janus.webRTCAdapter.browserDetails.browser === 'chrome' &&
-				Janus.webRTCAdapter.browserDetails.version < 72) {
+				Janus.webRTCAdapter.browserDetails.version >= 72) {
 			// Chrome does, but it's only usable from version 72 on
-			Janus.unifiedPlan = false;
+			Janus.unifiedPlan = true;
 		} else if(!window.RTCRtpTransceiver || !('currentDirection' in RTCRtpTransceiver.prototype)) {
 			// Safari supports addTransceiver() but not Unified Plan when
 			// currentDirection is not defined (see codepen above).


### PR DESCRIPTION
Fix js client Chrome unified plan check, unified plan will be always false.

I think you guys maintain primary `janus.js`then build/wrap for several import methods, please let me know if isn't like this. Thanks.