### PR TITLE
mqttevh: added ability use relative to config paths in config

### DIFF
--- a/events/janus_mqttevh.c
+++ b/events/janus_mqttevh.c
@@ -929,7 +929,7 @@ static int janus_mqttevh_init(const char *config_path) {
 			item = janus_config_get(config, config_general, janus_config_type_item, "ssl_cacert");
 		}
 		if(item && item->value) {
-			ctx->tls.cacert_file = g_strdup(item->value);
+			ctx->tls.cacert_file = janus_make_absolute_path(config_path, item->value);
 		}
 
 		item = janus_config_get(config, config_general, janus_config_type_item, "tls_client_cert");
@@ -937,14 +937,14 @@ static int janus_mqttevh_init(const char *config_path) {
 			item = janus_config_get(config, config_general, janus_config_type_item, "ssl_client_cert");
 		}
 		if(item && item->value) {
-			ctx->tls.cert_file = g_strdup(item->value);
+			ctx->tls.cert_file = janus_make_absolute_path(config_path, item->value);
 		}
 		item = janus_config_get(config, config_general, janus_config_type_item, "tls_client_key");
 		if(!item) {
 			item = janus_config_get(config, config_general, janus_config_type_item, "ssl_client_key");
 		}
 		if(item && item->value) {
-			ctx->tls.key_file = g_strdup(item->value);
+			ctx->tls.key_file = janus_make_absolute_path(config_path, item->value);
 		}
 		item = janus_config_get(config, config_general, janus_config_type_item, "tls_verify_peer");
 		if(!item) {

--- a/utils.c
+++ b/utils.c
@@ -296,6 +296,16 @@ int janus_mkdir(const char *dir, mode_t mode) {
 	return 0;
 }
 
+gchar *janus_make_absolute_path(const gchar *base_dir, const gchar *path) {
+	if(!path)
+		return NULL;
+	if(g_path_is_absolute(path))
+		return g_strdup(path);
+	if(!base_dir)
+		return NULL;
+	return g_build_filename(base_dir, path, NULL);
+}
+
 int janus_get_codec_pt(const char *sdp, const char *codec) {
 	if(!sdp || !codec)
 		return -1;

--- a/utils.h
+++ b/utils.h
@@ -143,6 +143,13 @@ gboolean janus_flags_is_set(janus_flags *flags, gsize flag);
  * @note A failure may indicate that creating any of the subdirectories failed: some may still have been created */
 int janus_mkdir(const char *dir, mode_t mode);
 
+/*! \brief Helper to convert \c path relative to \c base_dir to absolute path.
+ *  If \c path already represents absolute path then just g_strdup it.
+ * @param[in] base_dir Path which will be prepended to \c path if it's relative
+ * @param[in] path Some relative or absolute path
+ * @returns g_strdup'ed absolute path. Should be freed with g_free() when no longer needed */
+gchar *janus_make_absolute_path(const gchar *base_dir, const gchar *path);
+
 /*! \brief Ugly and dirty helper to quickly get the payload type associated with a codec in an SDP
  * @param sdp The SDP to parse
  * @param codec The codec to look for


### PR DESCRIPTION
Sometimes it's useful to have ability use relative paths in configs.

Also, if you will find it useful, I can do the same for other plugins.