### PR TITLE
Added support for binary data recordings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -593,6 +593,8 @@ janus_pp_rec_SOURCES = \
 	postprocessing/pp-rtp.h \
 	postprocessing/pp-srt.c \
 	postprocessing/pp-srt.h \
+	postprocessing/pp-binary.c \
+	postprocessing/pp-binary.h \
 	postprocessing/pp-webm.c \
 	postprocessing/pp-webm.h \
 	postprocessing/janus-pp-rec.c \

--- a/html/recordplaytest.html
+++ b/html/recordplaytest.html
@@ -93,6 +93,10 @@
 							</div>
 							<div class="panel-body" id="videobox"></div>
 						</div>
+						<div class="input-group margin-bottom-sm hide">
+							<span class="input-group-addon"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<input class="form-control" type="text" placeholder="" autocomplete="off" id="datafield" onkeypress="return checkEnter(event);" disabled />
+						</div>
 					</div>
 				</div>
 			</div>

--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -67,7 +67,9 @@ var vcodec = (getQueryStringValue("vcodec") !== "" ? getQueryStringValue("vcodec
 var vprofile = (getQueryStringValue("vprofile") !== "" ? getQueryStringValue("vprofile") : null);
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
 var doSimulcast2 = (getQueryStringValue("simulcast2") === "yes" || getQueryStringValue("simulcast2") === "true");
-
+var recordData = (getQueryStringValue("data") !== "" ? getQueryStringValue("data") : null);
+if(recordData !== "text" && recordData !== "binary")
+	recordData = null;
 
 $(document).ready(function() {
 	// Initialize the library (all console debuggers enabled)
@@ -316,13 +318,17 @@ $(document).ready(function() {
 								},
 								ondataopen: function(data) {
 									Janus.log("The DataChannel is available!");
-									$('#videobox').append(
-										'<input class="form-control" type="text" id="datarecv" disabled></input>'
-									);
+									$('#datafield').parent().removeClass('hide');
+									if(playing === false) {
+										// We're recording, use this field to send data
+										$('#datafield').attr('placeholder', 'Write a message to record');
+										$('#datafield').removeAttr('disabled');
+									}
 								},
 								ondata: function(data) {
 									Janus.debug("We got data from the DataChannel!", data);
-									$('#datarecv').val(data);
+									if(playing === true)
+										$('#datafield').val(data);
 								},
 								oncleanup: function() {
 									Janus.log(" ::: Got a cleanup notification :::");
@@ -334,6 +340,8 @@ $(document).ready(function() {
 									$('#videobox').empty();
 									$("#videobox").parent().unblock();
 									$('#video').hide();
+									$('#datafield').attr('disabled', true).attr('placeholder', '').val('');
+									$('#datafield').parent().addClass('hide');
 									recording = false;
 									playing = false;
 									$('#record').removeAttr('disabled').click(startRecording);
@@ -359,15 +367,27 @@ $(document).ready(function() {
 	}});
 });
 
-function checkEnter(field, event) {
+function checkEnter(event) {
 	var theCode = event.keyCode ? event.keyCode : event.which ? event.which : event.charCode;
 	if(theCode == 13) {
-		if(field.id == 'name')
-			insertName();
+		sendData();
 		return false;
 	} else {
 		return true;
 	}
+}
+
+function sendData() {
+	var data = $('#datafield').val();
+	if(data === "") {
+		bootbox.alert('Insert a message to send on the DataChannel');
+		return;
+	}
+	recordplay.data({
+		text: data,
+		error: function(reason) { bootbox.alert(reason); },
+		success: function() { $('#datafield').val(''); },
+	});
 }
 
 function updateRecsList() {
@@ -436,7 +456,9 @@ function startRecording() {
 
 		recordplay.createOffer(
 			{
-				// By default, it's sendrecv for audio and video... no datachannels
+				// By default, it's sendrecv for audio and video... no datachannels,
+				// unless we've passed the query string argument to record those too
+				media: { data: (recordData != null) },
 				// If you want to test simulcasting (Chrome and Firefox only), then
 				// pass a ?simulcast=true when opening this demo page: it will turn
 				// the following 'simulcast' property to pass to janus.js to true
@@ -454,6 +476,9 @@ function startRecording() {
 					// profile as well (e.g., ?vprofile=2 for VP9, or ?vprofile=42e01f for H.264)
 					if(vprofile)
 						body["videoprofile"] = vprofile;
+					// If we're going to send binary data, let's tell the plugin
+					if(recordData === "binary")
+						body["textdata"] = false;
 					recordplay.send({ message: body, jsep: jsep });
 				},
 				error: function(error) {

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -42,7 +42,7 @@
  * 		audio = videoroom-audio.mjr
  * 		video = videoroom-video.mjr
  *
- * Data channel recordings are suppoered via a \c data attribute as well.
+ * Data channel recordings are supported via a \c data attribute as well.
  *
  * \section recplayapi Record&Play API
  *

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -42,6 +42,8 @@
  * 		audio = videoroom-audio.mjr
  * 		video = videoroom-video.mjr
  *
+ * Data channel recordings are suppoered via a \c data attribute as well.
+ *
  * \section recplayapi Record&Play API
  *
  * The Record&Play API supports several requests, some of which are
@@ -83,6 +85,7 @@
 			"date": "<Date of the recording>",
 			"audio": "<Audio rec file, if any; optional>",
 			"video": "<Video rec file, if any; optional>",
+			"data": "<Data rec file, if any; optional>",
 			"audio_codec": "<Audio codec, if any; optional>",
 			"video_codec": "<Video codec, if any; optional>"
 		},
@@ -131,7 +134,8 @@
 	"filename" : "<Base path/name for the file (media type and extension added by the plugin); optional>",
 	"audiocodec" : "<name of the audio codec we prefer for the recording; optional>",
 	"videocodec" : "<name of the video codec we prefer for the recording; optional>",
-	"videoprofile" : "<in case the video codec supports, profile to use (e.g., "2" for VP9, or "42e01f" for H.264); optional>"
+	"videoprofile" : "<in case the video codec supports, profile to use (e.g., "2" for VP9, or "42e01f" for H.264); optional>",
+	"textdata" : "<in case data channels have to be recorded, whether the data will be text (default) or binary; optional>"
 }
 \endverbatim
  *
@@ -301,6 +305,7 @@ json_t *janus_recordplay_handle_admin_message(json_t *message);
 void janus_recordplay_setup_media(janus_plugin_session *handle);
 void janus_recordplay_incoming_rtp(janus_plugin_session *handle, janus_plugin_rtp *packet);
 void janus_recordplay_incoming_rtcp(janus_plugin_session *handle, janus_plugin_rtcp *packet);
+void janus_recordplay_incoming_data(janus_plugin_session *handle, janus_plugin_data *packet);
 void janus_recordplay_slow_link(janus_plugin_session *handle, int uplink, int video);
 void janus_recordplay_hangup_media(janus_plugin_session *handle);
 void janus_recordplay_destroy_session(janus_plugin_session *handle, int *error);
@@ -326,6 +331,7 @@ static janus_plugin janus_recordplay_plugin =
 		.setup_media = janus_recordplay_setup_media,
 		.incoming_rtp = janus_recordplay_incoming_rtp,
 		.incoming_rtcp = janus_recordplay_incoming_rtcp,
+		.incoming_data = janus_recordplay_incoming_data,
 		.slow_link = janus_recordplay_slow_link,
 		.hangup_media = janus_recordplay_hangup_media,
 		.destroy_session = janus_recordplay_destroy_session,
@@ -353,6 +359,7 @@ static struct janus_json_parameter record_parameters[] = {
 	{"audiocodec", JSON_STRING, 0},
 	{"videocodec", JSON_STRING, 0},
 	{"videoprofile", JSON_STRING, 0},
+	{"textdata", JANUS_JSON_BOOL, 0},
 	{"update", JANUS_JSON_BOOL, 0}
 };
 static struct janus_json_parameter play_parameters[] = {
@@ -428,6 +435,7 @@ typedef struct janus_recordplay_session {
 	janus_recordplay_recording *recording;
 	janus_recorder *arc;	/* Audio recorder */
 	janus_recorder *vrc;	/* Video recorder */
+	janus_recorder *drc;	/* Data recorder */
 	janus_mutex rec_mutex;	/* Mutex to protect the recorders from race conditions */
 	janus_recordplay_frame_packet *aframes;	/* Audio frames (for playout) */
 	janus_recordplay_frame_packet *vframes;	/* Video frames (for playout) */
@@ -623,11 +631,21 @@ static const char *janus_recordplay_parse_codec(const char *dir, const char *fil
 				}
 				const char *c = json_string_value(codec);
 				if(data) {
+					const char *dtype = NULL;
+					if(c && !strcasecmp(c, "text")) {
+						dtype = "text";
+					} else if(c && !strcasecmp(c, "binary")) {
+						dtype = "binary";
+					} else {
+						JANUS_LOG(LOG_WARN, "Unsupported data channel format...\n");
+						json_decref(info);
+						fclose(file);
+						return NULL;
+					}
 					/* Found! */
-					c = "text";
 					json_decref(info);
 					fclose(file);
-					return c;					
+					return dtype;
 				}
 				const char *mcodec = janus_sdp_match_preferred_codec(video ? JANUS_SDP_VIDEO : JANUS_SDP_AUDIO, (char *)c);
 				if(mcodec != NULL) {
@@ -658,7 +676,7 @@ static int janus_recordplay_generate_offer(janus_recordplay_recording *rec) {
 	/* Prepare an SDP offer we'll send to playout viewers */
 	gboolean offer_audio = (rec->arc_file != NULL && rec->acodec != JANUS_AUDIOCODEC_NONE),
 		offer_video = (rec->vrc_file != NULL && rec->vcodec != JANUS_VIDEOCODEC_NONE),
-		offer_data = rec->drc_file != NULL;
+		offer_data = (rec->drc_file != NULL);
 	char s_name[100];
 	g_snprintf(s_name, sizeof(s_name), "Recording %"SCNu64, rec->id);
 	janus_sdp *offer = janus_sdp_generate_offer(
@@ -872,6 +890,7 @@ void janus_recordplay_create_session(janus_plugin_session *handle, int *error) {
 	session->firefox = FALSE;
 	session->arc = NULL;
 	session->vrc = NULL;
+	session->drc = NULL;
 	janus_mutex_init(&session->rec_mutex);
 	g_atomic_int_set(&session->hangingup, 0);
 	g_atomic_int_set(&session->destroyed, 0);
@@ -1024,6 +1043,7 @@ struct janus_plugin_result *janus_recordplay_handle_message(janus_plugin_session
 			json_object_set_new(ml, "video", rec->vrc_file ? json_true() : json_false());
 			if(rec->vcodec != JANUS_VIDEOCODEC_NONE)
 				json_object_set_new(ml, "video_codec", json_string(janus_videocodec_name(rec->vcodec)));
+			json_object_set_new(ml, "data", rec->drc_file ? json_true() : json_false());
 			janus_refcount_decrease(&rec->ref);
 			json_array_append_new(list, ml);
 		}
@@ -1277,6 +1297,24 @@ void janus_recordplay_incoming_rtcp(janus_plugin_session *handle, janus_plugin_r
 		return;
 }
 
+void janus_recordplay_incoming_data(janus_plugin_session *handle, janus_plugin_data *packet) {
+	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
+		return;
+	janus_recordplay_session *session = (janus_recordplay_session *)handle->plugin_handle;
+	if(!session) {
+		JANUS_LOG(LOG_ERR, "No session associated with this handle...\n");
+		return;
+	}
+	if(g_atomic_int_get(&session->destroyed))
+		return;
+	if(!session->recorder || !session->recording)
+		return;
+	char *buf = packet->buffer;
+	uint16_t len = packet->length;
+	/* Save the frame if we're recording */
+	janus_recorder_save_frame(session->drc, buf, len);
+}
+
 void janus_recordplay_slow_link(janus_plugin_session *handle, int uplink, int video) {
 	if(handle == NULL || g_atomic_int_get(&handle->stopped) || g_atomic_int_get(&stopping) || !g_atomic_int_get(&initialized))
 		return;
@@ -1353,6 +1391,13 @@ static void janus_recordplay_hangup_media_internal(janus_plugin_session *handle)
 		JANUS_LOG(LOG_INFO, "Closed video recording %s\n", rc->filename ? rc->filename : "??");
 		janus_recorder_destroy(rc);
 	}
+	if(session->drc) {
+		janus_recorder *rc = session->drc;
+		session->drc = NULL;
+		janus_recorder_close(rc);
+		JANUS_LOG(LOG_INFO, "Closed data recording %s\n", rc->filename ? rc->filename : "??");
+		janus_recorder_destroy(rc);
+	}
 	janus_mutex_unlock(&session->rec_mutex);
 	if(session->recorder) {
 		if(session->recording) {
@@ -1365,34 +1410,26 @@ static void janus_recordplay_hangup_media_internal(janus_plugin_session *handle)
 			if(file == NULL) {
 				JANUS_LOG(LOG_ERR, "Error creating file %s...\n", nfofile);
 			} else {
-				if(session->recording->arc_file && session->recording->vrc_file) {
-					g_snprintf(nfo, 1024,
-						"[%"SCNu64"]\r\n"
-						"name = %s\r\n"
-						"date = %s\r\n"
-						"audio = %s.mjr\r\n"
-						"video = %s.mjr\r\n",
-							session->recording->id, session->recording->name, session->recording->date,
-							session->recording->arc_file, session->recording->vrc_file);
-				} else if(session->recording->arc_file) {
-					g_snprintf(nfo, 1024,
-						"[%"SCNu64"]\r\n"
-						"name = %s\r\n"
-						"date = %s\r\n"
-						"audio = %s.mjr\r\n",
-							session->recording->id, session->recording->name, session->recording->date,
-							session->recording->arc_file);
-				} else if(session->recording->vrc_file) {
-					g_snprintf(nfo, 1024,
-						"[%"SCNu64"]\r\n"
-						"name = %s\r\n"
-						"date = %s\r\n"
-						"video = %s.mjr\r\n",
-							session->recording->id, session->recording->name, session->recording->date,
-							session->recording->vrc_file);
+				/* Write the first part */
+				g_snprintf(nfo, 1024,
+					"[%"SCNu64"]\r\n"
+					"name = %s\r\n"
+					"date = %s\r\n",
+						session->recording->id, session->recording->name, session->recording->date);
+				fwrite(nfo, sizeof(char), strlen(nfo), file);
+				/* Add lines for each recorded medium */
+				if(session->recording->arc_file) {
+					g_snprintf(nfo, 1024, "audio = %s.mjr\r\n", session->recording->arc_file);
+					fwrite(nfo, sizeof(char), strlen(nfo), file);
 				}
-				/* Write to the file now */
-				fwrite(nfo, strlen(nfo), sizeof(char), file);
+				if(session->recording->vrc_file) {
+					g_snprintf(nfo, 1024, "video = %s.mjr\r\n", session->recording->vrc_file);
+					fwrite(nfo, sizeof(char), strlen(nfo), file);
+				}
+				if(session->recording->drc_file) {
+					g_snprintf(nfo, 1024, "data = %s.mjr\r\n", session->recording->drc_file);
+					fwrite(nfo, sizeof(char), strlen(nfo), file);
+				}
 				fclose(file);
 				g_atomic_int_set(&session->recording->completed, 1);
 				/* Generate the offer */
@@ -1506,6 +1543,7 @@ static void *janus_recordplay_handler(void *data) {
 			json_t *audiocodec = json_object_get(root, "audiocodec");
 			json_t *videocodec = json_object_get(root, "videocodec");
 			json_t *videoprofile = json_object_get(root, "videoprofile");
+			json_t *dotextdata = json_object_get(root, "textdata");
 			json_t *update = json_object_get(root, "update");
 			gboolean do_update = update ? json_is_true(update) : FALSE;
 			if(do_update && !sdp_update) {
@@ -1514,7 +1552,7 @@ static void *janus_recordplay_handler(void *data) {
 			/* Check if this is a new recorder, or if an update is taking place (i.e., ICE restart) */
 			guint64 id = 0;
 			janus_recordplay_recording *rec = NULL;
-			gboolean audio = FALSE, video = FALSE;
+			gboolean audio = FALSE, video = FALSE, data = FALSE, textdata = TRUE;
 			if(sdp_update) {
 				/* Renegotiation: make sure the user provided an offer, and send answer */
 				JANUS_LOG(LOG_VERB, "Request to update existing recorder\n");
@@ -1529,6 +1567,8 @@ static void *janus_recordplay_handler(void *data) {
 				session->sdp_version++;		/* This needs to be increased when it changes */
 				audio = (session->arc != NULL);
 				video = (session->vrc != NULL);
+				data = (session->drc != NULL);
+				textdata = rec->textdata;
 				sdp_update = do_update;
 				e2ee = rec->e2ee;
 				goto recdone;
@@ -1668,6 +1708,22 @@ static void *janus_recordplay_handler(void *data) {
 					janus_recorder_encrypted(rc);
 				session->vrc = rc;
 			}
+			/* Check if we should record data too */
+			data = (janus_sdp_mline_find(offer, JANUS_SDP_APPLICATION) != NULL);
+			if(data) {
+				textdata = dotextdata ? json_is_true(dotextdata) : TRUE;
+				char filename[256];
+				if(filename_text != NULL) {
+					g_snprintf(filename, 256, "%s-data", filename_text);
+				} else {
+					g_snprintf(filename, 256, "rec-%"SCNu64"-data", id);
+				}
+				rec->drc_file = g_strdup(filename);
+				rec->textdata = textdata;
+				janus_recorder *rc = janus_recorder_create_full(recordings_path,
+					textdata ? "text" : "binary", NULL, rec->drc_file);
+				session->drc = rc;
+			}
 			session->recorder = TRUE;
 			session->recording = rec;
 			session->sdp_version = 1;	/* This needs to be increased when it changes */
@@ -1685,7 +1741,7 @@ recdone:
 				JANUS_SDP_OA_VP9_PROFILE, session->video_profile,
 				JANUS_SDP_OA_H264_PROFILE, session->video_profile,
 				JANUS_SDP_OA_VIDEO_DIRECTION, JANUS_SDP_RECVONLY,
-				JANUS_SDP_OA_DATA, FALSE,
+				JANUS_SDP_OA_DATA, data,
 				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_MID,
 				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_RID,
 				JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_REPAIRED_RID,
@@ -1735,6 +1791,7 @@ recdone:
 				json_object_set_new(info, "id", json_integer(id));
 				json_object_set_new(info, "audio", session->arc ? json_true() : json_false());
 				json_object_set_new(info, "video", session->vrc ? json_true() : json_false());
+				json_object_set_new(info, "data", session->drc ? json_true() : json_false());
 				gateway->notify_event(&janus_recordplay_plugin, session->handle, info);
 			}
 		} else if(!strcasecmp(request_text, "play")) {
@@ -1824,7 +1881,7 @@ recdone:
 					warning = "Broken data file, playing audio/video only";
 				}
 			}
-			if(session->aframes == NULL && session->vframes == NULL) {
+			if(session->aframes == NULL && session->vframes == NULL && session->dframes == NULL) {
 				error_code = JANUS_RECORDPLAY_ERROR_INVALID_RECORDING;
 				g_snprintf(error_cause, 512, "Error opening recording files");
 				goto error;
@@ -2073,8 +2130,7 @@ void janus_recordplay_update_recordings_list(void) {
 				*ext = '\0';
 			const char *textcodec = janus_recordplay_parse_codec(recordings_path,
 				rec->drc_file, NULL, sizeof(NULL), NULL);
-			if(textcodec)
-				rec->textdata = TRUE; /* Binary recordings not supported yet */
+			rec->textdata = textcodec && (!strcasecmp(textcodec, "text"));
 		}
 		rec->audio_pt = AUDIO_PT;
 		if(rec->acodec != JANUS_AUDIOCODEC_NONE) {
@@ -2174,8 +2230,13 @@ janus_recordplay_frame_packet *janus_recordplay_get_frames(const char *dir, cons
 				bytes = fread(prebuffer, sizeof(char), 5, file);
 				if(prebuffer[0] == 'v') {
 					JANUS_LOG(LOG_INFO, "This is an old video recording, assuming VP8\n");
+					video = 1;
 				} else if(prebuffer[0] == 'a') {
 					JANUS_LOG(LOG_INFO, "This is an old audio recording, assuming Opus\n");
+					audio = 1;
+				} else if(prebuffer[0] == 'd') {
+					JANUS_LOG(LOG_INFO, "This is an old data recording, assuming Text\n");
+					data = 1;
 				} else {
 					JANUS_LOG(LOG_WARN, "Unsupported recording media type...\n");
 					fclose(file);
@@ -2183,7 +2244,7 @@ janus_recordplay_frame_packet *janus_recordplay_get_frames(const char *dir, cons
 				}
 				offset += len;
 				continue;
-			} else if(len < 12) {
+			} else if(!data && len < 12) {
 				/* Not RTP, skip */
 				JANUS_LOG(LOG_VERB, "Skipping packet (not RTP?)\n");
 				offset += len;
@@ -2313,7 +2374,7 @@ janus_recordplay_frame_packet *janus_recordplay_get_frames(const char *dir, cons
 		len = ntohs(len);
 		JANUS_LOG(LOG_HUGE, "  -- Length: %"SCNu16"\n", len);
 		offset += 2;
-		if(prebuffer[1] == 'J' || len < 12) {
+		if(prebuffer[1] == 'J' || (!data && len < 12)) {
 			/* Not RTP, skip */
 			JANUS_LOG(LOG_HUGE, "  -- Not RTP, skipping\n");
 			offset += len;
@@ -2713,7 +2774,7 @@ static void *janus_recordplay_playout_thread(void *sessiondata) {
 		}
 		if(data) {
 			u_int64_t prev_ts = 0; /* All timestamps for data are indexed to 0, since when parsing ts = when - c_time */
-			if(data->prev) 
+			if(data->prev)
 				prev_ts = data->prev->ts;
 			ts_diff = data->ts - prev_ts;
 
@@ -2748,7 +2809,7 @@ static void *janus_recordplay_playout_thread(void *sessiondata) {
 				janus_plugin_data datapacket = {
 					.label = NULL,
 					.protocol = NULL,
-					.binary = rec->textdata ? FALSE : TRUE, 
+					.binary = rec->textdata ? FALSE : TRUE,
 					.buffer = (char *)buffer,
 					.length = bytes
 				};
@@ -2777,7 +2838,6 @@ static void *janus_recordplay_playout_thread(void *sessiondata) {
 		video = tmp;
 	}
 	session->vframes = NULL;
-
 	data = session->dframes;
 	while(data) {
 		tmp = data->next;

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -112,6 +112,7 @@ Usage: janus-pp-rec [OPTIONS] source.mjr [destination.[opus|wav|webm|mp4|srt]]
 #include "pp-g711.h"
 #include "pp-g722.h"
 #include "pp-srt.h"
+#include "pp-binary.h"
 
 #define htonll(x) ((1==htonl(1)) ? (x) : ((gint64)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
 #define ntohll(x) ((1==ntohl(1)) ? (x) : ((gint64)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
@@ -308,14 +309,6 @@ int main(int argc, char *argv[])
 			exit(1);
 		}
 		extension++;
-		if(strcasecmp(extension, "opus") && strcasecmp(extension, "wav") &&
-				strcasecmp(extension, "webm") && strcasecmp(extension, "mp4") &&
-				strcasecmp(extension, "srt")) {
-			/* Unsupported extension? */
-			JANUS_LOG(LOG_ERR, "Unsupported extension '%s'\n", extension);
-			cmdline_parser_free(&args_info);
-			exit(1);
-		}
 	}
 
 	if (janus_faststart && strcasecmp(extension, "mp4")) {
@@ -345,7 +338,7 @@ int main(int argc, char *argv[])
 		JANUS_LOG(LOG_INFO, "Pre-parsing file to generate ordered index...\n");
 	gboolean has_timestamps = FALSE;
 	gboolean parsed_header = FALSE;
-	gboolean video = FALSE, data = FALSE;
+	gboolean video = FALSE, data = FALSE, textdata = FALSE;
 	gboolean opus = FALSE, g711 = FALSE, g722 = FALSE,
 		vp8 = FALSE, vp9 = FALSE, h264 = FALSE, av1 = FALSE, h265 = FALSE;
 	gboolean e2ee = FALSE;
@@ -472,6 +465,7 @@ int main(int argc, char *argv[])
 				json_t *type = json_object_get(info, "t");
 				if(!type || !json_is_string(type)) {
 					JANUS_LOG(LOG_WARN, "Missing/invalid recording type in info header...\n");
+					json_decref(info);
 					cmdline_parser_free(&args_info);
 					exit(1);
 				}
@@ -487,6 +481,7 @@ int main(int argc, char *argv[])
 					data = TRUE;
 				} else {
 					JANUS_LOG(LOG_WARN, "Unsupported recording type '%s' in info header...\n", t);
+					json_decref(info);
 					cmdline_parser_free(&args_info);
 					exit(1);
 				}
@@ -503,6 +498,7 @@ int main(int argc, char *argv[])
 						vp8 = TRUE;
 						if(extension && strcasecmp(extension, "webm")) {
 							JANUS_LOG(LOG_ERR, "VP8 RTP packets can only be converted to a .webm file\n");
+							json_decref(info);
 							cmdline_parser_free(&args_info);
 							exit(1);
 						}
@@ -510,6 +506,7 @@ int main(int argc, char *argv[])
 						vp9 = TRUE;
 						if(extension && strcasecmp(extension, "webm")) {
 							JANUS_LOG(LOG_ERR, "VP9 RTP packets can only be converted to a .webm file\n");
+							json_decref(info);
 							cmdline_parser_free(&args_info);
 							exit(1);
 						}
@@ -517,6 +514,7 @@ int main(int argc, char *argv[])
 						h264 = TRUE;
 						if(extension && strcasecmp(extension, "mp4")) {
 							JANUS_LOG(LOG_ERR, "H.264 RTP packets can only be converted to a .mp4 file\n");
+							json_decref(info);
 							cmdline_parser_free(&args_info);
 							exit(1);
 						}
@@ -524,6 +522,7 @@ int main(int argc, char *argv[])
 						av1 = TRUE;
 						if(extension && strcasecmp(extension, "mp4")) {
 							JANUS_LOG(LOG_ERR, "AV1 RTP packets can only be converted to a .mp4 file\n");
+							json_decref(info);
 							cmdline_parser_free(&args_info);
 							exit(1);
 						}
@@ -531,11 +530,13 @@ int main(int argc, char *argv[])
 						h265 = TRUE;
 						if(extension && strcasecmp(extension, "mp4")) {
 							JANUS_LOG(LOG_ERR, "H.265 RTP packets can only be converted to a .mp4 file\n");
+							json_decref(info);
 							cmdline_parser_free(&args_info);
 							exit(1);
 						}
 					} else {
 						JANUS_LOG(LOG_WARN, "The post-processor only supports VP8, VP9 and H.264 video for now (was '%s')...\n", c);
+						json_decref(info);
 						cmdline_parser_free(&args_info);
 						exit(1);
 					}
@@ -544,17 +545,20 @@ int main(int argc, char *argv[])
 						opus = TRUE;
 						if(extension && strcasecmp(extension, "opus")) {
 							JANUS_LOG(LOG_ERR, "Opus RTP packets can only be converted to an .opus file\n");
+							json_decref(info);
 							cmdline_parser_free(&args_info);
 							exit(1);
 						}
 					} else if(!strcasecmp(c, "multiopus")) {
 						JANUS_LOG(LOG_ERR, "Surround Opus RTP packets are not supported, at the moment\n");
+						json_decref(info);
 						cmdline_parser_free(&args_info);
 						exit(1);
 					} else if(!strcasecmp(c, "g711") || !strcasecmp(c, "pcmu") || !strcasecmp(c, "pcma")) {
 						g711 = TRUE;
 						if(extension && strcasecmp(extension, "wav")) {
 							JANUS_LOG(LOG_ERR, "G.711 RTP packets can only be converted to a .wav file\n");
+							json_decref(info);
 							cmdline_parser_free(&args_info);
 							exit(1);
 						}
@@ -562,22 +566,27 @@ int main(int argc, char *argv[])
 						g722 = TRUE;
 						if(extension && strcasecmp(extension, "wav")) {
 							JANUS_LOG(LOG_ERR, "G.722 RTP packets can only be converted to a .wav file\n");
+							json_decref(info);
 							cmdline_parser_free(&args_info);
 							exit(1);
 						}
 					} else {
 						JANUS_LOG(LOG_WARN, "The post-processor only supports Opus, G.711 and G.722 audio for now (was '%s')...\n", c);
+						json_decref(info);
 						cmdline_parser_free(&args_info);
 						exit(1);
 					}
 				} else if(data) {
-					if(strcasecmp(c, "text")) {
-						JANUS_LOG(LOG_WARN, "The post-processor only supports text data for now (was '%s')...\n", c);
+					if(strcasecmp(c, "text") && strcasecmp(c, "binary")) {
+						JANUS_LOG(LOG_WARN, "The post-processor only supports text and binary data (was '%s')...\n", c);
+						json_decref(info);
 						cmdline_parser_free(&args_info);
 						exit(1);
 					}
-					if(extension && strcasecmp(extension, "srt")) {
-						JANUS_LOG(LOG_ERR, "Data channel packets can only be converted to a .srt file\n");
+					textdata = !strcasecmp(c, "text");
+					if(textdata && extension && strcasecmp(extension, "srt")) {
+						JANUS_LOG(LOG_ERR, "Text data channel packets can only be converted to a .srt file\n");
+						json_decref(info);
 						cmdline_parser_free(&args_info);
 						exit(1);
 					}
@@ -588,6 +597,7 @@ int main(int argc, char *argv[])
 				json_t *created = json_object_get(info, "s");
 				if(!created || !json_is_integer(created)) {
 					JANUS_LOG(LOG_WARN, "Missing recording created time in info header...\n");
+					json_decref(info);
 					cmdline_parser_free(&args_info);
 					exit(1);
 				}
@@ -596,6 +606,7 @@ int main(int argc, char *argv[])
 				json_t *written = json_object_get(info, "u");
 				if(!written || !json_is_integer(written)) {
 					JANUS_LOG(LOG_WARN, "Missing recording written time in info header...\n");
+					json_decref(info);
 					cmdline_parser_free(&args_info);
 					exit(1);
 				}
@@ -626,6 +637,17 @@ int main(int argc, char *argv[])
 		cmdline_parser_free(&args_info);
 		exit(0);
 	}
+
+	/* Now that we know what we're working with, check the extension */
+	if(strcasecmp(extension, "opus") && strcasecmp(extension, "wav") &&
+			strcasecmp(extension, "webm") && strcasecmp(extension, "mp4") &&
+			strcasecmp(extension, "srt") && (!data || (data && textdata))) {
+		/* Unsupported extension? */
+		JANUS_LOG(LOG_ERR, "Unsupported extension '%s'\n", extension);
+		cmdline_parser_free(&args_info);
+		exit(1);
+	}
+
 	/* Now let's parse the frames and order them */
 	uint32_t pkt_ts = 0, highest_rtp_ts = 0;
 	uint16_t highest_seq = 0;
@@ -1102,10 +1124,18 @@ int main(int argc, char *argv[])
 			}
 		}
 	} else if(data) {
-		if(janus_pp_srt_create(destination, metadata) < 0) {
-			JANUS_LOG(LOG_ERR, "Error creating .srt file...\n");
-			cmdline_parser_free(&args_info);
-			exit(1);
+		if(textdata) {
+			if(janus_pp_srt_create(destination, metadata) < 0) {
+				JANUS_LOG(LOG_ERR, "Error creating .srt file...\n");
+				cmdline_parser_free(&args_info);
+				exit(1);
+			}
+		} else {
+			if(janus_pp_binary_create(destination, metadata) < 0) {
+				JANUS_LOG(LOG_ERR, "Error creating binary file...\n");
+				cmdline_parser_free(&args_info);
+				exit(1);
+			}
 		}
 	} else {
 		if(vp8 || vp9) {
@@ -1151,8 +1181,14 @@ int main(int argc, char *argv[])
 			}
 		}
 	} else if(data) {
-		if(janus_pp_srt_process(file, list, &working) < 0) {
-			JANUS_LOG(LOG_ERR, "Error processing text data frames...\n");
+		if(textdata) {
+			if(janus_pp_srt_process(file, list, &working) < 0) {
+				JANUS_LOG(LOG_ERR, "Error processing text data frames...\n");
+			}
+		} else {
+			if(janus_pp_binary_process(file, list, &working) < 0) {
+				JANUS_LOG(LOG_ERR, "Error processing text data frames...\n");
+			}
 		}
 	} else {
 		if(vp8 || vp9) {
@@ -1186,7 +1222,11 @@ int main(int argc, char *argv[])
 			janus_pp_h265_close();
 		}
 	} else if(data) {
-		janus_pp_srt_close();
+		if(textdata) {
+			janus_pp_srt_close();
+		} else {
+			janus_pp_binary_close();
+		}
 	} else {
 		if(opus) {
 			janus_pp_opus_close();

--- a/postprocessing/pcap2mjr.c
+++ b/postprocessing/pcap2mjr.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
 			|| !strcasecmp(codec, "g711") || !strcasecmp(codec, "pcmu") || !strcasecmp(codec, "pcma")
 			|| !strcasecmp(codec, "g722")) {
 		video = FALSE;
-	} else if(!strcasecmp(codec, "text")) {
+	} else if(!strcasecmp(codec, "text") || !strcasecmp(codec, "binary")) {
 		/* We only do processing for RTP */
 		JANUS_LOG(LOG_ERR, "Data channels not supported by this tool\n");
 		cmdline_parser_free(&args_info);

--- a/postprocessing/pp-binary.c
+++ b/postprocessing/pp-binary.c
@@ -1,0 +1,92 @@
+/*! \file    pp-binary.c
+ * \author   Lorenzo Miniero <lorenzo@meetecho.com>
+ * \copyright GNU General Public License v3
+ * \brief    Post-processing to generate binary files out of binary data recordings
+ * \details  Implementation of the post-processing code needed to
+ * generate binary files out of binary data recordings: more precisely,
+ * the code simply extracts the data from the packets and appends it to
+ * the provided file exactly as it is, with no header/footer.
+ *
+ * \ingroup postprocessing
+ * \ref postprocessing
+ */
+
+#include <arpa/inet.h>
+#ifdef __MACH__
+#include <machine/endian.h>
+#else
+#include <endian.h>
+#endif
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "pp-binary.h"
+#include "../debug.h"
+
+
+FILE *binary_file = NULL;
+
+/* Processing methods */
+int janus_pp_binary_create(char *destination, char *metadata) {
+	/* Create the file */
+	binary_file = fopen(destination, "wb");
+	if(binary_file == NULL) {
+		JANUS_LOG(LOG_ERR, "Couldn't open output file\n");
+		return -1;
+	}
+	/* Note: we're creating a binary file whose only content will be the
+	 * binary data messages, so there's no way we can add a text prefix,
+	 * header or intro, and nothing we can do with the metadata either */
+
+	return 0;
+}
+
+int janus_pp_binary_process(FILE *file, janus_pp_frame_packet *list, int *working) {
+	if(!file || !list || !working || !binary_file)
+		return -1;
+	janus_pp_frame_packet *tmp = list;
+	uint bytes = 0;
+	uint16_t bufsize = 1500;
+	uint8_t *buffer = g_malloc0(bufsize);
+
+	while(*working && tmp != NULL) {
+		if(tmp->drop) {
+			/* We marked this packet as one to drop, before */
+			JANUS_LOG(LOG_WARN, "Dropping previously marked text packet (time ~%"SCNu64"s)\n", tmp->ts);
+			tmp = tmp->next;
+			continue;
+		}
+		/* Let's read the content and write it to the file */
+		fseek(file, tmp->offset, SEEK_SET);
+		JANUS_LOG(LOG_VERB, "Reading %d bytes...\n", tmp->len);
+		uint16_t total = tmp->len;
+		while(total > 0) {
+			bytes = fread(buffer, sizeof(char), total > bufsize ? bufsize : total, file);
+			if(bytes == 0) {
+				JANUS_LOG(LOG_ERR, "Error reading from file...\n");
+				break;
+			}
+			JANUS_LOG(LOG_VERB, "Read %d bytes...\n", bytes);
+			if(fwrite(buffer, sizeof(char), bytes, binary_file) != bytes) {
+				JANUS_LOG(LOG_ERR, "Couldn't write all the buffer...\n");
+			}
+			total -= bytes;
+		}
+		fflush(binary_file);
+		/* Next? */
+		tmp = tmp->next;
+	}
+	g_free(buffer);
+
+	return 0;
+}
+
+void janus_pp_binary_close(void) {
+	/* Flush and close file */
+	if(binary_file != NULL) {
+		fflush(binary_file);
+		fclose(binary_file);
+	}
+	binary_file = NULL;
+}

--- a/postprocessing/pp-binary.h
+++ b/postprocessing/pp-binary.h
@@ -1,0 +1,23 @@
+/*! \file    pp-binary.h
+ * \author   Lorenzo Miniero <lorenzo@meetecho.com>
+ * \copyright GNU General Public License v3
+ * \brief    Post-processing to generate binary files out of binary data recordings (headers)
+ * \details  Implementation of the post-processing code needed to
+ * generate .srt files out of text data recordings.
+ *
+ * \ingroup postprocessing
+ * \ref postprocessing
+ */
+
+#ifndef JANUS_PP_BINARY
+#define JANUS_PP_BINARY
+
+#include <stdio.h>
+
+#include "pp-rtp.h"
+
+int janus_pp_binary_create(char *destination, char *metadata);
+int janus_pp_binary_process(FILE *file, janus_pp_frame_packet *list, int *working);
+void janus_pp_binary_close(void);
+
+#endif

--- a/record.c
+++ b/record.c
@@ -97,8 +97,8 @@ janus_recorder *janus_recorder_create_full(const char *dir, const char *codec, c
 			|| !strcasecmp(codec, "g711") || !strcasecmp(codec, "pcmu") || !strcasecmp(codec, "pcma")
 			|| !strcasecmp(codec, "g722")) {
 		type = JANUS_RECORDER_AUDIO;
-	} else if(!strcasecmp(codec, "text")) {
-		/* FIXME We only handle text on data channels, so that's the only thing we can save too */
+	} else if(!strcasecmp(codec, "text") || !strcasecmp(codec, "binary")) {
+		/* Data channels may be text or binary, so that's what we can save too */
 		type = JANUS_RECORDER_DATA;
 	} else {
 		/* We don't recognize the codec: while we might go on anyway, we'd rather fail instead */


### PR DESCRIPTION
This PR expands on the effort made by @ricardo-salgado-tekever in #2468, and adds support for recording binary data channels too, rather than just text data channels. It also fixed a few other things I noticed.

In mjr files, binary recordings are now marked as "binary" (where text-based data channel recordings were already marked as "text"). Since there's no way to know what data is stored in those files and so we can't expect a specific extension for the destination file as we do for other formats, while text based data recordings are still converted to `.srt` files, the postprocessor converts binary recordings to raw files instead: meaning that it will just extract the data from each packet, and append it one after the other in the file name you provide. This should be the easiest and simplest way of handling them, rather than ignoring them altogether.

To test all this, I modified the Record&Play plugin to support saving data recordings as well (Ricardo's patch only added support for playout). To test this, you can add `?data=text` or `?data=binary` as a query string argument to the `recordplaytest.html` demo page, and the demo will show a text area where you can input some text: when you press enter, the message is sent to the plugin and saved to the file in the format you asked for. At the same time, the playout of a recording including data will render the messages in the same box (notice that binary data will simply be rendered as the presence of an ArrayBuffer object).

This seems to be working fine in my setup: if you're using Record&Play in your applications, please test to ensure you don't encounter any regression. I plan to merge soon otherwise.