### PR TITLE
Improve detection of maximum resolution in mjr file (postprocessor)

### DIFF
--- a/postprocessing/pp-av1.c
+++ b/postprocessing/pp-av1.c
@@ -366,10 +366,10 @@ int janus_pp_av1_preprocess(FILE *file, janus_pp_frame_packet *list) {
 				uint16_t width = 0, height = 0;
 				/* TODO Fix currently broken parsing of SH */
 				janus_pp_av1_parse_sh(payload+1, &width, &height);
-				if(width > max_width)
+				if(width*height > max_width*max_height) {
 					max_width = width;
-				if(height > max_height)
 					max_height = height;
+				}
 				JANUS_LOG(LOG_INFO, "  -- Detected new resolution: %"SCNu16"x%"SCNu16" (seq=%"SCNu16")\n", width, height, tmp->seq);
 			}
 			payload += obusize;

--- a/postprocessing/pp-h264.c
+++ b/postprocessing/pp-h264.c
@@ -288,10 +288,10 @@ int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list) {
 			JANUS_LOG(LOG_VERB, "Parsing width/height\n");
 			int width = 0, height = 0;
 			janus_pp_h264_parse_sps(prebuffer, &width, &height);
-			if(width > max_width)
+			if(width*height > max_width*max_height) {
 				max_width = width;
-			if(height > max_height)
 				max_height = height;
+			}
 		} else if((prebuffer[0] & 0x1F) == 24) {
 			/* May we find an SPS in this STAP-A? */
 			JANUS_LOG(LOG_HUGE, "Parsing STAP-A...\n");
@@ -310,10 +310,10 @@ int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list) {
 					JANUS_LOG(LOG_VERB, "Parsing width/height\n");
 					int width = 0, height = 0;
 					janus_pp_h264_parse_sps(buffer, &width, &height);
-					if(width > max_width)
+					if(width*height > max_width*max_height) {
 						max_width = width;
-					if(height > max_height)
 						max_height = height;
+					}
 				}
 				buffer += psize;
 				tot -= psize;

--- a/postprocessing/pp-h265.c
+++ b/postprocessing/pp-h265.c
@@ -331,10 +331,10 @@ int janus_pp_h265_preprocess(FILE *file, janus_pp_frame_packet *list) {
 			/* Parse to get width/height */
 			int width = 0, height = 0;
 			janus_pp_h265_parse_sps(prebuffer, &width, &height);
-			if(width > max_width)
+			if(width*height > max_width*max_height) {
 				max_width = width;
-			if(height > max_height)
 				max_height = height;
+			}
 		} else if(type == 34) {
 			/* PPS */
 			JANUS_LOG(LOG_HUGE, "[PPS] %u/%u/%u/%u\n", fbit, type, lid, tid);

--- a/postprocessing/pp-webm.c
+++ b/postprocessing/pp-webm.c
@@ -264,10 +264,10 @@ int janus_pp_webm_preprocess(FILE *file, janus_pp_frame_packet *list, gboolean v
 						int vp8h = swap2(*(unsigned short*)(c+5))&0x3fff;
 						int vp8hs = swap2(*(unsigned short*)(c+5))>>14;
 						JANUS_LOG(LOG_VERB, "(seq=%"SCNu16", ts=%"SCNu64") Key frame: %dx%d (scale=%dx%d)\n", tmp->seq, tmp->ts, vp8w, vp8h, vp8ws, vp8hs);
-						if(vp8w > max_width)
+						if(vp8w*vp8h > max_width*max_height) {
 							max_width = vp8w;
-						if(vp8h > max_height)
 							max_height = vp8h;
+						}
 					}
 				}
 			}
@@ -338,10 +338,10 @@ int janus_pp_webm_preprocess(FILE *file, janus_pp_frame_packet *list, gboolean v
 						uint16_t *h = (uint16_t *)buffer;
 						int height = ntohs(*h);
 						buffer += 2;
-						if(width > max_width)
+						if(width*height > max_width*max_height) {
 							max_width = width;
-						if(height > max_height)
 							max_height = height;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Attempt to simplify the patch originally provided in #2252, as explained in https://github.com/meetecho/janus-gateway/pull/2252#issuecomment-743140937.