### PR TITLE
Added support for simulcast and TWCC to Duktape and Lua plugins

### DIFF
--- a/plugins/duktape/echotest.js
+++ b/plugins/duktape/echotest.js
@@ -193,6 +193,26 @@ function dataReady(id) {
 	// to throttle outgoing data and not send too much at a time.
 }
 
+function substreamChanged(id, substream) {
+	// If simulcast is used, this callback is invoked when the substream
+	// we're sending to this session changes: 0=low, 1=medium, 2=high
+	console.log("Substream changed for session " + id + ": " + substream);
+	// Let's send an event so that the user is aware
+	var event = { echotest: "event", videocodec: "vp8", substream: substream };
+	var jsonevent = JSON.stringify(event);
+	pushEvent(id, null, jsonevent, null);
+}
+
+function temporalLayerChanged(id, temporal) {
+	// If simulcast is used, this callback is invoked when the temporal
+	// layer we're sending to this session changes: 0=lowfps, 1=maxfps
+	console.log("Temporal layer changed for session " + id + ": " + temporal);
+	// Let's send an event so that the user is aware
+	var event = { echotest: "event", videocodec: "vp8", temporal: temporal };
+	var jsonevent = JSON.stringify(event);
+	pushEvent(id, null, jsonevent, null);
+}
+
 function resumeScheduler() {
 	// This is the function responsible for resuming coroutines associated
 	// with whatever is relevant to the JS script, e.g., for this script,
@@ -239,6 +259,17 @@ function processRequest(id, msg) {
 	}
 	if(msg["bitrate"] !== null && msg["bitrate"] !== undefined) {
 		setBitrate(id, msg["bitrate"]);
+	}
+	if(msg["substream"] !== null && msg["substream"] !== undefined) {
+		setSubstream(id, msg["substream"]);
+		sendPli(id);
+	}
+	if(msg["temporal"] !== null && msg["temporal"] !== undefined) {
+		setTemporalLayer(id, msg["temporal"]);
+		sendPli(id);
+	}
+	if(msg["keyframe"] !== null && msg["keyframe"] !== undefined) {
+		sendPli(id);
 	}
 	if(msg["record"] === true) {
 		var fnbase = msg["filename"];

--- a/plugins/duktape/janus-sdp.js
+++ b/plugins/duktape/janus-sdp.js
@@ -303,6 +303,8 @@ JANUSSDP.generateAnswer = function(offer, options) {
 	}
 	if(options.data === null || options.data === undefined)
 		options.data = true;
+	if(options.disableTwcc === null || options.disableTwcc === undefined)
+		options.disableTwcc = false;
 	// Let's prepare the answer
 	var answer = [];
 	// Iterate on all lines
@@ -376,6 +378,17 @@ JANUSSDP.generateAnswer = function(offer, options) {
 					if(medium === "audio" && n === audioPt) {
 						answer.push(a);
 					} else if(medium === "video" && n === videoPt) {
+						answer.push(a);
+					}
+				} else if (a.name === "extmap") {
+					// We do negotiate some RTP extensions
+					if(a.value.indexOf("urn:ietf:params:rtp-hdrext:sdes:mid") !== -1) {
+						answer.push(a);
+					} else if(a.value.indexOf("urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id") !== -1) {
+						answer.push(a);
+					} else if(a.value.indexOf("urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id") !== -1) {
+						answer.push(a);
+					} else if(options.disableTwcc !== true && a.value.indexOf("draft-holmer-rmcat-transport-wide-cc-extensions-01") !== -1) {
 						answer.push(a);
 					}
 				}

--- a/plugins/janus_duktape.c
+++ b/plugins/janus_duktape.c
@@ -67,10 +67,14 @@
  * the JavaScript plugin will return its own info (i.e., "janus.plugin.javascript", etc.).
  * Most of the times, JavaScript scripts will not need to override this information,
  * unless they really want to register their own name spaces and versioning.
- * Finally, JavaScript scripts can receive information on slow links via the
+ * JavaScript scripts can also receive information on slow links via the
  * \c slowLink() callback, in order to react accordingly: e.g., reduce
  * the bitrate of a video sender if they, or their viewers, are experiencing
- * issues.
+ * issues. Finally, in case simulcast is used, JavaScript scripts may
+ * receive events on substream and/or temporal layer changes happening
+ * for receiving sessions via the \c substreamChanged() and the
+ * \c temporalLayerChanged() callbacks: this may be useful to track
+ * which layer is actually being sent, vs. what was requested.
  *
  * \section dtcapi C interfaces
  *
@@ -91,6 +95,8 @@
  * - \c removeRecipient(): specify which user should not receive a user's media anymore;
  * - \c setBitrate(): specify the bitrate to force on a user via REMB feedback;
  * - \c setPliFreq(): specify how often the plugin should send a PLI to this user;
+ * - \c setSubstream(): set the target simulcast substream;
+ * - \c setTemporalLayer(): set the target simulcast temporal layer;
  * - \c sendPli(): send a PLI (keyframe request);
  * - \c startRecording(): start recording audio, video and or data for a user;
  * - \c stopRecording(): start recording audio, video and or data for a user;
@@ -294,6 +300,8 @@ static gboolean has_incoming_data_legacy = FALSE,	/* Legacy callback */
 	has_incoming_binary_data = FALSE;
 static gboolean has_data_ready = FALSE;
 static gboolean has_slow_link = FALSE;
+static gboolean has_substream_changed = FALSE;
+static gboolean has_temporal_changed = FALSE;
 /* JavaScript C scheduler (for coroutines) */
 static GThread *scheduler_thread = NULL;
 static void *janus_duktape_scheduler(void *data);
@@ -357,10 +365,12 @@ static void janus_duktape_session_free(const janus_refcount *session_ref) {
 
 /* Packet data and routing */
 typedef struct janus_duktape_rtp_relay_packet {
-	rtp_header *data;
+	janus_duktape_session *sender;
+	janus_rtp_header *data;
 	gint length;
 	gboolean is_rtp;	/* This may be a data packet and not RTP */
 	gboolean is_video;
+	uint32_t ssrc[3];
 	uint32_t timestamp;
 	uint16_t seq_number;
 	/* The following is only relevant for datachannels */
@@ -576,6 +586,19 @@ static duk_ret_t janus_duktape_method_pushevent(duk_context *ctx) {
 	/* If there's an SDP attached, create a thread to send the event asynchronously:
 	 * sending it here would keep the locked Duktape context busy much longer than intended */
 	if(jsep != NULL) {
+		/* Let's parse the SDP first, though */
+		const char *sdp = json_string_value(json_object_get(jsep, "sdp"));
+		const char *sdp_type = json_string_value(json_object_get(jsep, "type"));
+		char error_str[512];
+		janus_sdp *parsed_sdp = janus_sdp_parse(sdp, error_str, sizeof(error_str));
+		if(parsed_sdp == NULL) {
+			JANUS_LOG(LOG_ERR, "Error parsing answer: %s\n", error_str);
+			json_decref(event);
+			json_decref(jsep);
+			janus_refcount_decrease(&session->ref);
+			duk_push_error_object(ctx, DUK_ERR_ERROR, "Error parsing answer: %s", error_str);
+			return duk_throw(ctx);
+		}
 		janus_duktape_async_event *asev = g_malloc0(sizeof(janus_duktape_async_event));
 		asev->session = session;
 		asev->type = janus_duktape_async_event_type_pushevent;
@@ -584,6 +607,24 @@ static duk_ret_t janus_duktape_method_pushevent(duk_context *ctx) {
 		asev->jsep = jsep;
 		if(json_is_true(json_object_get(jsep, "e2ee")))
 			session->e2ee = TRUE;
+		if(sdp_type && !strcasecmp(sdp_type, "answer")) {
+			/* Take note of which video codec were negotiated */
+			const char *vcodec = NULL;
+			janus_sdp_find_first_codecs(parsed_sdp, NULL, &vcodec);
+			if(vcodec)
+				session->vcodec = janus_videocodec_from_name(vcodec);
+			if(session->vcodec != JANUS_VIDEOCODEC_VP8 && session->vcodec != JANUS_VIDEOCODEC_H264) {
+				/* VP8 r H.264 were not negotiated, if simulcasting was enabled then disable it here */
+				int i=0;
+				for(i=0; i<3; i++) {
+					session->ssrc[i] = 0;
+					g_free(session->rid[0]);
+					session->rid[0] = NULL;
+				}
+			}
+		}
+		janus_sdp_destroy(parsed_sdp);
+		/* Send asynchronously */
 		GError *error = NULL;
 		g_thread_try_new("duktape pushevent", janus_duktape_async_event_helper, asev, &error);
 		if(error != NULL) {
@@ -933,6 +974,68 @@ static duk_ret_t janus_duktape_method_setplifreq(duk_context *ctx) {
 	return 1;
 }
 
+static duk_ret_t janus_duktape_method_setsubstream(duk_context *ctx) {
+	if(duk_get_type(ctx, 0) != DUK_TYPE_NUMBER) {
+		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
+			janus_duktape_type_string(DUK_TYPE_NUMBER), janus_duktape_type_string(duk_get_type(ctx, 0)));
+		return duk_throw(ctx);
+	}
+	if(duk_get_type(ctx, 1) != DUK_TYPE_NUMBER) {
+		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
+			janus_duktape_type_string(DUK_TYPE_NUMBER), janus_duktape_type_string(duk_get_type(ctx, 1)));
+		return duk_throw(ctx);
+	}
+	uint32_t id = (uint32_t)duk_get_number(ctx, 0);
+	uint16_t substream = (uint16_t)duk_get_number(ctx, 1);
+	/* Find the session */
+	janus_mutex_lock(&duktape_sessions_mutex);
+	janus_duktape_session *session = g_hash_table_lookup(duktape_ids, GUINT_TO_POINTER(id));
+	if(session == NULL || g_atomic_int_get(&session->destroyed)) {
+		janus_mutex_unlock(&duktape_sessions_mutex);
+		duk_push_error_object(ctx, DUK_ERR_ERROR, "Session %"SCNu32" doesn't exist", id);
+		return duk_throw(ctx);
+	}
+	janus_refcount_increase(&session->ref);
+	janus_mutex_unlock(&duktape_sessions_mutex);
+	if(substream <= 2)
+		session->sim_context.substream_target = substream;
+	/* Done */
+	janus_refcount_decrease(&session->ref);
+	duk_push_int(ctx, 0);
+	return 1;
+}
+
+static duk_ret_t janus_duktape_method_settemporallayer(duk_context *ctx) {
+	if(duk_get_type(ctx, 0) != DUK_TYPE_NUMBER) {
+		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
+			janus_duktape_type_string(DUK_TYPE_NUMBER), janus_duktape_type_string(duk_get_type(ctx, 0)));
+		return duk_throw(ctx);
+	}
+	if(duk_get_type(ctx, 1) != DUK_TYPE_NUMBER) {
+		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
+			janus_duktape_type_string(DUK_TYPE_NUMBER), janus_duktape_type_string(duk_get_type(ctx, 1)));
+		return duk_throw(ctx);
+	}
+	uint32_t id = (uint32_t)duk_get_number(ctx, 0);
+	uint16_t temporal = (uint16_t)duk_get_number(ctx, 1);
+	/* Find the session */
+	janus_mutex_lock(&duktape_sessions_mutex);
+	janus_duktape_session *session = g_hash_table_lookup(duktape_ids, GUINT_TO_POINTER(id));
+	if(session == NULL || g_atomic_int_get(&session->destroyed)) {
+		janus_mutex_unlock(&duktape_sessions_mutex);
+		duk_push_error_object(ctx, DUK_ERR_ERROR, "Session %"SCNu32" doesn't exist", id);
+		return duk_throw(ctx);
+	}
+	janus_refcount_increase(&session->ref);
+	janus_mutex_unlock(&duktape_sessions_mutex);
+	if(temporal <= 2)
+		session->sim_context.templayer_target = temporal;
+	/* Done */
+	janus_refcount_decrease(&session->ref);
+	duk_push_int(ctx, 0);
+	return 1;
+}
+
 static duk_ret_t janus_duktape_method_sendpli(duk_context *ctx) {
 	if(duk_get_type(ctx, 0) != DUK_TYPE_NUMBER) {
 		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
@@ -1233,6 +1336,10 @@ static duk_ret_t janus_duktape_method_startrecording(duk_context *ctx) {
 				JANUS_LOG(LOG_WARN, "Duplicate video recording, skipping\n");
 				continue;
 			}
+			janus_rtp_switching_context_reset(&session->rec_ctx);
+			janus_rtp_simulcasting_context_reset(&session->rec_simctx);
+			session->rec_simctx.substream_target = 2;
+			session->rec_simctx.templayer_target = 2;
 			/* If media is encrypted, mark it in the recording */
 			if(session->e2ee)
 				janus_recorder_encrypted(rc);
@@ -1425,6 +1532,10 @@ int janus_duktape_init(janus_callbacks *callback, const char *config_path) {
 	duk_put_global_string(duktape_ctx, "setBitrate");
 	duk_push_c_function(duktape_ctx, janus_duktape_method_setplifreq, 2);
 	duk_put_global_string(duktape_ctx, "setPliFreq");
+	duk_push_c_function(duktape_ctx, janus_duktape_method_setsubstream, 2);
+	duk_put_global_string(duktape_ctx, "setSubstream");
+	duk_push_c_function(duktape_ctx, janus_duktape_method_settemporallayer, 2);
+	duk_put_global_string(duktape_ctx, "setTemporalLayer");
 	duk_push_c_function(duktape_ctx, janus_duktape_method_sendpli, 1);
 	duk_put_global_string(duktape_ctx, "sendPli");
 	duk_push_c_function(duktape_ctx, janus_duktape_method_relayrtp, 4);
@@ -1539,6 +1650,12 @@ int janus_duktape_init(janus_callbacks *callback, const char *config_path) {
 	duk_get_global_string(duktape_ctx, "slowLink");
 	if(duk_is_function(duktape_ctx, duk_get_top(duktape_ctx)-1) != 0)
 		has_slow_link = TRUE;
+	duk_get_global_string(duktape_ctx, "substreamChanged");
+	if(duk_is_function(duktape_ctx, duk_get_top(duktape_ctx)-1) != 0)
+		has_substream_changed = TRUE;
+	duk_get_global_string(duktape_ctx, "temporalLayerChanged");
+	if(duk_is_function(duktape_ctx, duk_get_top(duktape_ctx)-1) != 0)
+		has_temporal_changed = TRUE;
 
 	duktape_sessions = g_hash_table_new_full(NULL, NULL, NULL, (GDestroyNotify)janus_duktape_session_destroy);
 	duktape_ids = g_hash_table_new(NULL, NULL);
@@ -1902,6 +2019,11 @@ void janus_duktape_create_session(janus_plugin_session *handle, int *error) {
 	session->handle = handle;
 	session->id = id;
 	janus_rtp_switching_context_reset(&session->rtpctx);
+	janus_rtp_simulcasting_context_reset(&session->sim_context);
+	session->sim_context.substream_target = 2;
+	session->sim_context.templayer_target = 2;
+	janus_vp8_simulcast_context_reset(&session->vp8_context);
+	session->vcodec = JANUS_VIDEOCODEC_NONE;
 	g_atomic_int_set(&session->hangingup, 0);
 	g_atomic_int_set(&session->destroyed, 0);
 	janus_refcount_init(&session->ref, janus_duktape_session_free);
@@ -2053,6 +2175,32 @@ struct janus_plugin_result *janus_duktape_handle_message(janus_plugin_session *h
 	}
 	char *jsep_text = jsep ? json_dumps(jsep, JSON_INDENT(0) | JSON_PRESERVE_ORDER) : NULL;
 	if(jsep != NULL) {
+		json_t *simulcast = json_object_get(jsep, "simulcast");
+		if(simulcast != NULL) {
+			janus_rtp_simulcasting_prepare(simulcast,
+				&session->rid_extmap_id, NULL,
+				session->ssrc, session->rid);
+		}
+		const char *sdp_type = json_string_value(json_object_get(jsep, "type"));
+		if(sdp_type && !strcasecmp(sdp_type, "answer")) {
+			char error_str[512];
+			const char *sdp = json_string_value(json_object_get(jsep, "sdp"));
+			janus_sdp *parsed_sdp = janus_sdp_parse(sdp, error_str, sizeof(error_str));
+			const char *vcodec = NULL;
+			janus_sdp_find_first_codecs(parsed_sdp, NULL, &vcodec);
+			if(vcodec)
+				session->vcodec = janus_videocodec_from_name(vcodec);
+			if(session->vcodec != JANUS_VIDEOCODEC_VP8 && session->vcodec != JANUS_VIDEOCODEC_H264) {
+				/* VP8 r H.264 were not negotiated, if simulcasting was enabled then disable it here */
+				int i=0;
+				for(i=0; i<3; i++) {
+					session->ssrc[i] = 0;
+					g_free(session->rid[0]);
+					session->rid[0] = NULL;
+				}
+			}
+			janus_sdp_destroy(parsed_sdp);
+		}
 		if(json_is_true(json_object_get(jsep, "e2ee")))
 			session->e2ee = TRUE;
 		json_decref(jsep);
@@ -2225,14 +2373,64 @@ void janus_duktape_incoming_rtp(janus_plugin_session *handle, janus_plugin_rtp *
 	/* Is this session allowed to send media? */
 	if((video && !session->send_video) || (!video && !session->send_audio))
 		return;
-	/* Are we recording? */
-	janus_recorder_save_frame(video ? session->vrc : session->arc, buf, len);
 	/* Handle the packet */
-	rtp_header *rtp = (rtp_header *)buf;
+	janus_rtp_header *rtp = (janus_rtp_header *)buf;
+	/* Check if we're simulcasting, and if so, keep track of the "layer" */
+	int sc = video ? 0 : -1;
+	if(video && (session->ssrc[0] != 0 || session->rid[0] != NULL)) {
+		uint32_t ssrc = ntohl(rtp->ssrc);
+		if(ssrc == session->ssrc[0])
+			sc = 0;
+		else if(ssrc == session->ssrc[1])
+			sc = 1;
+		else if(ssrc == session->ssrc[2])
+			sc = 2;
+		else if(session->rid_extmap_id > 0) {
+			/* We may not know the SSRC yet, try the rid RTP extension */
+			char sdes_item[16];
+			if(janus_rtp_header_extension_parse_rid(buf, len, session->rid_extmap_id, sdes_item, sizeof(sdes_item)) == 0) {
+				if(session->rid[0] != NULL && !strcmp(session->rid[0], sdes_item)) {
+					session->ssrc[0] = ssrc;
+					sc = 0;
+				} else if(session->rid[1] != NULL && !strcmp(session->rid[1], sdes_item)) {
+					session->ssrc[1] = ssrc;
+					sc = 1;
+				} else if(session->rid[2] != NULL && !strcmp(session->rid[2], sdes_item)) {
+					session->ssrc[2] = ssrc;
+					sc = 2;
+				}
+			}
+		}
+	}
+	/* Are we recording? */
+	if(!video || (session->ssrc[0] == 0 && session->rid[0] == NULL)) {
+		janus_recorder_save_frame(video ? session->vrc : session->arc, buf, len);
+	} else {
+		/* We're simulcasting, save the best video quality */
+		gboolean save = janus_rtp_simulcasting_context_process_rtp(&session->rec_simctx,
+			buf, len, session->ssrc, session->rid, session->vcodec, &session->rec_ctx);
+		if(save) {
+			uint32_t seq_number = ntohs(rtp->seq_number);
+			uint32_t timestamp = ntohl(rtp->timestamp);
+			uint32_t ssrc = ntohl(rtp->ssrc);
+			janus_rtp_header_update(rtp, &session->rec_ctx, TRUE, 0);
+			/* We use a fixed SSRC for the whole recording */
+			rtp->ssrc = session->ssrc[0];
+			janus_recorder_save_frame(session->vrc, buf, len);
+			/* Restore the header, as it will be needed by recipients of this packet */
+			rtp->ssrc = htonl(ssrc);
+			rtp->timestamp = htonl(timestamp);
+			rtp->seq_number = htons(seq_number);
+		}
+	}
 	janus_duktape_rtp_relay_packet packet;
+	packet.sender = session;
 	packet.data = rtp;
 	packet.length = len;
 	packet.is_video = video;
+	packet.ssrc[0] = (sc != -1 ? session->ssrc[0] : 0);
+	packet.ssrc[1] = (sc != -1 ? session->ssrc[1] : 0);
+	packet.ssrc[2] = (sc != -1 ? session->ssrc[2] : 0);
 	/* Backup the actual timestamp and sequence number set by the publisher, in case switching is involved */
 	packet.timestamp = ntohl(packet.data->timestamp);
 	packet.seq_number = ntohs(packet.data->seq_number);
@@ -2349,7 +2547,8 @@ void janus_duktape_incoming_data(janus_plugin_session *handle, janus_plugin_data
 		packet->binary ? "binary" : "text", len);
 	/* Relay to all recipients */
 	janus_duktape_rtp_relay_packet pkt;
-	pkt.data = (rtp_header *)buf;
+	pkt.sender = session;
+	pkt.data = (janus_rtp_header *)buf;
 	pkt.length = len;
 	pkt.is_rtp = FALSE;
 	pkt.textdata = !packet->binary;
@@ -2464,6 +2663,17 @@ void janus_duktape_hangup_media(janus_plugin_session *handle) {
 	session->pli_latest = 0;
 	session->e2ee = FALSE;
 	janus_rtp_switching_context_reset(&session->rtpctx);
+	janus_rtp_simulcasting_context_reset(&session->sim_context);
+	session->sim_context.substream_target = 2;
+	session->sim_context.templayer_target = 2;
+	janus_vp8_simulcast_context_reset(&session->vp8_context);
+	session->vcodec = JANUS_VIDEOCODEC_NONE;
+	int i=0;
+	for(i=0; i<3; i++) {
+		session->ssrc[i] = 0;
+		g_free(session->rid[i]);
+		session->rid[i] = NULL;
+	}
 
 	/* Get rid of the recipients */
 	janus_mutex_lock(&session->recipients_mutex);
@@ -2500,6 +2710,7 @@ static void janus_duktape_relay_rtp_packet(gpointer data, gpointer user_data) {
 		JANUS_LOG(LOG_ERR, "Invalid packet...\n");
 		return;
 	}
+	janus_duktape_session *sender = (janus_duktape_session *)packet->sender;
 	janus_duktape_session *session = (janus_duktape_session *)data;
 	if(!session || !session->handle || !g_atomic_int_get(&session->started)) {
 		return;
@@ -2510,17 +2721,97 @@ static void janus_duktape_relay_rtp_packet(gpointer data, gpointer user_data) {
 		/* Nope, don't relay */
 		return;
 	}
-	/* Fix sequence number and timestamp (publisher switching may be involved) */
-	janus_rtp_header_update(packet->data, &session->rtpctx, packet->is_video, 0);
-	/* Send the packet */
-	if(janus_core != NULL) {
-		janus_plugin_rtp rtp = { .video = packet->is_video, .buffer = (char *)packet->data, .length = packet->length };
-		janus_plugin_rtp_extensions_reset(&rtp.extensions);
-		janus_core->relay_rtp(session->handle, &rtp);
+	if(packet->ssrc[0] != 0) {
+		/* Handle simulcast: make sure we have a payload to work with */
+		int plen = 0;
+		char *payload = janus_rtp_payload((char *)packet->data, packet->length, &plen);
+		if(payload == NULL)
+			return;
+		/* Process this packet: don't relay if it's not the SSRC/layer we wanted to handle */
+		gboolean relay = janus_rtp_simulcasting_context_process_rtp(&session->sim_context,
+			(char *)packet->data, packet->length, packet->ssrc, NULL, sender->vcodec, &session->rtpctx);
+		if(session->sim_context.need_pli && sender->handle) {
+			/* Send a PLI */
+			JANUS_LOG(LOG_VERB, "We need a PLI for the simulcast context\n");
+			janus_core->send_pli(sender->handle);
+		}
+		/* Do we need to drop this? */
+		if(!relay)
+			return;
+		/* Any event we should notify? */
+		if(session->sim_context.changed_substream) {
+			/* Notify the script about the substream change */
+			if(has_substream_changed) {
+				janus_mutex_lock(&duktape_mutex);
+				duk_idx_t thr_idx = duk_push_thread(duktape_ctx);
+				duk_context *t = duk_get_context(duktape_ctx, thr_idx);
+				duk_get_global_string(t, "substreamChanged");
+				duk_push_number(t, session->id);
+				duk_push_number(t, session->sim_context.substream);
+				int res = duk_pcall(t, 2);
+				if(res != DUK_EXEC_SUCCESS) {
+					/* Something went wrong... */
+					JANUS_LOG(LOG_ERR, "Duktape error: %s\n", duk_safe_to_string(t, -1));
+				}
+				duk_pop(t);
+				duk_pop(duktape_ctx);
+				janus_mutex_unlock(&duktape_mutex);
+			}
+		}
+		if(session->sim_context.changed_temporal) {
+			/* Notify the user about the temporal layer change */
+			if(has_substream_changed) {
+				janus_mutex_lock(&duktape_mutex);
+				duk_idx_t thr_idx = duk_push_thread(duktape_ctx);
+				duk_context *t = duk_get_context(duktape_ctx, thr_idx);
+				duk_get_global_string(t, "temporalLayerChanged");
+				duk_push_number(t, session->id);
+				duk_push_number(t, session->sim_context.templayer);
+				int res = duk_pcall(t, 2);
+				if(res != DUK_EXEC_SUCCESS) {
+					/* Something went wrong... */
+					JANUS_LOG(LOG_ERR, "Duktape error: %s\n", duk_safe_to_string(t, -1));
+				}
+				duk_pop(t);
+				duk_pop(duktape_ctx);
+				janus_mutex_unlock(&duktape_mutex);
+			}
+		}
+		/* If we got here, update the RTP header and send the packet */
+		janus_rtp_header_update(packet->data, &session->rtpctx, TRUE, 0);
+		char vp8pd[6];
+		if(sender->vcodec == JANUS_VIDEOCODEC_VP8) {
+			/* For VP8, we save the original payload descriptor, to restore it after */
+			memcpy(vp8pd, payload, sizeof(vp8pd));
+			janus_vp8_simulcast_descriptor_update(payload, plen, &session->vp8_context,
+				session->sim_context.changed_substream);
+		}
+		/* Send the packet */
+		if(janus_core != NULL) {
+			janus_plugin_rtp rtp = { .video = packet->is_video, .buffer = (char *)packet->data, .length = packet->length };
+			janus_plugin_rtp_extensions_reset(&rtp.extensions);
+			janus_core->relay_rtp(session->handle, &rtp);
+		}
+		/* Restore the timestamp and sequence number to what the publisher set them to */
+		packet->data->timestamp = htonl(packet->timestamp);
+		packet->data->seq_number = htons(packet->seq_number);
+		if(sender->vcodec == JANUS_VIDEOCODEC_VP8) {
+			/* Restore the original payload descriptor as well, as it will be needed by the next viewer */
+			memcpy(payload, vp8pd, sizeof(vp8pd));
+		}
+	} else {
+		/* Fix sequence number and timestamp (publisher switching may be involved) */
+		janus_rtp_header_update(packet->data, &session->rtpctx, packet->is_video, 0);
+		/* Send the packet */
+		if(janus_core != NULL) {
+			janus_plugin_rtp rtp = { .video = packet->is_video, .buffer = (char *)packet->data, .length = packet->length };
+			janus_plugin_rtp_extensions_reset(&rtp.extensions);
+			janus_core->relay_rtp(session->handle, &rtp);
+		}
+		/* Restore the timestamp and sequence number to what the publisher set them to */
+		packet->data->timestamp = htonl(packet->timestamp);
+		packet->data->seq_number = htons(packet->seq_number);
 	}
-	/* Restore the timestamp and sequence number to what the publisher set them to */
-	packet->data->timestamp = htonl(packet->timestamp);
-	packet->data->seq_number = htons(packet->seq_number);
 
 	return;
 }

--- a/plugins/janus_duktape_data.h
+++ b/plugins/janus_duktape_data.h
@@ -58,7 +58,13 @@ typedef struct janus_duktape_session {
 	gboolean send_audio;				/* Whether outgoing audio can be sent or must be dropped */
 	gboolean send_video;				/* Whether outgoing video can be sent or must be dropped */
 	gboolean send_data;					/* Whether outgoing data can be sent or must be dropped */
-	janus_rtp_switching_context rtpctx;	/* Needed in case the source changes (e.g., stale operator/customer) */
+	janus_rtp_switching_context rtpctx;	/* RTP switching context */
+	janus_videocodec vcodec;			/* Video codec this session is using */
+	uint32_t ssrc[3];					/* Only needed in case VP8 (or H.264) simulcasting is involved */
+	char *rid[3];						/* Only needed if simulcasting is rid-based */
+	int rid_extmap_id;					/* rid extmap ID */
+	janus_rtp_simulcasting_context sim_context;
+	janus_vp8_simulcast_context vp8_context;
 	uint32_t bitrate;					/* Bitrate limit */
 	uint16_t pli_freq;					/* Regular PLI frequency (0=disabled) */
 	gint64 pli_latest;					/* Time of latest sent PLI (to avoid flooding) */
@@ -68,6 +74,8 @@ typedef struct janus_duktape_session {
 	janus_recorder *arc;				/* The Janus recorder instance for audio, if enabled */
 	janus_recorder *vrc;				/* The Janus recorder instance for video, if enabled */
 	janus_recorder *drc;				/* The Janus recorder instance for data, if enabled */
+	janus_rtp_switching_context rec_ctx;
+	janus_rtp_simulcasting_context rec_simctx;
 	gboolean e2ee;						/* Whether media is encrypted, e.g., using Insertable Streams */
 	janus_mutex rec_mutex;				/* Mutex to protect the recorders from race conditions */
 	volatile gint started;				/* Whether this session's PeerConnection is ready or not */

--- a/plugins/janus_lua.c
+++ b/plugins/janus_lua.c
@@ -67,10 +67,14 @@
  * the Lua plugin will return its own info (i.e., "janus.plugin.lua", etc.).
  * Most of the times, Lua scripts will not need to override this information,
  * unless they really want to register their own name spaces and versioning.
- * Finally, Lua scripts can receive information on slow links via the
+ * Lua scripts can also receive information on slow links via the
  * \c slowLink() callback, in order to react accordingly: e.g., reduce
  * the bitrate of a video sender if they, or their viewers, are experiencing
- * issues.
+ * issues. Finally, in case simulcast is used, Lia scripts may receive
+ * events on substream and/or temporal layer changes happening for
+ * receiving sessions via the \c substreamChanged() and the
+ * \c temporalLayerChanged() callbacks: this may be useful to track
+ * which layer is actually being sent, vs. what was requested.
  *
  * \section capi C interfaces
  *
@@ -92,6 +96,8 @@
  * - \c removeRecipient(): specify which user should not receive a user's media anymore;
  * - \c setBitrate(): specify the bitrate to force on a user via REMB feedback;
  * - \c setPliFreq(): specify how often the plugin should send a PLI to this user;
+ * - \c setSubstream(): set the target simulcast substream;
+ * - \c setTemporalLayer(): set the target simulcast temporal layer;
  * - \c sendPli(): send a PLI (keyframe request);
  * - \c startRecording(): start recording audio, video and or data for a user;
  * - \c stopRecording(): start recording audio, video and or data for a user;
@@ -294,6 +300,8 @@ static gboolean has_incoming_data_legacy = FALSE,	/* Legacy callback */
 	has_incoming_binary_data = FALSE;
 static gboolean has_data_ready = FALSE;
 static gboolean has_slow_link = FALSE;
+static gboolean has_substream_changed = FALSE;
+static gboolean has_temporal_changed = FALSE;
 /* Lua C scheduler (for coroutines) */
 static GThread *scheduler_thread = NULL;
 static void *janus_lua_scheduler(void *data);
@@ -357,10 +365,12 @@ static void janus_lua_session_free(const janus_refcount *session_ref) {
 
 /* Packet data and routing */
 typedef struct janus_lua_rtp_relay_packet {
-	rtp_header *data;
+	janus_lua_session *sender;
+	janus_rtp_header *data;
 	gint length;
 	gboolean is_rtp;	/* This may be a data packet and not RTP */
 	gboolean is_video;
+	uint32_t ssrc[3];
 	uint32_t timestamp;
 	uint16_t seq_number;
 	/* The following is only relevant for datachannels */
@@ -505,6 +515,19 @@ static int janus_lua_method_pushevent(lua_State *s) {
 	/* If there's an SDP attached, create a thread to send the event asynchronously:
 	 * sending it here would keep the locked Lua state busy much longer than intended */
 	if(jsep != NULL) {
+		/* Let's parse the SDP first, though */
+		const char *sdp = json_string_value(json_object_get(jsep, "sdp"));
+		const char *sdp_type = json_string_value(json_object_get(jsep, "type"));
+		char error_str[512];
+		janus_sdp *parsed_sdp = janus_sdp_parse(sdp, error_str, sizeof(error_str));
+		if(parsed_sdp == NULL) {
+			JANUS_LOG(LOG_ERR, "Error parsing answer: %s\n", error_str);
+			json_decref(event);
+			json_decref(jsep);
+			janus_refcount_decrease(&session->ref);
+			lua_pushnumber(s, -1);
+			return 1;
+		}
 		janus_lua_async_event *asev = g_malloc0(sizeof(janus_lua_async_event));
 		asev->session = session;
 		asev->type = janus_lua_async_event_type_pushevent;
@@ -513,6 +536,24 @@ static int janus_lua_method_pushevent(lua_State *s) {
 		asev->jsep = jsep;
 		if(json_is_true(json_object_get(jsep, "e2ee")))
 			session->e2ee = TRUE;
+		if(sdp_type && !strcasecmp(sdp_type, "answer")) {
+			/* Take note of which video codec were negotiated */
+			const char *vcodec = NULL;
+			janus_sdp_find_first_codecs(parsed_sdp, NULL, &vcodec);
+			if(vcodec)
+				session->vcodec = janus_videocodec_from_name(vcodec);
+			if(session->vcodec != JANUS_VIDEOCODEC_VP8 && session->vcodec != JANUS_VIDEOCODEC_H264) {
+				/* VP8 r H.264 were not negotiated, if simulcasting was enabled then disable it here */
+				int i=0;
+				for(i=0; i<3; i++) {
+					session->ssrc[i] = 0;
+					g_free(session->rid[0]);
+					session->rid[0] = NULL;
+				}
+			}
+		}
+		janus_sdp_destroy(parsed_sdp);
+		/* Send asynchronously */
 		GError *error = NULL;
 		g_thread_try_new("lua pushevent", janus_lua_async_event_helper, asev, &error);
 		if(error != NULL) {
@@ -839,6 +880,62 @@ static int janus_lua_method_setplifreq(lua_State *s) {
 	return 1;
 }
 
+static int janus_lua_method_setsubstream(lua_State *s) {
+	/* Get the arguments from the provided state */
+	int n = lua_gettop(s);
+	if(n != 2) {
+		JANUS_LOG(LOG_ERR, "Wrong number of arguments: %d (expected 2)\n", n);
+		lua_pushnumber(s, -1);
+		return 1;
+	}
+	guint32 id = lua_tonumber(s, 1);
+	guint16 substream = lua_tonumber(s, 2);
+	/* Find the session */
+	janus_mutex_lock(&lua_sessions_mutex);
+	janus_lua_session *session = g_hash_table_lookup(lua_ids, GUINT_TO_POINTER(id));
+	if(session == NULL || g_atomic_int_get(&session->destroyed)) {
+		janus_mutex_unlock(&lua_sessions_mutex);
+		lua_pushnumber(s, -1);
+		return 1;
+	}
+	janus_refcount_increase(&session->ref);
+	janus_mutex_unlock(&lua_sessions_mutex);
+	if(substream <= 2)
+		session->sim_context.substream_target = substream;
+	/* Done */
+	janus_refcount_decrease(&session->ref);
+	lua_pushnumber(s, 0);
+	return 1;
+}
+
+static int janus_lua_method_settemporallayer(lua_State *s) {
+	/* Get the arguments from the provided state */
+	int n = lua_gettop(s);
+	if(n != 2) {
+		JANUS_LOG(LOG_ERR, "Wrong number of arguments: %d (expected 2)\n", n);
+		lua_pushnumber(s, -1);
+		return 1;
+	}
+	guint32 id = lua_tonumber(s, 1);
+	guint16 temporal = lua_tonumber(s, 2);
+	/* Find the session */
+	janus_mutex_lock(&lua_sessions_mutex);
+	janus_lua_session *session = g_hash_table_lookup(lua_ids, GUINT_TO_POINTER(id));
+	if(session == NULL || g_atomic_int_get(&session->destroyed)) {
+		janus_mutex_unlock(&lua_sessions_mutex);
+		lua_pushnumber(s, -1);
+		return 1;
+	}
+	janus_refcount_increase(&session->ref);
+	janus_mutex_unlock(&lua_sessions_mutex);
+	if(temporal <= 2)
+		session->sim_context.templayer_target = temporal;
+	/* Done */
+	janus_refcount_decrease(&session->ref);
+	lua_pushnumber(s, 0);
+	return 1;
+}
+
 static int janus_lua_method_sendpli(lua_State *s) {
 	/* Get the arguments from the provided state */
 	int n = lua_gettop(s);
@@ -1104,6 +1201,10 @@ static int janus_lua_method_startrecording(lua_State *s) {
 				JANUS_LOG(LOG_WARN, "Duplicate video recording, skipping\n");
 				continue;
 			}
+			janus_rtp_switching_context_reset(&session->rec_ctx);
+			janus_rtp_simulcasting_context_reset(&session->rec_simctx);
+			session->rec_simctx.substream_target = 2;
+			session->rec_simctx.templayer_target = 2;
 			/* If media is encrypted, mark it in the recording */
 			if(session->e2ee)
 				janus_recorder_encrypted(rc);
@@ -1289,6 +1390,8 @@ int janus_lua_init(janus_callbacks *callback, const char *config_path) {
 	lua_register(lua_state, "removeRecipient", janus_lua_method_removerecipient);
 	lua_register(lua_state, "setBitrate", janus_lua_method_setbitrate);
 	lua_register(lua_state, "setPliFreq", janus_lua_method_setplifreq);
+	lua_register(lua_state, "setSubstream", janus_lua_method_setsubstream);
+	lua_register(lua_state, "setTemporalLayer", janus_lua_method_settemporallayer);
 	lua_register(lua_state, "sendPli", janus_lua_method_sendpli);
 	lua_register(lua_state, "relayRtp", janus_lua_method_relayrtp);
 	lua_register(lua_state, "relayRtcp", janus_lua_method_relayrtcp);
@@ -1369,6 +1472,12 @@ int janus_lua_init(janus_callbacks *callback, const char *config_path) {
 	lua_getglobal(lua_state, "slowLink");
 	if(lua_isfunction(lua_state, lua_gettop(lua_state)) != 0)
 		has_slow_link = TRUE;
+	lua_getglobal(lua_state, "substreamChanged");
+	if(lua_isfunction(lua_state, lua_gettop(lua_state)) != 0)
+		has_substream_changed = TRUE;
+	lua_getglobal(lua_state, "temporalLayerChanged");
+	if(lua_isfunction(lua_state, lua_gettop(lua_state)) != 0)
+		has_temporal_changed = TRUE;
 
 	lua_sessions = g_hash_table_new_full(NULL, NULL, NULL, (GDestroyNotify)janus_lua_session_destroy);
 	lua_ids = g_hash_table_new(NULL, NULL);
@@ -1653,6 +1762,11 @@ void janus_lua_create_session(janus_plugin_session *handle, int *error) {
 	session->handle = handle;
 	session->id = id;
 	janus_rtp_switching_context_reset(&session->rtpctx);
+	janus_rtp_simulcasting_context_reset(&session->sim_context);
+	session->sim_context.substream_target = 2;
+	session->sim_context.templayer_target = 2;
+	janus_vp8_simulcast_context_reset(&session->vp8_context);
+	session->vcodec = JANUS_VIDEOCODEC_NONE;
 	g_atomic_int_set(&session->hangingup, 0);
 	g_atomic_int_set(&session->destroyed, 0);
 	janus_refcount_init(&session->ref, janus_lua_session_free);
@@ -1781,6 +1895,33 @@ struct janus_plugin_result *janus_lua_handle_message(janus_plugin_session *handl
 	}
 	char *jsep_text = jsep ? json_dumps(jsep, JSON_INDENT(0) | JSON_PRESERVE_ORDER) : NULL;
 	if(jsep != NULL) {
+		json_t *simulcast = json_object_get(jsep, "simulcast");
+		if(simulcast != NULL) {
+			janus_rtp_simulcasting_prepare(simulcast,
+				&session->rid_extmap_id, NULL,
+				session->ssrc, session->rid);
+		}
+		const char *sdp_type = json_string_value(json_object_get(jsep, "type"));
+		if(sdp_type && !strcasecmp(sdp_type, "answer")) {
+			/* Take note of which video codec were negotiated */
+			char error_str[512];
+			const char *sdp = json_string_value(json_object_get(jsep, "sdp"));
+			janus_sdp *parsed_sdp = janus_sdp_parse(sdp, error_str, sizeof(error_str));
+			const char *vcodec = NULL;
+			janus_sdp_find_first_codecs(parsed_sdp, NULL, &vcodec);
+			if(vcodec)
+				session->vcodec = janus_videocodec_from_name(vcodec);
+			if(session->vcodec != JANUS_VIDEOCODEC_VP8 && session->vcodec != JANUS_VIDEOCODEC_H264) {
+				/* VP8 r H.264 were not negotiated, if simulcasting was enabled then disable it here */
+				int i=0;
+				for(i=0; i<3; i++) {
+					session->ssrc[i] = 0;
+					g_free(session->rid[0]);
+					session->rid[0] = NULL;
+				}
+			}
+			janus_sdp_destroy(parsed_sdp);
+		}
 		if(json_is_true(json_object_get(jsep, "e2ee")))
 			session->e2ee = TRUE;
 		json_decref(jsep);
@@ -1925,15 +2066,65 @@ void janus_lua_incoming_rtp(janus_plugin_session *handle, janus_plugin_rtp *rtp_
 	/* Is this session allowed to send media? */
 	if((video && !session->send_video) || (!video && !session->send_audio))
 		return;
-	/* Are we recording? */
-	janus_recorder_save_frame(video ? session->vrc : session->arc, buf, len);
 	/* Handle the packet */
-	rtp_header *rtp = (rtp_header *)buf;
+	janus_rtp_header *rtp = (janus_rtp_header *)buf;
+	/* Check if we're simulcasting, and if so, keep track of the "layer" */
+	int sc = video ? 0 : -1;
+	if(video && (session->ssrc[0] != 0 || session->rid[0] != NULL)) {
+		uint32_t ssrc = ntohl(rtp->ssrc);
+		if(ssrc == session->ssrc[0])
+			sc = 0;
+		else if(ssrc == session->ssrc[1])
+			sc = 1;
+		else if(ssrc == session->ssrc[2])
+			sc = 2;
+		else if(session->rid_extmap_id > 0) {
+			/* We may not know the SSRC yet, try the rid RTP extension */
+			char sdes_item[16];
+			if(janus_rtp_header_extension_parse_rid(buf, len, session->rid_extmap_id, sdes_item, sizeof(sdes_item)) == 0) {
+				if(session->rid[0] != NULL && !strcmp(session->rid[0], sdes_item)) {
+					session->ssrc[0] = ssrc;
+					sc = 0;
+				} else if(session->rid[1] != NULL && !strcmp(session->rid[1], sdes_item)) {
+					session->ssrc[1] = ssrc;
+					sc = 1;
+				} else if(session->rid[2] != NULL && !strcmp(session->rid[2], sdes_item)) {
+					session->ssrc[2] = ssrc;
+					sc = 2;
+				}
+			}
+		}
+	}
+	/* Are we recording? */
+	if(!video || (session->ssrc[0] == 0 && session->rid[0] == NULL)) {
+		janus_recorder_save_frame(video ? session->vrc : session->arc, buf, len);
+	} else {
+		/* We're simulcasting, save the best video quality */
+		gboolean save = janus_rtp_simulcasting_context_process_rtp(&session->rec_simctx,
+			buf, len, session->ssrc, session->rid, session->vcodec, &session->rec_ctx);
+		if(save) {
+			uint32_t seq_number = ntohs(rtp->seq_number);
+			uint32_t timestamp = ntohl(rtp->timestamp);
+			uint32_t ssrc = ntohl(rtp->ssrc);
+			janus_rtp_header_update(rtp, &session->rec_ctx, TRUE, 0);
+			/* We use a fixed SSRC for the whole recording */
+			rtp->ssrc = session->ssrc[0];
+			janus_recorder_save_frame(session->vrc, buf, len);
+			/* Restore the header, as it will be needed by recipients of this packet */
+			rtp->ssrc = htonl(ssrc);
+			rtp->timestamp = htonl(timestamp);
+			rtp->seq_number = htons(seq_number);
+		}
+	}
 	janus_lua_rtp_relay_packet packet;
+	packet.sender = session;
 	packet.data = rtp;
 	packet.length = len;
 	packet.is_rtp = TRUE;
 	packet.is_video = video;
+	packet.ssrc[0] = (sc != -1 ? session->ssrc[0] : 0);
+	packet.ssrc[1] = (sc != -1 ? session->ssrc[1] : 0);
+	packet.ssrc[2] = (sc != -1 ? session->ssrc[2] : 0);
 	/* Backup the actual timestamp and sequence number set by the publisher, in case switching is involved */
 	packet.timestamp = ntohl(packet.data->timestamp);
 	packet.seq_number = ntohs(packet.data->seq_number);
@@ -2039,7 +2230,8 @@ void janus_lua_incoming_data(janus_plugin_session *handle, janus_plugin_data *pa
 		packet->binary ? "binary" : "text", len);
 	/* Relay to all recipients */
 	janus_lua_rtp_relay_packet pkt;
-	pkt.data = (rtp_header *)buf;
+	pkt.sender = session;
+	pkt.data = (janus_rtp_header *)buf;
 	pkt.length = len;
 	pkt.is_rtp = FALSE;
 	pkt.textdata = !packet->binary;
@@ -2142,6 +2334,17 @@ void janus_lua_hangup_media(janus_plugin_session *handle) {
 	session->pli_latest = 0;
 	session->e2ee = FALSE;
 	janus_rtp_switching_context_reset(&session->rtpctx);
+	janus_rtp_simulcasting_context_reset(&session->sim_context);
+	session->sim_context.substream_target = 2;
+	session->sim_context.templayer_target = 2;
+	janus_vp8_simulcast_context_reset(&session->vp8_context);
+	session->vcodec = JANUS_VIDEOCODEC_NONE;
+	int i=0;
+	for(i=0; i<3; i++) {
+		session->ssrc[i] = 0;
+		g_free(session->rid[i]);
+		session->rid[i] = NULL;
+	}
 
 	/* Get rid of the recipients */
 	janus_mutex_lock(&session->recipients_mutex);
@@ -2172,8 +2375,9 @@ static void janus_lua_relay_rtp_packet(gpointer data, gpointer user_data) {
 		JANUS_LOG(LOG_ERR, "Invalid packet...\n");
 		return;
 	}
+	janus_lua_session *sender = (janus_lua_session *)packet->sender;
 	janus_lua_session *session = (janus_lua_session *)data;
-	if(!session || !session->handle || !g_atomic_int_get(&session->started)) {
+	if(!sender || !session || !session->handle || !g_atomic_int_get(&session->started)) {
 		return;
 	}
 
@@ -2182,17 +2386,85 @@ static void janus_lua_relay_rtp_packet(gpointer data, gpointer user_data) {
 		/* Nope, don't relay */
 		return;
 	}
-	/* Fix sequence number and timestamp (publisher switching may be involved) */
-	janus_rtp_header_update(packet->data, &session->rtpctx, packet->is_video, 0);
-	/* Send the packet */
-	if(janus_core != NULL) {
-		janus_plugin_rtp rtp = { .video = packet->is_video, .buffer = (char *)packet->data, .length = packet->length };
-		janus_plugin_rtp_extensions_reset(&rtp.extensions);
-		janus_core->relay_rtp(session->handle, &rtp);
+	if(packet->ssrc[0] != 0) {
+		/* Handle simulcast: make sure we have a payload to work with */
+		int plen = 0;
+		char *payload = janus_rtp_payload((char *)packet->data, packet->length, &plen);
+		if(payload == NULL)
+			return;
+		/* Process this packet: don't relay if it's not the SSRC/layer we wanted to handle */
+		gboolean relay = janus_rtp_simulcasting_context_process_rtp(&session->sim_context,
+			(char *)packet->data, packet->length, packet->ssrc, NULL, sender->vcodec, &session->rtpctx);
+		if(session->sim_context.need_pli && sender->handle) {
+			/* Send a PLI */
+			JANUS_LOG(LOG_VERB, "We need a PLI for the simulcast context\n");
+			janus_core->send_pli(sender->handle);
+		}
+		/* Do we need to drop this? */
+		if(!relay)
+			return;
+		/* Any event we should notify? */
+		if(session->sim_context.changed_substream) {
+			/* Notify the script about the substream change */
+			if(has_substream_changed) {
+				janus_mutex_lock(&lua_mutex);
+				lua_State *t = lua_newthread(lua_state);
+				lua_getglobal(t, "substreamChanged");
+				lua_pushnumber(t, session->id);
+				lua_pushnumber(t, session->sim_context.substream);
+				lua_call(t, 2, 0);
+				lua_pop(lua_state, 1);
+				janus_mutex_unlock(&lua_mutex);
+			}
+		}
+		if(session->sim_context.changed_temporal) {
+			/* Notify the user about the temporal layer change */
+			if(has_substream_changed) {
+				janus_mutex_lock(&lua_mutex);
+				lua_State *t = lua_newthread(lua_state);
+				lua_getglobal(t, "temporalLayerChanged");
+				lua_pushnumber(t, session->id);
+				lua_pushnumber(t, session->sim_context.templayer);
+				lua_call(t, 2, 0);
+				lua_pop(lua_state, 1);
+				janus_mutex_unlock(&lua_mutex);
+			}
+		}
+		/* If we got here, update the RTP header and send the packet */
+		janus_rtp_header_update(packet->data, &session->rtpctx, TRUE, 0);
+		char vp8pd[6];
+		if(sender->vcodec == JANUS_VIDEOCODEC_VP8) {
+			/* For VP8, we save the original payload descriptor, to restore it after */
+			memcpy(vp8pd, payload, sizeof(vp8pd));
+			janus_vp8_simulcast_descriptor_update(payload, plen, &session->vp8_context,
+				session->sim_context.changed_substream);
+		}
+		/* Send the packet */
+		if(janus_core != NULL) {
+			janus_plugin_rtp rtp = { .video = packet->is_video, .buffer = (char *)packet->data, .length = packet->length };
+			janus_plugin_rtp_extensions_reset(&rtp.extensions);
+			janus_core->relay_rtp(session->handle, &rtp);
+		}
+		/* Restore the timestamp and sequence number to what the publisher set them to */
+		packet->data->timestamp = htonl(packet->timestamp);
+		packet->data->seq_number = htons(packet->seq_number);
+		if(sender->vcodec == JANUS_VIDEOCODEC_VP8) {
+			/* Restore the original payload descriptor as well, as it will be needed by the next viewer */
+			memcpy(payload, vp8pd, sizeof(vp8pd));
+		}
+	} else {
+		/* Fix sequence number and timestamp (publisher switching may be involved) */
+		janus_rtp_header_update(packet->data, &session->rtpctx, packet->is_video, 0);
+		/* Send the packet */
+		if(janus_core != NULL) {
+			janus_plugin_rtp rtp = { .video = packet->is_video, .buffer = (char *)packet->data, .length = packet->length };
+			janus_plugin_rtp_extensions_reset(&rtp.extensions);
+			janus_core->relay_rtp(session->handle, &rtp);
+		}
+		/* Restore the timestamp and sequence number to what the publisher set them to */
+		packet->data->timestamp = htonl(packet->timestamp);
+		packet->data->seq_number = htons(packet->seq_number);
 	}
-	/* Restore the timestamp and sequence number to what the publisher set them to */
-	packet->data->timestamp = htonl(packet->timestamp);
-	packet->data->seq_number = htons(packet->seq_number);
 
 	return;
 }

--- a/plugins/janus_lua_data.h
+++ b/plugins/janus_lua_data.h
@@ -58,7 +58,13 @@ typedef struct janus_lua_session {
 	gboolean send_audio;				/* Whether outgoing audio can be sent or must be dropped */
 	gboolean send_video;				/* Whether outgoing video can be sent or must be dropped */
 	gboolean send_data;					/* Whether outgoing data can be sent or must be dropped */
-	janus_rtp_switching_context rtpctx;	/* Needed in case the source changes (e.g., stale operator/customer) */
+	janus_rtp_switching_context rtpctx;	/* RTP switching context */
+	janus_videocodec vcodec;			/* Video codec this session is using */
+	uint32_t ssrc[3];					/* Only needed in case VP8 (or H.264) simulcasting is involved */
+	char *rid[3];						/* Only needed if simulcasting is rid-based */
+	int rid_extmap_id;					/* rid extmap ID */
+	janus_rtp_simulcasting_context sim_context;
+	janus_vp8_simulcast_context vp8_context;
 	uint32_t bitrate;					/* Bitrate limit */
 	uint16_t pli_freq;					/* Regular PLI frequency (0=disabled) */
 	gint64 pli_latest;					/* Time of latest sent PLI (to avoid flooding) */
@@ -68,6 +74,8 @@ typedef struct janus_lua_session {
 	janus_recorder *arc;				/* The Janus recorder instance for audio, if enabled */
 	janus_recorder *vrc;				/* The Janus recorder instance for video, if enabled */
 	janus_recorder *drc;				/* The Janus recorder instance for data, if enabled */
+	janus_rtp_switching_context rec_ctx;
+	janus_rtp_simulcasting_context rec_simctx;
 	gboolean e2ee;						/* Whether media is encrypted, e.g., using Insertable Streams */
 	janus_mutex rec_mutex;				/* Mutex to protect the recorders from race conditions */
 	volatile gint started;				/* Whether this session's PeerConnection is ready or not */

--- a/plugins/lua/echotest.lua
+++ b/plugins/lua/echotest.lua
@@ -191,6 +191,26 @@ function dataReady(id)
 	-- to throttle outgoing data and not send too much at a time.
 end
 
+function substreamChanged(id, substream)
+	-- If simulcast is used, this callback is invoked when the substream
+	-- we're sending to this session changes: 0=low, 1=medium, 2=high
+	logger.print("Substream changed for session " .. id .. ": " .. substream);
+	-- Let's send an event so that the user is aware
+	local event = { echotest = "event", videocodec = "vp8", substream = substream }
+	local jsonevent = json.encode(event)
+	pushEvent(id, nil, jsonevent, nil)
+end
+
+function temporalLayerChanged(id, temporal)
+	-- If simulcast is used, this callback is invoked when the temporal
+	-- layer we're sending to this session changes: 0=lowfps, 1=maxfps
+	logger.print("Temporal layer changed for session " .. id .. ": " .. temporal);
+	-- Let's send an event so that the user is aware
+	local event = { echotest = "event", videocodec = "vp8", temporal = temporal }
+	local jsonevent = json.encode(event)
+	pushEvent(id, nil, jsonevent, nil)
+end
+
 function resumeScheduler()
 	-- This is the function responsible for resuming coroutines associated
 	-- with whatever is relevant to the Lua script, e.g., for this script,
@@ -238,6 +258,17 @@ function processRequest(id, msg)
 	end
 	if msg["bitrate"] ~= nil then
 		setBitrate(id, msg["bitrate"])
+	end
+	if msg["substream"] ~= nil then
+		setSubstream(id, msg["substream"])
+		sendPli(id)
+	end
+	if msg["temporal"] ~= nil then
+		setTemporalLayer(id, msg["temporal"])
+		sendPli(id)
+	end
+	if msg["keyframe"] ~= nil then
+		sendPli(id)
 	end
 	if msg["record"] == true then
 		local fnbase = msg["filename"]

--- a/plugins/lua/janus-sdp.lua
+++ b/plugins/lua/janus-sdp.lua
@@ -344,6 +344,7 @@ function JANUSSDP.generateAnswer(offer, options)
 		end
 	end
 	if options.data == nil then options.data = true end
+	if options.disableTwcc == nil then options.disableTwcc = false end
 	-- Let's prepare the answer
 	local answer = {}
 	-- Iterate on all lines
@@ -424,6 +425,17 @@ function JANUSSDP.generateAnswer(offer, options)
 					if medium == "audio" and tonumber(n()) == audioPt then
 						answer[#answer+1] = a
 					elseif medium == "video" and tonumber(n()) == videoPt then
+						answer[#answer+1] = a
+					end
+				elseif a.name == "extmap" then
+					-- We do negotiate some RTP extensions
+					if a.value:find("urn:ietf:params:rtp-hdrext:sdes:mid", 1, true) then
+						answer[#answer+1] = a
+					elseif a.value:find("urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id", 1, true) then
+						answer[#answer+1] = a
+					elseif a.value:find("urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id", 1, true) then
+						answer[#answer+1] = a
+					elseif options.disableTwcc ~= true and a.value:find("draft-holmer-rmcat-transport-wide-cc-extensions-01", 1, true) then
 						answer[#answer+1] = a
 					end
 				end


### PR DESCRIPTION
This patch adds support for both simulcast and TWCC (transport-wide CC, i.e., sender side bandwidth estimation) negotiation to the Duktape and Lua plugins. This was made possible thanks to a generous sponsorship by our good friends at [Voicenter](https://www.voicenter.com/), so make sure to properly thank them if you needed these features in your scripts! :heart: 

In case you want to start using the simulcast features in a Duktape/Lua script, while negotiation and RTP management is automatic there's a couple of things you'll need to do:

1. You can use the `setSubstream(id, substream)` and `setTemporalLayer(id, temporal)` methods from your scripts to configure which layer you're interested in: by default both plugins will assume you'll want the highest quality (`2`, even though the maximum temporal layer is really `1` right now). Notice that it's up to you to ask for a keyframe after a layer change request, which you can do using the already existing `sendPli(id)` request.
2. You can be notified when a substream/layer actually changes via the `substreamChanged(id, substream)` and `temporalLayerChanged(id, temporal)` callbacks: this is especially useful when you want to be aware of when a layer change request was actually done (which may not be right away, e.g., if a keyframe was missing), and/or to notify users about when things change (which is what we do in our demos, for instance).

You can find an example of how those new methods and callbacks are used in Duktape's `echotest.js` and Lua's `echotest.lua` scripts, which will work nicely with the existing EchoTest demo if you have it connect to those plugins rather than the C EchoTest one.

For what concerns TWCC, instead, we now automatically negotiate a few RTP extensions in both plugins, namely `mid`, `rid` and `repaired-rid`: the TWCC RTP extension is also negotiated by default, but you can disable it by passing `disableTwcc: true` when calling `generateAnswer()`. I'd always suggest negotiating it, as it will make publisher streams more stable, but if for some reason you'd rather disable it, that's the way to do it.

I only tested this with the EchoTest demo, since that's the script available in both plugins, and it seems to be working as expected. Looking forward to your feedback to see if there's anything that needs to be fixed, tweaked or improved: the sooner that happens, the sooner we can merge!