### PR TITLE
SIP plugin: SIP MESSAGE out of dialog

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -406,14 +406,16 @@
  * and will restore the media direction that was set in the SDP before
  * putting the call on-hold.
  *
- * The \c message request allows you to send a SIP MESSAGE to the peer:
+ * The \c message request allows you to send a SIP MESSAGE to the peer.
+ * By default, it is sent in dialog, during active call.
+ * But, if the user is registered, it might be sent out of dialog also. In that case the uri parameter is required.
  *
 \verbatim
 {
 	"request" : "message",
 	"content_type" : "<content type; optional>"
 	"content" : "<text to send>",
- 	"uri" : "<SIP URI; optional>"
+ 	"uri" : "<SIP URI of the peer; optional; if set, the message will be sent out of dialog>"
 }
 \endverbatim
  *
@@ -4470,8 +4472,8 @@ static void *janus_sip_handler(void *data) {
 		} else if(!strcasecmp(request_text, "message")) {
 			/* Send a SIP MESSAGE request: we'll only need the content and optional payload type */
 			JANUS_VALIDATE_JSON_OBJECT(root, sipmessage_parameters,
-			      	error_code, error_cause, TRUE,
-			      	JANUS_SIP_ERROR_MISSING_ELEMENT, JANUS_SIP_ERROR_INVALID_ELEMENT);
+			      error_code, error_cause, TRUE,
+			      JANUS_SIP_ERROR_MISSING_ELEMENT, JANUS_SIP_ERROR_INVALID_ELEMENT);
 			if(error_code != 0) {
 				goto error;
 			}

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4472,8 +4472,8 @@ static void *janus_sip_handler(void *data) {
 		} else if(!strcasecmp(request_text, "message")) {
 			/* Send a SIP MESSAGE request: we'll only need the content and optional payload type */
 			JANUS_VALIDATE_JSON_OBJECT(root, sipmessage_parameters,
-			      error_code, error_cause, TRUE,
-			      JANUS_SIP_ERROR_MISSING_ELEMENT, JANUS_SIP_ERROR_INVALID_ELEMENT);
+			      	error_code, error_cause, TRUE,
+			      	JANUS_SIP_ERROR_MISSING_ELEMENT, JANUS_SIP_ERROR_INVALID_ELEMENT);
 			if(error_code != 0) {
 				goto error;
 			}

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -806,7 +806,8 @@ static struct janus_json_parameter info_parameters[] = {
 static struct janus_json_parameter sipmessage_parameters[] = {
 	{"content_type", JSON_STRING, 0},
 	{"content", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
-	{"uri", JSON_STRING, 0}
+	{"uri", JSON_STRING, 0},
+	{"headers", JSON_OBJECT, 0}
 };
 
 /* Useful stuff */
@@ -4532,8 +4533,8 @@ static void *janus_sip_handler(void *data) {
 					TAG_IF(strlen(custom_headers) > 0, SIPTAG_HEADER_STR(custom_headers)),
 					TAG_END());
 			} else {
+				janus_mutex_lock(&session->stack->smutex);
 				if(session->stack->s_nh_m == NULL) {
-					janus_mutex_lock(&session->stack->smutex);
 					if (session->stack->s_nua == NULL) {
 						janus_mutex_unlock(&session->stack->smutex);
 						JANUS_LOG(LOG_ERR, "NUA destroyed while sending message?\n");
@@ -4542,8 +4543,8 @@ static void *janus_sip_handler(void *data) {
 						goto error;
 					}
 					session->stack->s_nh_m = nua_handle(session->stack->s_nua, session, TAG_END());
-					janus_mutex_unlock(&session->stack->smutex);
 				}
+				janus_mutex_unlock(&session->stack->smutex);
 				nua_message(session->stack->s_nh_m,
 					SIPTAG_TO_STR(uri_text),
 					SIPTAG_CONTENT_TYPE_STR(content_type),


### PR DESCRIPTION
Hello,

In this pull request, I added the option to send a SIP MESSAGE "out of dialog". The message will be sent out of dialog if you pass the new parameter called "uri" with the SIP URI of the peer. If the "uri" parameter is not set, the message will be sent in the active dialog as it is in the current implementation. In order to send a message out of dialog, the user must be registered.

I tested it with the Kamailio and it works fine.