### PR TITLE
Save media extmaps to recordings

### DIFF
--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -1787,16 +1787,20 @@ recdone:
 			answer->o_version = session->sdp_version;
 			/* Refresh extmaps */
 			if(audio) {
-				janus_recordplay_map_extmaps(rec->audio_extmaps,
-					janus_sdp_mline_find(answer, JANUS_SDP_AUDIO)->attributes);
-				if(session->arc != NULL)
-					janus_recordplay_copy_extmaps(session->arc->extmaps, rec->audio_extmaps);
+				janus_sdp_mline *media = janus_sdp_mline_find(answer, JANUS_SDP_AUDIO);
+				if(media) {
+					janus_recordplay_map_extmaps(rec->audio_extmaps, media->attributes);
+					if(session->arc != NULL)
+						janus_recordplay_copy_extmaps(session->arc->extmaps, rec->audio_extmaps);
+				}
 			}
 			if(video) {
-				janus_recordplay_map_extmaps(rec->video_extmaps,
-					janus_sdp_mline_find(answer, JANUS_SDP_VIDEO)->attributes);
-				if(session->vrc != NULL)
-					janus_recordplay_copy_extmaps(session->vrc->extmaps, rec->video_extmaps);
+				janus_sdp_mline *media = janus_sdp_mline_find(answer, JANUS_SDP_VIDEO);
+				if(media) {
+					janus_recordplay_map_extmaps(rec->video_extmaps, media->attributes);
+					if(session->vrc != NULL)
+						janus_recordplay_copy_extmaps(session->vrc->extmaps, rec->video_extmaps);
+				}
 			}
 			/* Generate the SDP string */
 			sdp = janus_sdp_write(answer);

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -451,7 +451,7 @@ static GHashTable *sessions;
 static janus_mutex sessions_mutex = JANUS_MUTEX_INITIALIZER;
 
 /*! \brief Helper function to filter and map \ref janus_sdp_attribute list to
- * (int)id:(char*)info extmap hash table
+ * (char*)id:(char*)info extmap hash table
  * \param extmaps Hash table to contain filtered and mapped extmaps
  * \param attributes List of sdp media attributes
  */
@@ -472,7 +472,7 @@ static void janus_recordplay_map_extmaps(GHashTable *extmaps, const GList *attri
 	}
 }
 
-/*! \brief Helper function to copy extmaps from one tablo to other
+/*! \brief Helper function to copy extmaps from one table to other
  * \param dst Destination table
  * \param src Source table
  */
@@ -489,7 +489,7 @@ static void janus_recordplay_copy_extmaps(GHashTable *dst, GHashTable *src) {
 		g_hash_table_insert(dst, g_strdup(ext_id), g_strdup(ext_info));
 }
 
-/*! \brief Helper function to add extmap attributes to media
+/*! \brief Helper function to update extmap attributes in media
  * \param media Parsed SDP mline
  * \param extmaps Table of extmaps to add to media
  */
