### PR TITLE
New option to enforce CORS in HTTP and WS transport plugins

### DIFF
--- a/conf/janus.transport.http.jcfg.sample
+++ b/conf/janus.transport.http.jcfg.sample
@@ -52,8 +52,12 @@ admin: {
 # you need that, uncomment and set the 'allow_origin' below to specify
 # what must be returned in 'Access-Control-Allow-Origin'. More details:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
+# In case you want to enforce the Origin validation, rather than leave
+# it to browsers, you can set 'enforce_cors' to 'true' to have Janus
+# return a '403 Forbidden' for all requests that don't comply.
 cors: {
 	#allow_origin = "http://foo.example"
+	#enforce_cors = true
 }
 
 # Certificate and key to use for HTTPS, if enabled (and passphrase if needed).

--- a/conf/janus.transport.websockets.jcfg.sample
+++ b/conf/janus.transport.websockets.jcfg.sample
@@ -37,6 +37,21 @@ admin: {
 	#admin_ws_acl = "127.,192.168.0."	# Only allow requests coming from this comma separated list of addresses
 }
 
+# The HTTP servers created in Janus support CORS out of the box, but by
+# default they return a wildcard (*) in the 'Access-Control-Allow-Origin'
+# header. This works fine in most situations, except when we have to
+# respond to a credential request (withCredentials=true in the XHR). If
+# you need that, uncomment and set the 'allow_origin' below to specify
+# what must be returned in 'Access-Control-Allow-Origin'. More details:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
+# In case you want to enforce the Origin validation, rather than leave
+# it to browsers, you can set 'enforce_cors' to 'true' to have Janus
+# return a '403 Forbidden' for all requests that don't comply.
+cors: {
+	#allow_origin = "http://foo.example"
+	#enforce_cors = true
+}
+
 # Certificate and key to use for any secure WebSocket server, if enabled (and passphrase if needed).
 # You can also disable insecure protocols and ciphers by configuring the
 # 'ciphers' property accordingly (no limitation by default).


### PR DESCRIPTION
As the title says, this PR adds a new option to both the HTTP and WebSocket transport plugins to actually enforce CORS. In fact, it's up to browsers to enforce CORS once the relevant headers have been exchanged, and in case of WebSockets that actually never happens anyway. This PR allows you to enforce it on the server side too, if you want: by returning a `403` in the HTTP plugin, and just closing the connection attempt in the WS plugin.

I haven't tested this much, so I'd appreciate some feedback on whether or not the way I'm dealing with this works. For instance, GET messages are known to rarely include an `Origin` header, which is why in the HTTP plugin I'm relying on the `Referer` header instead; besides, I only played a bit with Chrome, but not other browsers, so there may be other things that need fixing before this can be merged.