### PR TITLE
Prevent race conditions on socket close in SIP and NoSIP plugins

### DIFF
--- a/plugins/janus_nosip.c
+++ b/plugins/janus_nosip.c
@@ -1238,7 +1238,9 @@ static void janus_nosip_hangup_media_internal(janus_plugin_session *handle) {
 	}
 	/* Do cleanup if media thread has not been created */
 	if(!session->media.ready && !session->relayer_thread) {
+		janus_mutex_lock(&session->mutex);
 		janus_nosip_media_cleanup(session);
+		janus_mutex_unlock(&session->mutex);
 	}
 	/* Get rid of the recorders, if available */
 	janus_mutex_lock(&session->rec_mutex);
@@ -1438,13 +1440,16 @@ static void *janus_nosip_handler(void *data) {
 					JANUS_LOG(LOG_VERB, "Going to negotiate video...\n");
 					session->media.has_video = 1;	/* FIXME Maybe we need a better way to signal this */
 				}
+				janus_mutex_lock(&session->mutex);
 				if(janus_nosip_allocate_local_ports(session, sdp_update) < 0) {
+					janus_mutex_unlock(&session->mutex);
 					JANUS_LOG(LOG_ERR, "Could not allocate RTP/RTCP ports\n");
 					janus_sdp_destroy(parsed_sdp);
 					error_code = JANUS_NOSIP_ERROR_IO_ERROR;
 					g_snprintf(error_cause, 512, "Could not allocate RTP/RTCP ports");
 					goto error;
 				}
+				janus_mutex_unlock(&session->mutex);
 
 				char *sdp = janus_nosip_sdp_manipulate(session, parsed_sdp, FALSE);
 				if(sdp == NULL) {
@@ -2351,13 +2356,17 @@ static void *janus_nosip_relay_thread(void *data) {
 					if(fds[i].fd == session->media.audio_rtcp_fd) {
 						JANUS_LOG(LOG_WARN, "[NoSIP-%p] Got a '%s' on the audio RTCP socket, closing it\n",
 							session, g_strerror(error));
+						janus_mutex_lock(&session->mutex);
 						close(session->media.audio_rtcp_fd);
 						session->media.audio_rtcp_fd = -1;
+						janus_mutex_unlock(&session->mutex);
 					} else if(fds[i].fd == session->media.video_rtcp_fd) {
 						JANUS_LOG(LOG_WARN, "[NoSIP-%p] Got a '%s' on the video RTCP socket, closing it\n",
 							session, g_strerror(error));
+						janus_mutex_lock(&session->mutex);
 						close(session->media.video_rtcp_fd);
 						session->media.video_rtcp_fd = -1;
+						janus_mutex_unlock(&session->mutex);
 					}
 				}
 				/* FIXME Should we be more tolerant of ICMP errors on RTP sockets as well? */
@@ -2484,7 +2493,9 @@ static void *janus_nosip_relay_thread(void *data) {
 		}
 	}
 	/* Cleanup the media session */
+	janus_mutex_lock(&session->mutex);
 	janus_nosip_media_cleanup(session);
+	janus_mutex_unlock(&session->mutex);
 	/* Done */
 	JANUS_LOG(LOG_INFO, "Leaving NoSIP relay thread\n");
 	session->relayer_thread = NULL;


### PR DESCRIPTION
We noticed that in some cases, in misconfigured instances of Janus with high socket contention and high traffic, a race condition could happen where a socket would be closed twice. This is an issue whenever the second time we close a socket it was actually assigned to someone else in the meanwhile: if the socket was used internally by `getifaddrs`, for instance, this could cause that method to lock and never return, and since in Janus that call may be on a critical path, deadlock relevant functionality.

This PR tries to fix this behaviour in SIP and NoSIP plugins, as the SIP plugin is where we noticed this happening, and the NoSIP plugin borrows a lot of the same code. The Streaming plugin doesn't seem to be affected instead, as only a mountpoint thread messes with the struct file descriptor values.

Feedback welcome, especially if you use those plugins a lot in production.