### PR TITLE
Dont send bye on early dialog

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -2528,7 +2528,12 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 		session->media.ready = FALSE;
 		session->media.on_hold = FALSE;
 		janus_sip_call_update_status(session, janus_sip_call_status_closing);
-		nua_bye(session->stack->s_nh_i, TAG_END());
+
+		if(g_atomic_int_get(&session->established))
+			nua_bye(session->stack->s_nh_i, TAG_END());
+		else
+			nua_respond(session->stack->s_nh_i, 486, sip_status_phrase(486), TAG_END());
+
 		/* Notify the operation */
 		json_t *event = json_object();
 		json_object_set_new(event, "sip", json_string("event"));

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -2532,7 +2532,7 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 		if(g_atomic_int_get(&session->established))
 			nua_bye(session->stack->s_nh_i, TAG_END());
 		else
-			nua_respond(session->stack->s_nh_i, 486, sip_status_phrase(486), TAG_END());
+			nua_respond(session->stack->s_nh_i, 480, sip_status_phrase(480), TAG_END());
 
 		/* Notify the operation */
 		json_t *event = json_object();


### PR DESCRIPTION
When session is destroyed, Janus sends BYE, regardless of session state.

Per RFC 3261, section 15, if session is not established, it must not send BYE:
https://tools.ietf.org/html/rfc3261#section-15

> The caller's UA MAY send a BYE for either
>    confirmed or early dialogs, and the callee's UA MAY send a BYE on
>    confirmed dialogs, but MUST NOT send a BYE on early dialogs.

> However, the callee's UA MUST NOT send a BYE on a confirmed dialog
>    until it has received an ACK for its 2xx response or until the server
>    transaction times out.  If no SIP extensions have defined other
>    application layer states associated with the dialog, the BYE also
>    terminates the dialog

   
This PR implements sending final non-2xx response, which is better behaviour.
I chose 480 Temporarily unavailable.