### PR TITLE
Add Custom Headers Hold Event

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4129,10 +4129,15 @@ static void *janus_sip_handler(void *data) {
 						m->direction = session->media.pre_hold_video_dir;
 					}
 				}
+				/* Check if the INVITE needs to be enriched with custom headers */
+				char custom_headers[2048];
+				janus_sip_parse_custom_headers(root, (char *)&custom_headers, sizeof(custom_headers));
+				
 				/* Send the re-INVITE */
 				char *sdp = janus_sdp_write(session->sdp);
 				nua_invite(session->stack->s_nh_i,
 					SOATAG_USER_SDP_STR(sdp),
+					TAG_IF(strlen(custom_headers) > 0, SIPTAG_HEADER_STR(custom_headers)),
 					TAG_END());
 				g_free(sdp);
 			}


### PR DESCRIPTION
Reception of custom headers when sending the hold event according to the following format
 {
        "message": {
            "request": "hold",
            "headers": <array of key/value objects, to specify custom headers to add to the SIP REGISTER; optional>
        }
Referring to:
https://groups.google.com/g/meetecho-janus/c/aM4zLt7Il3o