### PR TITLE
Fixed sending responses from Janus for incoming SIP MESSAGE/SIP INFO

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -5083,8 +5083,6 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			JANUS_LOG(LOG_VERB, "[%s][%s]: %d %s\n", session->account.username, nua_event_name(event), status, phrase ? phrase : "??");
 			/* We expect a payload */
 			if(!sip->sip_content_type || !sip->sip_content_type->c_type || !sip->sip_payload || !sip->sip_payload->pl_data) {
-				nua_respond(nh, 488, sip_status_phrase(488),
-					NUTAG_WITH_CURRENT(nua), TAG_END());
 				return;
 			}
 			const char *type = sip->sip_content_type->c_type;
@@ -5112,17 +5110,12 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, info, NULL);
 			JANUS_LOG(LOG_VERB, "  >> Pushing event to peer: %d (%s)\n", ret, janus_get_api_error(ret));
 			json_decref(info);
-			/* Send a 200 back */
-			nua_respond(nh, 200, sip_status_phrase(200),
-				NUTAG_WITH_CURRENT(nua), TAG_END());
 			break;
 		}
 		case nua_i_message: {
 			JANUS_LOG(LOG_VERB, "[%s][%s]: %d %s\n", session->account.username, nua_event_name(event), status, phrase ? phrase : "??");
 			/* We expect a payload */
 			if(!sip->sip_content_type || !sip->sip_content_type->c_type || !sip->sip_payload || !sip->sip_payload->pl_data) {
-				nua_respond(nh, 488, sip_status_phrase(488),
-					NUTAG_WITH_CURRENT(nua), TAG_END());
 				return;
 			}
 			const char *content_type = sip->sip_content_type->c_type;
@@ -5150,9 +5143,6 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, message, NULL);
 			JANUS_LOG(LOG_VERB, "  >> Pushing event to peer: %d (%s)\n", ret, janus_get_api_error(ret));
 			json_decref(message);
-			/* Send a 200 back */
-			nua_respond(nh, 200, sip_status_phrase(200),
-				NUTAG_WITH_CURRENT(nua), TAG_END());
 			break;
 		}
 		case nua_i_notify: {


### PR DESCRIPTION
For SIP MESSAGE and SIP INFO the response is already handled by Sofia sip. If Janus is trying to send the 200 OK, we get :
`[WARN] [tijmen][nua_i_error]: 500 Responding to a Non-Existing Request`

I also removed the 488 for the case of missing payload, because my guess is Sofia SIP will also handle this and send a proper response. If this is the case we simple need to return and do nothing since it is an invalid packet anyway.