### PR TITLE
fix a small memory leak in turnrest.c

### DIFF
--- a/turnrest.c
+++ b/turnrest.c
@@ -117,6 +117,7 @@ void janus_turnrest_response_destroy(janus_turnrest_response *response) {
 	g_free(response->username);
 	g_free(response->password);
 	g_list_free_full(response->servers, janus_turnrest_instance_destroy);
+	g_free(response);
 }
 
 janus_turnrest_response *janus_turnrest_request(const char *user) {


### PR DESCRIPTION
While testing a TURN REST API, I've found a small memory leak. A `janus_turnrest_response_destroy` function frees everything but the `response` itself. This pull request should fix that.

<details>
<summary>ASAN output</summary>
<p>

```
Direct leak of 896 byte(s) in 28 object(s) allocated from:
    #0 0x7f1e25cfdb40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f1e24ea4f58 in g_malloc ../glib/gmem.c:106
    #2 0x5588950fc302 in janus_turnrest_request /sources/janus-gateway/turnrest.c:230
    #3 0x55889507eb0c in janus_ice_setup_local /sources/janus-gateway/ice.c:3473
    #4 0x558895093a9c in janus_process_incoming_request /sources/janus-gateway/janus.c:1440
    #5 0x5588950a2c3b in janus_transport_task /sources/janus-gateway/janus.c:3287
    #6 0x7f1e24ec90b1 in g_thread_pool_thread_proxy ../glib/gthreadpool.c:354
    #7 0x7f1e24ec8857 in g_thread_proxy ../glib/gthread.c:826
    #8 0x7f1e23b026da in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76da)
    #9 0x7f1e2382b71e in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x12171e)
```

</p>
</details>  