### PR TITLE
 Error negotiating bandwidth with multiple line b

### DIFF
--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -507,17 +507,12 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen) {
 						break;
 					}
 					case 'b': {
-						if(strcmp(line, "AS") && strcmp(line, "TIAS")) {
-							/* We only support b=AS and b=TIAS, skip */
-							line += 2;
-							break;
-						}
-						if(mline->b_name) {
-							if(error)
-								g_snprintf(error, errlen, "Multiple m-line b= lines: %s", line);
-							success = FALSE;
-							break;
-						}
+						//if(mline->b_name) {
+							//if(error)
+							//	g_snprintf(error, errlen, "Multiple m-line b= lines: %s", line);
+							//success = FALSE;
+							//break;
+						//}
 						line += 2;
 						char *semicolon = strchr(line, ':');
 						if(semicolon == NULL || (*(semicolon+1) == '\0')) {
@@ -527,6 +522,10 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen) {
 							break;
 						}
 						*semicolon = '\0';
+						if(strcmp(line, "AS") && strcmp(line, "TIAS")) {	
+							/* We only support b=AS and b=TIAS, skip */	
+							break;	
+						}
 						mline->b_name = g_strdup(line);
 						mline->b_value = atol(semicolon+1);
 						*semicolon = ':';

--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -507,6 +507,10 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen) {
 						break;
 					}
 					case 'b': {
+						if(strcmp(line, "AS") && strcmp(line, "TIAS")) {
+							/* We only support b=AS and b=TIAS, skip */
+							break;
+						}
 						if(mline->b_name) {
 							if(error)
 								g_snprintf(error, errlen, "Multiple m-line b= lines: %s", line);
@@ -522,10 +526,6 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen) {
 							break;
 						}
 						*semicolon = '\0';
-						if(strcmp(line, "AS") && strcmp(line, "TIAS")) {
-							/* We only support b=AS and b=TIAS, skip */
-							break;
-						}
 						mline->b_name = g_strdup(line);
 						mline->b_value = atol(semicolon+1);
 						*semicolon = ':';

--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -509,6 +509,7 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen) {
 					case 'b': {
 						if(strcmp(line, "AS") && strcmp(line, "TIAS")) {
 							/* We only support b=AS and b=TIAS, skip */
+							line += 2;
 							break;
 						}
 						if(mline->b_name) {

--- a/sdp-utils.c
+++ b/sdp-utils.c
@@ -522,9 +522,9 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen) {
 							break;
 						}
 						*semicolon = '\0';
-						if(strcmp(line, "AS") && strcmp(line, "TIAS")) {	
-							/* We only support b=AS and b=TIAS, skip */	
-							break;	
+						if(strcmp(line, "AS") && strcmp(line, "TIAS")) {
+							/* We only support b=AS and b=TIAS, skip */
+							break;
 						}
 						mline->b_name = g_strdup(line);
 						mline->b_value = atol(semicolon+1);


### PR DESCRIPTION
Error negotiating bandwidth.
When receiving a sdp with the following lines b:

    v=0
    o=- ********* ********* IN IP4 **.**.**.**
    s=SBC call
    c=IN IP4 10.89.255.105
    t=0 0
    m=audio 8664 RTP/AVP 18 8 110
    b=AS:41
    b=RS:612
    b=RR:1837
    a=rtpmap:18 G729/8000
    a=rtpmap:8 PCMA/8000
    a=rtpmap:110 telephone-event/8000
    a=fmtp:110 0-15
    a=sendrecv
    a=maxptime:240

The following lines b were received, in this order: AS, RS and RR.
In our case there was a line B with "AS" which made it impossible to enter other lines, even if that line was RS or RR, generating a Multiple m-line b error when the RS arrived.

We propose to advance the check that prevents AS lines and TIAS lines from being mixed together at the beginning of the case, instead of at the end