@@ -1789,12 +1789,14 @@ recdone:
 			if(audio) {
 				janus_recordplay_map_extmaps(rec->audio_extmaps,
 					janus_sdp_mline_find(answer, JANUS_SDP_AUDIO)->attributes);
-				janus_recordplay_copy_extmaps(session->arc->extmaps, rec->audio_extmaps);
+				if(session->arc != NULL)
+					janus_recordplay_copy_extmaps(session->arc->extmaps, rec->audio_extmaps);
 			}
 			if(video) {
 				janus_recordplay_map_extmaps(rec->video_extmaps,
 					janus_sdp_mline_find(answer, JANUS_SDP_VIDEO)->attributes);
-				janus_recordplay_copy_extmaps(session->vrc->extmaps, rec->video_extmaps);
+				if(session->vrc != NULL)
+					janus_recordplay_copy_extmaps(session->vrc->extmaps, rec->video_extmaps);
 			}
 			/* Generate the SDP string */
 			sdp = janus_sdp_write(answer);

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -400,12 +400,12 @@ typedef struct janus_recordplay_recording {
 	janus_audiocodec acodec;	/* Codec used for audio, if available */
 	char *afmtp;				/* Audio fmtp, if any */
 	int audio_pt;				/* Payload types to use for audio when playing recordings */
-	GList *audio_extmaps;       /* Audio extmaps */
+	GList *audio_extmaps;		/* Audio extmaps */
 	char *vrc_file;				/* Video file name */
 	janus_videocodec vcodec;	/* Codec used for video, if available */
 	char *vfmtp;				/* Video fmtp, if any */
 	int video_pt;				/* Payload types to use for audio when playing recordings */
-	GList *video_extmaps;       /* Video extmaps */
+	GList *video_extmaps;		/* Video extmaps */
 	char *offer;				/* The SDP offer that will be sent to watchers */
 	gboolean e2ee;				/* Whether media in the recording is encrypted, e.g., using Insertable Streams */
 	GList *viewers;				/* List of users watching this recording */

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -526,7 +526,6 @@ static void janus_recordplay_regenerate_extmaps(janus_sdp_mline *media, GHashTab
 			JANUS_LOG(LOG_WARN, "Extmap has null fields\n");
 			continue;
 		}
-		JANUS_LOG(LOG_INFO, " > %d:%s\n", *ext_id, ext_info);
 		g_hash_table_insert(id2info, ext_id, ext_info);
 		g_hash_table_insert(info2id, ext_info, ext_id);
 	}

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -587,6 +587,7 @@ int main(int argc, char *argv[])
 				if(ext_json) {
 					if(!json_is_object(ext_json)) {
 						JANUS_LOG(LOG_WARN, "Malformed extmaps in info header...\n");
+						g_free(json_header);
 						cmdline_parser_free(&args_info);
 						exit(1);
 					}
@@ -594,9 +595,10 @@ int main(int argc, char *argv[])
 					ext = g_new(char *, ext_n);
 					const char *ext_id;
 					json_t *ext_value;
+					i = 0;
 					json_object_foreach(ext_json, ext_id, ext_value) {
 						sprintf(prebuffer, "%s%s", ext_id, json_string_value(ext_value));
-						ext[i] = g_strdup(prebuffer);
+						ext[i++] = g_strdup(prebuffer);
 					}
 				}
 				/* When was the file created? */

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -592,13 +592,15 @@ int main(int argc, char *argv[])
 						exit(1);
 					}
 					ext_n = json_object_size(ext_json);
-					ext = g_new(char *, ext_n);
-					const char *ext_id;
-					json_t *ext_value;
-					i = 0;
-					json_object_foreach(ext_json, ext_id, ext_value) {
-						sprintf(prebuffer, "%s%s", ext_id, json_string_value(ext_value));
-						ext[i++] = g_strdup(prebuffer);
+					if(ext_n > 0) {
+						ext = g_new(char *, ext_n);
+						const char *ext_id;
+						json_t *ext_value;
+						i = 0;
+						json_object_foreach(ext_json, ext_id, ext_value) {
+							sprintf(prebuffer, "%s%s", ext_id, json_string_value(ext_value));
+							ext[i++] = g_strdup(prebuffer);
+						}
 					}
 				}
 				/* When was the file created? */
@@ -666,9 +668,9 @@ int main(int argc, char *argv[])
 	uint16_t rtp_header_len, rtp_read_n;
 	/* Set extmap ids from attr list if not set */
 	for(i = 0; i < ext_n; i++) {
-		if(audio_level_extmap_id < 1 && strstr(ext[i], JANUS_RTP_EXTMAP_AUDIO_LEVEL))
+		if(audio_level_extmap_id < 1 && ext[i] != NULL && strstr(ext[i], JANUS_RTP_EXTMAP_AUDIO_LEVEL))
 			audio_level_extmap_id = atoi(ext[i]);
-		if(video_orient_extmap_id < 1 && strstr(ext[i], JANUS_RTP_EXTMAP_VIDEO_ORIENTATION))
+		if(video_orient_extmap_id < 1 && ext[i] != NULL && strstr(ext[i], JANUS_RTP_EXTMAP_VIDEO_ORIENTATION))
 			video_orient_extmap_id = atoi(ext[i]);
 	}
 	/* Start loop */

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -161,8 +161,6 @@ typedef struct janus_pp_rtp_skew_context {
 } janus_pp_rtp_skew_context;
 static gint janus_pp_skew_compensate_audio(janus_pp_frame_packet *pkt, janus_pp_rtp_skew_context *context);
 
