### PR TITLE
Fix types

### DIFF
--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -1,9 +1,17 @@
 declare namespace JanusJS {
 	interface Dependencies {
 		adapter: any;
+		WebSocket: (server: string, protocol: string) => WebSocket;
+		isArray: (array: any) => array is Array<any>;
+		extension: () => boolean;
+		httpAPICall: (url: string, options: any) => void;
+    }
+    
+    interface DependenciesResult {
+		adapter: any;
 		newWebSocket: (server: string, protocol: string) => WebSocket;
 		isArray: (array: any) => array is Array<any>;
-		checkJanusExtension: () => boolean;
+		extension: () => boolean;
 		httpAPICall: (url: string, options: any) => void;
 	}
 
@@ -20,7 +28,7 @@ declare namespace JanusJS {
 	interface InitOptions {
 		debug?: boolean | 'all' | DebugLevel[];
 		callback?: Function;
-		dependencies?: Dependencies;
+		dependencies?: DependenciesResult;
 	}
 
 	interface ConstructorOptions {
@@ -128,8 +136,8 @@ declare namespace JanusJS {
 	}
 
 	class Janus {
-		static useDefaultDependencies(deps: Partial<Dependencies>): Dependencies;
-		static useOldDependencies(deps: Partial<Dependencies>): Dependencies;
+		static useDefaultDependencies(deps: Partial<Dependencies>): DependenciesResult;
+		static useOldDependencies(deps: Partial<Dependencies>): DependenciesResult;
 		static init(options: InitOptions): void;
 		static isWebrtcSupported(): boolean;
 		static debug(...args: any[]): void;


### PR DESCRIPTION
Hello,

This PR fixes typescript definitions:

1. Janus lib expects Websocket method in Dependencies and not newWebSocket which is returned after.
2. there is no method checkJanusExtension but it's called extension