### PR TITLE
[janus_sip] Add "call_id" to "calling", "declining", "updatingcall" & "incomingcall" events

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -3577,6 +3577,7 @@ static void *janus_sip_handler(void *data) {
 			/* Send an ack back */
 			result = json_object();
 			json_object_set_new(result, "event", json_string("calling"));
+			json_object_set_new(result, "call_id", json_string(session->callid));
 		} else if(!strcasecmp(request_text, "accept")) {
 			if(session->status != janus_sip_call_status_invited) {
 				JANUS_LOG(LOG_ERR, "Wrong state (not invited? status=%s)\n", janus_sip_call_status_string(session->status));
@@ -4037,6 +4038,8 @@ static void *janus_sip_handler(void *data) {
 			result = json_object();
 			json_object_set_new(result, "event", json_string("declining"));
 			json_object_set_new(result, "code", json_integer(response_code));
+			if(session->callid)
+				json_object_set_new(result, "call_id", json_string(session->callid));
 		} else if(!strcasecmp(request_text, "transfer")) {
 			/* Transfer an existing call */
 			JANUS_VALIDATE_JSON_OBJECT(root, transfer_parameters,
@@ -4924,6 +4927,8 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			json_t *calling = json_object();
 			json_object_set_new(calling, "event", json_string(reinvite ? "updatingcall" : "incomingcall"));
 			json_object_set_new(calling, "username", json_string(session->callee));
+			if(session->callid)
+				json_object_set_new(calling, "call_id", json_string(session->callid));
 			if(sip->sip_from->a_display) {
 				json_object_set_new(calling, "displayname", json_string(sip->sip_from->a_display));
 			}


### PR DESCRIPTION
As the title mentions, this PR adds an extra `call_id` property (already added in other events such as `hangup`, `missed_call` or `accepted`) to the following events
* `calling`
* `declining`
* `updatingcall`
* `incomingcall`