### PR TITLE
clang/ubsan fixes

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -3916,7 +3916,7 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 		/* Create a SR/SDES compound */
 		int srlen = 28;
 		int sdeslen = 16;
-		char rtcpbuf[srlen+sdeslen];
+		char rtcpbuf[sizeof(janus_rtcp_sr)+sdeslen];
 		memset(rtcpbuf, 0, sizeof(rtcpbuf));
 		rtcp_sr *sr = (rtcp_sr *)&rtcpbuf;
 		sr->header.version = 2;
@@ -3942,7 +3942,7 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 		}
 		sr->si.s_packets = htonl(stream->component->out_stats.audio.packets);
 		sr->si.s_octets = htonl(stream->component->out_stats.audio.bytes);
-		rtcp_sdes *sdes = (rtcp_sdes *)&rtcpbuf[28];
+		rtcp_sdes *sdes = (rtcp_sdes *)&rtcpbuf[srlen];
 		janus_rtcp_sdes_cname((char *)sdes, sdeslen, "janus", 5);
 		sdes->chunk.ssrc = htonl(stream->audio_ssrc);
 		/* Enqueue it, we'll send it later */
@@ -3977,7 +3977,7 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 		/* Create a SR/SDES compound */
 		int srlen = 28;
 		int sdeslen = 16;
-		char rtcpbuf[srlen+sdeslen];
+		char rtcpbuf[sizeof(janus_rtcp_sr)+sdeslen];
 		memset(rtcpbuf, 0, sizeof(rtcpbuf));
 		rtcp_sr *sr = (rtcp_sr *)&rtcpbuf;
 		sr->header.version = 2;
@@ -4003,7 +4003,7 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 		}
 		sr->si.s_packets = htonl(stream->component->out_stats.video[0].packets);
 		sr->si.s_octets = htonl(stream->component->out_stats.video[0].bytes);
-		rtcp_sdes *sdes = (rtcp_sdes *)&rtcpbuf[28];
+		rtcp_sdes *sdes = (rtcp_sdes *)&rtcpbuf[srlen];
 		janus_rtcp_sdes_cname((char *)sdes, sdeslen, "janus", 5);
 		sdes->chunk.ssrc = htonl(stream->video_ssrc);
 		/* Enqueue it, we'll send it later */

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4748,8 +4748,8 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 				nua_respond(nh, 500, sip_status_phrase(500), TAG_END());
 				break;
 			}
-			if(sip->sip_from == NULL || sip->sip_from->a_url == NULL ||
-					sip->sip_to == NULL || sip->sip_to->a_url == NULL) {
+			if(sip->sip_from == NULL || sip->sip_from->a_url->url_user == NULL ||
+					sip->sip_to == NULL || sip->sip_to->a_url->url_user == NULL) {
 				JANUS_LOG(LOG_ERR, "\tInvalid request (missing From or To)\n");
 				nua_respond(nh, 400, sip_status_phrase(400), TAG_END());
 				break;

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -816,7 +816,7 @@ int main(int argc, char *argv[])
 			rtp_read_n = (rtp->csrccount + rtp->extension)*4;
 			bytes = fread(prebuffer+rtp_header_len, sizeof(char), rtp_read_n, file);
 			if(bytes < rtp_read_n) {
-				JANUS_LOG(LOG_WARN, "Missing RTP packet header data (%d instead %"SCNu16")\n",
+				JANUS_LOG(LOG_WARN, "Missing RTP packet header data (%d instead %d)\n",
 					rtp_header_len+bytes, rtp_header_len+rtp_read_n);
 				break;
 			} else {
@@ -833,7 +833,7 @@ int main(int argc, char *argv[])
 			skip += 4 + rtp_read_n;
 			bytes = fread(prebuffer+rtp_header_len, sizeof(char), rtp_read_n, file);
 			if(bytes < rtp_read_n) {
-				JANUS_LOG(LOG_WARN, "Missing RTP packet header data (%d instead %"SCNu16")\n",
+				JANUS_LOG(LOG_WARN, "Missing RTP packet header data (%d instead %d)\n",
 					rtp_header_len+bytes, rtp_header_len+rtp_read_n);
 				break;
 			} else {

--- a/rtcp.c
+++ b/rtcp.c
@@ -316,7 +316,7 @@ static void janus_rtcp_incoming_transport_cc(janus_rtcp_context *ctx, janus_rtcp
 		}
 		delta_us = delta*250;
 		/* Print summary */
-		JANUS_LOG(LOG_HUGE, "  [%02"SCNu16"][%"SCNu16"] %s (%"SCNu32"us)\n", num, base_seq+num-1,
+		JANUS_LOG(LOG_HUGE, "  [%02"SCNu16"][%"SCNu16"] %s (%"SCNu32"us)\n", num, (uint16_t)(base_seq+num-1),
 			janus_rtp_packet_status_description(s), delta_us);
 		iter = iter->next;
 	}

--- a/sctp.c
+++ b/sctp.c
@@ -478,7 +478,7 @@ void janus_sctp_send_data(janus_sctp_association *sctp, char *label, char *proto
 	int res = janus_sctp_send_text_or_binary(sctp, i, textdata, buf, len);
 	if(res == -2) {
 		/* Delivery failed with an EAGAIN, queue and retry later */
-		JANUS_LOG(LOG_WARN, "[%"SCNu64"] Got EAGAIN when trying to send message on channel %"SCNu16", retrying later\n",
+		JANUS_LOG(LOG_WARN, "[%"SCNu64"] Got EAGAIN when trying to send message on channel %d, retrying later\n",
 			sctp->handle_id, i);
 		janus_sctp_pending_message *m = janus_sctp_pending_message_create(i, textdata, buf, len);
 		if(sctp->pending_messages == NULL)

--- a/transports/janus_http.c
+++ b/transports/janus_http.c
@@ -1051,7 +1051,7 @@ int janus_http_send_message(janus_transport_session *transport, void *request_id
 			transport = (janus_transport_session *)session->longpolls->data;
 			msg = (janus_http_msg *)(transport ? transport->transport_p : NULL);
 			/* Is this connection ready to send a response back? */
-			if(msg && g_atomic_pointer_compare_and_exchange(&msg->longpoll, session, NULL)) {
+			if(msg && g_atomic_pointer_compare_and_exchange(&msg->longpoll, (volatile void *)session, NULL)) {
 				janus_refcount_increase(&msg->ref);
 				/* Send the events back */
 				if(g_atomic_int_compare_and_exchange(&msg->timeout_flag, 1, 0)) {
@@ -1176,7 +1176,7 @@ void janus_http_session_claimed(janus_transport_session *transport, guint64 sess
 				g_source_unref(msg->timeout);
 			}
 			msg->timeout = NULL;
-			if(g_atomic_pointer_compare_and_exchange(&msg->longpoll, session, NULL)) {
+			if(g_atomic_pointer_compare_and_exchange(&msg->longpoll, (volatile void *)session, NULL)) {
 				/* Return an error on the long poll right away */
 				janus_http_timeout(transport, old_session);
 			}


### PR DESCRIPTION
As the title mentions, this  PR addresses: 
- some warnings generated during compilation with `clang`
- a runtime error from UBSanitizer when sending RTCP SR (probably the same happens on `gcc`)