### PR TITLE
Added configurable mechanism for manually setting static event loop to use for new handles

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -105,6 +105,18 @@ general: {
 									# As such, if you want to use this you should
 									# provision the correct value according to the
 									# available resources (e.g., CPUs available).
+	#allow_loop_indication = true	# In case a static number of event loops is
+									# configured as explained above, by default
+									# new handles will be allocated on one loop or
+									# another by the Janus core itself. In some cases
+									# it may be helpful to manually tell the Janus
+									# core which loop a handle should be added to,
+									# e.g., to group viewers of the same stream on
+									# the same loop. This is possible via the Janus
+									# API when performing the 'attach' request, but
+									# only if allow_loop_indication is set to true;
+									# it's set to false by default to avoid abuses.
+									# Don't change if you don't know what you're doing!
 	#opaqueid_in_api = true			# Opaque IDs set by applications are typically
 									# only passed to event handlers for correlation
 									# purposes, but not sent back to the user or

--- a/html/janus.js
+++ b/html/janus.js
@@ -1173,9 +1173,10 @@ function Janus(gatewayCallbacks) {
 			return;
 		}
 		var opaqueId = callbacks.opaqueId;
+		var loopIndex = callbacks.loopIndex;
 		var handleToken = callbacks.token ? callbacks.token : token;
 		var transaction = Janus.randomString(12);
-		var request = { "janus": "attach", "plugin": plugin, "opaque_id": opaqueId, "transaction": transaction };
+		var request = { "janus": "attach", "plugin": plugin, "opaque_id": opaqueId, "loop_index": loopIndex, "transaction": transaction };
 		if(handleToken)
 			request["token"] = handleToken;
 		if(apisecret)

--- a/ice.c
+++ b/ice.c
@@ -120,6 +120,7 @@ typedef struct janus_ice_static_event_loop {
 	GThread *thread;
 } janus_ice_static_event_loop;
 static int static_event_loops = 0;
+static gboolean allow_loop_indication = FALSE;
 static GSList *event_loops = NULL, *current_loop = NULL;
 static janus_mutex event_loops_mutex = JANUS_MUTEX_INITIALIZER;
 static void *janus_ice_static_event_loop_thread(void *data) {
@@ -141,7 +142,7 @@ static void *janus_ice_static_event_loop_thread(void *data) {
 int janus_ice_get_static_event_loops(void) {
 	return static_event_loops;
 }
-void janus_ice_set_static_event_loops(int loops) {
+void janus_ice_set_static_event_loops(int loops, gboolean allow_api) {
 	if(loops == 0)
 		return;
 	else if(loops < 1) {
@@ -174,6 +175,9 @@ void janus_ice_set_static_event_loops(int loops) {
 	}
 	current_loop = event_loops;
 	JANUS_LOG(LOG_INFO, "Spawned %d static event loops (handles won't have a dedicated loop)\n", static_event_loops);
+	allow_loop_indication = allow_api;
+	JANUS_LOG(LOG_INFO, "  -- Janus API %s be able to drive the loop choice for new handles\n",
+		allow_loop_indication ? "will" : "will NOT");
 	return;
 }
 void janus_ice_stop_static_event_loops(void) {
@@ -1231,7 +1235,7 @@ janus_ice_handle *janus_ice_handle_create(void *core_session, const char *opaque
 	return handle;
 }
 
-gint janus_ice_handle_attach_plugin(void *core_session, janus_ice_handle *handle, janus_plugin *plugin) {
+gint janus_ice_handle_attach_plugin(void *core_session, janus_ice_handle *handle, janus_plugin *plugin, int loop_index) {
 	if(core_session == NULL)
 		return JANUS_ERROR_SESSION_NOT_FOUND;
 	janus_session *session = (janus_session *)core_session;
@@ -1270,14 +1274,34 @@ gint janus_ice_handle_attach_plugin(void *core_session, janus_ice_handle *handle
 		handle->mainloop = g_main_loop_new(handle->mainctx, FALSE);
 	} else {
 		/* We're actually using static event loops, pick one from the list */
+		if(!allow_loop_indication && loop_index > -1) {
+			JANUS_LOG(LOG_WARN, "[%"SCNu64"] Manual allocation of event loops forbidden, ignoring provided loop index %d\n", handle->handle_id, loop_index);
+		}
 		janus_refcount_increase(&handle->ref);
 		janus_mutex_lock(&event_loops_mutex);
-		janus_ice_static_event_loop *loop = (janus_ice_static_event_loop *)current_loop->data;
-		handle->mainctx = loop->mainctx;
-		handle->mainloop = loop->mainloop;
-		current_loop = current_loop->next;
-		if(current_loop == NULL)
-			current_loop = event_loops;
+		gboolean automatic_selection = TRUE;
+		if(allow_loop_indication && loop_index != -1) {
+			/* The API can drive the selection and an index was provided, check if it exists */
+			janus_ice_static_event_loop *loop = g_slist_nth_data(event_loops, loop_index);
+			if(loop == NULL) {
+				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Invalid loop index %d, picking event loop automatically\n", handle->handle_id, loop_index);
+			} else {
+				automatic_selection = FALSE;
+				handle->mainctx = loop->mainctx;
+				handle->mainloop = loop->mainloop;
+				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Manually added handle to loop #%d\n", handle->handle_id, loop->id);
+			}
+		}
+		if(automatic_selection) {
+			/* Pick an available loop automatically (round robin) */
+			janus_ice_static_event_loop *loop = (janus_ice_static_event_loop *)current_loop->data;
+			handle->mainctx = loop->mainctx;
+			handle->mainloop = loop->mainloop;
+			current_loop = current_loop->next;
+			if(current_loop == NULL)
+				current_loop = event_loops;
+			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Automatically added handle to loop #%d\n", handle->handle_id, loop->id);
+		}
 		janus_mutex_unlock(&event_loops_mutex);
 	}
 	handle->rtp_source = janus_ice_outgoing_traffic_create(handle, (GDestroyNotify)g_free);

--- a/ice.h
+++ b/ice.h
@@ -609,8 +609,10 @@ janus_ice_handle *janus_ice_handle_create(void *core_session, const char *opaque
  * @param[in] core_session The core/peer session this ICE handle belongs to
  * @param[in] handle The Janus ICE handle
  * @param[in] plugin The plugin the ICE handle needs to be attached to
+ * @param[in] loop_index In case static event loops are used, an indication on which loop to use for this handle
+ * (-1 will let the core pick one; in case API selection is disabled in the settings, this value is ignored)
  * @returns 0 in case of success, a negative integer otherwise */
-gint janus_ice_handle_attach_plugin(void *core_session, janus_ice_handle *handle, janus_plugin *plugin);
+gint janus_ice_handle_attach_plugin(void *core_session, janus_ice_handle *handle, janus_plugin *plugin, int loop_index);
 /*! \brief Method to destroy a Janus ICE handle
  * @param[in] core_session The core/peer session this ICE handle belongs to
  * @param[in] handle The Janus ICE handle to destroy
@@ -714,8 +716,9 @@ void janus_ice_resend_trickles(janus_ice_handle *handle);
 /*! \brief Method to configure the static event loops mechanism at startup
  * @note Check the \c event_loops property in the \c janus.jcfg configuration
  * for an explanation of this feature, and the possible impact on Janus and users
- * @param[in] loops The number of static event loops to start (0 to disable the feature) */
-void janus_ice_set_static_event_loops(int loops);
+ * @param[in] loops The number of static event loops to start (0 to disable the feature)
+ * @param[in] allow_api Whether allocation on a specific loop driven via API should be allowed or not (false by default) */
+void janus_ice_set_static_event_loops(int loops, gboolean allow_api);
 /*! \brief Method to return the number of static event loops, if enabled
  * @returns The number of static event loops, if configured, or 0 if the feature is disabled */
 int janus_ice_get_static_event_loops(void);

--- a/janus.c
+++ b/janus.c
@@ -96,6 +96,7 @@ static struct janus_json_parameter incoming_request_parameters[] = {
 static struct janus_json_parameter attach_parameters[] = {
 	{"plugin", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
 	{"opaque_id", JSON_STRING, 0},
+	{"loop_index", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 };
 static struct janus_json_parameter body_parameters[] = {
 	{"body", JSON_OBJECT, JANUS_JSON_PARAM_REQUIRED}
@@ -1170,6 +1171,8 @@ int janus_process_incoming_request(janus_request *request) {
 		}
 		json_t *opaque = json_object_get(root, "opaque_id");
 		const char *opaque_id = opaque ? json_string_value(opaque) : NULL;
+		json_t *loop = json_object_get(root, "loop_index");
+		int loop_index = loop ? json_integer_value(loop) : -1;
 		/* Create handle */
 		handle = janus_ice_handle_create(session, opaque_id, token_value);
 		if(handle == NULL) {
@@ -1181,7 +1184,7 @@ int janus_process_incoming_request(janus_request *request) {
 		janus_refcount_increase(&handle->ref);
 		/* Attach to the plugin */
 		int error = 0;
-		if((error = janus_ice_handle_attach_plugin(session, handle, plugin_t)) != 0) {
+		if((error = janus_ice_handle_attach_plugin(session, handle, plugin_t, loop_index)) != 0) {
 			/* TODO Make error struct to pass verbose information */
 			janus_session_handles_remove(session, handle);
 			JANUS_LOG(LOG_ERR, "Couldn't attach to plugin '%s', error '%d'\n", plugin_text, error);
@@ -4760,8 +4763,15 @@ gint main(int argc, char *argv[])
 #endif
 	/* Do we need a limited number of static event loops, or is it ok to have one per handle (the default)? */
 	item = janus_config_get(config, config_general, janus_config_type_item, "event_loops");
-	if(item && item->value)
-		janus_ice_set_static_event_loops(atoi(item->value));
+	if(item && item->value) {
+		int loops = atoi(item->value);
+		/* Check if we should allow API calls to specify which loops to use for new handles */
+		gboolean loops_api = FALSE;
+		item = janus_config_get(config, config_general, janus_config_type_item, "allow_loop_indication");
+		if(item && item->value)
+			loops_api = janus_is_true(item->value);
+		janus_ice_set_static_event_loops(loops, loops_api);
+	}
 	/* Initialize the ICE stack now */
 	janus_ice_init(ice_lite, ice_tcp, full_trickle, ignore_mdns, ipv6, rtp_min_port, rtp_max_port);
 	if(janus_ice_set_stun_server(stun_server, stun_port) < 0) {


### PR DESCRIPTION
For some context, please refer to the exchange [this comment](https://github.com/meetecho/janus-gateway/pull/2295#issuecomment-709337448) belongs to, as it's where the idea came from.

To summarize, normally when you use the static `event_loops` configuration, new handles are automatically added to loops following a round robin distribution. This patch allows you to configure Janus so that you can also optionally use the Janus API itself to tell the core which loop a new handle you're attaching should be added to. The discussion above provides some information on why it may be useful in some cases.

To enable the functionality, `event_loops` must be configured, and `allow_loop_indication` set to `true` (it's `false` by default). In that case, adding a `loop_index` to an `attach` request will instruct the core to manually add the handle to the specified core, rather than doing it automatically. Providing an invalid index will fall back to round robin.

This PR is based on the `sendmmsg` branch, as #2295 is where we're trying to work on most optimizations. Please test and provide feedback, as that's the fastest way to get this merged soon.