### PR TITLE
Use PKG_CONFIG_PATH as configured for nice version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -208,7 +208,7 @@ version.c: FORCE | $(dir_target)
 	echo "$(build_date)" | awk 'BEGIN {} {print "const char *janus_build_git_time = \""$$0"\";"} END {} ' >> version.c
 	echo "$(JANUS_VERSION)" | awk 'BEGIN {} {print "int janus_version = "$$0";"} END {} ' >> version.c
 	echo "$(JANUS_VERSION_STRING)" | awk 'BEGIN {} {print "const char *janus_version_string = \""$$0"\";"} END {} ' >> version.c
-	pkg-config --modversion nice | awk 'BEGIN {} {print "const char *libnice_version_string = \""$$0"\";"} END {} ' >> version.c
+	PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" pkg-config --modversion nice | awk 'BEGIN {} {print "const char *libnice_version_string = \""$$0"\";"} END {} ' >> version.c
 
 $(dir_present):
 	`which git` rev-parse HEAD | awk 'BEGIN {print "#include \"version.h\""} {print "const char *janus_build_git_sha = \"" $$0"\";"} END {}' > version.c


### PR DESCRIPTION
Its possible that libnice location was configured via PKG_CONFIG_PATH in the configure step.
Configure passes this var to the Makefile, we should use it so that we are checking the version of the correct lib (instead of possibly the system lib).
This will also fix a build error here if there is no system version installed.

https://github.com/meetecho/janus-gateway/issues/2403