### PR TITLE
Allow marking of RTP extensions in MJR recordings

### DIFF
--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -593,6 +593,44 @@ int main(int argc, char *argv[])
 				}
 				/* Any codec-specific info? (just informational) */
 				const char *f = json_string_value(json_object_get(info, "f"));
+				/* Check if there are RTP extensions */
+				json_t *exts = json_object_get(info, "x");
+				if(exts != NULL) {
+					/* There are: check if audio-level and/or video-orientation
+					 * are among them, as we might need them */
+					int extid = 0;
+					const char *key = NULL, *extmap = NULL;
+					json_t *value = NULL;
+					json_object_foreach(exts, key, value) {
+						if(key == NULL || value == NULL || !json_is_string(value))
+							continue;
+						extid = atoi(key);
+						extmap = json_string_value(value);
+						if(!strcasecmp(extmap, JANUS_PP_RTP_EXTMAP_AUDIO_LEVEL)) {
+							/* Audio level */
+							if(audio_level_extmap_id != -1) {
+								if(audio_level_extmap_id != extid) {
+									JANUS_LOG(LOG_WARN, "Audio level extension ID found in header (%d) is different from the one provided via argument (%d)\n",
+										audio_level_extmap_id, extid);
+								}
+							} else {
+								audio_level_extmap_id = extid;
+								JANUS_LOG(LOG_INFO, "Audio level extension ID: %d\n", audio_level_extmap_id);
+							}
+						} else if(!strcasecmp(extmap, JANUS_PP_RTP_EXTMAP_VIDEO_ORIENTATION)) {
+							/* Video orientation */
+							if(video_orient_extmap_id != -1) {
+								if(video_orient_extmap_id != extid) {
+									JANUS_LOG(LOG_WARN, "Video orientation extension ID found in header (%d) is different from the one provided via argument (%d)\n",
+										video_orient_extmap_id, extid);
+								}
+							} else {
+								video_orient_extmap_id = extid;
+								JANUS_LOG(LOG_INFO, "Video orientation extension ID: %d\n", video_orient_extmap_id);
+							}
+						}
+					}
+				}
 				/* When was the file created? */
 				json_t *created = json_object_get(info, "s");
 				if(!created || !json_is_integer(created)) {
@@ -639,7 +677,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Now that we know what we're working with, check the extension */
-	if(strcasecmp(extension, "opus") && strcasecmp(extension, "wav") &&
+	if(extension && strcasecmp(extension, "opus") && strcasecmp(extension, "wav") &&
 			strcasecmp(extension, "webm") && strcasecmp(extension, "mp4") &&
 			strcasecmp(extension, "srt") && (!data || (data && textdata))) {
 		/* Unsupported extension? */

--- a/postprocessing/pp-rtp.h
+++ b/postprocessing/pp-rtp.h
@@ -24,6 +24,9 @@
 
 #include <glib.h>
 
+#define JANUS_PP_RTP_EXTMAP_AUDIO_LEVEL			"urn:ietf:params:rtp-hdrext:ssrc-audio-level"
+#define JANUS_PP_RTP_EXTMAP_VIDEO_ORIENTATION	"urn:3gpp:video-orientation"
+
 typedef struct janus_pp_rtp_header
 {
 #if __BYTE_ORDER == __BIG_ENDIAN

--- a/record.h
+++ b/record.h
@@ -48,6 +48,8 @@ typedef struct janus_recorder {
 	char *codec;
 	/*! \brief Codec-specific info (e.g., H.264 or VP9 profile) */
 	char *fmtp;
+	/*! \brief List of RTP extensions (as a hashtable, indexed by ID) in this recording */
+	GHashTable *extensions;
 	/*! \brief When the recording file has been created and started */
 	gint64 created, started;
 	/*! \brief Media this instance is recording */
@@ -90,6 +92,14 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
  * @param[in] filename Filename to use for the recording
  * @returns A valid janus_recorder instance in case of success, NULL otherwise */
 janus_recorder *janus_recorder_create_full(const char *dir, const char *codec, const char *fmtp, const char *filename);
+/*! \brief Add an RTP extension to this recording
+ * \note This will only be possible BEFORE the first frame is written, as it needs to
+ * be reflected in the .mjr header: doing this after that will return an error.
+ * @param[in] recorder The janus_recorder instance to add the extension to
+ * @param[in] id Numeric ID of the RTP extension
+ * @param[in] extmap Namespace of the RTP extension
+ * @returns 0 in case of success, a negative integer otherwise */
+int janus_recorder_add_extmap(janus_recorder *recorder, int id, const char *extmap);
 /*! \brief Mark this recorder as end-to-end encrypted (e.g., via Insertable Streams)
  * \note This will only be possible BEFORE the first frame is written, as it needs to
  * be reflected in the .mjr header: doing this after that will return an error. Also


### PR DESCRIPTION
This is a functional rewrite of #2422 which was initially submitted by @isnumanagic. It's hopefully a simpler integration and implementation than that one was, and should provide the same functionality. As the original PR, I've only modified the Record&Play plugin to support it, and as you'll see from the code the scope is much narrower, since it explicitly only checks for audio-level and video-orientation, ignoring other extensions: this means it's probably less flexible than the original PR, but also much simpler. I've done this on purpose as those are the only two extensions we care about in most plugins anyway. The MJR code itself is flexible, though: if you want to store a different extension from your plugin, you can.

I've reused the same syntax for how extensions are stored in the header, using an `x` object where IDs are the key and the extension namespace the value. This is an example of the post-processor analysing an audio recording which had the audio-level extension negotiated:

```
[lminiero@lminiero mjr-extmaps]$ ./janus-pp-rec -j ~/Work/code/test/mjrextmap/share/janus/recordings/rec-5815531892194331-audio.mjr 
{"t": "a", "c": "opus", "x": {"1": "urn:ietf:params:rtp-hdrext:ssrc-audio-level"}, "s": 1611333015010041, "u": 1611333015071425}
```

```
[lminiero@lminiero mjr-extmaps]$ ./janus-pp-rec -p ~/Work/code/test/mjrextmap/share/janus/recordings/rec-5815531892194331-audio.mjr 
Janus version: 110 (0.10.10)
Janus commit: 46a6c71b0fb7e54cb9acfbec84391c75eb224c13
Compiled on:  Fri 22 Jan 17:41:03 CET 2021

Logging level: 4
RTP silence suppression distance: 100

Source file: /home/lminiero/Work/code/test/mjrextmap/share/janus/recordings/rec-5815531892194331-audio.mjr
  -- Parsing header only

File is 104006 bytes
Pre-parsing file to generate ordered index...
Audio level extension ID: 1
This is an audio recording:
  -- Codec:   opus
  -- Created: 1611333015010041
  -- Written: 1611333015071425
SSRC detected: 632194773
Counted 909 RTP packets
Counted 909 frame packets
Parsing and reordering completed, bye!
```

As you can see, the audio-level extension is automatically recognized, and so there's no need to manually pass it via command line if it's listed in the MJR itself already (and so will be used if necessary).

Tested briefly and it seems to be working, but feedback is welcome of course.