### PR TITLE
Add hold parameter media_direction

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4098,20 +4098,31 @@ static void *janus_sip_handler(void *data) {
 				/* To put the call on-hold, we need to set the direction to recvonly:
 				 * resuming it means resuming the direction we had before */
 				session->media.on_hold = hold;
+				json_t *media_direction = json_object_get(root, "media_direction");
+				const char *media_direction_text = json_string_value(media_direction);
 				janus_sdp_mline *m = janus_sdp_mline_find(session->sdp, JANUS_SDP_AUDIO);
 				if(m) {
 					if(hold) {
 						/* Take note of the original media direction */
 						session->media.pre_hold_audio_dir = m->direction;
 						/* Update the media direction */
-						switch(m->direction) {
-							case JANUS_SDP_DEFAULT:
-							case JANUS_SDP_SENDRECV:
+						if(media_direction_text){
+							if(!strcasecmp(media_direction_text, "sendonly")){
 								m->direction = JANUS_SDP_SENDONLY;
-								break;
-							default:
+							} else if(!strcasecmp(media_direction_text, "inactive")){
 								m->direction = JANUS_SDP_INACTIVE;
-								break;
+							} else {
+							}
+						} else {
+							switch(m->direction) {
+								case JANUS_SDP_DEFAULT:
+								case JANUS_SDP_SENDRECV:
+									m->direction = JANUS_SDP_SENDONLY;
+									break;
+								default:
+									m->direction = JANUS_SDP_INACTIVE;
+									break;
+							}						
 						}
 					} else {
 						m->direction = session->media.pre_hold_audio_dir;
@@ -4123,14 +4134,23 @@ static void *janus_sip_handler(void *data) {
 						/* Take note of the original media direction */
 						session->media.pre_hold_video_dir = m->direction;
 						/* Update the media direction */
-						switch(m->direction) {
-							case JANUS_SDP_DEFAULT:
-							case JANUS_SDP_SENDRECV:
+						if(media_direction_text){
+							if(!strcasecmp(media_direction_text, "sendonly")){
 								m->direction = JANUS_SDP_SENDONLY;
-								break;
-							default:
+							} else if(!strcasecmp(media_direction_text, "inactive")){
 								m->direction = JANUS_SDP_INACTIVE;
-								break;
+							} else {
+							}
+						} else {
+							switch(m->direction) {
+								case JANUS_SDP_DEFAULT:
+								case JANUS_SDP_SENDRECV:
+									m->direction = JANUS_SDP_SENDONLY;
+									break;
+								default:
+									m->direction = JANUS_SDP_INACTIVE;
+									break;
+							}
 						}
 					} else {
 						m->direction = session->media.pre_hold_video_dir;

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4106,7 +4106,7 @@ static void *janus_sip_handler(void *data) {
 						/* Take note of the original media direction */
 						session->media.pre_hold_audio_dir = m->direction;
 						/* Update the media direction */
-						if(media_direction_text){
+						if(strlen(media_direction_text) > 0){
 							if(!strcasecmp(media_direction_text, "sendonly")){
 								m->direction = JANUS_SDP_SENDONLY;
 							} else if(!strcasecmp(media_direction_text, "inactive")){
@@ -4134,7 +4134,7 @@ static void *janus_sip_handler(void *data) {
 						/* Take note of the original media direction */
 						session->media.pre_hold_video_dir = m->direction;
 						/* Update the media direction */
-						if(media_direction_text){
+						if(strlen(media_direction_text) > 0){
 							if(!strcasecmp(media_direction_text, "sendonly")){
 								m->direction = JANUS_SDP_SENDONLY;
 							} else if(!strcasecmp(media_direction_text, "inactive")){

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4106,7 +4106,7 @@ static void *janus_sip_handler(void *data) {
 						/* Take note of the original media direction */
 						session->media.pre_hold_audio_dir = m->direction;
 						/* Update the media direction */
-						if(strlen(media_direction_text) > 0){
+						if(media_direction_text != NULL && strlen(media_direction_text) > 0){
 							if(!strcasecmp(media_direction_text, "sendonly")){
 								m->direction = JANUS_SDP_SENDONLY;
 							} else if(!strcasecmp(media_direction_text, "inactive")){
@@ -4134,7 +4134,7 @@ static void *janus_sip_handler(void *data) {
 						/* Take note of the original media direction */
 						session->media.pre_hold_video_dir = m->direction;
 						/* Update the media direction */
-						if(strlen(media_direction_text) > 0){
+						if(media_direction_text != NULL && strlen(media_direction_text) > 0){
 							if(!strcasecmp(media_direction_text, "sendonly")){
 								m->direction = JANUS_SDP_SENDONLY;
 							} else if(!strcasecmp(media_direction_text, "inactive")){

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4107,11 +4107,10 @@ static void *janus_sip_handler(void *data) {
 						session->media.pre_hold_audio_dir = m->direction;
 						/* Update the media direction */
 						if(media_direction_text != NULL && strlen(media_direction_text) > 0){
-							if(!strcasecmp(media_direction_text, "sendonly")){
-								m->direction = JANUS_SDP_SENDONLY;
-							} else if(!strcasecmp(media_direction_text, "inactive")){
+							if(!strcasecmp(media_direction_text, "inactive")){
 								m->direction = JANUS_SDP_INACTIVE;
 							} else {
+								m->direction = JANUS_SDP_SENDONLY;
 							}
 						} else {
 							switch(m->direction) {
@@ -4135,11 +4134,10 @@ static void *janus_sip_handler(void *data) {
 						session->media.pre_hold_video_dir = m->direction;
 						/* Update the media direction */
 						if(media_direction_text != NULL && strlen(media_direction_text) > 0){
-							if(!strcasecmp(media_direction_text, "sendonly")){
-								m->direction = JANUS_SDP_SENDONLY;
-							} else if(!strcasecmp(media_direction_text, "inactive")){
+							if(!strcasecmp(media_direction_text, "inactive")){
 								m->direction = JANUS_SDP_INACTIVE;
 							} else {
+								m->direction = JANUS_SDP_SENDONLY;
 							}
 						} else {
 							switch(m->direction) {


### PR DESCRIPTION
add hold parameter: media_direction

Added optional parameter "media_direction" , with the different possibilities such as:
media_direction = sendonly
media_direction = inactive
{
         "message": {
             "request": "hold",
             "media_direction": "sendonly"
         }
     };