### PR TITLE
fix warning about being deployed on private IP

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -4707,11 +4707,15 @@ gint main(int argc, char *argv[])
 	if(stun_server == NULL && turn_server == NULL) {
 		/* No STUN and TURN server provided for Janus: make sure it isn't on a private address */
 		int num_ips = janus_get_public_ip_count();
-		if(num_ips == 0) num_ips++;	/* if nat_1_1_mapping is off, the first (and only) public IP is the local_ip */
-		/* check each public IP */
-		for (int i = 0; i < num_ips; i++) {
+		if(num_ips == 0) {
+			/* If nat_1_1_mapping is off, the first (and only) public IP is the local_ip */
+			num_ips++;
+		}
+		/* Check each public IP */
+		int i=0;
+		for(i = 0; i < num_ips; i++) {
 			gboolean private_address = FALSE;
-			const gchar* test_ip = janus_get_public_ip(i);
+			const gchar *test_ip = janus_get_public_ip(i);
 			janus_network_address addr;
 			if(janus_network_string_to_address(janus_network_query_options_any_ip, test_ip, &addr) != 0) {
 				JANUS_LOG(LOG_ERR, "Invalid address %s..?\n", test_ip);

--- a/janus.c
+++ b/janus.c
@@ -4712,7 +4712,7 @@ gint main(int argc, char *argv[])
 			num_ips++;
 		}
 		/* Check each public IP */
-		int i=0;
+		int i = 0;
 		for(i = 0; i < num_ips; i++) {
 			gboolean private_address = FALSE;
 			const gchar *test_ip = janus_get_public_ip(i);


### PR DESCRIPTION
When no STUN or TURN server is configured and janus is on a NAT, a warning about being deployed on a private IP appears, even when nat_1_1_mapping is set in janus.jcfg.

Not sure when the warning starting popping up--sometime after v0.9.5.

There is a variable "const char* nat_1_1_mapping". Before support for multiple IPs was added, this variable was set to the value of the nat_1_1_mapping config value. However, while the const char* variable still exists, it is not used and not set. That causes the code that checks for private IPs to ignore the nat_1_1_mapping config setting, and issue the warning incorrectly.

This fix removes the 'const char* nat_1_1_mapping' variable, and replaces the single private-IP test with a test of each public IP address.

The warning can be safely ignored, so not a big deal in any case.