### PR TITLE
Added support for datachannel label/protocol to Lua and Duktape plugins

### DIFF
--- a/plugins/duktape/echotest.js
+++ b/plugins/duktape/echotest.js
@@ -173,16 +173,16 @@ function hangupMedia(id) {
 	}
 }
 
-function incomingTextData(id, buf, len) {
+function incomingTextData(id, buf, len, label, protocol) {
 	// Relaying RTP/RTCP in JavaScript makes no sense, but just for fun
 	// we handle data channel messages ourselves to manipulate them
 	var edit = "[" + name + "] --> " + buf;
-	relayTextData(id, edit, edit.length);
+	relayTextData(id, edit, edit.length, label, protocol);
 }
 
-function incomingBinaryData(id, buf, len) {
+function incomingBinaryData(id, buf, len, label, protocol) {
 	// If the data we're getting is binary, send it back as it is
-	relayBinaryData(id, buf, len);
+	relayBinaryData(id, buf, len, label, protocol);
 }
 
 function dataReady(id) {

--- a/plugins/janus_duktape.c
+++ b/plugins/janus_duktape.c
@@ -1156,6 +1156,7 @@ static duk_ret_t janus_duktape_method_relayrtcp(duk_context *ctx) {
 }
 
 static duk_ret_t janus_duktape_method_relaytextdata(duk_context *ctx) {
+	int n = duk_get_top(ctx);
 	if(duk_get_type(ctx, 0) != DUK_TYPE_NUMBER) {
 		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
 			janus_duktape_type_string(DUK_TYPE_NUMBER), janus_duktape_type_string(duk_get_type(ctx, 0)));
@@ -1171,7 +1172,16 @@ static duk_ret_t janus_duktape_method_relaytextdata(duk_context *ctx) {
 			janus_duktape_type_string(DUK_TYPE_NUMBER), janus_duktape_type_string(duk_get_type(ctx, 2)));
 		return duk_throw(ctx);
 	}
-	/* FIXME We should add support for labels, here */
+	if(n > 3 && duk_get_type(ctx, 3) != DUK_TYPE_STRING) {
+		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
+			janus_duktape_type_string(DUK_TYPE_STRING), janus_duktape_type_string(duk_get_type(ctx, 3)));
+		return duk_throw(ctx);
+	}
+	if(n > 4 && duk_get_type(ctx, 4) != DUK_TYPE_STRING) {
+		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
+			janus_duktape_type_string(DUK_TYPE_STRING), janus_duktape_type_string(duk_get_type(ctx, 4)));
+		return duk_throw(ctx);
+	}
 	uint32_t id = (uint32_t)duk_get_number(ctx, 0);
 	const char *payload = duk_get_string(ctx, 1);
 	int len = (int)duk_get_number(ctx, 2);
@@ -1179,6 +1189,13 @@ static duk_ret_t janus_duktape_method_relaytextdata(duk_context *ctx) {
 		JANUS_LOG(LOG_ERR, "Invalid data\n");
 		duk_push_error_object(ctx, DUK_ERR_ERROR, "Invalid payload of declared size %d", len);
 		return duk_throw(ctx);
+	}
+	/* Check if label and/or protocol were provided as well */
+	const char *label = NULL, *protocol = NULL;
+	if(n > 3) {
+		label = duk_get_string(ctx, 3);
+		if(n > 4)
+			protocol = duk_get_string(ctx, 4);
 	}
 	/* Find the session */
 	janus_mutex_lock(&duktape_sessions_mutex);
@@ -1197,8 +1214,8 @@ static duk_ret_t janus_duktape_method_relaytextdata(duk_context *ctx) {
 	}
 	/* Send the data */
 	janus_plugin_data data = {
-		.label = NULL,
-		.protocol = NULL,
+		.label = (char *)label,
+		.protocol = (char *)protocol,
 		.binary = FALSE,
 		.buffer = (char *)payload,
 		.length = len
@@ -1210,6 +1227,7 @@ static duk_ret_t janus_duktape_method_relaytextdata(duk_context *ctx) {
 }
 
 static duk_ret_t janus_duktape_method_relaybinarydata(duk_context *ctx) {
+	int n = duk_get_top(ctx);
 	if(duk_get_type(ctx, 0) != DUK_TYPE_NUMBER) {
 		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
 			janus_duktape_type_string(DUK_TYPE_NUMBER), janus_duktape_type_string(duk_get_type(ctx, 0)));
@@ -1225,14 +1243,30 @@ static duk_ret_t janus_duktape_method_relaybinarydata(duk_context *ctx) {
 			janus_duktape_type_string(DUK_TYPE_NUMBER), janus_duktape_type_string(duk_get_type(ctx, 2)));
 		return duk_throw(ctx);
 	}
+	if(n > 3 && duk_get_type(ctx, 3) != DUK_TYPE_STRING) {
+		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
+			janus_duktape_type_string(DUK_TYPE_STRING), janus_duktape_type_string(duk_get_type(ctx, 4)));
+		return duk_throw(ctx);
+	}
+	if(n > 4 && duk_get_type(ctx, 4) != DUK_TYPE_STRING) {
+		duk_push_error_object(ctx, DUK_RET_TYPE_ERROR, "Invalid argument (expected %s, got %s)\n",
+			janus_duktape_type_string(DUK_TYPE_STRING), janus_duktape_type_string(duk_get_type(ctx, 5)));
+		return duk_throw(ctx);
+	}
 	uint32_t id = (uint32_t)duk_get_number(ctx, 0);
-	/* FIXME We should add support for labels, here */
 	const char *payload = duk_get_string(ctx, 1);
 	int len = (int)duk_get_number(ctx, 2);
 	if(payload == NULL || len < 1) {
 		JANUS_LOG(LOG_ERR, "Invalid data\n");
 		duk_push_error_object(ctx, DUK_ERR_ERROR, "Invalid payload of declared size %d", len);
 		return duk_throw(ctx);
+	}
+	/* Check if label and/or protocol were provided as well */
+	const char *label = NULL, *protocol = NULL;
+	if(n > 3) {
+		label = duk_get_string(ctx, 3);
+		if(n > 4)
+			protocol = duk_get_string(ctx, 4);
 	}
 	/* Find the session */
 	janus_mutex_lock(&duktape_sessions_mutex);
@@ -1250,8 +1284,8 @@ static duk_ret_t janus_duktape_method_relaybinarydata(duk_context *ctx) {
 		return duk_throw(ctx);
 	}
 	janus_plugin_data data = {
-		.label = NULL,
-		.protocol = NULL,
+		.label = (char *)label,
+		.protocol = (char *)protocol,
 		.binary = TRUE,
 		.buffer = (char *)payload,
 		.length = len
@@ -1542,11 +1576,11 @@ int janus_duktape_init(janus_callbacks *callback, const char *config_path) {
 	duk_put_global_string(duktape_ctx, "relayRtp");
 	duk_push_c_function(duktape_ctx, janus_duktape_method_relayrtcp, 4);
 	duk_put_global_string(duktape_ctx, "relayRtcp");
-	duk_push_c_function(duktape_ctx, janus_duktape_method_relaydata, 3);	/* Legacy function, deprecated */
+	duk_push_c_function(duktape_ctx, janus_duktape_method_relaydata, 5);	/* Legacy function, deprecated */
 	duk_put_global_string(duktape_ctx, "relayData");
-	duk_push_c_function(duktape_ctx, janus_duktape_method_relaytextdata, 3);
+	duk_push_c_function(duktape_ctx, janus_duktape_method_relaytextdata, 5);
 	duk_put_global_string(duktape_ctx, "relayTextData");
-	duk_push_c_function(duktape_ctx, janus_duktape_method_relaybinarydata, 3);
+	duk_push_c_function(duktape_ctx, janus_duktape_method_relaybinarydata, 5);
 	duk_put_global_string(duktape_ctx, "relayBinaryData");
 	duk_push_c_function(duktape_ctx, janus_duktape_method_startrecording, 13);
 	duk_put_global_string(duktape_ctx, "startRecording");
@@ -2519,6 +2553,8 @@ void janus_duktape_incoming_data(janus_plugin_session *handle, janus_plugin_data
 		return;
 	char *buf = packet->buffer;
 	uint16_t len = packet->length;
+	char *label = packet->label;
+	char *protocol = packet->protocol;
 	/* Are we recording? */
 	janus_recorder_save_frame(session->drc, buf, len);
 	/* Check if the JS script wants to handle/manipulate data channel packets itself */
@@ -2534,7 +2570,9 @@ void janus_duktape_incoming_data(janus_plugin_session *handle, janus_plugin_data
 		/* We use a string for both text and binary data */
 		duk_push_lstring(t, buf, len);
 		duk_push_number(t, len);
-		int res = duk_pcall(t, 3);
+		duk_push_lstring(t, label, label ? strlen(label) : 0);
+		duk_push_lstring(t, protocol, protocol ? strlen(protocol) : 0);
+		int res = duk_pcall(t, 5);
 		if(res != DUK_EXEC_SUCCESS) {
 			/* Something went wrong... */
 			JANUS_LOG(LOG_ERR, "Duktape error: %s\n", duk_safe_to_string(t, -1));

--- a/plugins/janus_lua.c
+++ b/plugins/janus_lua.c
@@ -1035,12 +1035,11 @@ static int janus_lua_method_relayrtcp(lua_State *s) {
 static int janus_lua_method_relaytextdata(lua_State *s) {
 	/* Get the arguments from the provided state */
 	int n = lua_gettop(s);
-	if(n != 3) {
-		JANUS_LOG(LOG_ERR, "Wrong number of arguments: %d (expected 3)\n", n);
+	if(n < 3 || n > 5) {
+		JANUS_LOG(LOG_ERR, "Wrong number of arguments: %d (expected 3-5)\n", n);
 		lua_pushnumber(s, -1);
 		return 1;
 	}
-	/* FIXME We should add support for labels, here */
 	guint32 id = lua_tonumber(s, 1);
 	const char *payload = lua_tostring(s, 2);
 	int len = lua_tonumber(s, 3);
@@ -1048,6 +1047,13 @@ static int janus_lua_method_relaytextdata(lua_State *s) {
 		JANUS_LOG(LOG_ERR, "Invalid data\n");
 		lua_pushnumber(s, -1);
 		return 1;
+	}
+	/* Check if label and/or protocol were provided as well */
+	const char *label = NULL, *protocol = NULL;
+	if(n > 3) {
+		label = lua_tostring(s, 4);
+		if(n > 4)
+			protocol = lua_tostring(s, 5);
 	}
 	/* Find the session */
 	janus_mutex_lock(&lua_sessions_mutex);
@@ -1067,8 +1073,8 @@ static int janus_lua_method_relaytextdata(lua_State *s) {
 	}
 	/* Send the data */
 	janus_plugin_data data = {
-		.label = NULL,
-		.protocol = NULL,
+		.label = (char *)label,
+		.protocol = (char *)protocol,
 		.binary = FALSE,
 		.buffer = (char *)payload,
 		.length = len
@@ -1082,19 +1088,25 @@ static int janus_lua_method_relaytextdata(lua_State *s) {
 static int janus_lua_method_relaybinarydata(lua_State *s) {
 	/* Get the arguments from the provided state */
 	int n = lua_gettop(s);
-	if(n != 3) {
-		JANUS_LOG(LOG_ERR, "Wrong number of arguments: %d (expected 3)\n", n);
+	if(n < 3 || n > 5) {
+		JANUS_LOG(LOG_ERR, "Wrong number of arguments: %d (expected 3-5)\n", n);
 		lua_pushnumber(s, -1);
 		return 1;
 	}
 	guint32 id = lua_tonumber(s, 1);
-	/* FIXME We should add support for labels, here */
 	const char *payload = lua_tostring(s, 2);
 	int len = lua_tonumber(s, 3);
 	if(!payload || len < 1) {
 		JANUS_LOG(LOG_ERR, "Invalid data\n");
 		lua_pushnumber(s, -1);
 		return 1;
+	}
+	/* Check if label and/or protocol were provided as well */
+	const char *label = NULL, *protocol = NULL;
+	if(n > 3) {
+		label = lua_tostring(s, 4);
+		if(n > 4)
+			protocol = lua_tostring(s, 5);
 	}
 	/* Find the session */
 	janus_mutex_lock(&lua_sessions_mutex);
@@ -1114,8 +1126,8 @@ static int janus_lua_method_relaybinarydata(lua_State *s) {
 	}
 	/* Send the data */
 	janus_plugin_data data = {
-		.label = NULL,
-		.protocol = NULL,
+		.label = (char *)label,
+		.protocol = (char *)protocol,
 		.binary = TRUE,
 		.buffer = (char *)payload,
 		.length = len
@@ -2208,6 +2220,8 @@ void janus_lua_incoming_data(janus_plugin_session *handle, janus_plugin_data *pa
 		return;
 	char *buf = packet->buffer;
 	uint16_t len = packet->length;
+	char *label = packet->label;
+	char *protocol = packet->protocol;
 	/* Are we recording? */
 	janus_recorder_save_frame(session->drc, buf, len);
 	/* Check if the Lua script wants to handle/manipulate data channel packets itself */
@@ -2222,7 +2236,9 @@ void janus_lua_incoming_data(janus_plugin_session *handle, janus_plugin_data *pa
 		/* We use a string for both text and binary data */
 		lua_pushlstring(t, buf, len);
 		lua_pushnumber(t, len);
-		lua_call(t, 3, 0);
+		lua_pushlstring(t, label, label ? strlen(label) : 0);
+		lua_pushlstring(t, protocol, protocol ? strlen(protocol) : 0);
+		lua_call(t, 5, 0);
 		lua_pop(lua_state, 1);
 		janus_mutex_unlock(&lua_mutex);
 		return;

--- a/plugins/lua/echotest.lua
+++ b/plugins/lua/echotest.lua
@@ -171,16 +171,16 @@ function hangupMedia(id)
 	end
 end
 
-function incomingTextData(id, buf, len)
+function incomingTextData(id, buf, len, label, protocol)
 	-- Relaying RTP/RTCP in Lua makes no sense, but just for fun
 	-- we handle text data channel messages ourselves to manipulate them
 	local edit = "[" .. name .. "] --> " .. buf
-	relayTextData(id, edit, string.len(edit));
+	relayTextData(id, edit, string.len(edit), label, protocol);
 end
 
-function incomingBinaryData(id, buf, len)
+function incomingBinaryData(id, buf, len, label, protocol)
 	-- If the data we're getting is binary, send it back as it is
-	relayBinaryData(id, buf, len);
+	relayBinaryData(id, buf, len, label, protocol);
 end
 
 function dataReady(id)


### PR DESCRIPTION
I realized that, despite labels and subprotocols support had been added to Janus for some time already (in #1551 and #2157 respectively), we still hadn't updated the Lua and Duktape plugins accordingly. This is what this patch does.

In theory, this change is backwards compatible, meaning that if you're using datachannels and don't change anything in your lua and js script, they should just work, but you may want to double check that. Label and subprotocol are now two additional (and again, in theory optional) parameters you can add both to your `incomingTextData`/`incomingBinaryData` callbacks, and the related `relayTextData`/`relayBinaryData` methods. I updated both `echotest.lua` and `echotest.js`, so it should be trivial to see how you can change your scripts.

Feedback welcome, as I plan to merge soon.