### PR TITLE
Differentiate between IPv4 and IPv6 NAT-1-1 addresses

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -201,6 +201,7 @@ gchar *janus_get_local_ip(void) {
 }
 static GHashTable *public_ips_table = NULL;
 static GList *public_ips = NULL;
+gboolean public_ips_ipv4 = FALSE, public_ips_ipv6 = FALSE;
 guint janus_get_public_ip_count(void) {
 	return public_ips_table ? g_hash_table_size(public_ips_table) : 0;
 }
@@ -226,7 +227,20 @@ void janus_add_public_ip(const gchar *ip) {
 		g_list_free(public_ips);
 		public_ips = g_hash_table_get_keys(public_ips_table);
 	}
+	/* Take note of whether we received at least one IPv4 and/or IPv6 address */
+	if(strchr(ip, ':')) {
+		public_ips_ipv6 = TRUE;
+	} else {
+		public_ips_ipv4 = TRUE;
+	}
 }
+gboolean janus_has_public_ipv4_ip(void) {
+	return public_ips_ipv4;
+}
+gboolean janus_has_public_ipv6_ip(void) {
+	return public_ips_ipv6;
+}
+
 static volatile gint stop = 0;
 static gint stop_signal = 0;
 gint janus_is_stopping(void) {

--- a/janus.h
+++ b/janus.h
@@ -277,6 +277,11 @@ gchar *janus_get_public_ip(guint index);
 guint janus_get_public_ip_count(void);
 /*! \brief Helper method to add an IP address to use in the SDP */
 void janus_add_public_ip(const char *ip);
+/*! \brief Helper method to check if we have at least one manually passed public IPv4 address (for 1-1 NAT management) */
+gboolean janus_has_public_ipv4_ip(void);
+/*! \brief Helper method to check if we have at least one manually passed public IPv6 address (for 1-1 NAT management) */
+gboolean janus_has_public_ipv6_ip(void);
+
 /*! \brief Helper method to check whether the server is being shut down */
 gint janus_is_stopping(void);
 


### PR DESCRIPTION
As the title says, this new PR tries to add some awareness in Janus about the nature of the provided address(es) for NAT-1-1 mapping purposes. At the moment, when you specify one or more addresses, they're blindly set for all candidates, independently of the protocol family: this means that if you set, for instance, `1.2.3.4`, this would be set for IPv6 candidates as well, which is clearly wrong. This new patch corrects that, and ensures that a NAT-1-1 address is only enforced if it's the same family as the candidate it's being applied on.

There's no change in how you configure the feature, it works exactly the same way: it's Janus that will look at the address(es) you pass, and figures out if they're IPv4 or IPv6 to handle them accordingly.

I tested this in several scenarios and it seems to be working, but of course I encourage you to test this carefully, especially if you're using the NAT-1-1 feature a lot (e.g., deploying on AWS, Azure, or other cloud providers). If I don't get any feedback, I plan to merge this relatively soon.