### PR TITLE
Add JSEP flag to invert processing order of rid in SDP

### DIFF
--- a/ice.h
+++ b/ice.h
@@ -379,6 +379,8 @@ struct janus_ice_stream {
 	guint32 video_ssrc_peer_rtx[3], video_ssrc_peer_rtx_new[3], video_ssrc_peer_rtx_orig[3];
 	/*! \brief Array of RTP Stream IDs (for Firefox simulcasting, if enabled) */
 	char *rid[3];
+	/*! \brief Whether the order of the rids in the SDP will be h-m-l (TRUE) or l-m-h (FALSE) */
+	gboolean rids_hml;
 	/*! \brief Whether we should use the legacy simulcast syntax (a=simulcast:recv rid=..) or the proper one (a=simulcast:recv ..) */
 	gboolean legacy_rid;
 	/*! \brief RTP switching context(s) in case of renegotiations (audio+video and/or simulcast) */

--- a/sdp.h
+++ b/sdp.h
@@ -53,9 +53,10 @@ janus_sdp *janus_sdp_preparse(void *handle, const char *jsep_sdp, char *error_st
  * and supporting multiple streams in the same PeerConnection are still WIP.
  * @param[in] handle Opaque pointer to the ICE handle this session description will modify
  * @param[in] sdp The Janus SDP object to process
+ * @param[in] rids_hml Whether the order of rids in the SDP, if present, will be h-m-l (TRUE) or l-m-h (FALSE)
  * @param[in] update Whether this SDP is an update to an existing session or not
  * @returns 0 in case of success, -1 in case of an error */
-int janus_sdp_process(void *handle, janus_sdp *sdp, gboolean update);
+int janus_sdp_process(void *handle, janus_sdp *sdp, gboolean rids_hml, gboolean update);
 
 /*! \brief Method to parse a single candidate
  * \details This method will parse a single remote candidate provided by a peer, whether it is trickling or not


### PR DESCRIPTION
I described in detail the way simulcast works in Janus in [this blog post](https://www.meetecho.com/blog/simulcast-janus-ssrc/), last year, so I won't spend too many words on that. One thing worth mentioning, though, is that when `rid` is used, Janus expects a specific order: high substream first, then medium, and finally low. This means that the encoding object should be initialized like this:

```
parameters.encodings = [
	{ rid: "h", active: true, maxBitrate: 900000 },
	{ rid: "m", active: true, maxBitrate: 300000, scaleResolutionDownBy: 2 },
	{ rid: "l", active: true, maxBitrate: 100000, scaleResolutionDownBy: 4 }
];
```

which would result in an SDP containing something like this:

```
a=rid:h send
a=rid:m send
a=rid:l send
a=simulcast: send rid=h;m;l
```

This assumption on the order is required, because otherwise Janus has no clue on what will constitute a high quality substream, and what would be something else: the name of the `rid` values are of course useless for that, as they're user-provided and so can be anything. As such, we simply assume that the order will always be high-medium-low, and expect that in the SDP we receive. That said, I've been made aware that there are some implementations that fail to initialize when that's the enforced order, and only work when doing it the other way around, that is low-medium-high. Of course, in that case Janus messes up the mappings, because it ends up mapping the SSRC of what actually is a low quality stream to what it thinks is the high quality one instead, and viceversa, which breaks the automated switches too.

As such, I've come up with this simple PR, which simply just adds a way for you to specify whether the order will be high-medium-low (the default) or low-medium-high, so that Janus can do the mapping properly. Specifically, this can be specified in a new property you can set in the `jsep` object when sending the offer, called `rid_order`: the _only_ allowed values are `"hml"` (which is the default if omitted) and `"lmh"`. Notice that these strings have nothing to do with how you actually called your `rid` identifiers: `"hml"` is simply a compact way of saying High-Medium-Low, and `"lmh"` does the other way around. Trying to pass strings that differ from those patterns will simply result in Janus ignoring them, and so assuming the default `"hml"` value. I'm not going to add any mapping more complex than that, so don't ask.

I tested this by messing with `janus.js` to invert the order of encodings, and passing the proper `rid_order` property, and it seems to be working as expected. I only tested with the EchoTest, though. Feedback welcome.