### PR TITLE
FreeBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,16 +209,14 @@ You can also selectively enable/disable other features (e.g., specific plugins y
 
 ### Building on FreeBSD
 * *Note*: rtp_forward of streams only works streaming to IPv6,
-because of [2051](https://github.com/meetecho/janus-gateway/issues/2051) and thus the feature
-is not supported on FreeBSD at the moment
+because of #2051 and thus the feature is not supported on FreeBSD at the moment.
 
-
-When building on FreeBSD you can install the depencencies from ports or packages, here only pkg method is used. You also need to use gmake instead of make,
-since it is a GNU makefile. ./configure can be run without arguments since the default prefix is /usr/local which is your default LOCALBASE.
-Note that the configure.ac is coded to use openssl in base. If you wish to use openssl from ports or any other ssl you must change configure.ac accordingly.
+When building on FreeBSD you can install the depencencies from ports or packages, here only pkg method is used. You also need to use `gmake` instead of `make`,
+since it is a GNU makefile. `./configure` can be run without arguments since the default prefix is `/usr/local` which is your default `LOCALBASE`.
+Note that the `configure.ac` is coded to use openssl in base. If you wish to use openssl from ports or any other ssl you must change `configure.ac` accordingly.
 
 	pkg install libsrtp2 libusrsctp jansson libnice libmicrohttpd libwebsockets curl opus sofia-sip libogg jansson libnice libconfig \
-        libtool gmake autoconf autoconf-wrapper glib
+        libtool gmake autoconf autoconf-wrapper glib gengetopt
 
 
 ### Building on MacOS

--- a/README.md
+++ b/README.md
@@ -208,29 +208,13 @@ If Doxygen and graphviz are available, the process can also build the documentat
 You can also selectively enable/disable other features (e.g., specific plugins you don't care about, or whether or not you want to build the recordings post-processor). Use the --help option when configuring for more info.
 
 ### Building on FreeBSD
-	pkg install libsrtp2 \
-        libusrsctp \
-        jansson \
-        libnice \
-        libmicrohttpd \
-        libwebsockets \
-        curl \
-        opus \
-        sofia-sip \
-        libogg \
-        jansson \
-        libnice \
-        libconfig \
-        libtool \
-        gmake \
-        autoconf \
-        autoconf-wrapper \
-        glib
+When building on FreeBSD you can install the depencencies from ports or packages, here only pkg method is used. You also need to use gmake instead of make,
+since it is a GNU makefile. ./configure can be run without arguments since the default prefix is /usr/local which is your default LOCALBASE.
+Note that the configure.ac is coded to use openssl in base. If you wish to use openssl from ports or any other ssl you must change configure.ac accordingly.
 
-	sh autogen.sh
-	./configure
-	gmake
-	gmake install
+	pkg install libsrtp2 libusrsctp jansson libnice libmicrohttpd libwebsockets curl opus sofia-sip libogg jansson libnice libconfig \
+        libtool gmake autoconf autoconf-wrapper glib
+
 
 ### Building on MacOS
 While most of the above instructions will work when compiling Janus on MacOS as well, there are a few aspects to highlight when doing that.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,30 @@ If Doxygen and graphviz are available, the process can also build the documentat
 
 You can also selectively enable/disable other features (e.g., specific plugins you don't care about, or whether or not you want to build the recordings post-processor). Use the --help option when configuring for more info.
 
+### Building on FreeBSD
+	pkg install libsrtp2 \
+        libusrsctp \
+        jansson \
+        libnice \
+        libmicrohttpd \
+        libwebsockets \
+        curl \
+        opus \
+        sofia-sip \
+        libogg \
+        jansson \
+        libnice \
+        libconfig \
+        libtool \
+        gmake \
+        autoconf \
+        autoconf-wrapper \
+        glib
+
+	sh autogen.sh
+	./configure
+	gmake
+	gmake install
 
 ### Building on MacOS
 While most of the above instructions will work when compiling Janus on MacOS as well, there are a few aspects to highlight when doing that.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ If Doxygen and graphviz are available, the process can also build the documentat
 You can also selectively enable/disable other features (e.g., specific plugins you don't care about, or whether or not you want to build the recordings post-processor). Use the --help option when configuring for more info.
 
 ### Building on FreeBSD
+* *Note*: rtp_forward of streams only works streaming to IPv6,
+because of [2051](https://github.com/meetecho/janus-gateway/issues/2051) and thus the feature
+is not supported on FreeBSD at the moment
+
+
 When building on FreeBSD you can install the depencencies from ports or packages, here only pkg method is used. You also need to use gmake instead of make,
 since it is a GNU makefile. ./configure can be run without arguments since the default prefix is /usr/local which is your default LOCALBASE.
 Note that the configure.ac is coded to use openssl in base. If you wish to use openssl from ports or any other ssl you must change configure.ac accordingly.

--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,12 @@ darwin*)
 	LDFLAGS="$LDFLAGS -L/usr/local/lib -L/usr/local/opt/openssl/lib -L/opt/local/lib -L/usr/local/libsrtp/lib"
 	AM_CONDITIONAL([DARWIN_OS], true)
 ;;
+freebsd*)
+	CFLAGS="$CFLAGS -I /usr/include/openssl -I/usr/local/lib/include/nice"
+	LDFLAGS="$LDFLAGS -Xlinker --export-dynamic"
+	LDFLAGS="$LDFLAGS -L/usr/lib/openssl -lcrypto -lssl -L/usr/local/lib -lnice"
+	AM_CONDITIONAL([DARWIN_OS], false)
+;;
 *)
 	LDFLAGS="$LDFLAGS -Wl,--export-dynamic"
 	AM_CONDITIONAL([DARWIN_OS], false)
@@ -343,8 +349,6 @@ PKG_CHECK_MODULES([JANUS],
                     libconfig
                     nice
                     jansson >= $jansson_version
-                    libssl >= $ssl_version
-                    libcrypto
                     zlib
                   ])
 JANUS_MANUAL_LIBS="${JANUS_MANUAL_LIBS} -lm"

--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,11 @@ clang*)
 		-Wno-cast-align \
 		-Wno-initializer-overrides"
 ;;
+cc*)
+	CFLAGS="$CFLAGS \
+		-Wno-cast-align \
+		-Wno-initializer-overrides"
+;;
 *)
 	# Specific gcc flags
 	CFLAGS="$CFLAGS \
@@ -68,7 +73,6 @@ clang*)
 		-Wunsafe-loop-optimizations \
 		-Wunused-but-set-variable"
 esac
