### PR TITLE
Do not require a cacertfile, pass null to openssl

### DIFF
--- a/transports/janus_mqtt.c
+++ b/transports/janus_mqtt.c
@@ -377,12 +377,12 @@ int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path
 
 		ctx->ssl_enabled = TRUE;
 
-		janus_config_item *cacertfile = janus_config_get(config, config_general, janus_config_type_item, "cacertfile");
+		janus_config_item *cacertfile = janus_config_get(config, config_general, janus_config_type_item, "cacertfile");		
 		if(!cacertfile || !cacertfile->value) {
-			JANUS_LOG(LOG_FATAL, "Missing CA certificate for MQTT integration...\n");
-			goto error;
+			JANUS_LOG(LOG_WARN, "No CA certificate for MQTT integration, using OpenSSL defaults\n");
 		}
-		ctx->cacert_file = g_strdup(cacertfile->value);
+		ctx->cacert_file = (cacertfile && cacertfile->value) ? g_strdup(cacertfile->value) : NULL;
+
 
 		janus_config_item *certfile = janus_config_get(config, config_general, janus_config_type_item, "certfile");
 		ctx->cert_file = (certfile && certfile->value) ? g_strdup(certfile->value) : NULL;

--- a/transports/janus_mqtt.c
+++ b/transports/janus_mqtt.c
@@ -377,7 +377,7 @@ int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path
 
 		ctx->ssl_enabled = TRUE;
 
-		janus_config_item *cacertfile = janus_config_get(config, config_general, janus_config_type_item, "cacertfile");		
+		janus_config_item *cacertfile = janus_config_get(config, config_general, janus_config_type_item, "cacertfile");
 		if(!cacertfile || !cacertfile->value) {
 			JANUS_LOG(LOG_WARN, "No CA certificate for MQTT integration, using OpenSSL defaults\n");
 		}


### PR DESCRIPTION
This will allow OpenSSL to choose where to find the CACert, or if to use one at all.
See issue #2484 
This can be super helpful for Docker deploys where you don't want to build your own CACert files, and you want OpenSSL to choose how to validate the connection.