### PR TITLE
[janus-pp-rec] Add in-band opus FEC support.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -610,7 +610,7 @@ janus_pp_rec_CFLAGS = \
 
 janus_pp_rec_LDADD = \
 	$(POST_PROCESSING_LIBS) \
-	$(LIBCURL_LDFLAGS) $(LIBCURL_LIBS) \
+	$(LIBCURL_LDFLAGS) $(LIBCURL_LIBS) $(OPUS_LDFLAGS) $(OPUS_LIBS) \
 	$(NULL)
 
 BUILT_SOURCES += postprocessing/pp-cmdline.c postprocessing/pp-cmdline.h

--- a/configure.ac
+++ b/configure.ac
@@ -770,6 +770,7 @@ AC_SUBST([SOFIA_LIBS])
 PKG_CHECK_MODULES([OPUS],
                   [opus],
                   [
+                    AC_DEFINE(HAVE_LIBOPUS)
                     AS_IF([test "x$enable_plugin_audiobridge" = "xmaybe"],
                           [enable_plugin_audiobridge=yes])
                   ],

--- a/postprocessing/janus-pp-rec.1
+++ b/postprocessing/janus-pp-rec.1
@@ -59,6 +59,8 @@ For mp4 files write the MOOV atom at the head of the file  (default=off)
 .TP
 .BR \-S ", " \-\-audioskew=milliseconds
 Time threshold to trigger an audio skew compensation, disabled if 0 (default=0)
+.BR \-F ", " \-\-fec
+For opus content, try to use in-band FEC data to recover lost packets (default=off)
 .SH EXAMPLES
 \fBjanus-pp-rec \-\-header rec1234.mjr\fR \- Parse the recordings header (shows metadata info)
 .TP

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -75,6 +75,8 @@ Usage: janus-pp-rec [OPTIONS] source.mjr [destination.[opus|wav|webm|mp4|srt]]
                                   of the file  (default=off)
   -S, --audioskew=milliseconds  Time threshold to trigger an audio skew
                                   compensation, disabled if 0 (default=0)
+  -F, --fec                     For opus content, try to use in-band FEC data
+                                  to recover lost packets (default=off)
 \endverbatim
  *
  * \note This utility does not do any form of transcoding. It just
@@ -136,6 +138,7 @@ static int ignore_first_packets = 0;
 #define DEFAULT_AUDIO_SKEW_TH 0
 static int audioskew_th = DEFAULT_AUDIO_SKEW_TH;
 
+static gboolean enable_opus_fec = FALSE;
 
 /* Signal handler */
 static void janus_pp_handle_signal(int signum) {
@@ -225,6 +228,8 @@ int main(int argc, char *argv[])
 		if(val >= 0)
 			audioskew_th = val;
 	}
+	if(args_info.fec_given)
+		enable_opus_fec = TRUE;
 
 	/* Evaluate arguments to find source and target */
 	char *source = NULL, *destination = NULL, *setting = NULL;
@@ -1040,7 +1045,7 @@ int main(int argc, char *argv[])
 
 	if(!video && !data) {
 		if(opus) {
-			if(janus_pp_opus_create(destination, metadata) < 0) {
+			if(janus_pp_opus_create(destination, enable_opus_fec, metadata) < 0) {
 				JANUS_LOG(LOG_ERR, "Error creating .opus file...\n");
 				cmdline_parser_free(&args_info);
 				exit(1);

--- a/postprocessing/janus-pp-rec.ggo
+++ b/postprocessing/janus-pp-rec.ggo
@@ -14,3 +14,4 @@ option "disable-colors" o "Disable color in the logging" flag off
 option "format" f "Specifies the output format (overrides the format from the destination)" string values="opus", "wav", "webm", "mp4", "srt" optional
 option "faststart" t "For mp4 files write the MOOV atom at the head of the file" flag off
 option "audioskew" S "Time threshold to trigger an audio skew compensation, disabled if 0 (default=0)" int typestr="milliseconds" optional
+option "fec" F "For opus content, try to use in-band FEC data to recover lost packets"  flag off

--- a/postprocessing/pp-opus.c
+++ b/postprocessing/pp-opus.c
@@ -137,7 +137,7 @@ int janus_pp_opus_process(FILE *file, janus_pp_frame_packet *list, int *working)
 		decoder = opus_decoder_create(sampling_rate, channels, &error);
 		encoder = opus_encoder_create(sampling_rate, channels, OPUS_APPLICATION_VOIP, &error);
 		max_frame_size = (sampling_rate*120/1000);
-		JANUS_LOG(LOG_INFO, "Detcted opus stream parameters (channels=%d, sampling=%d)\n", channels, sampling_rate);
+		JANUS_LOG(LOG_INFO, "Detected opus stream parameters (channels=%d, sampling=%d)\n", channels, sampling_rate);
 		buflen = max_frame_size*channels*sizeof(opus_int16);
 		pcm_data = g_malloc0(buflen);
 		out_buffer = g_malloc0(1500);

--- a/postprocessing/pp-opus.c
+++ b/postprocessing/pp-opus.c
@@ -146,8 +146,8 @@ int janus_pp_opus_process(FILE *file, janus_pp_frame_packet *list, int *working)
 #endif
 
 	while(*working && tmp != NULL) {
-		/* Discontinuity detected */
 		if(tmp->prev != NULL && ((tmp->ts - tmp->prev->ts)/48/20 > 1)) {
+			/* Discontinuity detected */
 			JANUS_LOG(LOG_WARN, "Lost a packet here? (got seq %"SCNu16" after %"SCNu16", time ~%"SCNu64"s)\n",
 				tmp->seq, tmp->prev->seq, (tmp->ts-list->ts)/48000);
 
@@ -273,10 +273,12 @@ int janus_pp_opus_process(FILE *file, janus_pp_frame_packet *list, int *working)
 		tmp = tmp->next;
 	}
 
+#ifdef HAVE_LIBOPUS
 	g_free(encoder);
 	g_free(decoder);
 	g_free(pcm_data);
 	g_free(out_buffer);
+#endif
 	g_free(buffer);
 	return 0;
 }

--- a/postprocessing/pp-opus.h
+++ b/postprocessing/pp-opus.h
@@ -13,7 +13,9 @@
 #define JANUS_PP_OPUS
 
 #include <stdio.h>
+#ifdef HAVE_LIBOPUS
 #include <opus/opus.h>
+#endif
 
 #include "pp-rtp.h"
 

--- a/postprocessing/pp-opus.h
+++ b/postprocessing/pp-opus.h
@@ -13,10 +13,11 @@
 #define JANUS_PP_OPUS
 
 #include <stdio.h>
+#include <opus/opus.h>
 
 #include "pp-rtp.h"
 
-int janus_pp_opus_create(char *destination, char *metadata);
+int janus_pp_opus_create(char *destination, gboolean use_fec, char *metadata);
 int janus_pp_opus_process(FILE *file, janus_pp_frame_packet *list, int *working);
 void janus_pp_opus_close(void);
 


### PR DESCRIPTION
This is a highly experimental patch that lets janus-pp-rec use opus in-band FEC data to recover lost packets.
The implementation has been inspired by the audiobridge plugin, where the FEC  support has been already implemented.
The current janus-pp-rec detects RTP discontinuities in opus recordings and fills them with opus silence packets. 
With this patch janus-pp-rec accepts a new CLI parameter `--fec, -F` that will try to recover lost packets using opus FEC data.

In order to support FEC pp-rec **must decode and re-encode the packets**, thus leading to longer processing times. Conversely, by sticking to the traditional fill-with-silence approach, pp-rec will just output an ogg file with the payloads stored in the available RTP packets, filling the voids with blank opus packets.

Two important notes to consider about opus fec in WebRTC:
1) in-band opus FEC is only capable of recovering ONE single packet (the previous one in the stream)
2) in-band opus FEC seems to kick-in only when severe packet loss is being experienced

**What I expect from testers**
I'm having some difficulties trying to validate the effects of FEC recovery. Maybe someone (more experienced than me!) is able to verify that a packet is correctly restored by inspecting the bitstream.
What is weird is that in case of lost bursts, all the packets that might not be recovered (e.g. the N-8, N-7 ... N-2 ths) seems to contain some data. I'd expect silence in that spots, so this is making me question the validity of the implementation and approach.
Due to previous points 1) and 2) testing the patch is not very easy, so feedback is very very welcome.

 