### PR TITLE
Fix streaming plugin RTSP sample in config template

### DIFF
--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -257,8 +257,8 @@ file-ondemand-sample: {
 	#rtsp_user = "username"
 	#rtsp_pwd = "password"
 	#secret = "adminpwd"
-	#reconnect_delay = 5
-	#session_timeout = 0
-	# rtsp_timeout = 10
-	# rtsp_conn_timeout = 5
+	#rtsp_reconnect_delay = 5
+	#rtsp_session_timeout = 0
+	#rtsp_timeout = 10
+	#rtsp_conn_timeout = 5
 #}


### PR DESCRIPTION
This make the example fit with in-template documentation :

https://github.com/meetecho/janus-gateway/blob/4dd379ab6952ccaaa027d5c150da1fbf0fecff16/conf/janus.plugin.streaming.jcfg.sample.in#L83-L90