### PR TITLE
audiobridge: announcement leak fixed

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -4189,7 +4189,6 @@ static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_s
 			goto prepare_response;
 		}
 		/* We're done, add the announcement to the room */
-		janus_refcount_increase(&p->ref);
 		g_hash_table_insert(audiobridge->anncs, g_strdup(p->user_id_str), p);
 		janus_mutex_unlock(&audiobridge->mutex);
 		janus_mutex_unlock(&rooms_mutex);


### PR DESCRIPTION
According to docs [janus_refcount_init](https://janus.conf.meetecho.com/docs/refcount_8h.html#a4f0d5bd94a8cc56133dae364ca6989ca) already set reference counter to 1 here:  https://github.com/meetecho/janus-gateway/blob/master/plugins/janus_audiobridge.c#L4153 so [`janus_refcount_increase`](https://github.com/meetecho/janus-gateway/blob/master/plugins/janus_audiobridge.c#L4192) just will lead to memory leak.
Please correct me if I'm wrong.

P.S.: Right now this bug leads to `Too many open files` error at runtime on intensive use of announcements.