### PR TITLE
Renamed extern janus_callbacks variables in Lua and Duktape plugins

### DIFF
--- a/plugins/janus_duktape_data.h
+++ b/plugins/janus_duktape_data.h
@@ -41,7 +41,7 @@
 
 /* Core pointer and related flags */
 extern volatile gint duktape_initialized, duktape_stopping;
-extern janus_callbacks *janus_core;
+extern janus_callbacks *duktape_janus_core;
 
 /* Duktape context: we define context and mutex as extern */
 extern duk_context *duktape_ctx;

--- a/plugins/janus_lua_data.h
+++ b/plugins/janus_lua_data.h
@@ -41,7 +41,7 @@
 
 /* Core pointer and related flags */
 extern volatile gint lua_initialized, lua_stopping;
-extern janus_callbacks *janus_core;
+extern janus_callbacks *lua_janus_core;
 
 /* Lua state: we define state and mutex as extern */
 extern lua_State *lua_state;


### PR DESCRIPTION
For a while my asan stack was complaining when starting Janus with both Lua and Duktape plugins active at the same time, mentioning an `odr-violation` somewhere. The error message was a bit obscure at the time, but recently it has become much more explicit:

```
==31680==ERROR: AddressSanitizer: odr-violation (0x7fce8ac79ce0):
  [1] size=8 'janus_core' plugins/janus_duktape.c:269:18
  [2] size=8 'janus_core' plugins/janus_lua.c:270:18
```

and confirmed it was indeed our fault. Normally all plugins initialize their own reference to the Janus core (e.g., to push events or send RTP packets) as a static variable, e.g.:

```
static janus_callbacks *gateway = NULL;
```

The Lua and Duktape plugins, though, defined it globally instead, since it was defined as an extern in `janus_lua_data.h` and `janus_duktape_data.h`, and then implemented in `janus_lua.c` and `janus_duktape.c`:

```
[_data.h]
extern janus_callbacks *janus_core = NULL;

[.c]
janus_callbacks *janus_core = NULL;
```

That's done on purpose, as both the Lua and Duktape plugins have `_extra.c/.h` files where people can add extensions, as in new C hooks, new Lua/JS functions, etc., all of which may need to have access to the plugin core reference to push events, RTP/RTCP/data packets, and so on. This was also causing this "poisoning" of the global space, though, which is what libasan was telling us about with that `odr-violation`.

This PR fixes that by using different names for the two plugins. It's a PR and not a direct commit, as this might be a breaking change for people who extended either plugin, as their custom code may be referencing the old `janus_core` variable name. As such, putting this out there so that people are aware of the fix, and can fix their code for when this will be merged. Pinging @voicenter in particular as I know they've been working with the Duktape plugin recently.