### PR TITLE
janus.d.ts: correct mediaState definition

### DIFF
--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -64,7 +64,7 @@ declare namespace JanusJS {
 		consentDialog?: (on: boolean) => void;
 		webrtcState?: (isConnected: boolean) => void;
 		iceState?: (state: 'connected' | 'failed') => void;
-		mediaState?: (state: { type: 'audio' | 'video'; on: boolean }) => void;
+		mediaState?: (medium: 'audio' | 'video', receiving: boolean, mid?: number) => void;
 		slowLink?: (state: { uplink: boolean }) => void;
 		onmessage?: (message: Message, jsep?: JSEP) => void;
 		onlocalstream?: (stream: MediaStream) => void;


### PR DESCRIPTION
The declaration for `PluginOptions.mediaState` in janus.d.ts is incorrect - it specifies that it takes an object, rather than three parameters. This PR corrects that.