### PR TITLE
Fix incompatible-pointer-types compiler warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -522,6 +522,13 @@ PKG_CHECK_MODULES([MHD],
 AC_SUBST([MHD_CFLAGS])
 AC_SUBST([MHD_LIBS])
 AM_CONDITIONAL([ENABLE_REST], [test "x$enable_rest" = "xyes"])
+AM_COND_IF([ENABLE_REST],
+           [
+             AC_CHECK_TYPES([enum MHD_Result],
+                            [],
+                            [],
+                            [#include <microhttpd.h>])
+           ])
 
 AC_CHECK_LIB([websockets],
 			 [lws_create_vhost],

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -35,6 +35,13 @@
 #include <netdb.h>
 
 #include <microhttpd.h>
+#ifdef HAVE_ENUM_MHD_RESULT
+	/* enum MHD_Result introduced in libmicrohttpd v0.9.71 */
+	typedef enum MHD_Result MHD_Result;
+#else
+	typedef int MHD_Result;
+#endif
+
 
 #include "../debug.h"
 #include "../apierror.h"
@@ -252,17 +259,17 @@ static GSource *janus_http_request_timeout_create(janus_transport_session *ts, j
 
 
 /* Callback (libmicrohttpd) invoked when a new connection is attempted on the REST API */
-static int janus_http_client_connect(void *cls, const struct sockaddr *addr, socklen_t addrlen);
+static MHD_Result janus_http_client_connect(void *cls, const struct sockaddr *addr, socklen_t addrlen);
 /* Callback (libmicrohttpd) invoked when a new connection is attempted on the admin/monitor webserver */
-static int janus_http_admin_client_connect(void *cls, const struct sockaddr *addr, socklen_t addrlen);
+static MHD_Result janus_http_admin_client_connect(void *cls, const struct sockaddr *addr, socklen_t addrlen);
 /* Callback (libmicrohttpd) invoked when an HTTP message (GET, POST, OPTIONS, etc.) is available */
-static int janus_http_handler(void *cls, struct MHD_Connection *connection,
+static MHD_Result janus_http_handler(void *cls, struct MHD_Connection *connection,
 	const char *url, const char *method, const char *version, const char *upload_data, size_t *upload_data_size, void **ptr);
 /* Callback (libmicrohttpd) invoked when an admin/monitor HTTP message (GET, POST, OPTIONS, etc.) is available */
-static int janus_http_admin_handler(void *cls, struct MHD_Connection *connection,
+static MHD_Result janus_http_admin_handler(void *cls, struct MHD_Connection *connection,
 	const char *url, const char *method, const char *version, const char *upload_data, size_t *upload_data_size, void **ptr);
 /* Callback (libmicrohttpd) invoked when headers of an incoming HTTP message have been parsed */
-static int janus_http_headers(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
+static MHD_Result janus_http_headers(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
 /* Callback (libmicrohttpd) invoked when a request has been processed and can be freed */
 static void janus_http_request_completed(void *cls, struct MHD_Connection *connection,
 	void **con_cls, enum MHD_RequestTerminationCode toe);
@@ -271,9 +278,9 @@ static ssize_t janus_http_response_callback(void *cls, uint64_t pos, char *buf, 
 /* Worker to handle requests that are actually long polls */
 static int janus_http_notifier(janus_http_msg *msg);
 /* Helper to quickly send a success response */
-static int janus_http_return_success(janus_transport_session *ts, char *payload);
+static MHD_Result janus_http_return_success(janus_transport_session *ts, char *payload);
 /* Helper to quickly send an error response */
-static int janus_http_return_error(janus_transport_session *ts, uint64_t session_id,
+static MHD_Result janus_http_return_error(janus_transport_session *ts, uint64_t session_id,
 	const char *transaction, gint error, const char *format, ...) G_GNUC_PRINTF(5, 6);
 
 
@@ -1275,7 +1282,7 @@ plugin_response:
 }
 
 /* Connection notifiers */
-static int janus_http_client_connect(void *cls, const struct sockaddr *addr, socklen_t addrlen) {
+static MHD_Result janus_http_client_connect(void *cls, const struct sockaddr *addr, socklen_t addrlen) {
 	janus_network_address naddr;
 	janus_network_address_string_buffer naddr_buf;
 	if(janus_network_address_from_sockaddr((struct sockaddr *)addr, &naddr) != 0 ||
@@ -1294,7 +1301,7 @@ static int janus_http_client_connect(void *cls, const struct sockaddr *addr, soc
 	return MHD_YES;
 }
 
-static int janus_http_admin_client_connect(void *cls, const struct sockaddr *addr, socklen_t addrlen) {
+static MHD_Result janus_http_admin_client_connect(void *cls, const struct sockaddr *addr, socklen_t addrlen) {
 	janus_network_address naddr;
 	janus_network_address_string_buffer naddr_buf;
 	if(janus_network_address_from_sockaddr((struct sockaddr *)addr, &naddr) != 0 ||
@@ -1315,7 +1322,7 @@ static int janus_http_admin_client_connect(void *cls, const struct sockaddr *add
 
 
 /* WebServer requests handler */
-static int janus_http_handler(void *cls, struct MHD_Connection *connection,
+static MHD_Result janus_http_handler(void *cls, struct MHD_Connection *connection,
 		const char *url, const char *method, const char *version,
 		const char *upload_data, size_t *upload_data_size, void **ptr) {
 	if(!g_atomic_int_get(&initialized) || g_atomic_int_get(&stopping))
@@ -1711,7 +1718,7 @@ done:
 }
 
 /* Admin/monitor WebServer requests handler */
-static int janus_http_admin_handler(void *cls, struct MHD_Connection *connection,
+static MHD_Result janus_http_admin_handler(void *cls, struct MHD_Connection *connection,
 		const char *url, const char *method, const char *version,
 		const char *upload_data, size_t *upload_data_size, void **ptr) {
 	if(!g_atomic_int_get(&initialized) || g_atomic_int_get(&stopping))
@@ -1960,7 +1967,7 @@ done:
 	return ret;
 }
 
-static int janus_http_headers(void *cls, enum MHD_ValueKind kind, const char *key, const char *value) {
+static MHD_Result janus_http_headers(void *cls, enum MHD_ValueKind kind, const char *key, const char *value) {
 	janus_http_msg *request = (janus_http_msg *)cls;
 	JANUS_LOG(LOG_DBG, "%s: %s\n", key, value);
 	if(!request)
@@ -2101,7 +2108,7 @@ static int janus_http_notifier(janus_http_msg *msg) {
 }
 
 /* Helper to quickly send a success response */
-static int janus_http_return_success(janus_transport_session *ts, char *payload) {
+static MHD_Result janus_http_return_success(janus_transport_session *ts, char *payload) {
 	if(!ts) {
 		g_free(payload);
 		return MHD_NO;
@@ -2125,7 +2132,7 @@ static int janus_http_return_success(janus_transport_session *ts, char *payload)
 }
 
 /* Helper to quickly send an error response */
-static int janus_http_return_error(janus_transport_session *ts, uint64_t session_id,
+static MHD_Result janus_http_return_error(janus_transport_session *ts, uint64_t session_id,
 		const char *transaction, gint error, const char *format, ...) {
 	gchar *error_string = NULL;
 	gchar error_buf[512];


### PR DESCRIPTION
Continuing on from #2437 
> An alternative might be making your change, but also define MHD_Result to int if it doesn't exist.

Good idea. How about this new PR?