### PR TITLE
Use single thread for usrsctp stack

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -105,6 +105,9 @@ general: {
 									# As such, if you want to use this you should
 									# provision the correct value according to the
 									# available resources (e.g., CPUs available).
+	#usrsctp_singlethread = true	# You can also choose whether to use a single thread
+									# for the usrsctp stack, or use their internal
+									# threads instead (default=multiple threads).
 	#opaqueid_in_api = true			# Opaque IDs set by applications are typically
 									# only passed to event handlers for correlation
 									# purposes, but not sent back to the user or
@@ -205,6 +208,7 @@ media: {
 	#slowlink_threshold = 4
 	#twcc_period = 100
 	#dtls_timeout = 500
+	#usrsctp_single_thread = true
 
 	# If you need DSCP packet marking and prioritization, you can configure
 	# the 'dscp' property to a specific values, and Janus will try to

--- a/janus.c
+++ b/janus.c
@@ -4846,7 +4846,9 @@ gint main(int argc, char *argv[])
 
 #ifdef HAVE_SCTP
 	/* Initialize SCTP for DataChannels */
-	if(janus_sctp_init() < 0) {
+	item = janus_config_get(config, config_general, janus_config_type_item, "usrsctp_singlethread");
+	gboolean st = (item && item->value && janus_is_true(item->value));
+	if(janus_sctp_init(st) < 0) {
 		exit(1);
 	}
 #else

--- a/sctp.c
+++ b/sctp.c
@@ -148,29 +148,36 @@ static gboolean janus_sctp_timer(gpointer user_data) {
 	usrsctp_handle_timers(elapsed);
 	return TRUE;
 }
-int janus_sctp_init(void) {
-	/* Create a loop that we'll use for SCTP timers */
-	sctp_mainctx = g_main_context_new();
-	sctp_mainloop = g_main_loop_new(sctp_mainctx, FALSE);
-	GError *error = NULL;
-	char tname[16];
-	g_snprintf(tname, sizeof(tname), "sctp timers");
-	sctp_thread = g_thread_try_new(tname, &janus_sctp_thread, NULL, &error);
-	if(error != NULL) {
-		g_main_loop_unref(sctp_mainloop);
-		g_main_context_unref(sctp_mainctx);
-		JANUS_LOG(LOG_FATAL, "Got error %d (%s) trying to launch the SCTP timer thread...\n",
-			error->code, error->message ? error->message : "??");
-		g_error_free(error);
-		return -1;
+int janus_sctp_init(gboolean single_thread) {
+	JANUS_LOG(LOG_INFO, "Using %s for the usrsctp stack\n",
+		single_thread ? "a single thread" : "multiple treads");
+	if(!single_thread) {
+		/* Initialize the SCTP stack */
+		usrsctp_init(0, janus_sctp_data_to_dtls, NULL);
+	} else {
+		/* Create a loop that we'll use for SCTP timers */
+		sctp_mainctx = g_main_context_new();
+		sctp_mainloop = g_main_loop_new(sctp_mainctx, FALSE);
+		GError *error = NULL;
+		char tname[16];
+		g_snprintf(tname, sizeof(tname), "sctp timers");
+		sctp_thread = g_thread_try_new(tname, &janus_sctp_thread, NULL, &error);
+		if(error != NULL) {
+			g_main_loop_unref(sctp_mainloop);
+			g_main_context_unref(sctp_mainctx);
+			JANUS_LOG(LOG_FATAL, "Got error %d (%s) trying to launch the SCTP timer thread...\n",
+				error->code, error->message ? error->message : "??");
+			g_error_free(error);
+			return -1;
+		}
+		/* Initialize the SCTP stack */
+		usrsctp_init_nothreads(0, janus_sctp_data_to_dtls, NULL);
+		/* Add a timer source (every 10ms) */
+		sctp_timer = g_timeout_source_new(10);
+		g_source_set_callback(sctp_timer, janus_sctp_timer, sctp_mainctx, NULL);
+		g_source_attach(sctp_timer, sctp_mainctx);
+		g_source_unref(sctp_timer);
 	}
-	/* Initialize the SCTP stack */
-	usrsctp_init_nothreads(0, janus_sctp_data_to_dtls, NULL);
-	/* Add a timer source (every 10ms) */
-	sctp_timer = g_timeout_source_new(10);
-	g_source_set_callback(sctp_timer, janus_sctp_timer, sctp_mainctx, NULL);
-	g_source_attach(sctp_timer, sctp_mainctx);
-	g_source_unref(sctp_timer);
 	sctp_running = TRUE;
 
 #ifdef DEBUG_SCTP
@@ -195,7 +202,8 @@ void janus_sctp_deinit(void) {
 	janus_mutex_unlock(&sctp_mutex);
 	if(sctp_mainloop != NULL && g_main_loop_is_running(sctp_mainloop))
 		g_main_loop_quit(sctp_mainloop);
-	g_thread_join(sctp_thread);
+	if(sctp_thread != NULL)
+		g_thread_join(sctp_thread);
 }
 
 static void janus_sctp_association_unref(janus_sctp_association *sctp) {

--- a/sctp.h
+++ b/sctp.h
@@ -49,7 +49,7 @@
 
 /*! \brief SCTP stuff initialization
  * \returns 0 on success, a negative integer otherwise */
-int janus_sctp_init(void);
+int janus_sctp_init(gboolean single_thread);
 
 /*! \brief SCTP stuff de-initialization */
 void janus_sctp_deinit(void);


### PR DESCRIPTION
Yesterday we noticed that the usrsctp stack always created, and bound to, two random UDP ports: one for IPv4 and one for IPv6. Digging in the code, we found out the cause was the `usrsctp_init(0, janus_sctp_data_to_dtls, NULL)` call: as part of the initialization process, the usrsctp stack creates a thread and binds to the provided port (random one, in our case, since we pass `0`) in order to [support SCTP over UDP encapsulation](https://github.com/sctplab/usrsctp/blob/master/Manual.md#usrsctp_init).

Clearly we don't need that kind of encapsulation in Janus: actually, we don't want it at all! But apparently the only way to get rid of it is starting the usrsctp stack without its internal threads, which means driving it using an external loop. This is a feature that was added [last year](https://github.com/sctplab/usrsctp/pull/339), thanks to the efforts by @jmillan and @ibc that revived an older contribution that had been discarded at the time. More specifically, when you initialize the usrsctp stack with `usrsctp_init_nothreads` instead of `usrsctp_init`, no threads are created in the stack, which means the UDP encapsulation stuff isn't created either. Of course, it also means as an application you're responsible for "running" the stack somehow, which in the context of usrsctp means running the `usrsctp_handle_timers()` timer as part of your event loop.

This patch tries to do exactly that, by adding support for this _nothreads_ mode. By default we still behave as before (`usrsctp_init` called at startup), but if you set `usrsctp_singlethread = true` in the `general` section of `janus.jcfg`, we switch to the single thread mode instead: this means initializing the stack with `usrsctp_init_nothreads`, and creating a dedicated thread in `sctp.c` to host a Glib context/loop that can then serve the regular source that will invoke `usrsctp_handle_timers` (which we do every 10ms, at the moment, as José Luis and Iñaki did in mediasoup). I considered re-using one of the existing loops for that timer, like the main loop in the Janus core, but I don't have a clear understanding of the impact the usrsctp stack may have on loops yet, and so I thought it safer to have a dedicated thread instead.

From a few simple tests this seems to be working, but this needs proper testing, especially with higher numbers and a higher datachannel traffic (which is why in this PR it's optional and disabled by default). Feedback welcome!