### PR TITLE
Send PLI when starting a paused stream

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -6884,9 +6884,16 @@ static void *janus_videoroom_handler(void *data) {
 			} else if(!strcasecmp(request_text, "start")) {
 				/* Start/restart receiving the publisher streams */
 				if(subscriber->paused && msg->jsep == NULL) {
+					janus_videoroom_publisher *feed = subscriber->feed;
+
 					/* This is just resuming a paused stream, reset the RTP sequence numbers */
 					subscriber->context.a_seq_reset = TRUE;
 					subscriber->context.v_seq_reset = TRUE;
+
+					if(feed && feed->session && g_atomic_int_get(&feed->session->started)) {
+						/* Send a FIR */
+						janus_videoroom_reqpli(feed, "Subscriber start");
+					}
 				}
 				subscriber->paused = FALSE;
 				event = json_object();


### PR DESCRIPTION
We have noticed that sometimes resuming a paused stream takes long (even 10 seconds or more) before getting displayed on the subscriber. This depends on framerate / frame size (eg. on a nHD stream from a webcam with a somewhat high fps takes less than a desktop stream shared in FHD with maybe 3/5 fps), but also on the rtcp feedback from the browser that may not be immediate.

By sending a pli when starting the stream, the restart is more consistent.

This is a wip for the following reasons:
- makes sense to always send a pli request or is better to add a parameter to the start request?
- I'm not sure about the guard for the `janus_videoroom_reqpli` call, the one here is taken from the recording portion and seems ok
-  maybe is better to call it only if the subscriber is paused, so get's triggered only on stream resume?