### PR TITLE
added enable_recording api for audiobridge plugin.

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -243,7 +243,7 @@ room-<unique room ID>: {
 	"request" : "enable_recording",
 	"room" : <unique numeric ID of the room>,
 	"secret" : "<room secret; mandatory if configured>"
-	"record" : <true|false, whether participants in this room should be automatically recorded or not>,
+	"record" : <true|false, whether this room should be automatically recorded or not>,
 }
 \endverbatim 
  *
@@ -3299,7 +3299,6 @@ static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_s
 			goto prepare_response;
 		json_t *record = json_object_get(root, "record");
 		gboolean recording_active = json_is_true(record);
-		JANUS_LOG(LOG_VERB, "Enable Recording : %d \n", (recording_active ? 1 : 0));
 		/* Lookup room */
 		janus_mutex_lock(&rooms_mutex);
 		janus_audiobridge_room *audiobridge = NULL;
@@ -3314,7 +3313,7 @@ static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_s
 		gint room_prev_recording_active = recording_active ? 1 : 0;
 		if (room_prev_recording_active != g_atomic_int_get(&audiobridge->record)) {
 			/* Room recording state has changed */
-			JANUS_LOG(LOG_VERB, "Recording status changed : prev = %d curr = %d \n", g_atomic_int_get(&audiobridge->record), recording_active);
+			JANUS_LOG(LOG_VERB, "Recording status changed: prev=%d, curr = %d\n", g_atomic_int_get(&audiobridge->record), recording_active);
 			g_atomic_int_set(&audiobridge->record, room_prev_recording_active);
 		}
 		response = json_object();


### PR DESCRIPTION
- Added support in audio bridge plugin to start/stop recording in the middle of call.
- This is using the similar structure as "enable_recording" of videoroom plugin.
- WAV file is created with start timestamp so that audiobridge output can be combined with mrj dumps from videoroom
- i think it still have issue, when the 'janus_audiobridge_mixer_thread' is not closed, we probably need to update the wav header during the audioroom destroy call.

