### PR TITLE
janus.js - renegotiate with external stream

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2196,10 +2196,6 @@ function Janus(gatewayCallbacks) {
 				if(media.addData) {
 					media.data = true;
 				}
-				// Reset external stream flag when replacing MediaStream with user media
-				if(config.streamExternal) {
-					config.streamExternal = false;
-				}
 			}
 			// If we're updating and keeping all tracks, let's skip the getUserMedia part
 			if((isAudioSendEnabled(media) && media.keepAudio) &&

--- a/html/janus.js
+++ b/html/janus.js
@@ -1741,7 +1741,7 @@ function Janus(gatewayCallbacks) {
 		}
 		// We're now capturing the new stream: check if we're updating or if it's a new thing
 		var addTracks = false;
-    if(!config.myStream || !media.update || (config.streamExternal && !media.replaceVideoExternalStream)) {
+		if(!config.myStream || !media.update || (config.streamExternal && !media.replaceVideoExternalStream)) {
 			config.myStream = stream;
 			addTracks = true;
 		} else {
@@ -2079,12 +2079,12 @@ function Janus(gatewayCallbacks) {
 			// can go directly to preparing the new SDP offer or answer
 			if(callbacks.stream) {
 				// External stream: is this the same as the one we were using before?
-        var newStream = (callbacks.stream.externalStream ? callbacks.stream.externalStream : callbacks.stream);
+				var newStream = (callbacks.stream.externalStream ? callbacks.stream.externalStream : callbacks.stream);
 				if(newStream !== config.myStream) {
 					Janus.log("Renegotiation involves a new external stream");
-          if(callbacks.stream.replaceVideo) {
-            media.replaceVideoExternalStream = true;
-          }
+					if(callbacks.stream.replaceVideo) {
+						media.replaceVideoExternalStream = true;
+					}
 				}
 			} else {
 				// Check if there are changes on audio
@@ -2264,7 +2264,7 @@ function Janus(gatewayCallbacks) {
 		}
 		// Was a MediaStream object passed, or do we need to take care of that?
 		if(callbacks.stream) {
-      var stream = callbacks.stream.externalStream ? callbacks.stream.externalStream : callbacks.stream;
+			var stream = callbacks.stream.externalStream ? callbacks.stream.externalStream : callbacks.stream;
 			Janus.log("MediaStream provided by the application");
 			Janus.debug(stream);
 			// If this is an update, let's check if we need to release the previous stream

--- a/html/janus.js
+++ b/html/janus.js
@@ -2210,7 +2210,7 @@ function Janus(gatewayCallbacks) {
 			}
 		}
 		// If we're updating, check if we need to remove/replace one of the tracks
-		if(media.update && !config.streamExternal || (config.streamExternal && (media.replaceAudio || media.replaceVideo))) {
+		if(media.update && (!config.streamExternal || (config.streamExternal && (media.replaceAudio || media.replaceVideo)))) {
 			if(media.removeAudio || media.replaceAudio) {
 				if(config.myStream && config.myStream.getAudioTracks() && config.myStream.getAudioTracks().length) {
 					var at = config.myStream.getAudioTracks()[0];

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -649,12 +649,6 @@ janus.attach(
  * - \c replaceVideo: if set, stop capturing the current video (remove the
  * local video track), and capture a new video source.
  *
- * The new object with properties you can pass to \c stream in \c createOffer and
- * \c createAnswer are the following:
- *
- * - \c externalStream: \c MediaStream a MediaStream object you obtained yourself;
- * - \c replaceVideo: if set, stop capturing the current video or stream (remove the local video track), and replace it with the new MediaStream;
- *
  * Notice that these properties are only processed when you're trying a
  * renegotiation, and will be ignored when creating a new PeerConnection.
  *

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -653,7 +653,7 @@ janus.attach(
  * \c createAnswer are the following:
  *
  * - \c externalStream: \c MediaStream a MediaStream object you obtained yourself;
- * - \c replaceVideo: if set, stop capturing the current video (remove the local video track), and replace it with the new MediaStream;
+ * - \c replaceVideo: if set, stop capturing the current video or stream (remove the local video track), and replace it with the new MediaStream;
  *
  * Notice that these properties are only processed when you're trying a
  * renegotiation, and will be ignored when creating a new PeerConnection.

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -649,6 +649,13 @@ janus.attach(
  * - \c replaceVideo: if set, stop capturing the current video (remove the
  * local video track), and capture a new video source.
  *
+ * The new object with properties you can pass to \c stream in \c createOffer and
+ * \c createAnswer are the following:
+ *
+ * - \c externalStream: \c MediaStream a MediaStream object you obtained yourself;
+ * - \c replaceVideo: if set, stop capturing the current video (remove the local video track), and replace it with the new MediaStream;
+ * this option can either be a MediaStream object
+ *
  * Notice that these properties are only processed when you're trying a
  * renegotiation, and will be ignored when creating a new PeerConnection.
  *

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -654,7 +654,6 @@ janus.attach(
  *
  * - \c externalStream: \c MediaStream a MediaStream object you obtained yourself;
  * - \c replaceVideo: if set, stop capturing the current video (remove the local video track), and replace it with the new MediaStream;
- * this option can either be a MediaStream object
  *
  * Notice that these properties are only processed when you're trying a
  * renegotiation, and will be ignored when creating a new PeerConnection.


### PR DESCRIPTION
This PR adds the ability for an existing PeerConnection to `replaceVideo` with an external `stream` and back again through the `createOffer` renegotiation.

The issue this PR solves is described in this Google Group post [https://groups.google.com/g/meetecho-janus/c/Ucz-U3OORHM/m/mo6lXkdjAwAJ](https://groups.google.com/g/meetecho-janus/c/Ucz-U3OORHM/m/mo6lXkdjAwAJ)
To summarize the issue, a renegotiation `createOffer` sent with a canvas `MediaStream` (external stream) does not replace the track of the existing PeerConnection.

This PR allows the `stream` property sent in a `createOffer` parameter to be an object which can include the `replaceVideo` and `externalStream` properties, similar to the `media` property. The existing stream property behavior has not been modified.

Here is a working example:
```javascript
// Assume Janus is correctly initialized
var canvas = document.getElementById('canvas');
var stream = canvas.captureStream();
janusPlugin.createOffer({
  stream: {
    externalStream: stream,
    replaceVideo: true,
  },
  simulcast: false,
  simulcast2: false,
  success: (jsep) => {
    janusPlugin.send({ message: { request: "configure", audio: true, video: true}, jsep });
  },
  error: (error) => { Janus.error('error', error); },
});
```

Using `createOffer` in this manner replaces a user media (video camera) stream with an external `MediaStream` *and* an external `MediaStream` with another external `MediaStream`.

To renegotiate the same peer connection from an external `MediaStream` back to user media (video camera) utilizes the same `media` property as before. Here is a working example:
```javascript
// Assume Janus is correctly initialized
janusPlugin.createOffer({
  media: {
    video: userMediaVideoDevice,
    replaceVideo: true,
  },
  simulcast: false,
  simulcast2: false,
  success: (jsep) => {
    janusPlugin.send({ message: { request: "configure", audio: true, video: true}, jsep });
  },
  error: (error) => { Janus.error('error', error); },
});
```

In summary this change allows a PeerConnection renegotiation to replace the video in the following three conditions:
1. User media -> external MediaStream
2. External MediaStream -> external MediaStream
3. External MediaStream -> User media


#### Implementation decision making
I was a bit unsure of design implications regarding this note in the `createOffer`/`createAnswer` documentation (emphasis added):

>stream: optional, only to be passed in case you obtained a MediaStream object yourself with a getUserMedia request, and that you want the library to use instead of having it get one by itself **(makes the media property useless, as it won't be read for accessing any device);**

This is why I chose to modify the `stream` object instead of using the already available `{ media: { video: true, replaceVideo: true } }` property.