### PR TITLE
janus.js handleRemoteJsep(prepareWebrtcPeer) customizeSdp callback

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2566,6 +2566,7 @@ function Janus(gatewayCallbacks) {
 		callbacks = callbacks || {};
 		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
 		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : webrtcError;
+		callbacks.customizeSdp = (typeof callbacks.customizeSdp == "function") ? callbacks.customizeSdp : Janus.noop;
 		var jsep = callbacks.jsep;
 		var pluginHandle = pluginHandles[handleId];
 		if(!pluginHandle || !pluginHandle.webrtcStuff) {
@@ -2580,6 +2581,7 @@ function Janus(gatewayCallbacks) {
 				callbacks.error("No PeerConnection: if this is an answer, use createAnswer and not handleRemoteJsep");
 				return;
 			}
+			callbacks.customizeSdp(jsep);
 			config.pc.setRemoteDescription(jsep)
 				.then(function() {
 					Janus.log("Remote description accepted!");


### PR DESCRIPTION
janus.js
 - customizeSdp callback added to the handleRemoteJsep(prepareWebrtcPeer) to be able to mangle remote SDP if needed. Related to #2547 