-static int janus_pp_get_extmap_id(const char *attr, const char *urn);
-
 /* Main Code */
 int main(int argc, char *argv[])
 {
@@ -662,10 +660,10 @@ int main(int argc, char *argv[])
 	uint16_t rtp_header_len, rtp_read_n;
 	/* Set extmap ids from attr list if not set */
 	for(i = 0; i < ext_n; i++) {
-		if(audio_level_extmap_id < 1)
-			audio_level_extmap_id = janus_pp_get_extmap_id(ext[i], JANUS_RTP_EXTMAP_AUDIO_LEVEL);
-		if(video_orient_extmap_id < 1)
-			video_orient_extmap_id = janus_pp_get_extmap_id(ext[i], JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
+		if(audio_level_extmap_id < 1 && strstr(ext[i], JANUS_RTP_EXTMAP_AUDIO_LEVEL))
+			audio_level_extmap_id = atoi(ext[i]);
+		if(video_orient_extmap_id < 1 && strstr(ext[i], JANUS_RTP_EXTMAP_VIDEO_ORIENTATION))
+			video_orient_extmap_id = atoi(ext[i]);
 	}
 	/* Start loop */
 	while(working && offset < fsize) {
@@ -1210,16 +1208,6 @@ int main(int argc, char *argv[])
 
 	JANUS_LOG(LOG_INFO, "Bye!\n");
 	return 0;
-}
-
-/* Static helper to quickly get extmap id */
-static int janus_pp_get_extmap_id(const char *attr, const char *urn) {
-	if(strncmp(attr, "extmap:", 7))
-		return -1;
-	uint32_t attr_n = strlen(attr), urn_n = strlen(urn);
-	if(attr_n<urn_n || strcmp(attr+attr_n-urn_n, urn))
-		return -1;
-	return atoi(attr+7);
 }
 
 /* Static helper to quickly find the extension data */

--- a/postprocessing/mjr2pcap.c
+++ b/postprocessing/mjr2pcap.c
@@ -233,10 +233,13 @@ int main(int argc, char *argv[])
 			offset += 2;
 			if(len > 0 && !parsed_header) {
 				/* This is the info header */
-				bytes = fread(prebuffer, sizeof(char), len, file);
-				prebuffer[len] = '\0';
+				char *json_header = malloc(sizeof(char)*(len+1));
+				bytes = fread(json_header, sizeof(char), len, file);
+				parsed_header = TRUE;
+				json_header[len] = '\0';
 				json_error_t error;
-				mjr_header = json_loads(prebuffer, 0, &error);
+				mjr_header = json_loads(json_header, 0, &error);
+				free(json_header);
 				if(!mjr_header) {
 					fclose(file);
 					JANUS_LOG(LOG_ERR, "Error parsing header, JSON error: on line %d: %s\n", error.line, error.text);

--- a/postprocessing/mjr2pcap.c
+++ b/postprocessing/mjr2pcap.c
@@ -233,13 +233,13 @@ int main(int argc, char *argv[])
 			offset += 2;
 			if(len > 0 && !parsed_header) {
 				/* This is the info header */
-				char *json_header = malloc(sizeof(char)*(len+1));
+				char *json_header = g_new(char, len+1);
 				bytes = fread(json_header, sizeof(char), len, file);
 				parsed_header = TRUE;
 				json_header[len] = '\0';
 				json_error_t error;
 				mjr_header = json_loads(json_header, 0, &error);
-				free(json_header);
+				g_free(json_header);
 				if(!mjr_header) {
 					fclose(file);
 					JANUS_LOG(LOG_ERR, "Error parsing header, JSON error: on line %d: %s\n", error.line, error.text);

--- a/record.c
+++ b/record.c
@@ -115,7 +115,7 @@ janus_recorder *janus_recorder_create_full(const char *dir, const char *codec, c
 	rc->file = NULL;
 	rc->codec = g_strdup(codec);
 	rc->fmtp = fmtp ? g_strdup(fmtp) : NULL;
-	rc->extmaps = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+	rc->extmaps = g_hash_table_new_full(g_int_hash, g_int_equal, g_free, g_free);
 	rc->created = janus_get_real_time();
 	const char *rec_dir = NULL;
 	const char *rec_file = NULL;
@@ -307,10 +307,13 @@ int janus_recorder_save_frame(janus_recorder *recorder, char *buffer, uint lengt
 		if(recorder->extmaps) {
 			json_t *ext_json = json_object();
 			GHashTableIter iter;
-			char *ext_id, *ext_info;
+			uint32_t *ext_id;
+			char ext_id_str[3], *ext_info;
 			g_hash_table_iter_init(&iter, recorder->extmaps);
-			while(g_hash_table_iter_next(&iter, (gpointer *)&ext_id, (gpointer *)&ext_info))
-				json_object_set_new(ext_json, ext_id, json_string(ext_info));
+			while(g_hash_table_iter_next(&iter, (gpointer *)&ext_id, (gpointer *)&ext_info)) {
+				snprintf(ext_id_str, 3, "%u", *ext_id);
+				json_object_set_new(ext_json, ext_id_str, json_string(ext_info));
+			}
 			json_object_set(info, "x", ext_json);
 		}
 		gchar *info_text = json_dumps(info, JSON_PRESERVE_ORDER);

--- a/record.h
+++ b/record.h
@@ -20,6 +20,7 @@
 #ifndef JANUS_RECORD_H
 #define JANUS_RECORD_H
 
+#include <glib.h>
 #include <inttypes.h>
 #include <string.h>
 #include <stdio.h>
@@ -48,6 +49,8 @@ typedef struct janus_recorder {
 	char *codec;
 	/*! \brief Codec-specific info (e.g., H.264 or VP9 profile) */
 	char *fmtp;
+	/*! \brief Media extmaps */
+	GList *extmaps;
 	/*! \brief When the recording file has been created and started */
 	gint64 created, started;
 	/*! \brief Media this instance is recording */

--- a/record.h
+++ b/record.h
@@ -49,8 +49,8 @@ typedef struct janus_recorder {
 	char *codec;
 	/*! \brief Codec-specific info (e.g., H.264 or VP9 profile) */
 	char *fmtp;
-	/*! \brief Media extmaps */
-	GList *extmaps;
+	/*! \brief Media extmap table in (char*)id:(char*)info format */
+	GHashTable *extmaps;
 	/*! \brief When the recording file has been created and started */
 	gint64 created, started;
 	/*! \brief Media this instance is recording */

--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -1282,7 +1282,7 @@ janus_sdp *janus_sdp_generate_offer(const char *name, const char *address, ...) 
 				char *extmap = g_hash_table_lookup(audio_extids, iter->data);
 				if(extmap != NULL) {
 					janus_sdp_attribute *a = janus_sdp_attribute_create("extmap",
-						"%d %s\r\n", GPOINTER_TO_INT(iter->data), extmap);
+						"%d %s", GPOINTER_TO_INT(iter->data), extmap);
 					janus_sdp_attribute_add_to_mline(m, a);
 				}
 				iter = iter->next;
@@ -1320,7 +1320,7 @@ janus_sdp *janus_sdp_generate_offer(const char *name, const char *address, ...) 
 				char *extmap = g_hash_table_lookup(video_extids, iter->data);
 				if(extmap != NULL) {
 					janus_sdp_attribute *a = janus_sdp_attribute_create("extmap",
-						"%d %s\r\n", GPOINTER_TO_INT(iter->data), extmap);
+						"%d %s", GPOINTER_TO_INT(iter->data), extmap);
 					janus_sdp_attribute_add_to_mline(m, a);
 				}
 				iter = iter->next;

--- a/utils.c
+++ b/utils.c
@@ -129,6 +129,12 @@ char *janus_random_uuid(void) {
 #endif
 }
 
+uint32_t *janus_uint32_dup(uint32_t num) {
+	uint32_t *numdup = g_malloc(sizeof(uint32_t));
+	*numdup = num;
+	return numdup;
+}
+
 guint64 *janus_uint64_dup(guint64 num) {
 	guint64 *numdup = g_malloc(sizeof(guint64));
 	*numdup = num;

--- a/utils.h
+++ b/utils.h
@@ -73,6 +73,15 @@ guint64 janus_random_uint64(void);
  * @returns A random UUID string, which must be deallocated with \c g_free */
 char *janus_random_uuid(void);
 
+/*! \brief Helper to generate an allocated copy of a uint32_t number
+ * @note While apparently silly, this is needed in order to make sure uint32_t values
+ * used as keys in GHashTable operations are not lost: using temporary uint32_t numbers
+ * in a g_hash_table_insert, for instance, will cause the key to contain garbage as
+ * soon as the temporary variable is lost, and all opererations on the key to fail
+ * @param num The uint32_t number to duplicate
+ * @returns A pointer to a uint32_t number, if successful, NULL otherwise */
+uint32_t *janus_uint32_dup(uint32_t num);
+
 /*! \brief Helper to generate an allocated copy of a guint64 number
  * @note While apparently silly, this is needed in order to make sure guint64 values
  * used as keys in GHashTable operations are not lost: using temporary guint64 numbers


### PR DESCRIPTION
This PR allows recordplay plugin and recorder to save and read media extmaps in .mjr header as array with `x` key. This in turn allows recordings with video-orient extmap to replay with correct orientation (among others), and allows rtp header extensions to be correctly mapped in janus-pp-rec tool without needing to pass `--videoorient-ext` or `--audiolevel-ext` params.