-
 JANUS_VERSION=110
 AC_SUBST(JANUS_VERSION)
 JANUS_VERSION_STRING="0.10.10"
@@ -341,16 +345,29 @@ AC_ARG_ENABLE([systemd-sockets],
                               [Enable Systemd Unix Sockets management])],
               [],
               [enable_systemd_sockets=no])
-
-PKG_CHECK_MODULES([JANUS],
-                  [
-                    glib-2.0 >= $glib_version
+case "$host_os" in
+freebsd*)
+	PKGCHECKMODULES="glib-2.0 >= $glib_version
                     gio-2.0 >= $glib_version
                     libconfig
                     nice
                     jansson >= $jansson_version
-                    zlib
-                  ])
+                    zlib"
+;;
+*)
+	PKGCHECKMODULES="glib-2.0 >= $glib_version
+                    gio-2.0 >= $glib_version
+                    libconfig
+                    nice
+                    jansson >= $jansson_version
+                    libssl >= $ssl_version
+                    libcrypto
+                    zlib"
+
+esac
+PKG_CHECK_MODULES([JANUS],"$PKGCHECKMODULES")
+
+
 JANUS_MANUAL_LIBS="${JANUS_MANUAL_LIBS} -lm"
 AC_SUBST(JANUS_MANUAL_LIBS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,7 @@ cc*)
 		-Wunsafe-loop-optimizations \
 		-Wunused-but-set-variable"
 esac
