### PR TITLE
set webrtc-adapter verstion to 7.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   },
   "homepage": "https://github.com/meetecho/janus-gateway#readme",
   "dependencies": {
-    "webrtc-adapter": "7.7.0"
+    "webrtc-adapter": "7.4.0"
   }
 }


### PR DESCRIPTION
After a clean npm pkg rebuild, 7.4.0 version of webrtc-adapter does appear to play well with janus.js