### PR TITLE
audiobridge: GList leak fixed

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -6663,6 +6663,7 @@ static void *janus_audiobridge_mixer_thread(void *data) {
 				}
 				ps = ps->next;
 			}
+			g_list_free(anncs_list);
 		}
 #endif
 		/* Are we recording the mix? (only do it if there's someone in, though...) */


### PR DESCRIPTION
According to [docs](https://developer.gnome.org/glib/stable/glib-Hash-Tables.html#g-hash-table-get-values) `g_list_free()` should be called for `GList` returned by `g_hash_table_get_values`