### PR TITLE
Bugfix: make sure that every destroyed plugin handle is 'detached'

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -721,7 +721,6 @@ function Janus(gatewayCallbacks) {
 				// Don't warn here because destroyHandle causes this situation.
 				return;
 			}
-			pluginHandle.detached = true;
 			pluginHandle.ondetached();
 			pluginHandle.detach();
 		} else if(json["janus"] === "media") {
@@ -1679,6 +1678,7 @@ function Janus(gatewayCallbacks) {
 			callbacks.success();
 			return;
 		}
+		pluginHandle.detached = true;
 		if(noRequest) {
 			// We're only removing the handle locally
 			delete pluginHandles[handleId];


### PR DESCRIPTION
Sometimes, when sessions are destroyed, the `detached` property is not correctly set in plugin handle.
This patch attempts to fix this bad behaviour