### PR TITLE
[janus-pp-rec] Drop audio RTP silence suppression packets.

### DIFF
--- a/postprocessing/janus-pp-rec.1
+++ b/postprocessing/janus-pp-rec.1
@@ -59,6 +59,8 @@ For mp4 files write the MOOV atom at the head of the file  (default=off)
 .TP
 .BR \-S ", " \-\-audioskew=milliseconds
 Time threshold to trigger an audio skew compensation, disabled if 0 (default=0)
+.BR \-C ", " \-\-silence-distance=count
+RTP packets distance used to detect RTP silence suppression, disabled if 0 (default=100)
 .SH EXAMPLES
 \fBjanus-pp-rec \-\-header rec1234.mjr\fR \- Parse the recordings header (shows metadata info)
 .TP

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -819,8 +819,12 @@ int main(int argc, char *argv[])
 			highest_seq = p->seq;
 			p->ts = (times_resetted*max32)+rtp_ts;
 		} else {
-			if(!video && !data && rtp->markerbit == 1) {
-				if(!dtx_on) {
+			if(!video && !data) {
+				if(dtx_on) {
+					/* Leaving DTX mode (RTP started flowing again) */
+					dtx_on = FALSE;
+					JANUS_LOG(LOG_WARN, "Leaving RTP silence suppression (seq=%"SCNu16", rtp_ts=%"SCNu32")\n", ntohs(rtp->seq_number), rtp_ts);
+				} else if(rtp->markerbit == 1) {
 					/* Try to detect RTP silence suppression */
 					int32_t seq_distance = abs((int16_t)(p->seq - highest_seq));
 					if(seq_distance < silence_distance) {
@@ -840,10 +844,6 @@ int main(int argc, char *argv[])
 							continue;
 						}
 					}
-				} else {
-					/* Leaving DTX mode (RTP started flowing again) */
-					dtx_on = FALSE;
-					JANUS_LOG(LOG_WARN, "Leaving RTP silence suppression (seq=%"SCNu16", rtp_ts=%"SCNu32")\n", ntohs(rtp->seq_number), rtp_ts);
 				}
 			}
 

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -73,6 +73,8 @@ Usage: janus-pp-rec [OPTIONS] source.mjr [destination.[opus|wav|webm|mp4|srt]]
                                   of the file  (default=off)
   -S, --audioskew=milliseconds  Time threshold to trigger an audio skew
                                   compensation, disabled if 0 (default=0)
+  -C, --silence-distance=count  RTP packets distance used to detect RTP silence
+								  suppression, disabled if 0 (default=100)
 \endverbatim
  *
  * \note This utility does not do any form of transcoding. It just
@@ -132,6 +134,8 @@ static int ignore_first_packets = 0;
 #define DEFAULT_AUDIO_SKEW_TH 0
 static int audioskew_th = DEFAULT_AUDIO_SKEW_TH;
 
+#define DEFAULT_SILENCE_DISTANCE 100
+static int silence_distance = DEFAULT_SILENCE_DISTANCE;
 
 /* Signal handler */
 static void janus_pp_handle_signal(int signum) {
@@ -223,6 +227,11 @@ int main(int argc, char *argv[])
 		if(val >= 0)
 			audioskew_th = val;
 	}
+	if(args_info.silence_distance_given || (g_getenv("JANUS_PPREC_SILENCE_DISTANCE") != NULL)) {
+		int val = args_info.silence_distance_given ? args_info.silence_distance_arg : atoi(g_getenv("JANUS_PPREC_SILENCE_DISTANCE"));
+		if(val >= 0)
+			silence_distance = val;
+	}
 
 	/* Evaluate arguments to find source and target */
 	char *source = NULL, *destination = NULL, *setting = NULL;
@@ -244,7 +253,8 @@ int main(int argc, char *argv[])
 				(strcmp(setting, "-v")) && (strcmp(setting, "--videoorient-ext")) &&
 				(strcmp(setting, "-d")) && (strcmp(setting, "--debug-level")) &&
 				(strcmp(setting, "-f")) && (strcmp(setting, "--format")) &&
-				(strcmp(setting, "-S")) && (strcmp(setting, "--audioskew"))
+				(strcmp(setting, "-S")) && (strcmp(setting, "--audioskew")) &&
+				(strcmp(setting, "-C")) && (strcmp(setting, "--silence-distance"))
 		)) {
 			if(source == NULL)
 				source = argv[i];
@@ -274,6 +284,8 @@ int main(int argc, char *argv[])
 			JANUS_LOG(LOG_INFO, "Audio level extension ID: %d\n", audio_level_extmap_id);
 		if(video_orient_extmap_id > 0)
 			JANUS_LOG(LOG_INFO, "Video orientation extension ID: %d\n", video_orient_extmap_id);
+		if(silence_distance > 0)
+			JANUS_LOG(LOG_INFO, "RTP silence suppression distance: %d\n", silence_distance);
 		JANUS_LOG(LOG_INFO, "\n");
 		if(source != NULL)
 			JANUS_LOG(LOG_INFO, "Source file: %s\n", source);
@@ -808,7 +820,7 @@ int main(int argc, char *argv[])
 			if(!video && !data && rtp->markerbit == 1) {
 				/* Try to detect RTP silence suppression */
 				int32_t seq_distance = abs((int16_t)(p->seq - highest_seq));
-				if(seq_distance < 100) {
+				if(seq_distance < silence_distance) {
 					/* Consider 20 ms audio packets */
 					int32_t inter_rtp_ts = (p->pt != 0 && p->pt != 8 && p->pt != 9) ? 960 : 160;
 					int32_t expected_rtp_distance = inter_rtp_ts * seq_distance;

--- a/postprocessing/janus-pp-rec.ggo
+++ b/postprocessing/janus-pp-rec.ggo
@@ -14,3 +14,4 @@ option "disable-colors" o "Disable color in the logging" flag off
 option "format" f "Specifies the output format (overrides the format from the destination)" string values="opus", "wav", "webm", "mp4", "srt" optional
 option "faststart" t "For mp4 files write the MOOV atom at the head of the file" flag off
 option "audioskew" S "Time threshold to trigger an audio skew compensation, disabled if 0 (default=0)" int typestr="milliseconds" optional
+option "silence-distance" C "RTP packets distance used to detect RTP silence suppression, disabled if 0 (default=100)" int typestr="count" optional

--- a/postprocessing/pp-g722.c
+++ b/postprocessing/pp-g722.c
@@ -138,18 +138,17 @@ int janus_pp_g722_process(FILE *file, janus_pp_frame_packet *list, int *working)
 	uint8_t *buffer = g_malloc0(1500);
 	int16_t samples[1500];
 	memset(samples, 0, sizeof(samples));
+	uint num_samples = 320;
 	while(*working && tmp != NULL) {
-		if(tmp->prev != NULL && (tmp->seq - tmp->prev->seq > 1)) {
+		if(tmp->prev != NULL && ((tmp->ts - tmp->prev->ts)/8/20 > 1)) {
 			JANUS_LOG(LOG_WARN, "Lost a packet here? (got seq %"SCNu16" after %"SCNu16", time ~%"SCNu64"s)\n",
-				tmp->seq, tmp->prev->seq, (tmp->ts-list->ts)/48000);
-			/* FIXME Write the silence packet N times to fill in the gaps */
+				tmp->seq, tmp->prev->seq, (tmp->ts-list->ts)/8000);
+			int silence_count = (tmp->ts - tmp->prev->ts)/8/20 - 1;
 			int i=0;
-			for(i=0; i<(tmp->seq-tmp->prev->seq-1); i++) {
-				/* FIXME We should actually also look at the timestamp differences */
+			for(i=0; i<silence_count; i++) {
 				JANUS_LOG(LOG_WARN, "[FILL] Writing silence (seq=%d, index=%d)\n",
 					tmp->prev->seq+i+1, i+1);
 				/* Add silence */
-				uint num_samples = 320;
 				memset(samples, 0, num_samples*2);
 				if(wav_file != NULL) {
 					if(fwrite(samples, sizeof(uint16_t), num_samples, wav_file) != num_samples) {
@@ -161,7 +160,7 @@ int janus_pp_g722_process(FILE *file, janus_pp_frame_packet *list, int *working)
 		}
 		if(tmp->drop) {
 			/* We marked this packet as one to drop, before */
-			JANUS_LOG(LOG_WARN, "Dropping previously marked audio packet (time ~%"SCNu64"s)\n", (tmp->ts-list->ts)/48000);
+			JANUS_LOG(LOG_WARN, "Dropping previously marked audio packet (time ~%"SCNu64"s)\n", (tmp->ts-list->ts)/8000);
 			tmp = tmp->next;
 			continue;
 		}

--- a/postprocessing/pp-opus.c
+++ b/postprocessing/pp-opus.c
@@ -76,7 +76,6 @@ int janus_pp_opus_process(FILE *file, janus_pp_frame_packet *list, int *working)
 		if(tmp->prev != NULL && ((tmp->ts - tmp->prev->ts)/48/20 > 1)) {
 			JANUS_LOG(LOG_WARN, "Lost a packet here? (got seq %"SCNu16" after %"SCNu16", time ~%"SCNu64"s)\n",
 				tmp->seq, tmp->prev->seq, (tmp->ts-list->ts)/48000);
-			/* FIXME Write the silence packet N times to fill in the gaps */
 			ogg_packet *op = op_from_pkt((const unsigned char *)opus_silence, sizeof(opus_silence));
 			/* use ts differ to insert silence packet */
 			int silence_count = (tmp->ts - tmp->prev->ts)/48/20 - 1;


### PR DESCRIPTION
This PR aims at detecting RTP silence suppression (aka Discontinuous Transmission DTX) packets in `janus-pp-rec` and dropping them in order to avoid huge files being generated like described in #2328.

Quoting RFC 3389
```
   RTP allows discontinuous transmission (silence suppression) on any audio payload
   format.  The receiver can detect silence suppression on the first
   packet received after the silence by observing that the RTP timestamp
   is not contiguous with the end of the interval covered by the
   previous packet even though the RTP sequence number has incremented
   only by one.  The RTP marker bit is also normally set on such a
   packet.
```

The added check basically looks for audio packets with marker bit=1, close enough (in range of 100) to the highest sequence number received. If that packet RTP timestamp is very different (> 10x) from the expected one, we simply drop that packet.

A new CLI option has been added (`--silence-distance`) to control the range of packets for which the silence suppression detection acts (default is 100, while 0 means disabled).

Tested against a recording with a couple of DTX packets and it seems to work.

Fixes #2414.
