### PR TITLE
Set libmicrohttpd connections limit in http transport configuration.

### DIFF
--- a/conf/janus.transport.http.jcfg.sample
+++ b/conf/janus.transport.http.jcfg.sample
@@ -20,6 +20,7 @@ general: {
 	#secure_interface = "eth0"		# Whether we should bind this server to a specific interface only
 	#secure_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address (v4 or v6) only
 	#acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+	#mhd_connection_limit = 1020		# Open connections limit in libmicrohttpd (default=1020)
 	#mhd_debug = false					# Ask libmicrohttpd to write warning and error messages to stderr (default=false)
 }
 

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -110,6 +110,9 @@ janus_transport *create(void) {
 	return &janus_http_transport;
 }
 
+/* MHD uses this value as default */
+static const unsigned int default_connection_limit = FD_SETSIZE - 4;
+static unsigned int connection_limit = default_connection_limit;
 
 /* Useful stuff */
 static gint initialized = 0, stopping = 0;
@@ -504,6 +507,7 @@ static struct MHD_Daemon *janus_http_create_daemon(gboolean admin, char *path,
 				path,
 				MHD_OPTION_NOTIFY_COMPLETED, &janus_http_request_completed, NULL,
 				MHD_OPTION_CONNECTION_TIMEOUT, 120,
+				MHD_OPTION_CONNECTION_LIMIT, connection_limit,
 				MHD_OPTION_END);
 		} else {
 			/* Bind to the interface that was specified */
@@ -520,6 +524,7 @@ static struct MHD_Daemon *janus_http_create_daemon(gboolean admin, char *path,
 				MHD_OPTION_NOTIFY_COMPLETED, &janus_http_request_completed, NULL,
 				MHD_OPTION_SOCK_ADDR, ipv6 ? (struct sockaddr *)&addr6 : (struct sockaddr *)&addr,
 				MHD_OPTION_CONNECTION_TIMEOUT, 120,
+				MHD_OPTION_CONNECTION_LIMIT, connection_limit,
 				MHD_OPTION_END);
 		}
 	} else {
@@ -545,6 +550,7 @@ static struct MHD_Daemon *janus_http_create_daemon(gboolean admin, char *path,
 				MHD_OPTION_HTTPS_MEM_KEY, cert_key_bytes,
 				MHD_OPTION_HTTPS_KEY_PASSWORD, password,
 				MHD_OPTION_CONNECTION_TIMEOUT, 120,
+				MHD_OPTION_CONNECTION_LIMIT, connection_limit,
 				MHD_OPTION_END);
 		} else {
 			/* Bind to the interface that was specified */
@@ -565,6 +571,7 @@ static struct MHD_Daemon *janus_http_create_daemon(gboolean admin, char *path,
 				MHD_OPTION_HTTPS_KEY_PASSWORD, password,
 				MHD_OPTION_SOCK_ADDR, ipv6 ? (struct sockaddr *)&addr6 : (struct sockaddr *)&addr,
 				MHD_OPTION_CONNECTION_TIMEOUT, 120,
+				MHD_OPTION_CONNECTION_LIMIT, connection_limit,
 				MHD_OPTION_END);
 		}
 	}
@@ -699,6 +706,12 @@ int janus_http_init(janus_transport_callbacks *callback, const char *config_path
 			}
 		} else {
 			admin_ws_path = g_strdup("/admin");
+		}
+		/* Check the open connections limit for mhd */
+		item = janus_config_get(config, config_general, janus_config_type_item, "mhd_connection_limit");
+		if(item && item->value && janus_string_to_uint32(item->value, &connection_limit) < 0) {
+			JANUS_LOG(LOG_ERR, "Invalid mhd_connection_limit (%s), falling back to default\n", item->value);
+			connection_limit = default_connection_limit;
 		}
 		/* Should we set the debug flag in libmicrohttpd? */
 		item = janus_config_get(config, config_general, janus_config_type_item, "mhd_debug");

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -111,8 +111,8 @@ janus_transport *create(void) {
 }
 
 /* MHD uses this value as default */
-static const unsigned int default_connection_limit = FD_SETSIZE - 4;
-static unsigned int connection_limit = default_connection_limit;
+#define DEFAULT_CONNECTION_LIMIT (FD_SETSIZE-4)
+static unsigned int connection_limit = DEFAULT_CONNECTION_LIMIT;
 
 /* Useful stuff */
 static gint initialized = 0, stopping = 0;
@@ -711,7 +711,7 @@ int janus_http_init(janus_transport_callbacks *callback, const char *config_path
 		item = janus_config_get(config, config_general, janus_config_type_item, "mhd_connection_limit");
 		if(item && item->value && janus_string_to_uint32(item->value, &connection_limit) < 0) {
 			JANUS_LOG(LOG_ERR, "Invalid mhd_connection_limit (%s), falling back to default\n", item->value);
-			connection_limit = default_connection_limit;
+			connection_limit = DEFAULT_CONNECTION_LIMIT;
 		}
 		/* Should we set the debug flag in libmicrohttpd? */
 		item = janus_config_get(config, config_general, janus_config_type_item, "mhd_debug");


### PR DESCRIPTION
This PR lets the user define the maximum number of open connection in libmicrohttpd through the `mhd_connection_limit` setting in the http transport configuration.

As explained [in the official docs](https://www.gnu.org/software/libmicrohttpd/manual/libmicrohttpd.html).

> MHD_OPTION_CONNECTION_LIMIT
>Maximum number of concurrent connections to accept (followed by an unsigned int). The default is FD_SETSIZE - 4

(`FD_SETSIZE` is `1024` in most environments)
This should be useful for deployments that make intensive use of http transport and could hit that limit. 
Default value has been preserved to `FD_SETSIZE - 4`.