### PR TITLE
Fix memory leak on aborted RTSP connection

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -6480,8 +6480,13 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 	int asport = 0, asport_rtcp = 0;
 	multiple_fds audio_fds = {-1, -1};
 
-	if(g_atomic_int_get(&mp->destroyed))
+	if(g_atomic_int_get(&mp->destroyed)) {
+		curl_easy_cleanup(curl);
+		g_free(curldata->buffer);
+		g_free(curldata);
 		return -8;
+	}
+
 	janus_mutex_lock(&mountpoints_mutex);
 	/* Parse both video and audio first before proceed to setup as curldata will be reused */
 	int vresult = -1;
@@ -6498,6 +6503,9 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 
 	if(vresult == -1 && aresult == -1) {
 		/* Both audio and video failed? Give up... */
+		curl_easy_cleanup(curl);
+		g_free(curldata->buffer);
+		g_free(curldata);
 		return -7;
 	}
 


### PR DESCRIPTION
Two return statements without cleaning up `libcurl` data