### PR TITLE
fix: disable responses to NOTIFY requests in janus_sip plugin (response is already handled in sofia-sip)

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -5092,9 +5092,6 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, notify, NULL);
 			JANUS_LOG(LOG_VERB, "  >> Pushing event to peer: %d (%s)\n", ret, janus_get_api_error(ret));
 			json_decref(notify);
-			/* Sending a 200 back will trigger a 'Responding to a Non-Existing Request' error
-			 * in sofia-sip since response is already handled internally */
-			//nua_respond(nh, 200, sip_status_phrase(200), TAG_END());
 			break;
 		}
 		case nua_i_options:

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -5092,8 +5092,9 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, notify, NULL);
 			JANUS_LOG(LOG_VERB, "  >> Pushing event to peer: %d (%s)\n", ret, janus_get_api_error(ret));
 			json_decref(notify);
-			/* Send a 200 back */
-			nua_respond(nh, 200, sip_status_phrase(200), TAG_END());
+			/* Sending a 200 back will trigger a 'Responding to a Non-Existing Request' error
+			 * in sofia-sip since response is already handled internally */
+			//nua_respond(nh, 200, sip_status_phrase(200), TAG_END());
 			break;
 		}
 		case nua_i_options:


### PR DESCRIPTION
This PR disable unecessary response tos `NOTIFY` request in `janus_sip.c`. Responses are already automatically handled by *sofia-sip*

