### PR TITLE
Update Webpack instruction after webrtc-adapter dependency update

### DIFF
--- a/mainpage.dox
+++ b/mainpage.dox
@@ -885,7 +885,7 @@ echotest.createOffer({
      // janus.js does not use 'import' to access to the functionality of webrtc-adapter,
      // instead it expects a global object called 'adapter' for that.
      // Let's make that object available.
-     new webpack.ProvidePlugin({ adapter: 'webrtc-adapter' })
+     new webpack.ProvidePlugin({ adapter: ['webrtc-adapter', 'default'] })
    ]
  }
  \endverbatim


### PR DESCRIPTION
webrtc-adapter version 7+ (#2515) use ES2015 module, so "For importing the default export of an ES2015 module, you have to specify the default property of module." ([example](https://webpack.js.org/plugins/provide-plugin/#usage-vuejs)).

Without this instead of `Janus.webRTCAdapter.browserDetails` we got `Janus.webRTCAdapter.default.browserDetails` and as result `janus.js` is broken.