### PR TITLE
Updates RabbitMQ logic

### DIFF
--- a/conf/janus.eventhandler.rabbitmqevh.jcfg.sample
+++ b/conf/janus.eventhandler.rabbitmqevh.jcfg.sample
@@ -18,9 +18,11 @@ general: {
 	#password = "guest"				# Password to use to authenticate, if needed
 	#vhost = "/"					# Virtual host to specify when logging in, if needed
 	#exchange = "janus-exchange"
-	route_key = "janus.events" 		# Routing key to use when publishing messages
+	route_key = "janus-events" 		# Routing key to use when publishing messages
 	#exchange_type = "fanout" 		# Rabbitmq exchange_type can be one of the available types: direct, topic, headers and fanout (fanout by defualt).
 	#heartbeat = 60 				# Defines the seconds without communication that should pass before considering the TCP connection has unreachable.
+
+	#declare_outgoing_queue = true # By default (for backwards compatibility), we declare an outgoing queue. Set this to false to disable that behavior
 
 	#ssl_enable = false				# Whether ssl support must be enabled
 	#ssl_verify_peer = true			# Whether peer verification must be enabled

--- a/conf/janus.eventhandler.rabbitmqevh.jcfg.sample
+++ b/conf/janus.eventhandler.rabbitmqevh.jcfg.sample
@@ -18,7 +18,7 @@ general: {
 	#password = "guest"				# Password to use to authenticate, if needed
 	#vhost = "/"					# Virtual host to specify when logging in, if needed
 	#exchange = "janus-exchange"
-	route_key = "janus-events"		# Name of the queue for event messages
+	route_key = "janus.events" 		# Routing key to use when publishing messages
 	#exchange_type = "fanout" 		# Rabbitmq exchange_type can be one of the available types: direct, topic, headers and fanout (fanout by defualt).
 	#heartbeat = 60 				# Defines the seconds without communication that should pass before considering the TCP connection has unreachable.
 

--- a/conf/janus.eventhandler.rabbitmqevh.jcfg.sample
+++ b/conf/janus.eventhandler.rabbitmqevh.jcfg.sample
@@ -18,10 +18,9 @@ general: {
 	#password = "guest"				# Password to use to authenticate, if needed
 	#vhost = "/"					# Virtual host to specify when logging in, if needed
 	#exchange = "janus-exchange"
-	route_key = "janus-events" 		# Routing key to use when publishing messages
+	route_key = "janus-events"		# Routing key to use when publishing messages
 	#exchange_type = "fanout" 		# Rabbitmq exchange_type can be one of the available types: direct, topic, headers and fanout (fanout by defualt).
 	#heartbeat = 60 				# Defines the seconds without communication that should pass before considering the TCP connection has unreachable.
-
 	#declare_outgoing_queue = true # By default (for backwards compatibility), we declare an outgoing queue. Set this to false to disable that behavior
 
 	#ssl_enable = false				# Whether ssl support must be enabled

--- a/conf/janus.transport.rabbitmq.jcfg.sample
+++ b/conf/janus.transport.rabbitmq.jcfg.sample
@@ -24,10 +24,15 @@ general: {
 	#username = "guest"					# Username to use to authenticate, if needed
 	#password = "guest"					# Password to use to authenticate, if needed
 	#vhost = "/"						# Virtual host to specify when logging in, if needed
-	to_janus = "to-janus"				# Name of the queue for incoming messages
-	from_janus = "from-janus"			# Name of the queue for outgoing messages
+
 	#janus_exchange = "janus-exchange"	# Exchange for outgoing messages, using default if not provided
 	#janus_exchange_type = "fanout" 		# Rabbitmq exchange_type can be one of the available types: direct, topic, headers and fanout (fanout by defualt).
+
+	queue_name = "janus-gateway" # Queue name for incoming messages (if this is set and janus_exchange_type is topic, to_janus will be the topic the queue is bound to the exchange on)
+
+	to_janus = "to-janus"				# Name of the queue for incoming messages if queue_name isn't set, otherwise, the topic that queue_name is bound to
+	from_janus = "from-janus"			# Topic of the message sent from janus
+
 	#ssl_enabled = false					# Whether ssl support must be enabled
 	#ssl_verify_peer = true				# Whether peer verification must be enabled
 	#ssl_verify_hostname = true			# Whether hostname verification must be enabled
@@ -44,6 +49,10 @@ general: {
 # Notice that by default the Admin API support via RabbitMQ is disabled.
 admin: {
 	#admin_enabled = false					# Whether the support must be enabled
+
+	queue_name_admin = "janus-gateway-admin" # Queue name for incoming admin messages (if this is set and janus_exchange_type is topic, to_janus_admin will be the topic the queue is bound to the exchange on)
+
+	# Deprecated config values, ignored if admin_queue_name is set above
 	#to_janus_admin = "to-janus-admin"		# Name of the queue for incoming messages
-	#from_janus_admin = "from-janus-admin"	# Name of the queue for outgoing messages
+	#from_janus_admin = "from-janus-admin"	# Topic of the message sent from janus
 }

--- a/conf/janus.transport.rabbitmq.jcfg.sample
+++ b/conf/janus.transport.rabbitmq.jcfg.sample
@@ -28,14 +28,16 @@ general: {
 	#janus_exchange = "janus-exchange"	# Exchange for outgoing messages, using default if not provided
 	#janus_exchange_type = "fanout" 		# Rabbitmq exchange_type can be one of the available types: direct, topic, headers and fanout (fanout by defualt).
 
-	queue_name = "janus-gateway" # Queue name for incoming messages (if this is set and janus_exchange_type is topic, to_janus will be the topic the queue is bound to the exchange on)
+	#queue_name = "janus-gateway" # Queue name for incoming messages (if this is set and janus_exchange_type is topic, to_janus will be the topic the queue is bound to the exchange on)
 
 	to_janus = "to-janus"				# Name of the queue for incoming messages if queue_name isn't set, otherwise, the topic that queue_name is bound to
 	from_janus = "from-janus"			# Topic of the message sent from janus
 
-	#queue_durable = false				# Whether or not queue should remain after a RabbitMQ reboot
-	#queue_autodelete = false		# Whether or not queue should autodelete after janus disconnects from RabbitMQ
-	#queue_exclusive = false			# Whether or not queue should only allow one subscriber
+	#declare_outgoing_queue = true # By default (for backwards compatibility), we declare an outgoing queue. Set this to false to disable that behavior
+
+	#queue_durable = false				# Whether or not incoming queue should remain after a RabbitMQ reboot
+	#queue_autodelete = false		# Whether or not incoming queue should autodelete after janus disconnects from RabbitMQ
+	#queue_exclusive = false			# Whether or not incoming queue should only allow one subscriber
 
 	#ssl_enabled = false					# Whether ssl support must be enabled
 	#ssl_verify_peer = true				# Whether peer verification must be enabled
@@ -54,13 +56,15 @@ general: {
 admin: {
 	#admin_enabled = false					# Whether the support must be enabled
 
-	queue_name_admin = "janus-gateway-admin" # Queue name for incoming admin messages (if this is set and janus_exchange_type is topic, to_janus_admin will be the topic the queue is bound to the exchange on)
+	#queue_name_admin = "janus-gateway-admin" # Queue name for incoming admin messages (if this is set and janus_exchange_type is topic, to_janus_admin will be the topic the queue is bound to the exchange on)
 
 	#to_janus_admin = "to-janus-admin"		# Name of the queue for incoming messages if queue_name_admin isn't set, otherwise, the topic that queue_name_admin is bound to
 	#from_janus_admin = "from-janus-admin"	# Topic of the message sent from janus
 
-	#queue_durable_admin = false				# Whether or not queue should remain after a RabbitMQ reboot
-	#queue_autodelete_admin = false		# Whether or not queue should autodelete after janus disconnects from RabbitMQ
-	#queue_exclusive_admin = false			# Whether or not queue should only allow one subscriber
+	#declare_outgoing_queue_admin = true # By default (for backwards compatibility), we declare an outgoing queue. Set this to false to disable that behavior
+
+	#queue_durable_admin = false				# Whether or not incoming queue should remain after a RabbitMQ reboot
+	#queue_autodelete_admin = false		# Whether or not incoming queue should autodelete after janus disconnects from RabbitMQ
+	#queue_exclusive_admin = false			# Whether or not incoming queue should only allow one subscriber
 
 }

--- a/conf/janus.transport.rabbitmq.jcfg.sample
+++ b/conf/janus.transport.rabbitmq.jcfg.sample
@@ -33,6 +33,10 @@ general: {
 	to_janus = "to-janus"				# Name of the queue for incoming messages if queue_name isn't set, otherwise, the topic that queue_name is bound to
 	from_janus = "from-janus"			# Topic of the message sent from janus
 
+	#queue_durable = false				# Whether or not queue should remain after a RabbitMQ reboot
+	#queue_autodelete = false		# Whether or not queue should autodelete after janus disconnects from RabbitMQ
+	#queue_exclusive = false			# Whether or not queue should only allow one subscriber
+
 	#ssl_enabled = false					# Whether ssl support must be enabled
 	#ssl_verify_peer = true				# Whether peer verification must be enabled
 	#ssl_verify_hostname = true			# Whether hostname verification must be enabled
@@ -52,7 +56,11 @@ admin: {
 
 	queue_name_admin = "janus-gateway-admin" # Queue name for incoming admin messages (if this is set and janus_exchange_type is topic, to_janus_admin will be the topic the queue is bound to the exchange on)
 
-	# Deprecated config values, ignored if admin_queue_name is set above
-	#to_janus_admin = "to-janus-admin"		# Name of the queue for incoming messages
+	#to_janus_admin = "to-janus-admin"		# Name of the queue for incoming messages if queue_name_admin isn't set, otherwise, the topic that queue_name_admin is bound to
 	#from_janus_admin = "from-janus-admin"	# Topic of the message sent from janus
+
+	#queue_durable_admin = false				# Whether or not queue should remain after a RabbitMQ reboot
+	#queue_autodelete_admin = false		# Whether or not queue should autodelete after janus disconnects from RabbitMQ
+	#queue_exclusive_admin = false			# Whether or not queue should only allow one subscriber
+
 }

--- a/conf/janus.transport.rabbitmq.jcfg.sample
+++ b/conf/janus.transport.rabbitmq.jcfg.sample
@@ -26,20 +26,16 @@ general: {
 	#vhost = "/"						# Virtual host to specify when logging in, if needed
 
 	#janus_exchange = "janus-exchange"	# Exchange for outgoing messages, using default if not provided
-	#janus_exchange_type = "fanout" 		# Rabbitmq exchange_type can be one of the available types: direct, topic, headers and fanout (fanout by defualt).
-
-	#queue_name = "janus-gateway" # Queue name for incoming messages (if this is set and janus_exchange_type is topic, to_janus will be the topic the queue is bound to the exchange on)
-
-	to_janus = "to-janus"				# Name of the queue for incoming messages if queue_name isn't set, otherwise, the topic that queue_name is bound to
-	from_janus = "from-janus"			# Topic of the message sent from janus
-
-	#declare_outgoing_queue = true # By default (for backwards compatibility), we declare an outgoing queue. Set this to false to disable that behavior
-
+	#janus_exchange_type = "fanout"		# Rabbitmq exchange_type can be one of the available types: direct, topic, headers and fanout (fanout by defualt).
+	#queue_name = "janus-gateway"		# Queue name for incoming messages (if set and janus_exchange_type is topic/direct, to_janus will be the routing key the queue is bound to the exchange on)
+	to_janus = "to-janus"				# Name of the queue for incoming messages if queue_name isn't set, otherwise, the routing key that queue_name is bound to
+	from_janus = "from-janus"			# Routing key of the message sent from janus (as well as the name of the outgoing queue if declare_outgoing_queue = true)
+	#declare_outgoing_queue = true		# By default (for backwards compatibility), we declare an outgoing queue. Set this to false to disable that behavior
 	#queue_durable = false				# Whether or not incoming queue should remain after a RabbitMQ reboot
-	#queue_autodelete = false		# Whether or not incoming queue should autodelete after janus disconnects from RabbitMQ
+	#queue_autodelete = false			# Whether or not incoming queue should autodelete after janus disconnects from RabbitMQ
 	#queue_exclusive = false			# Whether or not incoming queue should only allow one subscriber
 
-	#ssl_enabled = false					# Whether ssl support must be enabled
+	#ssl_enabled = false				# Whether ssl support must be enabled
 	#ssl_verify_peer = true				# Whether peer verification must be enabled
 	#ssl_verify_hostname = true			# Whether hostname verification must be enabled
 
@@ -54,17 +50,14 @@ general: {
 # Admin API messaging. The same RabbitMQ server is supposed to be used.
 # Notice that by default the Admin API support via RabbitMQ is disabled.
 admin: {
-	#admin_enabled = false					# Whether the support must be enabled
+	#admin_enabled = false						# Whether the support must be enabled
 
-	#queue_name_admin = "janus-gateway-admin" # Queue name for incoming admin messages (if this is set and janus_exchange_type is topic, to_janus_admin will be the topic the queue is bound to the exchange on)
-
-	#to_janus_admin = "to-janus-admin"		# Name of the queue for incoming messages if queue_name_admin isn't set, otherwise, the topic that queue_name_admin is bound to
-	#from_janus_admin = "from-janus-admin"	# Topic of the message sent from janus
-
-	#declare_outgoing_queue_admin = true # By default (for backwards compatibility), we declare an outgoing queue. Set this to false to disable that behavior
-
+	#queue_name_admin = "janus-gateway-admin"	# Queue name for incoming admin messages (if set and janus_exchange_type is topic/direct, to_janus_admin will be the the routing key the queue is bound to the exchange on)
+	#to_janus_admin = "to-janus-admin"			# Name of the queue for incoming messages if queue_name_admin isn't set, otherwise, the routing key that queue_name_admin is bound to
+	#from_janus_admin = "from-janus-admin"		# Routing key of the message sent from janus  (as well as the name of the outgoing queue if declare_outgoing_queue_admin = true)
+	#declare_outgoing_queue_admin = true		# By default (for backwards compatibility), we declare an outgoing queue. Set this to false to disable that behavior
 	#queue_durable_admin = false				# Whether or not incoming queue should remain after a RabbitMQ reboot
-	#queue_autodelete_admin = false		# Whether or not incoming queue should autodelete after janus disconnects from RabbitMQ
-	#queue_exclusive_admin = false			# Whether or not incoming queue should only allow one subscriber
+	#queue_autodelete_admin = false				# Whether or not incoming queue should autodelete after janus disconnects from RabbitMQ
+	#queue_exclusive_admin = false				# Whether or not incoming queue should only allow one subscriber
 
 }

--- a/events/janus_rabbitmqevh.c
+++ b/events/janus_rabbitmqevh.c
@@ -100,7 +100,6 @@ static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
 static amqp_connection_state_t rmq_conn;
 static amqp_channel_t rmq_channel = 0;
 static amqp_bytes_t rmq_exchange;
-static amqp_bytes_t rmq_route_key;
 
 static janus_mutex mutex;
 
@@ -408,14 +407,7 @@ int janus_rabbitmqevh_connect(void) {
 			return -1;
 		}
 	}
-	JANUS_LOG(LOG_VERB, "Declaring outgoing queue... (%s)\n", route_key);
-	rmq_route_key = amqp_cstring_bytes(route_key);
-	amqp_queue_declare(rmq_conn, rmq_channel, rmq_route_key, 0, 0, 0, 0, amqp_empty_table);
-	result = amqp_get_rpc_reply(rmq_conn);
-	if(result.reply_type != AMQP_RESPONSE_NORMAL) {
-		JANUS_LOG(LOG_FATAL, "RabbitMQEventHandler: Can't connect to RabbitMQ server: error declaring queue... %s, %s\n", amqp_error_string2(result.library_error), amqp_method_name(result.reply.id));
-		return -1;
-	}
+
 	return 0;
 }
 
@@ -444,8 +436,6 @@ void janus_rabbitmqevh_destroy(void) {
 	}
 	if(rmq_exchange.bytes)
 		g_free((char *)rmq_exchange.bytes);
-	if(rmq_route_key.bytes)
-		g_free((char *)rmq_route_key.bytes);
 	if(rmqhost)
 		g_free((char *)rmqhost);
 	if(vhost)
@@ -611,7 +601,7 @@ static void *jns_rmqevh_hdlr(void *data) {
 			props.content_type = amqp_cstring_bytes("application/json");
 			amqp_bytes_t message = amqp_cstring_bytes(event_text);
 			janus_mutex_lock(&mutex);
-			int status = amqp_basic_publish(rmq_conn, rmq_channel, rmq_exchange, rmq_route_key, 0, 0, &props, message);
+			int status = amqp_basic_publish(rmq_conn, rmq_channel, rmq_exchange, amqp_cstring_bytes(route_key), 0, 0, &props, message);
 			if(status != AMQP_STATUS_OK) {
 				JANUS_LOG(LOG_ERR, "RabbitMQEventHandler: Error publishing... %d, %s\n", status, amqp_error_string2(status));
 			}

--- a/transports/janus_rabbitmq.c
+++ b/transports/janus_rabbitmq.c
@@ -914,7 +914,7 @@ void *janus_rmq_out_thread(void *data) {
 			janus_mutex_lock(&rmq_client->mutex);
 			/* Gotcha! Convert json_t to string */
 			char *payload_text = response->payload;
-			JANUS_LOG(LOG_VERB, "Sending %s API message to RabbitMQ (%zu bytes)...\n", response->admin ? "Admin" : "Janus", strlen(payload_text));
+			JANUS_LOG(LOG_VERB, "Sending %s API message to RabbitMQ (%zu bytes) on exchange %s with topic %s...\n", response->admin ? "Admin" : "Janus", strlen(payload_text), janus_exchange, response->admin ? from_janus_admin : from_janus);
 			JANUS_LOG(LOG_VERB, "%s\n", payload_text);
 			amqp_basic_properties_t props;
 			props._flags = 0;

--- a/transports/janus_rabbitmq.c
+++ b/transports/janus_rabbitmq.c
@@ -463,11 +463,31 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 		rmq_client->janus_api_enabled = FALSE;
 		if(rmq_janus_api_enabled) {
 			rmq_client->janus_api_enabled = TRUE;
+
+			// Set queue options
+			amqp_boolean_t queue_durable = 0;
+			item = janus_config_get(config, config_general, janus_config_type_item, "queue_durable");
+			if(item && item->value && janus_is_true(item->value)) {
+				queue_durable = 1;
+			}
+
+			amqp_boolean_t queue_exclusive = 0;
+			item = janus_config_get(config, config_general, janus_config_type_item, "queue_exclusive");
+			if(item && item->value && janus_is_true(item->value)) {
+				queue_exclusive = 1;
+			}
+
+			amqp_boolean_t queue_autodelete = 0;
+			item = janus_config_get(config, config_general, janus_config_type_item, "queue_autodelete");
+			if(item && item->value && janus_is_true(item->value)) {
+				queue_autodelete = 1;
+			}
+
 			// Case when we have a queue_name, and to_janus is the name of the topic to bind on (if exchange_type is topic)
 			if (queue_name != NULL) {
 				JANUS_LOG(LOG_VERB, "Declaring incoming queue (using queue_name)... (%s)\n", queue_name);
 				rmq_client->to_janus_queue = amqp_cstring_bytes(queue_name);
-				amqp_queue_declare(rmq_client->rmq_conn, rmq_client->rmq_channel, rmq_client->to_janus_queue, 0, 0, 0, 0, amqp_empty_table);
+				amqp_queue_declare(rmq_client->rmq_conn, rmq_client->rmq_channel, rmq_client->to_janus_queue, 0, queue_durable, queue_exclusive, queue_autodelete, amqp_empty_table);
 				result = amqp_get_rpc_reply(rmq_client->rmq_conn);
 				if(result.reply_type != AMQP_RESPONSE_NORMAL) {
 					JANUS_LOG(LOG_FATAL, "Can't connect to RabbitMQ server: error declaring queue... %s, %s\n", amqp_error_string2(result.library_error), amqp_method_name(result.reply.id));
@@ -488,7 +508,7 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 			} else {
 				JANUS_LOG(LOG_VERB, "Declaring incoming queue (using to_janus)... (%s)\n", to_janus);
 				rmq_client->to_janus_queue = amqp_cstring_bytes(to_janus);
-				amqp_queue_declare(rmq_client->rmq_conn, rmq_client->rmq_channel, rmq_client->to_janus_queue, 0, 0, 0, 0, amqp_empty_table);
+				amqp_queue_declare(rmq_client->rmq_conn, rmq_client->rmq_channel, rmq_client->to_janus_queue, 0, queue_durable, queue_exclusive, queue_autodelete, amqp_empty_table);
 				result = amqp_get_rpc_reply(rmq_client->rmq_conn);
 				if(result.reply_type != AMQP_RESPONSE_NORMAL) {
 					JANUS_LOG(LOG_FATAL, "Can't connect to RabbitMQ server: error declaring queue... %s, %s\n", amqp_error_string2(result.library_error), amqp_method_name(result.reply.id));
@@ -506,11 +526,31 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 		rmq_client->admin_api_enabled = FALSE;
 		if(rmq_admin_api_enabled) {
 			rmq_client->admin_api_enabled = TRUE;
+
+			// Set queue options
+			amqp_boolean_t queue_durable_admin = 0;
+			item = janus_config_get(config, config_admin, janus_config_type_item, "queue_durable_admin");
+			if(item && item->value && janus_is_true(item->value)) {
+				queue_durable_admin = 1;
+			}
+
+			amqp_boolean_t queue_exclusive_admin = 0;
+			item = janus_config_get(config, config_admin, janus_config_type_item, "queue_exclusive_admin");
+			if(item && item->value && janus_is_true(item->value)) {
+				queue_exclusive_admin = 1;
+			}
+
+			amqp_boolean_t queue_autodelete_admin = 0;
+			item = janus_config_get(config, config_admin, janus_config_type_item, "queue_autodelete_admin");
+			if(item && item->value && janus_is_true(item->value)) {
+				queue_autodelete_admin = 1;
+			}
+
 			// Case when we have a queue_name_admin, and to_janus_admin is the name of the topic to bind on (if exchange_type is topic)
 			if (queue_name_admin != NULL) {
 				JANUS_LOG(LOG_VERB, "Declaring incoming admin queue (using queue_name_admin)... (%s)\n", queue_name_admin);
 				rmq_client->to_janus_admin_queue = amqp_cstring_bytes(queue_name_admin);
-				amqp_queue_declare(rmq_client->rmq_conn, rmq_client->rmq_channel, rmq_client->to_janus_admin_queue, 0, 0, 0, 0, amqp_empty_table);
+				amqp_queue_declare(rmq_client->rmq_conn, rmq_client->rmq_channel, rmq_client->to_janus_admin_queue, 0, queue_durable_admin, queue_exclusive_admin, queue_autodelete_admin, amqp_empty_table);
 				result = amqp_get_rpc_reply(rmq_client->rmq_conn);
 				if(result.reply_type != AMQP_RESPONSE_NORMAL) {
 					JANUS_LOG(LOG_FATAL, "Can't connect to RabbitMQ server: error declaring queue... %s, %s\n", amqp_error_string2(result.library_error), amqp_method_name(result.reply.id));
@@ -531,7 +571,7 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 			} else {
 				JANUS_LOG(LOG_VERB, "Declaring incoming admin queue (using to_janus_admin)... (%s)\n", to_janus_admin);
 				rmq_client->to_janus_admin_queue = amqp_cstring_bytes(to_janus_admin);
-				amqp_queue_declare(rmq_client->rmq_conn, rmq_client->rmq_channel, rmq_client->to_janus_admin_queue, 0, 0, 0, 0, amqp_empty_table);
+				amqp_queue_declare(rmq_client->rmq_conn, rmq_client->rmq_channel, rmq_client->to_janus_admin_queue, 0, queue_durable_admin, queue_exclusive_admin, queue_autodelete_admin, amqp_empty_table);
 				result = amqp_get_rpc_reply(rmq_client->rmq_conn);
 				if(result.reply_type != AMQP_RESPONSE_NORMAL) {
 					JANUS_LOG(LOG_FATAL, "Can't connect to RabbitMQ server: error declaring queue... %s, %s\n", amqp_error_string2(result.library_error), amqp_method_name(result.reply.id));

--- a/transports/janus_rabbitmq.c
+++ b/transports/janus_rabbitmq.c
@@ -839,17 +839,10 @@ void *janus_rmq_in_thread(void *data) {
 			JANUS_LOG(LOG_VERB, "Delivery #%u, %.*s\n", (unsigned) d->delivery_tag, (int) d->routing_key.len, (char *) d->routing_key.bytes);
 			/* Check if this is a Janus or Admin API request */
 			if(rmq_client->admin_api_enabled) {
-				if(d->routing_key.len == rmq_client->to_janus_admin_queue.len) {
-					size_t i=0;
+				char incoming_topic[d->routing_key.len + 2];
+				strlcpy(incoming_topic, (char *)d->routing_key.bytes, d->routing_key.len + 1); // Convert the amqp_bytes_t back to char*
+				if (strcmp(incoming_topic, to_janus_admin) == 0) {
 					admin = TRUE;
-					char *inq = (char *)d->routing_key.bytes;
-					char *expq = (char *)rmq_client->to_janus_admin_queue.bytes;
-					for(i=0; i< d->routing_key.len; i++) {
-						if(inq[i] != expq[i]) {
-							admin = FALSE;
-							break;
-						}
-					}
 				}
 			}
 			JANUS_LOG(LOG_VERB, "  -- This is %s API request\n", admin ? "an admin" : "a Janus");

--- a/transports/janus_rabbitmq.c
+++ b/transports/janus_rabbitmq.c
@@ -465,7 +465,7 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 			rmq_client->janus_api_enabled = TRUE;
 			// Case when we have a queue_name, and to_janus is the name of the topic to bind on (if exchange_type is topic)
 			if (queue_name != NULL) {
-				JANUS_LOG(LOG_VERB, "Declaring incoming queue... (%s)\n", queue_name);
+				JANUS_LOG(LOG_VERB, "Declaring incoming queue (using queue_name)... (%s)\n", queue_name);
 				rmq_client->to_janus_queue = amqp_cstring_bytes(queue_name);
 				amqp_queue_declare(rmq_client->rmq_conn, rmq_client->rmq_channel, rmq_client->to_janus_queue, 0, 0, 0, 0, amqp_empty_table);
 				result = amqp_get_rpc_reply(rmq_client->rmq_conn);
@@ -486,7 +486,7 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 
 			// Case when to_janus is the name of the queue (and there's no binding)
 			} else {
-				JANUS_LOG(LOG_VERB, "Declaring incoming queue... (%s)\n", to_janus);
+				JANUS_LOG(LOG_VERB, "Declaring incoming queue (using to_janus)... (%s)\n", to_janus);
 				rmq_client->to_janus_queue = amqp_cstring_bytes(to_janus);
 				amqp_queue_declare(rmq_client->rmq_conn, rmq_client->rmq_channel, rmq_client->to_janus_queue, 0, 0, 0, 0, amqp_empty_table);
 				result = amqp_get_rpc_reply(rmq_client->rmq_conn);
@@ -508,7 +508,7 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 			rmq_client->admin_api_enabled = TRUE;
 			// Case when we have a queue_name_admin, and to_janus_admin is the name of the topic to bind on (if exchange_type is topic)
 			if (queue_name_admin != NULL) {
-				JANUS_LOG(LOG_VERB, "Declaring incoming queue... (%s)\n", queue_name_admin);
+				JANUS_LOG(LOG_VERB, "Declaring incoming admin queue (using queue_name_admin)... (%s)\n", queue_name_admin);
 				rmq_client->to_janus_admin_queue = amqp_cstring_bytes(queue_name_admin);
 				amqp_queue_declare(rmq_client->rmq_conn, rmq_client->rmq_channel, rmq_client->to_janus_admin_queue, 0, 0, 0, 0, amqp_empty_table);
 				result = amqp_get_rpc_reply(rmq_client->rmq_conn);
@@ -529,7 +529,7 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 
 			// Case when to_janus_admin is the name of the queue (and there's no binding
 			} else {
-				JANUS_LOG(LOG_VERB, "Declaring incoming queue... (%s)\n", to_janus_admin);
+				JANUS_LOG(LOG_VERB, "Declaring incoming admin queue (using to_janus_admin)... (%s)\n", to_janus_admin);
 				rmq_client->to_janus_admin_queue = amqp_cstring_bytes(to_janus_admin);
 				amqp_queue_declare(rmq_client->rmq_conn, rmq_client->rmq_channel, rmq_client->to_janus_admin_queue, 0, 0, 0, 0, amqp_empty_table);
 				result = amqp_get_rpc_reply(rmq_client->rmq_conn);

--- a/transports/janus_rabbitmq.c
+++ b/transports/janus_rabbitmq.c
@@ -359,7 +359,7 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 		JANUS_LOG(LOG_WARN, "RabbitMQ support disabled (Admin API)\n");
 	} else {
 		/* Parse configuration */
-		item = janus_config_get(config, config_general, janus_config_type_item, "queue_name_admin");
+		item = janus_config_get(config, config_admin, janus_config_type_item, "queue_name_admin");
 		if(item && item->value) {
 			queue_name_admin = g_strdup(item->value);
 		}


### PR DESCRIPTION
The RabbitMQ logic inside Janus followed some conventions that were non-standard. I suspect the author wasn't completely across the way AMQP is supposed to work, which is very easy to do if you don't work with it every day! (I say that from experience 💯 )

- Publishing to a topic does not require an outgoing queue, just the topic, so the outgoing queues are no longer declared
- When the janus_exchange_type is topic, we want to be able to name the queue, and then bind an incoming topic from the exchange to that queue, so that functionality has been added (see `queue_name` variable)
- Adds options to allow configuring the following queue options: `durable`, `autodelete`, `exclusive`
- This is all backwards compatible, and won't break existing applications

I understand this is quite a big change, so happy to discuss it in depth. To note also I've moved some of the logic/config around so that it follows exchange/queue/topic process

I'm also still fully testing this, but wanted to open the PR to get initial feedback