### PR TITLE
Add durable flag for rabbitmq event handler

### DIFF
--- a/conf/janus.eventhandler.rabbitmqevh.jcfg.sample
+++ b/conf/janus.eventhandler.rabbitmqevh.jcfg.sample
@@ -21,6 +21,7 @@ general: {
 	route_key = "janus-events"		# Name of the queue for event messages
 	#exchange_type = "fanout" 		# Rabbitmq exchange_type can be one of the available types: direct, topic, headers and fanout (fanout by defualt).
 	#heartbeat = 60 				# Defines the seconds without communication that should pass before considering the TCP connection has unreachable.
+	#durable = true					# Create durable exchange and queue (default is false)
 
 	#ssl_enable = false				# Whether ssl support must be enabled
 	#ssl_verify_peer = true			# Whether peer verification must be enabled


### PR DESCRIPTION
Added configuration for RabbitMQ Event Handler (rabbitmqevh.jcfg) to enable or disable durable flag while declaring exchange & queue (default is false). 

RabbitMQ Durability:
https://www.rabbitmq.com/queues.html#durability
https://www.rabbitmq.com/reliability.html#broker-side

Configuration `rabbitmqevh.jcfg`:
```
durable = true  # Default is false
```

I have tested this with both values (durable true & false) and it is working as expected.