In current [master](https://github.com/meetecho/janus-gateway/blob/8491eb860bf7fdcee94b5fdec9e9e430fbe2421c/plugins/janus_sip.c#L5096), responses to `NOTIFY` request are triggered from *Janus*. When running *Janus* with environment variable `NUA_DEBUG=9`, following logs can be observed

```
1>	 Compiled on:  Wed Nov 18 15:53:50 CET 2020
2>	 
3>	 Logger plugins folder: /usr/local/janus/lib/janus/loggers
4>	 ---------------------------------------------------
5>	   Starting Meetecho Janus (WebRTC Server) v0.10.7
6>	 ---------------------------------------------------
7>	 
8>	 Checking command line arguments...  
9>	 Debug/log level is 3
10>	 Debug/log timestamps are enabled
11>	 Debug/log colors are disabled
12>	 [Wed Nov 18 16:15:40 2020] [WARN] Session timeouts have been disabled (note, may result in orphaned sessions)
13>	 [Wed Nov 18 16:15:40 2020] [WARN] Token based authentication disabled
14>	 [Wed Nov 18 16:15:40 2020] [WARN] The libsrtp installation does not support AES-GCM profiles
15>	 [Wed Nov 18 16:15:40 2020] [WARN] DTLS timeout set to 500 ms, but not using BoringSSL: ignoring
16>	 [Wed Nov 18 16:15:40 2020] [WARN] Event handlers support disabled
17>	 [Wed Nov 18 16:15:40 2020] [WARN] Plugin 'libjanus_audiobridge.so' has been disabled, skipping...
18>	 [Wed Nov 18 16:15:40 2020] [WARN] Plugin 'libjanus_echotest.so' has been disabled, skipping...
19>	 [Wed Nov 18 16:15:40 2020] [WARN] Plugin 'libjanus_recordplay.so' has been disabled, skipping...
20>	 [Wed Nov 18 16:15:40 2020] [WARN] Plugin 'libjanus_nosip.so' has been disabled, skipping...
21>	 [Wed Nov 18 16:15:40 2020] [WARN] Plugin 'libjanus_streaming.so' has been disabled, skipping...
22>	 [Wed Nov 18 16:15:40 2020] [WARN] Plugin 'libjanus_videocall.so' has been disabled, skipping...
23>	 [Wed Nov 18 16:15:40 2020] [WARN] Plugin 'libjanus_textroom.so' has been disabled, skipping...
24>	 [Wed Nov 18 16:15:40 2020] [WARN] Plugin 'libjanus_textroom.so' has been disabled, skipping...
25>	 [Wed Nov 18 16:15:40 2020] [WARN] Plugin 'libjanus_videoroom.so' has been disabled, skipping...
26>	 [Wed Nov 18 16:15:40 2020] [WARN] Plugin 'libjanus_voicemail.so' has been disabled, skipping...
27>	 [Wed Nov 18 16:15:40 2020] [WARN] Transport plugin 'libjanus_pfunix.so' has been disabled, skipping...
28>	 [Wed Nov 18 16:15:40 2020] [WARN] libwebsockets has been built without IPv6 support, will bind to IPv4 only
29>	 [Wed Nov 18 16:15:40 2020] [WARN] Secure WebSockets server disabled
30>	 [Wed Nov 18 16:15:40 2020] [WARN] Admin WebSockets server disabled
31>	 [Wed Nov 18 16:15:40 2020] [WARN] Secure Admin WebSockets server disabled
32>	 [Wed Nov 18 16:15:40 2020] [WARN] Admin/monitor HTTPS webserver disabled
33>	 nua: nua_create: entering
34>	 nua: nua_stack_init: entering
35>	 nua: nua_stack_set_params: entering 
36>	 nua_register: Adding contact URL '192.168.84.87' to list.
37>	 nua: nh_create_handle: entering
38>	 nua: nua_register: entering
39>	 nua(0x7f18e8001800): sent signal r_register
40>	 nua(0x7f18e8001800): recv signal r_register
41>	 nua: nua_stack_set_params: entering 
42>	 nua(0x7f18e8001800): adding register usage
43>	 nua: nua_application_event: entering
44>	 nua(0x7f18e8001800): event r_register 401 Unauthorized
45>	 nua: nua_application_event: entering
46>	 nua: nua_authenticate: entering
47>	 nua(0x7f18e8001800): sent signal r_authenticate
48>	 nua(0x7f18e8001800): recv signal r_authenticate
49>	 nua(): refresh register after 1971 seconds (in [900..2700])
50>	 nua(0x7f18e8001800): event r_register 200 OK
51>	 nua: nua_application_event: entering
52>	 nua: nua_stack_process_request: entering
53>	 nua: nh_create: entering
54>	 nua: nh_create_handle: entering
55>	 nua: nua_stack_set_params: entering 
56>	 nua(0x7f18e000d6f0): adding session usage
57>	 nua(0x7f18e000d6f0): event i_invite 100 Trying
58>	 nua: nua_application_event: entering
59>	 nua(0x7f18e000d6f0): call state changed: init -> received, received offer
60>	 nua(0x7f18e000d6f0): event i_state 100 Trying
61>	 nua: nua_respond: entering
62>	 nua(0x7f18e000d6f0): sent signal r_respond
63>	 nua: nua_application_event: entering
64>	 nua(0x7f18e000d6f0): recv signal r_respond 180 Ringing
65>	 nua: nua_stack_set_params: entering 
66>	 nua: nua_invite_server_respond: entering
67>	 nua(0x7f18e000d6f0): call state changed: received -> early
68>	 nua(0x7f18e000d6f0): event i_state 180 Ringing
69>	 nua: nua_application_event: entering
70>	 nua: nua_respond: entering
71>	 nua(0x7f18e000d6f0): sent signal r_respond
72>	 nua(0x7f18e000d6f0): recv signal r_respond 200 OK
73>	 nua: nua_stack_set_params: entering 
74>	 nua: nua_invite_server_respond: entering
75>	 nua(0x7f18e000d6f0): call state changed: early -> completed, sent answer
76>	 nua(0x7f18e000d6f0): event i_state 200 OK
77>	 nua: nua_application_event: entering
78>	 nua: process_ack_or_cancel: entering
79>	 nua(0x7f18e000d6f0): event i_ack 200 OK
80>	 nua: nua_application_event: entering
81>	 nua(0x7f18e000d6f0): call state changed: completed -> ready
82>	 nua(0x7f18e000d6f0): event i_state 200 OK
83>	 nua: nua_application_event: entering
84>	 nua(0x7f18e000d6f0): event i_active 200 Call active
85>	 nua: nua_application_event: entering
86>	 nua: nua_refer: entering
87>	 nua(0x7f18e000d6f0): sent signal r_refer
88>	 nua(0x7f18e000d6f0): recv signal r_refer
89>	 nua: nua_stack_set_params: entering 
90>	 nua(0x7f18e000d6f0): adding subscribe usage with event refer
91>	 nua(0x7f18e000d6f0): event r_refer 100 Trying
92>	 nua: nua_application_event: entering
93>	 nua(0x7f18e000d6f0): event r_refer 202 Accepted
94>	 nua: nua_application_event: entering
95>	 nua: nua_stack_process_request: entering
96>	 nua(0x7f18e000d6f0): nua_notify_server_preprocess: terminated (noresource)
97>	 nua(0x7f18e000d6f0): event i_notify 200 OK
98>	 nua(0x7f18e000d6f0): removing subscribe usage with event refer
99>	 nua(0x7f18e000d6f0): handle with session and
100>	 nua: nua_application_event: entering
101>	 nua: nua_respond: entering
102>	 nua(0x7f18e000d6f0): sent signal r_respond
103>	 nua(0x7f18e000d6f0): recv signal r_respond 200 OK
104>	 nua(0x7f18e000d6f0): event i_error 500 Responding to a Non-Existing Request
105>	 nua: nua_application_event: entering
106>	 [Wed Nov 18 16:16:20 2020] [WARN] [997102801110][nua_i_error]: 500 Responding to a Non-Existing Request
107>	 ^CStopping server, please wait...   
108>	 Bye!
109>	
```
* on line 97, log indicates that 200 response was handled by *sofia-sip*
* on line 103, log indicates that another 200 response was requested [(triggered by *Janus*](https://github.com/meetecho/janus-gateway/blob/master/plugins/janus_sip.c#L5096))
* on line 104, log indicates an error since response was already processed

This behaviour is observed with at least *sofia-sip* version `1.12.11` (part of *debian* repo). The version hosted on [*FreeSWITCH* repo](https://github.com/freeswitch/sofia-sip/blob/33974b9bd24c2a25d514b3d5372263115f28c525/libsofia-sip-ua/nua/nua_subnotref.c#L641) seems to also handle responses to `NOTIFY` requests internally
