### PR TITLE
Don't chain error handler to success handler in Janus.httpAPICall in janus.js

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -137,8 +137,12 @@ Janus.useDefaultDependencies = function (deps) {
 				if(response.ok) {
 					if(typeof(options.success) === typeof(Janus.noop)) {
 						return response.json().then(function(parsed) {
-							options.success(parsed);
-						}).catch(function(error) {
+							try {
+								options.success(parsed);
+							} catch(error) {
+								Janus.error('Unhandled httpAPICall success callback error', error);
+							}
+						}, function(error) {
 							return p.reject({message: 'Failed to parse response body', error: error, response: response});
 						});
 					}


### PR DESCRIPTION
I ran into a problem in janus.js where multiple HTTP longpoll requests were running simultaneously. This was caused by the success handler and error handler in Janus.httpAPICall for longpoll both being called, which happened because the error handler was chained to the success handler, and the success handler threw an error from running a user supplied callback

This change separates the success handler from the error handler so they won't both be called