### PR TITLE
Fix parsing of SDP to find payload type matching profiles (fixes #2544)

### DIFF
--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -703,22 +703,24 @@ int janus_sdp_get_codec_pt_full(janus_sdp *sdp, const char *codec, const char *p
 		/* Look in all rtpmap attributes */
 		GList *ma = m->attributes;
 		int pt = -1;
-		gboolean check_profile = FALSE;
-		gboolean got_profile = FALSE;
+		GList *pts = NULL;
 		while(ma) {
 			janus_sdp_attribute *a = (janus_sdp_attribute *)ma->data;
 			if(profile != NULL && a->name != NULL && a->value != NULL && !strcasecmp(a->name, "fmtp")) {
+				/* Does this match the payload types we're looking for? */
+				pt = atoi(a->value);
+				if(g_list_find(pts, GINT_TO_POINTER(pt)) == NULL) {
+					/* Not what we're looking for */
+					ma = ma->next;
+					continue;
+				}
 				if(vp9) {
 					char profile_id[20];
 					g_snprintf(profile_id, sizeof(profile_id), "profile-id=%s", profile);
 					if(strstr(a->value, profile_id) != NULL) {
 						/* Found */
 						JANUS_LOG(LOG_VERB, "VP9 profile %s found --> %d\n", profile, pt);
-						if(check_profile) {
-							return pt;
-						} else {
-							got_profile = TRUE;
-						}
+						return pt;
 					}
 				} else if(h264 && strstr(a->value, "packetization-mode=0") == NULL) {
 					/* We only support packetization-mode=1, no matter the profile */
@@ -729,11 +731,7 @@ int janus_sdp_get_codec_pt_full(janus_sdp *sdp, const char *codec, const char *p
 					if(strstr(a->value, profile_level_id) != NULL) {
 						/* Found */
 						JANUS_LOG(LOG_VERB, "H.264 profile %s found --> %d\n", profile, pt);
-						if(check_profile) {
-							return pt;
-						} else {
-							got_profile = TRUE;
-						}
+						return pt;
 					}
 					/* Not found, try converting the profile to upper case */
 					char *profile_upper = g_ascii_strup(profile, -1);
@@ -742,22 +740,17 @@ int janus_sdp_get_codec_pt_full(janus_sdp *sdp, const char *codec, const char *p
 					if(strstr(a->value, profile_level_id) != NULL) {
 						/* Found */
 						JANUS_LOG(LOG_VERB, "H.264 profile %s found --> %d\n", profile, pt);
-						if(check_profile) {
-							return pt;
-						} else {
-							got_profile = TRUE;
-						}
+						return pt;
 					}
 				}
 			} else if(a->name != NULL && a->value != NULL && !strcasecmp(a->name, "rtpmap")) {
 				pt = atoi(a->value);
-				check_profile = FALSE;
 				if(pt < 0) {
 					JANUS_LOG(LOG_ERR, "Invalid payload type (%s)\n", a->value);
 				} else if(strstr(a->value, format) || strstr(a->value, format2)) {
-					if(profile != NULL && !got_profile && (vp9 || h264)) {
-						/* Let's check the profile first */
-						check_profile = TRUE;
+					if(profile != NULL && (vp9 || h264)) {
+						/* Let's keep track of this payload type */
+						pts = g_list_append(pts, GINT_TO_POINTER(pt));
 					} else {
 						/* Payload type for codec found */
 						return pt;
@@ -766,6 +759,8 @@ int janus_sdp_get_codec_pt_full(janus_sdp *sdp, const char *codec, const char *p
 			}
 			ma = ma->next;
 		}
+		if(pts != NULL)
+			g_list_free(pts);
 		ml = ml->next;
 	}
 	return -1;


### PR DESCRIPTION
See #2544 for details, and https://github.com/meetecho/janus-gateway/pull/2543#issuecomment-772447679 for an explanation of this fix. I expanded the test @tmatth provided to validate finding codecs without a profile too, and with this PR it seems to be working as expected in all cases, so I assume this is now working as it should: please test to make sure there are no regressions, though.

This is important because this PR gets rid of a check we had before. In the old check, you could have a `fmtp` attribute before `rtpmap`, and it would still "work": now we always assume `rtpmap` attributes are listed before `fmtp` attributes, instead. This seems to be the case for the SDPs I've seen, but not sure if it's indeed like that in all browser (or non-browser) WebRTC implementations for instance. Again, feedback would help here.