### PR TITLE
Optionally allow IPv6 link-local addresses to be gathered too

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ or on the command line:
                                   vmnet,192.168., default=vmnet)
 	-6, --ipv6-candidates         Whether to enable IPv6 candidates or not
                                   (experimental)  (default=off)
+	-O, --ipv6-link-local         Whether IPv6 link-local candidates should be
+                                  gathered as well  (default=off)
 	-l, --libnice-debug           Whether to enable libnice debugging or not
                                   (default=off)
 	-f, --full-trickle            Do full-trickle instead of half-trickle

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -180,8 +180,8 @@ certificates: {
 	#rsa_private_key = false
 }
 
-# Media-related stuff: you can configure whether if you want
-# to enable IPv6 support, the minimum size of the NACK queue (in ms,
+# Media-related stuff: you can configure whether if you want to enable IPv6
+# support (and link-local IPs), the minimum size of the NACK queue (in ms,
 # defaults to 200ms) for retransmissions no matter the RTT, the range of
 # ports to use for RTP and RTCP (by default, no range is envisaged), the
 # starting MTU for DTLS (1200 by default, it adapts automatically),
@@ -198,6 +198,7 @@ certificates: {
 # you should pick a reasonable trade-off (usually 2*max expected RTT).
 media: {
 	#ipv6 = true
+	#ipv6_linklocal = true
 	#min_nack_queue = 500
 	#rtp_port_range = "20000-40000"
 	#dtls_mtu = 1200

--- a/ice.c
+++ b/ice.c
@@ -97,8 +97,13 @@ gboolean janus_ice_is_mdns_enabled(void) {
 
 /* IPv6 support */
 static gboolean janus_ipv6_enabled;
+static gboolean janus_ipv6_linklocal_enabled;
 gboolean janus_ice_is_ipv6_enabled(void) {
 	return janus_ipv6_enabled;
+}
+static gboolean janus_ipv6_linklocal_enabled;
+gboolean janus_ice_is_ipv6_linklocal_enabled(void) {
+	return janus_ipv6_linklocal_enabled;
 }
 
 #ifdef HAVE_ICE_NOMINATION
@@ -875,12 +880,14 @@ void janus_ice_trickle_destroy(janus_ice_trickle *trickle) {
 
 /* libnice initialization */
 void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean full_trickle, gboolean ignore_mdns,
-		gboolean ipv6, uint16_t rtp_min_port, uint16_t rtp_max_port) {
+		gboolean ipv6, gboolean ipv6_linklocal, uint16_t rtp_min_port, uint16_t rtp_max_port) {
 	janus_ice_lite_enabled = ice_lite;
 	janus_ice_tcp_enabled = ice_tcp;
 	janus_full_trickle_enabled = full_trickle;
 	janus_mdns_enabled = !ignore_mdns;
 	janus_ipv6_enabled = ipv6;
+	if(ipv6)
+		janus_ipv6_linklocal_enabled = ipv6_linklocal;
 	JANUS_LOG(LOG_INFO, "Initializing ICE stuff (%s mode, ICE-TCP candidates %s, %s-trickle, IPv6 support %s)\n",
 		janus_ice_lite_enabled ? "Lite" : "Full",
 		janus_ice_tcp_enabled ? "enabled" : "disabled",
@@ -3616,8 +3623,8 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 				JANUS_LOG(LOG_ERR, "[%"SCNu64"] getnameinfo() failed: %s\n", handle->handle_id, gai_strerror(s));
 				continue;
 			}
-			/* Skip 0.0.0.0, :: and local scoped addresses  */
-			if(!strcmp(host, "0.0.0.0") || !strcmp(host, "::") || !strncmp(host, "fe80:", 5))
+			/* Skip 0.0.0.0, :: and, unless otherwise configured, local scoped addresses  */
+			if(!strcmp(host, "0.0.0.0") || !strcmp(host, "::") || (!janus_ipv6_linklocal_enabled && !strncmp(host, "fe80:", 5)))
 				continue;
 			/* Check if this IP address is in the ignore/enforce list, now: the enforce list has the precedence */
 			if(janus_ice_enforce_list != NULL) {

--- a/ice.h
+++ b/ice.h
@@ -37,10 +37,11 @@
  * @param[in] full_trickle Whether full-trickle must be used (instead of half-trickle)
  * @param[in] ignore_mdns Whether mDNS candidates should be ignored, instead of resolved
  * @param[in] ipv6 Whether IPv6 candidates must be negotiated or not
+ * @param[in] ipv6_linklocal Whether IPv6 link-local candidates should be gathered
  * @param[in] rtp_min_port Minimum port to use for RTP/RTCP, if a range is to be used
  * @param[in] rtp_max_port Maximum port to use for RTP/RTCP, if a range is to be used */
 void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean full_trickle, gboolean ignore_mdns,
-	gboolean ipv6, uint16_t rtp_min_port, uint16_t rtp_max_port);
+	gboolean ipv6, gboolean ipv6_linklocal, uint16_t rtp_min_port, uint16_t rtp_max_port);
 /*! \brief ICE stuff de-initialization */
 void janus_ice_deinit(void);
 /*! \brief Method to check whether a STUN server is reachable
@@ -129,6 +130,10 @@ gboolean janus_ice_is_mdns_enabled(void);
 /*! \brief Method to check whether IPv6 candidates are enabled/supported or not
  * @returns true if IPv6 candidates are enabled/supported, false otherwise */
 gboolean janus_ice_is_ipv6_enabled(void);
+/*! \brief Method to check whether IPv6 link-local candidates will be gathered or not
+ * \note This obviously only makes sense if IPv6 support is enabled in general
+ * @returns true if IPv6 link-local candidates will be gathered, false otherwise */
+gboolean janus_ice_is_ipv6_linklocal_enabled(void);
 #ifdef HAVE_ICE_NOMINATION
 /*! \brief Method to configure the ICE nomination mode (regular or aggressive)
  * @param[in] nomination The ICE nomination mode (regular or aggressive) */

--- a/janus.1
+++ b/janus.1
@@ -72,7 +72,10 @@ Comma-separated list of the only interfaces to use for ICE gathering; partial st
 Comma-separated list of interfaces or IP addresses to ignore for ICE gathering; partial strings are supported (e.g., vmnet8,192.168.0.1,10.0.0.1 or vmnet,192.168., default=vmnet)
 .TP
 .BR \-6 ", " \-\-ipv6-candidates
-Whether to enable IPv6 candidates or not (experimental) (default=off)
+Whether to enable IPv6 candidates or not (default=off)
+.TP
+.BR \-O ", " \-\-ipv6-link-local
+Whether IPv6 link-local candidates should be gathered as well (default=off)
 .TP
 .BR \-l ", " \-\-libnice-debug
 Whether to enable libnice debugging or not (default=off)

--- a/janus.c
+++ b/janus.c
@@ -347,6 +347,8 @@ static json_t *janus_info(const char *transaction) {
 		json_object_set_new(info, "public-ips", ips);
 	}
 	json_object_set_new(info, "ipv6", janus_ice_is_ipv6_enabled() ? json_true() : json_false());
+	if(janus_ice_is_ipv6_enabled())
+		json_object_set_new(info, "ipv6-link-local", janus_ice_is_ipv6_linklocal_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "ice-lite", janus_ice_is_ice_lite_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "ice-tcp", janus_ice_is_ice_tcp_enabled() ? json_true() : json_false());
 #ifdef HAVE_ICE_NOMINATION
@@ -4481,6 +4483,9 @@ gint main(int argc, char *argv[])
 	if(args_info.ipv6_candidates_given) {
 		janus_config_add(config, config_media, janus_config_item_create("ipv6", "true"));
 	}
+	if(args_info.ipv6_link_local_given) {
+		janus_config_add(config, config_media, janus_config_item_create("ipv6_linklocal", "true"));
+	}
 	if(args_info.min_nack_queue_given) {
 		char mnq[20];
 		g_snprintf(mnq, 20, "%d", args_info.min_nack_queue_arg);
@@ -4691,9 +4696,13 @@ gint main(int argc, char *argv[])
 #endif
 	uint16_t rtp_min_port = 0, rtp_max_port = 0;
 	gboolean ice_lite = FALSE, ice_tcp = FALSE, full_trickle = FALSE, ipv6 = FALSE,
-		ignore_mdns = FALSE, ignore_unreachable_ice_server = FALSE;
+		ipv6_linklocal = FALSE, ignore_mdns = FALSE, ignore_unreachable_ice_server = FALSE;
 	item = janus_config_get(config, config_media, janus_config_type_item, "ipv6");
 	ipv6 = (item && item->value) ? janus_is_true(item->value) : FALSE;
+	if(ipv6) {
+		item = janus_config_get(config, config_media, janus_config_type_item, "ipv6_linklocal");
+		ipv6_linklocal = (item && item->value) ? janus_is_true(item->value) : FALSE;
+	}
 	item = janus_config_get(config, config_media, janus_config_type_item, "rtp_port_range");
 	if(item && item->value) {
 		/* Split in min and max port */
@@ -4817,7 +4826,7 @@ gint main(int argc, char *argv[])
 	if(item && item->value)
 		janus_ice_set_static_event_loops(atoi(item->value));
 	/* Initialize the ICE stack now */
-	janus_ice_init(ice_lite, ice_tcp, full_trickle, ignore_mdns, ipv6, rtp_min_port, rtp_max_port);
+	janus_ice_init(ice_lite, ice_tcp, full_trickle, ignore_mdns, ipv6, ipv6_linklocal, rtp_min_port, rtp_max_port);
 	if(janus_ice_set_stun_server(stun_server, stun_port) < 0) {
 		if(!ignore_unreachable_ice_server) {
 			JANUS_LOG(LOG_FATAL, "Invalid STUN address %s:%u\n", stun_server, stun_port);

--- a/janus.ggo
+++ b/janus.ggo
@@ -17,7 +17,8 @@ option "nat-1-1" 1 "Comma-separated list of public IPs to put in all host candid
 option "keep-private-host" 2 "When nat-1-1 is used (e.g., Amazon EC2 instances), don't remove the private host, but keep both to simulate STUN" flag off
 option "ice-enforce-list" E "Comma-separated list of the only interfaces to use for ICE gathering; partial strings are supported (e.g., eth0 or eno1,wlan0, default=none)" string typestr="list" optional
 option "ice-ignore-list" X "Comma-separated list of interfaces or IP addresses to ignore for ICE gathering; partial strings are supported (e.g., vmnet8,192.168.0.1,10.0.0.1 or vmnet,192.168., default=vmnet)" string typestr="list" optional
-option "ipv6-candidates" 6 "Whether to enable IPv6 candidates or not (experimental)" flag off
+option "ipv6-candidates" 6 "Whether to enable IPv6 candidates or not" flag off
+option "ipv6-link-local" O "Whether IPv6 link-local candidates should be gathered as well" flag off
 option "libnice-debug" l "Whether to enable libnice debugging or not" flag off
 option "full-trickle" f "Do full-trickle instead of half-trickle" flag off
 option "ice-lite" I "Whether to enable the ICE Lite mode or not" flag off


### PR DESCRIPTION
Addresses discussion made on the [group](https://groups.google.com/g/meetecho-janus/c/TcVt9-iaZQ8), where apparently our filtering of link-local addresses causes issues sometimes. This patch adds a configuration setting (and command-line flag) to allow them: default remains `FALSE` to be backwards compatible.