### PR TITLE
Feature/enhance typings

### DIFF
--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -72,11 +72,7 @@ declare namespace JanusJS {
 		consentDialog?: (on: boolean) => void;
 		webrtcState?: (isConnected: boolean) => void;
 		iceState?: (state: 'connected' | 'failed') => void;
-		mediaState?: (
-			medium: 'audio' | 'video',
-			receiving: boolean,
-			mid?: number
-		) => void;
+		mediaState?: (medium: 'audio' | 'video', receiving: boolean, mid?: number) => void;
 		slowLink?: (state: { uplink: boolean }) => void;
 		onmessage?: (message: Message, jsep?: JSEP) => void;
 		onlocalstream?: (stream: MediaStream) => void;
@@ -143,9 +139,7 @@ declare namespace JanusJS {
 	}
 
 	class Janus {
-		static useDefaultDependencies(
-			deps: Partial<Dependencies>
-		): DependenciesResult;
+		static useDefaultDependencies(deps: Partial<Dependencies>): DependenciesResult;
 		static useOldDependencies(deps: Partial<Dependencies>): DependenciesResult;
 		static init(options: InitOptions): void;
 		static isWebrtcSupported(): boolean;
@@ -154,14 +148,8 @@ declare namespace JanusJS {
 		static warn(...args: any[]): void;
 		static error(...args: any[]): void;
 		static randomString(length: number): string;
-		static attachMediaStream(
-			element: HTMLMediaElement,
-			stream: MediaStream
-		): void;
-		static reattachMediaStream(
-			to: HTMLMediaElement,
-			from: HTMLMediaElement
-		): void;
+		static attachMediaStream(element: HTMLMediaElement, stream: MediaStream): void;
+		static reattachMediaStream(to: HTMLMediaElement, from: HTMLMediaElement): void;
 
 		constructor(options: ConstructorOptions);
 

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -1,6 +1,6 @@
 declare namespace JanusJS {
 	interface Dependencies {
-		adapter: any;
+		adapter: import("webrtc-adapter").IAdapter;
 		WebSocket: (server: string, protocol: string) => WebSocket;
 		isArray: (array: any) => array is Array<any>;
 		extension: () => boolean;

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -5,9 +5,9 @@ declare namespace JanusJS {
 		isArray: (array: any) => array is Array<any>;
 		extension: () => boolean;
 		httpAPICall: (url: string, options: any) => void;
-    }
-    
-    interface DependenciesResult {
+	}
+
+	interface DependenciesResult {
 		adapter: any;
 		newWebSocket: (server: string, protocol: string) => WebSocket;
 		isArray: (array: any) => array is Array<any>;
@@ -16,17 +16,17 @@ declare namespace JanusJS {
 	}
 
 	enum DebugLevel {
-		Trace = 'trace',
-		Debug = 'debug',
-		Log = 'log',
-		Warning = 'warn',
-		Error = 'error'
+		Trace = "trace",
+		Debug = "debug",
+		Log = "log",
+		Warning = "warn",
+		Error = "error",
 	}
 
 	interface JSEP {}
 
 	interface InitOptions {
-		debug?: boolean | 'all' | DebugLevel[];
+		debug?: boolean | "all" | DebugLevel[];
 		callback?: Function;
 		dependencies?: DependenciesResult;
 	}
@@ -46,13 +46,13 @@ declare namespace JanusJS {
 	}
 
 	enum MessageType {
-		Recording = 'recording',
-		Starting = 'starting',
-		Started = 'started',
-		Stopped = 'stopped',
-		SlowLink = 'slow_link',
-		Preparing = 'preparing',
-		Refreshing = 'refreshing'
+		Recording = "recording",
+		Starting = "starting",
+		Started = "started",
+		Stopped = "stopped",
+		SlowLink = "slow_link",
+		Preparing = "preparing",
+		Refreshing = "refreshing",
 	}
 
 	interface Message {
@@ -71,8 +71,12 @@ declare namespace JanusJS {
 		error?: (error: any) => void;
 		consentDialog?: (on: boolean) => void;
 		webrtcState?: (isConnected: boolean) => void;
-		iceState?: (state: 'connected' | 'failed') => void;
-		mediaState?: (medium: 'audio' | 'video', receiving: boolean, mid?: number) => void;
+		iceState?: (state: "connected" | "failed") => void;
+		mediaState?: (
+			medium: "audio" | "video",
+			receiving: boolean,
+			mid?: number
+		) => void;
 		slowLink?: (state: { uplink: boolean }) => void;
 		onmessage?: (message: Message, jsep?: JSEP) => void;
 		onlocalstream?: (stream: MediaStream) => void;
@@ -93,12 +97,12 @@ declare namespace JanusJS {
 			video?:
 				| boolean
 				| { deviceId: string }
-				| 'lowres'
-				| 'lowres-16:9'
-				| 'stdres'
-				| 'stdres-16:9'
-				| 'hires'
-				| 'hires-16:9';
+				| "lowres"
+				| "lowres-16:9"
+				| "stdres"
+				| "stdres-16:9"
+				| "hires"
+				| "hires-16:9";
 			data?: boolean;
 			failIfNoAudio?: boolean;
 			failIfNoVideo?: boolean;
@@ -127,6 +131,9 @@ declare namespace JanusJS {
 		handleRemoteJsep(params: { jsep: JSEP }): void;
 		dtmf(params: any): void;
 		data(params: any): void;
+		isAudioMuted(): boolean;
+		muteAudio(): void;
+		unmuteAudio(): void;
 		isVideoMuted(): boolean;
 		muteVideo(): void;
 		unmuteVideo(): void;
@@ -136,7 +143,9 @@ declare namespace JanusJS {
 	}
 
 	class Janus {
-		static useDefaultDependencies(deps: Partial<Dependencies>): DependenciesResult;
+		static useDefaultDependencies(
+			deps: Partial<Dependencies>
+		): DependenciesResult;
 		static useOldDependencies(deps: Partial<Dependencies>): DependenciesResult;
 		static init(options: InitOptions): void;
 		static isWebrtcSupported(): boolean;
@@ -145,8 +154,14 @@ declare namespace JanusJS {
 		static warn(...args: any[]): void;
 		static error(...args: any[]): void;
 		static randomString(length: number): string;
-		static attachMediaStream(element: HTMLMediaElement, stream: MediaStream): void;
-		static reattachMediaStream(to: HTMLMediaElement, from: HTMLMediaElement): void;
+		static attachMediaStream(
+			element: HTMLMediaElement,
+			stream: MediaStream
+		): void;
+		static reattachMediaStream(
+			to: HTMLMediaElement,
+			from: HTMLMediaElement
+		): void;
 
 		constructor(options: ConstructorOptions);
 

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -1,6 +1,6 @@
 declare namespace JanusJS {
 	interface Dependencies {
-		adapter: import('webrtc-adapter').IAdapter;
+		adapter: any;
 		WebSocket: (server: string, protocol: string) => WebSocket;
 		isArray: (array: any) => array is Array<any>;
 		extension: () => boolean;
@@ -20,7 +20,7 @@ declare namespace JanusJS {
 		Debug = 'debug',
 		Log = 'log',
 		Warning = 'warn',
-		Error = 'error',
+		Error = 'error'
 	}
 
 	interface JSEP {}
@@ -52,7 +52,7 @@ declare namespace JanusJS {
 		Stopped = 'stopped',
 		SlowLink = 'slow_link',
 		Preparing = 'preparing',
-		Refreshing = 'refreshing',
+		Refreshing = 'refreshing'
 	}
 
 	interface Message {

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -1,6 +1,6 @@
 declare namespace JanusJS {
 	interface Dependencies {
-		adapter: import("webrtc-adapter").IAdapter;
+		adapter: import('webrtc-adapter').IAdapter;
 		WebSocket: (server: string, protocol: string) => WebSocket;
 		isArray: (array: any) => array is Array<any>;
 		extension: () => boolean;
@@ -16,17 +16,17 @@ declare namespace JanusJS {
 	}
 
 	enum DebugLevel {
-		Trace = "trace",
-		Debug = "debug",
-		Log = "log",
-		Warning = "warn",
-		Error = "error",
+		Trace = 'trace',
+		Debug = 'debug',
+		Log = 'log',
+		Warning = 'warn',
+		Error = 'error',
 	}
 
 	interface JSEP {}
 
 	interface InitOptions {
-		debug?: boolean | "all" | DebugLevel[];
+		debug?: boolean | 'all' | DebugLevel[];
 		callback?: Function;
 		dependencies?: DependenciesResult;
 	}
@@ -46,13 +46,13 @@ declare namespace JanusJS {
 	}
 
 	enum MessageType {
-		Recording = "recording",
-		Starting = "starting",
-		Started = "started",
-		Stopped = "stopped",
-		SlowLink = "slow_link",
-		Preparing = "preparing",
-		Refreshing = "refreshing",
+		Recording = 'recording',
+		Starting = 'starting',
+		Started = 'started',
+		Stopped = 'stopped',
+		SlowLink = 'slow_link',
+		Preparing = 'preparing',
+		Refreshing = 'refreshing',
 	}
 
 	interface Message {
@@ -71,9 +71,9 @@ declare namespace JanusJS {
 		error?: (error: any) => void;
 		consentDialog?: (on: boolean) => void;
 		webrtcState?: (isConnected: boolean) => void;
-		iceState?: (state: "connected" | "failed") => void;
+		iceState?: (state: 'connected' | 'failed') => void;
 		mediaState?: (
-			medium: "audio" | "video",
+			medium: 'audio' | 'video',
 			receiving: boolean,
 			mid?: number
 		) => void;
@@ -97,12 +97,12 @@ declare namespace JanusJS {
 			video?:
 				| boolean
 				| { deviceId: string }
-				| "lowres"
-				| "lowres-16:9"
-				| "stdres"
-				| "stdres-16:9"
-				| "hires"
-				| "hires-16:9";
+				| 'lowres'
+				| 'lowres-16:9'
+				| 'stdres'
+				| 'stdres-16:9'
+				| 'hires'
+				| 'hires-16:9';
 			data?: boolean;
 			failIfNoAudio?: boolean;
 			failIfNoVideo?: boolean;

--- a/npm/package.json
+++ b/npm/package.json
@@ -11,6 +11,7 @@
 	},
 	"devDependencies": {
 		"rollup": "^0.50.0",
-		"rollup-plugin-replace": "^2.0.0"
+		"rollup-plugin-replace": "^2.0.0",
+		"webrtc-adapter": "^7.7.0"
 	}
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -11,7 +11,6 @@
 	},
 	"devDependencies": {
 		"rollup": "^0.50.0",
-		"rollup-plugin-replace": "^2.0.0",
-		"webrtc-adapter": "^7.7.0"
+		"rollup-plugin-replace": "^2.0.0"
 	}
 }


### PR DESCRIPTION
This PR adds `muteAudio` handles typings. Also we can use IAdapter type from webrtc-adapter. Maybe at this point it will be better not to add it to dependencies, but just grab this interface from 7.4.0.
@lminiero do you plan to make janus npm installable? I can help.