### PR TITLE
createOffer crashes in Firefox (on Mac) when re-negotiating p2p (eg. when user mutes audio)

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2765,7 +2765,7 @@ function Janus(gatewayCallbacks) {
 		if(sendVideo && simulcast && Janus.webRTCAdapter.browserDetails.browser === "firefox") {
 			// FIXME Based on https://gist.github.com/voluntas/088bc3cc62094730647b
 			Janus.log("Enabling Simulcasting for Firefox (RID)");
-			var sender = config.pc.getSenders().find(function(s) {return s.track.kind === "video"});
+			var sender = config.pc.getSenders().find(function(s) {return s.track && s.track.kind === "video"});
 			if(sender) {
 				var parameters = sender.getParameters();
 				if(!parameters) {


### PR DESCRIPTION
```
TypeError: s.track is null
    sender janus.js:2768
    createOffer janus.js:2768
    streamsDone janus.js:2021
    prepareWebrtc janus.js:2546
    promise callback*prepareWebrtc janus.js:2506
    createOffer janus.js:1250
```