### PR TITLE
Fix SIP plugin unhold request docs typo

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -399,8 +399,7 @@
  *
 \verbatim
 {
-	"request" : "hold",
-	"direction" : "<sendonly, recvonly or inactive>"
+	"request" : "unhold"
 }
 \endverbatim
  *


### PR DESCRIPTION
It seems just copy-paste typo.