### PR TITLE
Make NACK buffer cleanup on outgoing keyframe configurable (see #2401)

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -213,7 +213,7 @@ media: {
 	# sent shortly before the keyframe was sent, since it can be assumed
 	# that the keyframe will restore a complete working image for the user
 	# anyway (which is the main reason why video retransmissions are typically
-	# required. While this optimization is known to work fine in most cases,
+	# required). While this optimization is known to work fine in most cases,
 	# it can backfire in some edge cases, and so is disabled by default.
 	#nack_optimizations = true
 

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -206,6 +206,17 @@ media: {
 	#twcc_period = 100
 	#dtls_timeout = 500
 
+	# Janus can do some optimizations on the NACK queue, specifically when
+	# keyframes are involved. Namely, you can configure Janus so that any
+	# time a keyframe is sent to a user, the NACK buffer for that connection
+	# is emptied. This allows Janus to ignore NACK requests for packets
+	# sent shortly before the keyframe was sent, since it can be assumed
+	# that the keyframe will restore a complete working image for the user
+	# anyway (which is the main reason why video retransmissions are typically
+	# required. While this optimization is known to work fine in most cases,
+	# it can backfire in some edge cases, and so is disabled by default.
+	#nack_optimizations = true
+
 	# If you need DSCP packet marking and prioritization, you can configure
 	# the 'dscp' property to a specific values, and Janus will try to
 	# set it on all outgoing packets using libnice. Normally, the specs

--- a/ice.h
+++ b/ice.h
@@ -125,7 +125,7 @@ gboolean janus_ice_is_full_trickle_enabled(void);
 /*! \brief Method to check whether mDNS resolution is enabled or not
  * @returns true if mDNS resolution is enabled, false otherwise */
 gboolean janus_ice_is_mdns_enabled(void);
-/*! \brief Method to check whether IPv6 candidates are enabled/supported or not (still WIP)
+/*! \brief Method to check whether IPv6 candidates are enabled/supported or not
  * @returns true if IPv6 candidates are enabled/supported, false otherwise */
 gboolean janus_ice_is_ipv6_enabled(void);
 /*! \brief Method to modify the min NACK value (i.e., the minimum time window of packets per handle to store for retransmissions)
@@ -134,6 +134,16 @@ void janus_set_min_nack_queue(uint16_t mnq);
 /*! \brief Method to get the current min NACK value (i.e., the minimum time window of packets per handle to store for retransmissions)
  * @returns The current min NACK value */
 uint16_t janus_get_min_nack_queue(void);
+/*! \brief Method to enable/disable the NACK optimizations on outgoing keyframes: when
+ * enabled, the NACK buffer for a PeerConnection is cleaned any time Janus sends a
+ * keyframe, as any missing packet won't be needed since the keyframe will allow the
+ * media recipient to still restore a complete image anyway. Since this optimization
+ * seems to cause some issues in some edge cases, it's disabled by default.
+ * @param[in] optimize Whether the opzimization should be enabled or disabled */
+void janus_set_nack_optimizations_enabled(gboolean optimize);
+/*! \brief Method to check whether NACK optimizations on outgoing keyframes are enabled or not
+ * @returns optimize if optimizations are enabled, false otherwise */
+gboolean janus_is_nack_optimizations_enabled(void);
 /*! \brief Method to modify the no-media event timer (i.e., the number of seconds where no media arrives before Janus notifies this)
  * @param[in] timer The new timer value, in seconds */
 void janus_set_no_media_timer(uint timer);


### PR DESCRIPTION
See [this post](https://groups.google.com/d/msg/meetecho-janus/8cg4QntHeIs/jKKoe9wDBQAJ) and #2401 for reference.

This PR adds a new `janus.jcfg` property called `nack_optimizations` to enable the behaviour master currently has, that is, the ability to clean the NACK buffer any time we're sending a keyframe to the peer. Quoting from the configuration file, which explains the property and the rationale:

	# Janus can do some optimizations on the NACK queue, specifically when
	# keyframes are involved. Namely, you can configure Janus so that any
	# time a keyframe is sent to a user, the NACK buffer for that connection
	# is emptied. This allows Janus to ignore NACK requests for packets
	# sent shortly before the keyframe was sent, since it can be assumed
	# that the keyframe will restore a complete working image for the user
	# anyway (which is the main reason why video retransmissions are typically
	# required). While this optimization is known to work fine in most cases,
	# it can backfire in some edge cases, and so is disabled by default.
	#nack_optimizations = true

The property can also be dynamically changed via Admin API, e.g.:

    curl -d '{"janus": "set_nack_optimizations", "admin_secret": "janusoverlord", "transaction": "123", "nack_optimizations": true}' http://localhost:7088/admin