### PR TITLE
Allow daemon to log to stdout as journald can still log the output

### DIFF
--- a/janus.1
+++ b/janus.1
@@ -26,6 +26,9 @@ Open the specified PID file when starting Janus (default=none)
 .BR \-N ", " \-\-disable-stdout
 Disable stdout based logging (default=off)
 .TP
+.BR \-L ", " \-\-log-stdout
+Log to stdout, even when the process is daemonized (default=off)
+.TP
 .BR \-L ", " \-\-log-file=\fIpath\fR
 Log to the specified file (default=stdout only)
 .TP

--- a/janus.c
+++ b/janus.c
@@ -4119,7 +4119,7 @@ gint main(int argc, char *argv[])
 	if(args_info.disable_stdout_given) {
 		use_stdout = FALSE;
 		janus_config_add(config, config_general, janus_config_item_create("log_to_stdout", "no"));
-	} else {
+	} else if(!args_info.log_stdout_given) {
 		/* Check if the configuration file is saying anything about this */
 		janus_config_item *item = janus_config_get(config, config_general, janus_config_type_item, "log_to_stdout");
 		if(item && item->value && !janus_is_true(item->value))
@@ -4147,12 +4147,8 @@ gint main(int argc, char *argv[])
 			daemonize = TRUE;
 	}
 	/* If we're going to daemonize, make sure logging to stdout is disabled and a log file has been specified */
-	if(daemonize && use_stdout) {
+	if(daemonize && use_stdout && !args_info.log_stdout_given) {
 		use_stdout = FALSE;
-	}
-	if(daemonize && logfile == NULL) {
-		g_print("Running Janus as a daemon but no log file provided, giving up...\n");
-		exit(1);
 	}
 	/* Daemonize now, if we need to */
 	if(daemonize) {

--- a/janus.ggo
+++ b/janus.ggo
@@ -2,6 +2,7 @@
 option "daemon" b "Launch Janus in background as a daemon" flag off
 option "pid-file" p "Open the specified PID file when starting Janus (default=none)" string typestr="path" optional
 option "disable-stdout" N "Disable stdout based logging" flag off
+option "log-stdout" - "Log to stdout, even when the process is daemonized" flag off
 option "log-file" L "Log to the specified file (default=stdout only)" string typestr="path" optional
 option "cwd-path" H "Working directory for Janus daemon process (default=/)" string typestr="path" optional
 option "interface" i "Interface to use (will be the public IP)" string typestr="ipaddress" optional

--- a/log.c
+++ b/log.c
@@ -239,7 +239,7 @@ int janus_log_init(gboolean daemon, gboolean console, const char *logfile) {
 		g_print("WARNING: logging completely disabled!\n");
 		g_print("         (no stdout and no logfile, this may not be what you want...)\n");
 	}
-	if(daemon) {
+	if(daemon && !console) {
 		/* Replace the standard file descriptors */
 		if (freopen("/dev/null", "r", stdin) == NULL) {
 			g_print("Error replacing stdin with /dev/null\n");


### PR DESCRIPTION
When trying to use janus within a systemd service unit, the best option is to use the `forking` type which means starting janus with `-b` to "daemonize" the process.

Even if I do this I don't want to log the process output to a file as `journald` is already capable of storing and timestamping the log from the process' stdout, as demonstrated by this journal logs (captured with a patched janus):

```
Mar 19 16:41:51 myserver systemd[1]: Starting Janus WebRTC Server...
Mar 19 16:41:51 myserver janus[1306664]: Janus commit: not-a-git-repo
Mar 19 16:41:51 myserver janus[1306664]: Compiled on:  Fri Mar 19 15:41:32 UTC 2021
Mar 19 16:41:51 myserver janus[1306664]: Running Janus as a daemon
Mar 19 16:41:51 myserver janus[1306664]: Logger plugins folder: /usr/lib64/janus/loggers
Mar 19 16:41:51 myserver janus[1306664]: [WARN]      Couldn't access logger plugins folder...
Mar 19 16:41:51 myserver janus[1306664]: ---------------------------------------------------
Mar 19 16:41:51 myserver janus[1306664]:   Starting Meetecho Janus (WebRTC Server) v0.10.10
Mar 19 16:41:51 myserver janus[1306664]: ---------------------------------------------------
Mar 19 16:41:51 myserver janus[1306664]: Checking command line arguments...
Mar 19 16:41:51 myserver janus[1306664]: Debug/log level is 4
Mar 19 16:41:51 myserver janus[1306664]: Debug/log timestamps are disabled
Mar 19 16:41:51 myserver janus[1306664]: Debug/log colors are disabled
Mar 19 16:41:51 myserver janus[1306664]: Adding 'vmnet' to the ICE ignore list...
Mar 19 16:41:51 myserver janus[1306664]: Using X.X.X.X as local IP...
Mar 19 16:41:51 myserver janus[1306664]: Token based authentication disabled
Mar 19 16:41:51 myserver janus[1306664]: Initializing recorder code
Mar 19 16:41:51 myserver janus[1306664]: Initializing ICE stuff (Full mode, ICE-TCP candidates disabled, half-trickle, IPv6 support disabled)
Mar 19 16:41:51 myserver janus[1306664]: TURN REST API backend: (disabled)
Mar 19 16:41:51 myserver janus[1306664]: Crypto: OpenSSL >= 1.1.0
...
```

Janus instead aborts the process lamenting the following:
```
Running Janus as a daemon but no log file provided, giving up...
```

BTW I think that I should be allowed to not log to anything if I really wanted to but this is beside the point.