### PR TITLE
Fixed secret authentication on GET requests

### DIFF
--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -1542,15 +1542,15 @@ static MHD_Result janus_http_handler(void *cls, struct MHD_Connection *connectio
 			token_authorized = TRUE;
 		} else {
 			if(gateway->is_api_secret_valid(&janus_http_transport, secret)) {
-				/* API secret is valid */
+				/* API secret is valid or disabled */
 				secret_authorized = TRUE;
 			}
 			if(gateway->is_auth_token_valid(&janus_http_transport, token)) {
-				/* Token is valid */
+				/* Token is valid or disabled */
 				token_authorized = TRUE;
 			}
-			/* We consider a request authorized if either the proper API secret or a valid token has been provided */
-			if(!secret_authorized && !token_authorized) {
+			/* We consider a request authorized if both the token and the API secret are either disabled or valid */
+			if(!secret_authorized || !token_authorized) {
 				response = MHD_create_response_from_buffer(0, NULL, MHD_RESPMEM_PERSISTENT);
 				janus_http_add_cors_headers(msg, response);
 				ret = MHD_queue_response(connection, MHD_HTTP_FORBIDDEN, response);


### PR DESCRIPTION
Follow-up to https://github.com/meetecho/janus-gateway/issues/2520

The secret-based authentication wasn't properly enforced on the long-poll request.

Using this small Node.js client:
```js
import axios from 'axios';

console.log('Testing janus yo');

async function test() {
    console.log('Creating session');

    const sessionResponse = await axios.post('http://localhost:8088/janus', {
        'janus': 'create',
        'transaction': 'createsession',
        'apisecret': 'somesecret',
    });
    const sessionId = sessionResponse.data.data.id;
    console.log(`Session ID is ${sessionId}`);


    console.log('Polling');
    let pollResponse;
    try {
        pollResponse = await axios.get(`http://localhost:8088/janus/${sessionId}`, {
        });
    } catch (err) {
        pollResponse = err.response;
    }

    console.log(pollResponse);

    if (pollResponse.status !== 403) {
        throw new Error('Did not get expected 403');
    }
}

test()
    .then(() => console.log('passed'))
    .catch((err) => console.error(err));
```

Without the fix, I get a keep-alive after 30 seconds (unexpected), with the fix, I get the 403 immediately (expected).

All credit goes to @lminiero for finding the broken part of the code 🙏 