### PR TITLE
Added janus-pp-rec option to only parse packets with a specific payload type

### DIFF
--- a/postprocessing/janus-pp-rec.1
+++ b/postprocessing/janus-pp-rec.1
@@ -33,6 +33,9 @@ Save this metadata string in the target file
 .BR \-i ", " \-\-ignore-first=count
 Number of first packets to ignore when processing, e.g., in case they're cause of issues (default=0)
 .TP
+.BR \-P ", " \-\-payload-type=pt
+Ignore all RTP packets that don't match the specified payload type (default=none)
+.TP
 .BR \-a ", " \-\-audiolevel-ext=id
 ID of the audio-levels RTP extension (default=none)
 .TP

--- a/postprocessing/janus-pp-rec.ggo
+++ b/postprocessing/janus-pp-rec.ggo
@@ -5,6 +5,7 @@ option "header" H "Only parse .mjr header" flag off
 option "parse" p "Only parse and re-order packets" flag off
 option "metadata" m "Save this metadata string in the target file" string typestr="metadata" optional
 option "ignore-first" i "Number of first packets to ignore when processing, e.g., in case they're cause of issues (default=0)" int typestr="count" optional
+option "payload-type" P "Ignore all RTP packets that don't match the specified payload type (default=none)" int typestr="pt" optional
 option "audiolevel-ext" a "ID of the audio-levels RTP extension (default=none)" int typestr="id" optional
 option "videoorient-ext" v "ID of the video-orientation RTP extension (default=none)" int typestr="id" optional
 option "debug-level" d "Debug/logging level (0=disable debugging, 7=maximum debug level; default=4)" int typestr="1-7" optional


### PR DESCRIPTION
As the title says, nothing too fancy: this can be used in case an .mjr file contains packets with different payload types (e.g., Opus and Comfort Noise) which would confuse the processor. The processor already skips packets when dealing with static payload types (G.711/G.722), so this is really only needed when the codec is negotiated using dynamic payload types instead.

Notice this is a patch on #2345, not master, so if you test this one you'll test that one too (and we'd appreciate feedback to expedite the merging process there).