+
 JANUS_VERSION=110
 AC_SUBST(JANUS_VERSION)
 JANUS_VERSION_STRING="0.10.10"
@@ -345,6 +346,7 @@ AC_ARG_ENABLE([systemd-sockets],
                               [Enable Systemd Unix Sockets management])],
               [],
               [enable_systemd_sockets=no])
+
 case "$host_os" in
 freebsd*)
 	PKGCHECKMODULES="glib-2.0 >= $glib_version
@@ -363,10 +365,8 @@ freebsd*)
                     libssl >= $ssl_version
                     libcrypto
                     zlib"
-
 esac
 PKG_CHECK_MODULES([JANUS],"$PKGCHECKMODULES")
-
 
 JANUS_MANUAL_LIBS="${JANUS_MANUAL_LIBS} -lm"
 AC_SUBST(JANUS_MANUAL_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -87,9 +87,9 @@ darwin*)
 	AM_CONDITIONAL([DARWIN_OS], true)
 ;;
 freebsd*)
-	CFLAGS="$CFLAGS -I /usr/include/openssl -I/usr/local/lib/include/nice"
+	CFLAGS="$CFLAGS -I /usr/include/openssl"
 	LDFLAGS="$LDFLAGS -Xlinker --export-dynamic"
-	LDFLAGS="$LDFLAGS -L/usr/lib/openssl -lcrypto -lssl -L/usr/local/lib -lnice"
+	LDFLAGS="$LDFLAGS -L/usr/lib/openssl -lcrypto -lssl -L/usr/local/lib"
 	AM_CONDITIONAL([DARWIN_OS], false)
 ;;
 *)

--- a/configure.ac
+++ b/configure.ac
@@ -87,7 +87,7 @@ darwin*)
 	AM_CONDITIONAL([DARWIN_OS], true)
 ;;
 freebsd*)
-	CFLAGS="$CFLAGS -I /usr/include/openssl"
+	CFLAGS="$CFLAGS -I/usr/include/openssl"
 	LDFLAGS="$LDFLAGS -Xlinker --export-dynamic"
 	LDFLAGS="$LDFLAGS -L/usr/lib/openssl -lcrypto -lssl -L/usr/local/lib"
 	AM_CONDITIONAL([DARWIN_OS], false)

