### PR TITLE
Cleanup calls to setsockopt et al

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -1829,8 +1829,7 @@ static int janus_audiobridge_create_udp_socket_if_needed(janus_audiobridge_room 
 		JANUS_LOG(LOG_ERR, "Could not open UDP socket for RTP forwarder (room %s)\n", audiobridge->room_id_str);
 		return -1;
 	}
-	int v6only = 0;
-	if(setsockopt(audiobridge->rtp_udp_sock, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) != 0) {
+	if(setsockopt(audiobridge->rtp_udp_sock, IPPROTO_IPV6, IPV6_V6ONLY, &(int){0}, sizeof(int)) != 0) {
 		JANUS_LOG(LOG_ERR, "Could not open UDP socket for RTP forwarder (room %s)\n", audiobridge->room_id_str);
 		return -1;
 	}

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -5415,8 +5415,7 @@ static int janus_streaming_create_fd(int port, in_addr_t mcast, const janus_netw
 					break;
 				}
 #ifdef IP_MULTICAST_ALL
-				int mc_all = 0;
-				if((setsockopt(fd, IPPROTO_IP, IP_MULTICAST_ALL, (void*) &mc_all, sizeof(mc_all))) < 0) {
+				if((setsockopt(fd, IPPROTO_IP, IP_MULTICAST_ALL, &(int){0}, sizeof(int))) < 0) {
 					JANUS_LOG(LOG_ERR, "[%s] %s listener setsockopt IP_MULTICAST_ALL failed... %d (%s)\n",
 						mountpointname, listenername, errno, strerror(errno));
 					close(fd);

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1866,8 +1866,7 @@ static guint32 janus_videoroom_rtp_forwarder_add_helper(janus_videoroom_publishe
 				errno, strerror(errno));
 			return 0;
 		}
-		int v6only = 0;
-		if(setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) != 0) {
+		if(setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &(int){0}, sizeof(int)) != 0) {
 			janus_mutex_unlock(&p->rtp_forwarders_mutex);
 			JANUS_LOG(LOG_ERR, "Error creating RTCP socket for new RTP forwarder... %d (%s)\n",
 				errno, strerror(errno));
@@ -3874,9 +3873,8 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 		janus_refcount_increase(&publisher->ref);	/* This is just to handle the request for now */
 		if(publisher->udp_sock <= 0) {
 			publisher->udp_sock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
-			int v6only = 0;
 			if(publisher->udp_sock <= 0 ||
-					setsockopt(publisher->udp_sock, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) != 0) {
+					setsockopt(publisher->udp_sock, IPPROTO_IPV6, IPV6_V6ONLY, &(int){0}, sizeof(int)) != 0) {
 				janus_refcount_decrease(&publisher->ref);
 				janus_mutex_unlock(&videoroom->mutex);
 				janus_refcount_decrease(&videoroom->ref);

--- a/sctp.c
+++ b/sctp.c
@@ -259,26 +259,19 @@ janus_sctp_association *janus_sctp_association_create(janus_dtls_srtp *dtls, jan
 		return NULL;
 	}
 	/* Set SO_LINGER */
-	struct linger linger_opt;
-	linger_opt.l_onoff = 1;
-	linger_opt.l_linger = 0;
-	if(usrsctp_setsockopt(sock, SOL_SOCKET, SO_LINGER, &linger_opt, sizeof(linger_opt))) {
+	if(usrsctp_setsockopt(sock, SOL_SOCKET, SO_LINGER, &(struct linger){.l_onoff = 1, .l_linger = 0}, sizeof(struct linger))) {
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] setsockopt error: SO_LINGER (%d)\n", sctp->handle_id, errno);
 		janus_sctp_association_destroy(sctp);
 		return NULL;
 	}
 	/* Allow resetting streams */
-	struct sctp_assoc_value av;
-	av.assoc_id = SCTP_ALL_ASSOC;
-	av.assoc_value = SCTP_ENABLE_RESET_STREAM_REQ | SCTP_ENABLE_CHANGE_ASSOC_REQ;
-	if(usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_ENABLE_STREAM_RESET, &av, sizeof(struct sctp_assoc_value)) < 0) {
+	if(usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_ENABLE_STREAM_RESET, &(struct sctp_assoc_value){.assoc_id = SCTP_ALL_ASSOC, .assoc_value = SCTP_ENABLE_RESET_STREAM_REQ | SCTP_ENABLE_CHANGE_ASSOC_REQ}, sizeof(struct sctp_assoc_value)) < 0) {
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] setsockopt error: SCTP_ENABLE_STREAM_RESET (%d)\n", sctp->handle_id, errno);
 		janus_sctp_association_destroy(sctp);
 		return NULL;
 	}
 	/* Disable Nagle */
-	uint32_t nodelay = 1;
-	if(usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_NODELAY, &nodelay, sizeof(nodelay))) {
+	if(usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_NODELAY, &(uint32_t){ 1 }, sizeof(uint32_t))) {
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] setsockopt error: SCTP_NODELAY (%d)\n", sctp->handle_id, errno);
 		janus_sctp_association_destroy(sctp);
 		return NULL;


### PR DESCRIPTION
For constants, we can directly use anonymous arrays in C for calls to setsockopt and similar instead of declaring variables that aren't used otherwise..