### PR TITLE
Fix hangup on inviting status after #2521

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -2560,7 +2560,7 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 		session->media.on_hold = FALSE;
 		janus_sip_call_update_status(session, janus_sip_call_status_closing);
 
-		if(g_atomic_int_get(&session->established))
+		if(!g_atomic_int_get(&session->destroyed))
 			nua_bye(session->stack->s_nh_i, TAG_END());
 		else
 			nua_respond(session->stack->s_nh_i, 480, sip_status_phrase(480), TAG_END());


### PR DESCRIPTION
The merge #2521 is causing a problem in the hangup of the call with status inviting, similar to the problem reported in #1856. I believe that the correct treatment for the situation of #2521, is to do with status different from destroyed.