### PR TITLE
conf: fix commented out ice nomination default

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -257,7 +257,7 @@ nat: {
 	#stun_port = 3478
 	nice_debug = false
 	#full_trickle = true
-	#ice_nomination = "regular"
+	#ice_nomination = "aggressive"
 	#ice_keepalive_conncheck = true
 	#ice_lite = true
 	#ice_tcp = true


### PR DESCRIPTION
Since 20dd2db2c60a99fb89a26e2ae53750ebab66da38 the default is actually `aggressive` (if libnice is recent enough).