--- a/janus.c
+++ b/janus.c
@@ -5333,6 +5333,7 @@ gint main(int argc, char *argv[])
 		if (!transport) {
 			JANUS_LOG(LOG_ERR, "\tCouldn't load transport plugin '%s': %s\n", transportent->d_name, dlerror());
 		} else {
+			dlerror();//clear errors
 			create_t *create = (create_t*) dlsym(transport, "create");
 			const char *dlsym_error = dlerror();
 			if (dlsym_error) {

--- a/janus.c
+++ b/janus.c
@@ -5333,7 +5333,6 @@ gint main(int argc, char *argv[])
 		if (!transport) {
 			JANUS_LOG(LOG_ERR, "\tCouldn't load transport plugin '%s': %s\n", transportent->d_name, dlerror());
 		} else {
-			dlerror();//clear errors
 			create_t *create = (create_t*) dlsym(transport, "create");
 			const char *dlsym_error = dlerror();
 			if (dlsym_error) {

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -857,6 +857,10 @@ room-<unique room ID>: {
  */
 
 #include "plugin.h"
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
 
 #include <jansson.h>
 #include <opus/opus.h>

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -88,7 +88,7 @@ Usage: janus-pp-rec [OPTIONS] source.mjr [destination.[opus|wav|webm|mp4|srt]]
  */
 
 #include <arpa/inet.h>
-#ifdef __MACH__
+#if defined(__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #else
 #include <endian.h>

--- a/postprocessing/mjr2pcap.c
+++ b/postprocessing/mjr2pcap.c
@@ -25,7 +25,7 @@
  */
 
 #include <arpa/inet.h>
-#ifdef __MACH__
+#if defined(__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #else
 #include <endian.h>

--- a/postprocessing/pp-av1.c
+++ b/postprocessing/pp-av1.c
@@ -10,7 +10,7 @@
  */
 
 #include <arpa/inet.h>
-#ifdef __MACH__
+#if defined(__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #else
 #include <endian.h>

--- a/postprocessing/pp-binary.c
+++ b/postprocessing/pp-binary.c
@@ -12,7 +12,7 @@
  */
 
 #include <arpa/inet.h>
-#ifdef __MACH__
+#if defined(__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #else
 #include <endian.h>

--- a/postprocessing/pp-g711.c
+++ b/postprocessing/pp-g711.c
@@ -10,7 +10,7 @@
  */
 
 #include <arpa/inet.h>
-#ifdef __MACH__
+#if defined(__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #else
 #include <endian.h>

--- a/postprocessing/pp-g722.c
+++ b/postprocessing/pp-g722.c
@@ -10,7 +10,7 @@
  */
 
 #include <arpa/inet.h>
-#ifdef __MACH__
+#if defined (__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #else
 #include <endian.h>

--- a/postprocessing/pp-h264.c
+++ b/postprocessing/pp-h264.c
@@ -10,7 +10,7 @@
  */
 
 #include <arpa/inet.h>
-#ifdef __MACH__
+#if defined(__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #else
 #include <endian.h>

--- a/postprocessing/pp-h265.c
+++ b/postprocessing/pp-h265.c
@@ -10,7 +10,7 @@
  */
 
 #include <arpa/inet.h>
-#ifdef __MACH__
+#if defined(__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #else
 #include <endian.h>

--- a/postprocessing/pp-opus.c
+++ b/postprocessing/pp-opus.c
@@ -10,7 +10,7 @@
  */
 
 #include <arpa/inet.h>
-#ifdef __MACH__
+#if defined(__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #else
 #include <endian.h>

--- a/postprocessing/pp-rtp.h
+++ b/postprocessing/pp-rtp.h
@@ -13,7 +13,7 @@
 #ifndef JANUS_PP_RTP
 #define JANUS_PP_RTP
 
-#ifdef __MACH__
+#if defined(__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN

--- a/postprocessing/pp-srt.c
+++ b/postprocessing/pp-srt.c
@@ -10,7 +10,7 @@
  */
 
 #include <arpa/inet.h>
-#ifdef __MACH__
+#if defined(__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #else
 #include <endian.h>

--- a/postprocessing/pp-webm.c
+++ b/postprocessing/pp-webm.c
@@ -10,7 +10,7 @@
  */
 
 #include <arpa/inet.h>
-#ifdef __MACH__
+#if defined(__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #else
 #include <endian.h>

--- a/rtcp.h
+++ b/rtcp.h
@@ -19,6 +19,8 @@
 #include <arpa/inet.h>
 #ifdef __MACH__
 #include <machine/endian.h>
+#elif defined(__FreeBSD__)
+#include <sys/endian.h>
 #else
 #include <endian.h>
 #endif

--- a/rtp.h
+++ b/rtp.h
@@ -14,7 +14,7 @@
 #define JANUS_RTP_H
 
 #include <arpa/inet.h>
-#ifdef __MACH__
+#if defined (__MACH__) || defined(__FreeBSD__)
 #include <machine/endian.h>
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN

--- a/text2pcap.c
+++ b/text2pcap.c
@@ -41,6 +41,11 @@
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN
+#elif defined(__FreeBSD__)
+#include <sys/endian.h>
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
 #else
 #include <endian.h>
 #endif

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -623,9 +623,8 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 				ip = (char *)item->value;
 #ifdef __FreeBSD__
 				struct in_addr addr;
-				if(inet_net_pton(AF_INET, ip, &addr, sizeof(addr))>0) {
+				if(inet_net_pton(AF_INET, ip, &addr, sizeof(addr)) > 0)
 					ipv4_only = 1;
-				}
 #endif
 				char *iface = janus_websockets_get_interface_name(ip);
 				if(iface == NULL) {
@@ -681,9 +680,8 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 				ip = (char *)item->value;
 #ifdef __FreeBSD__
 				struct in_addr addr;
-				if(inet_net_pton(AF_INET, ip, &addr, sizeof(addr))>0) {
+				if(inet_net_pton(AF_INET, ip, &addr, sizeof(addr)) > 0)
 					ipv4_only = 1;
-				}
 #endif
 				char *iface = janus_websockets_get_interface_name(ip);
 				if(iface == NULL) {
@@ -764,9 +762,8 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 				ip = (char *)item->value;
 #ifdef __FreeBSD__
 				struct in_addr addr;
-				if(inet_net_pton(AF_INET, ip, &addr, sizeof(addr))>0) {
+				if(inet_net_pton(AF_INET, ip, &addr, sizeof(addr)) > 0)
 					ipv4_only = 1;
-				}
 #endif
 				char *iface = janus_websockets_get_interface_name(ip);
 				if(iface == NULL) {
@@ -822,9 +819,8 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 				ip = (char *)item->value;
 #ifdef __FreeBSD__
 				struct in_addr addr;
-				if(inet_net_pton(AF_INET, ip, &addr, sizeof(addr))>0) {
+				if(inet_net_pton(AF_INET, ip, &addr, sizeof(addr)) > 0)
 					ipv4_only = 1;
-				}
 #endif
 				char *iface = janus_websockets_get_interface_name(ip);
 				if(iface == NULL) {

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -385,6 +385,7 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 #ifndef LWS_WITH_IPV6
 	JANUS_LOG(LOG_WARN, "libwebsockets has been built without IPv6 support, will bind to IPv4 only\n");
 #endif
+
 #ifdef __FreeBSD__
 	int ipv4_only = 0;
 #endif
@@ -726,7 +727,6 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 #else
 				info.options = 0;
 #endif
-
 #ifdef __FreeBSD__
 				if(ipv4_only) {
 					info.options |= LWS_SERVER_OPTION_DISABLE_IPV6;
@@ -863,8 +863,6 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 				info.ssl_cipher_list = ciphers;
 				info.gid = -1;
 				info.uid = -1;
-
-
 #if LWS_LIBRARY_VERSION_MAJOR >= 2
 				info.options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
 #else

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -790,9 +790,9 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 			info.options = 0;
 #ifdef __FreeBSD__
 			if (ipv4_only) {
-                            info.options |= LWS_SERVER_OPTION_DISABLE_IPV6;
-                            ipv4_only = 0;
-                        }
+				info.options |= LWS_SERVER_OPTION_DISABLE_IPV6;
+				ipv4_only = 0;
+			}
 #endif
 #if (LWS_LIBRARY_VERSION_MAJOR == 3 && LWS_LIBRARY_VERSION_MINOR >= 2) || (LWS_LIBRARY_VERSION_MAJOR > 3)
 			info.options |= LWS_SERVER_OPTION_FAIL_UPON_UNABLE_TO_BIND;

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -649,7 +649,7 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 #ifdef __FreeBSD__
 			if (ipv4_only) {
 				info.options |= LWS_SERVER_OPTION_DISABLE_IPV6;
-				ipv4_only=0;
+				ipv4_only = 0;
 			}
 #endif
 			/* Create the WebSocket context */

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -669,7 +669,6 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 				JANUS_LOG(LOG_ERR, "Invalid port (%s), falling back to default\n", item->value);
 				wsport = 8989;
 			}
-			ipv4_only = 0;
 			char *interface = NULL;
 			item = janus_config_get(config, config_general, janus_config_type_item, "wss_interface");
 			if(item && item->value)

--- a/transports/janus_websockets.c
+++ b/transports/janus_websockets.c
@@ -592,6 +592,7 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 #endif
 		/* Force single-thread server */
 		wscinfo.count_threads = 1;
+
 		/* Create the base context */
 		wsc = lws_create_context(&wscinfo);
 		if(wsc == NULL) {
@@ -675,7 +676,6 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 				interface = (char *)item->value;
 			char *ip = NULL;
 			item = janus_config_get(config, config_general, janus_config_type_item, "wss_ip");
-
 			if(item && item->value) {
 				ip = (char *)item->value;
 #ifdef __FreeBSD__
@@ -730,7 +730,7 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 #ifdef __FreeBSD__
 				if(ipv4_only) {
 					info.options |= LWS_SERVER_OPTION_DISABLE_IPV6;
-                    ipv4_only = 0;
+					ipv4_only = 0;
 				}
 #endif
 				/* Create the secure WebSocket context */
@@ -761,14 +761,13 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 			char *ip = NULL;
 			item = janus_config_get(config, config_admin, janus_config_type_item, "admin_ws_ip");
 			if(item && item->value) {
-                ip = (char *)item->value;
+				ip = (char *)item->value;
 #ifdef __FreeBSD__
-                struct in_addr addr;
-                if(inet_net_pton(AF_INET, ip, &addr, sizeof(addr))>0) {
-                    ipv4_only = 1;
-                }
+				struct in_addr addr;
+				if(inet_net_pton(AF_INET, ip, &addr, sizeof(addr))>0) {
+					ipv4_only = 1;
+				}
 #endif
-
 				char *iface = janus_websockets_get_interface_name(ip);
 				if(iface == NULL) {
 					JANUS_LOG(LOG_WARN, "No interface associated with %s? Falling back to no interface...\n", ip);
@@ -790,11 +789,10 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 			info.options = 0;
 #ifdef __FreeBSD__
 			if (ipv4_only) {
-                info.options |= LWS_SERVER_OPTION_DISABLE_IPV6;
-                ipv4_only = 0;
-            }
+                            info.options |= LWS_SERVER_OPTION_DISABLE_IPV6;
+                            ipv4_only = 0;
+                        }
 #endif
-
 			/* Create the WebSocket context */
 			admin_wss = lws_create_vhost(wsc, &info);
 			if(admin_wss == NULL) {
@@ -821,12 +819,12 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 			char *ip = NULL;
 			item = janus_config_get(config, config_admin, janus_config_type_item, "admin_wss_ip");
 			if(item && item->value) {
-			ip = (char *)item->value;
+				ip = (char *)item->value;
 #ifdef __FreeBSD__
 				struct in_addr addr;
-                if(inet_net_pton(AF_INET, ip, &addr, sizeof(addr))>0) {
-                    ipv4_only = 1;
-                }
+				if(inet_net_pton(AF_INET, ip, &addr, sizeof(addr))>0) {
+					ipv4_only = 1;
+				}
 #endif
 				char *iface = janus_websockets_get_interface_name(ip);
 				if(iface == NULL) {
@@ -874,9 +872,9 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 #endif
 #ifdef __FreeBSD__
 				if (ipv4_only) {
-                    info.options |= LWS_SERVER_OPTION_DISABLE_IPV6;
-                    ipv4_only = 0;
-                }
+					info.options |= LWS_SERVER_OPTION_DISABLE_IPV6;
+					ipv4_only = 0;
+				}
 #endif
 				/* Create the secure WebSocket context */
 				admin_swss = lws_create_vhost(wsc, &info);


### PR DESCRIPTION
I mostly corrected endianness includes and defines. 
Most notable change is in transports/janus_websockets.c
There I set LWS_SERVER_OPTION_DISABLE_IPV6, because of 
https://github.com/warmcat/libwebsockets/issues/1947.
This is probably a FreeBSD only issue, and  perhaps it should be in preprocessor macros.
I also did comment ip = iface out, since ws_ip is supposed to only bind to the ws_ip set.
This might be a bug common to all systems though. I have only tested build on FreeBSD.
Also see https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=219444
See also #2232