### PR TITLE
Fix deadlock on mountpoint destroy during RTSP reconnect

### DIFF
--- a/mutex.h
+++ b/mutex.h
@@ -28,17 +28,17 @@ typedef pthread_mutex_t janus_mutex;
 /*! \brief Janus mutex destruction */
 #define janus_mutex_destroy(a) pthread_mutex_destroy(a)
 /*! \brief Janus mutex lock without debug */
-#define janus_mutex_lock_nodebug(a) pthread_mutex_lock(a);
+#define janus_mutex_lock_nodebug(a) pthread_mutex_lock(a)
 /*! \brief Janus mutex lock with debug (prints the line that locked a mutex) */
-#define janus_mutex_lock_debug(a) { JANUS_PRINT("[%s:%s:%d:lock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); pthread_mutex_lock(a); };
+#define janus_mutex_lock_debug(a) { JANUS_PRINT("[%s:%s:%d:lock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); pthread_mutex_lock(a); }
 /*! \brief Janus mutex lock wrapper (selective locking debug) */
-#define janus_mutex_lock(a) { if(!lock_debug) { janus_mutex_lock_nodebug(a); } else { janus_mutex_lock_debug(a); } };
+#define janus_mutex_lock(a) { if(!lock_debug) { janus_mutex_lock_nodebug(a); } else { janus_mutex_lock_debug(a); } }
 /*! \brief Janus mutex unlock without debug */
-#define janus_mutex_unlock_nodebug(a) pthread_mutex_unlock(a);
+#define janus_mutex_unlock_nodebug(a) pthread_mutex_unlock(a)
 /*! \brief Janus mutex unlock with debug (prints the line that unlocked a mutex) */
-#define janus_mutex_unlock_debug(a) { JANUS_PRINT("[%s:%s:%d:unlock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); pthread_mutex_unlock(a); };
+#define janus_mutex_unlock_debug(a) { JANUS_PRINT("[%s:%s:%d:unlock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); pthread_mutex_unlock(a); }
 /*! \brief Janus mutex unlock wrapper (selective locking debug) */
-#define janus_mutex_unlock(a) { if(!lock_debug) { janus_mutex_unlock_nodebug(a); } else { janus_mutex_unlock_debug(a); } };
+#define janus_mutex_unlock(a) { if(!lock_debug) { janus_mutex_unlock_nodebug(a); } else { janus_mutex_unlock_debug(a); } }
 
 /*! \brief Janus condition implementation */
 typedef pthread_cond_t janus_condition;
@@ -72,17 +72,17 @@ typedef GMutex janus_mutex;
 /*! \brief Janus mutex destruction */
 #define janus_mutex_destroy(a) g_mutex_clear(a)
 /*! \brief Janus mutex lock without debug */
-#define janus_mutex_lock_nodebug(a) g_mutex_lock(a);
+#define janus_mutex_lock_nodebug(a) g_mutex_lock(a)
 /*! \brief Janus mutex lock with debug (prints the line that locked a mutex) */
-#define janus_mutex_lock_debug(a) { JANUS_PRINT("[%s:%s:%d:lock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); g_mutex_lock(a); };
+#define janus_mutex_lock_debug(a) { JANUS_PRINT("[%s:%s:%d:lock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); g_mutex_lock(a); }
 /*! \brief Janus mutex lock wrapper (selective locking debug) */
-#define janus_mutex_lock(a) { if(!lock_debug) { janus_mutex_lock_nodebug(a); } else { janus_mutex_lock_debug(a); } };
+#define janus_mutex_lock(a) { if(!lock_debug) { janus_mutex_lock_nodebug(a); } else { janus_mutex_lock_debug(a); } }
 /*! \brief Janus mutex unlock without debug */
-#define janus_mutex_unlock_nodebug(a) g_mutex_unlock(a);
+#define janus_mutex_unlock_nodebug(a) g_mutex_unlock(a)
 /*! \brief Janus mutex unlock with debug (prints the line that unlocked a mutex) */
-#define janus_mutex_unlock_debug(a) { JANUS_PRINT("[%s:%s:%d:unlock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); g_mutex_unlock(a); };
+#define janus_mutex_unlock_debug(a) { JANUS_PRINT("[%s:%s:%d:unlock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); g_mutex_unlock(a); }
 /*! \brief Janus mutex unlock wrapper (selective locking debug) */
-#define janus_mutex_unlock(a) { if(!lock_debug) { janus_mutex_unlock_nodebug(a); } else { janus_mutex_unlock_debug(a); } };
+#define janus_mutex_unlock(a) { if(!lock_debug) { janus_mutex_unlock_nodebug(a); } else { janus_mutex_unlock_debug(a); } }
 
 /*! \brief Janus condition implementation */
 typedef GCond janus_condition;

--- a/mutex.h
+++ b/mutex.h
@@ -33,6 +33,12 @@ typedef pthread_mutex_t janus_mutex;
 #define janus_mutex_lock_debug(a) { JANUS_PRINT("[%s:%s:%d:lock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); pthread_mutex_lock(a); }
 /*! \brief Janus mutex lock wrapper (selective locking debug) */
 #define janus_mutex_lock(a) { if(!lock_debug) { janus_mutex_lock_nodebug(a); } else { janus_mutex_lock_debug(a); } }
+/*! \brief Janus mutex try lock without debug */
+#define janus_mutex_trylock_nodebug(a) { ret = pthread_mutex_trylock(a); }
+/*! \brief Janus mutex try lock with debug (prints the line that tried to lock a mutex) */
+#define janus_mutex_trylock_debug(a) { JANUS_PRINT("[%s:%s:%d:trylock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); ret = pthread_mutex_trylock(a); }
+/*! \brief Janus mutex try lock wrapper (selective locking debug) */
+#define janus_mutex_trylock(a) ({ int ret; if(!lock_debug) { janus_mutex_trylock_nodebug(a); } else { janus_mutex_trylock_debug(a); } ret; })
 /*! \brief Janus mutex unlock without debug */
 #define janus_mutex_unlock_nodebug(a) pthread_mutex_unlock(a)
 /*! \brief Janus mutex unlock with debug (prints the line that unlocked a mutex) */
@@ -77,6 +83,12 @@ typedef GMutex janus_mutex;
 #define janus_mutex_lock_debug(a) { JANUS_PRINT("[%s:%s:%d:lock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); g_mutex_lock(a); }
 /*! \brief Janus mutex lock wrapper (selective locking debug) */
 #define janus_mutex_lock(a) { if(!lock_debug) { janus_mutex_lock_nodebug(a); } else { janus_mutex_lock_debug(a); } }
+/*! \brief Janus mutex try lock without debug */
+#define janus_mutex_trylock_nodebug(a) { ret = g_mutex_trylock(a); }
+/*! \brief Janus mutex try lock with debug (prints the line that tried to lock a mutex) */
+#define janus_mutex_trylock_debug(a) { JANUS_PRINT("[%s:%s:%d:trylock] %p\n", __FILE__, __FUNCTION__, __LINE__, a); ret = g_mutex_trylock(a); }
+/*! \brief Janus mutex try lock wrapper (selective locking debug) */
+#define janus_mutex_trylock(a) ({ gboolean ret; if(!lock_debug) { janus_mutex_trylock_nodebug(a); } else { janus_mutex_trylock_debug(a); } ret; })
 /*! \brief Janus mutex unlock without debug */
 #define janus_mutex_unlock_nodebug(a) g_mutex_unlock(a)
 /*! \brief Janus mutex unlock with debug (prints the line that unlocked a mutex) */

--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -6489,14 +6489,18 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 	int asport = 0, asport_rtcp = 0;
 	multiple_fds audio_fds = {-1, -1};
 
-	if(g_atomic_int_get(&mp->destroyed)) {
-		curl_easy_cleanup(curl);
-		g_free(curldata->buffer);
-		g_free(curldata);
-		return -8;
+	while (!janus_mutex_trylock(&mountpoints_mutex)) {
+		if(g_atomic_int_get(&mp->destroyed)) {
+			JANUS_LOG(LOG_WARN, "[%s] Destroying mountpoint while trying to reconnect, aborting\n", mp->name);
+			curl_easy_cleanup(curl);
+			g_free(curldata->buffer);
+			g_free(curldata);
+			return -8;
+		}
+
+		g_usleep(1000);
 	}
 
-	janus_mutex_lock(&mountpoints_mutex);
 	/* Parse both video and audio first before proceed to setup as curldata will be reused */
 	int vresult = -1;
 	if(dovideo) {


### PR DESCRIPTION
This fixes a deadlock which occurs under some conditions when an RTSP mountpoint destroy is requested from the API, while the mountpoint is reconnecting to the RTSP server.

When a `destroy` message is handled, the `mountpoints_mutex` is locked (https://github.com/meetecho/janus-gateway/blob/c621bb553a207ffb7843101d304564a31f4ec6e2/plugins/janus_streaming.c#L3777), then the mountpoint is removed from the hash table (https://github.com/meetecho/janus-gateway/blob/c621bb553a207ffb7843101d304564a31f4ec6e2/plugins/janus_streaming.c#L3798). The removal triggers `janus_streaming_mountpoint_destroy()` callback.

`janus_streaming_mountpoint_destroy()` interrupt the poll then join the relay thread to wait for it to exit (https://github.com/meetecho/janus-gateway/blob/c621bb553a207ffb7843101d304564a31f4ec6e2/plugins/janus_streaming.c#L1284).

But, if the mountpoint was trying to reconnect at the same moment (https://github.com/meetecho/janus-gateway/blob/c621bb553a207ffb7843101d304564a31f4ec6e2/plugins/janus_streaming.c#L7643) and `mountpoint->destroyed` not set to `1` yet, then the relay thread will also try to lock `mountpoints_mutex` (https://github.com/meetecho/janus-gateway/blob/c621bb553a207ffb7843101d304564a31f4ec6e2/plugins/janus_streaming.c#L6485). This results in a deadlock if the lock is currently held by the caller of `join()` on that mountpoint thread.

As the value of `mountpoint->destroyed` could change while waiting for the lock, the solution was to use `g_mutex_trylock()` to be able to abort the lock attempt when `destroyed` is eventually set to `1`.

I've added a `janus_mutex_unlock()` macro, with no trailing `;` to be able to use the macro in `if` or `while` statement (otherwise the compiler was [not happy](https://www.includehelp.com/c-programs/expected-bracket-before-semicolon-token-error-in-c.aspx)). I've also removed the semicolon in other `janus_mutex_*` definitions for consistency.

This is based on top of #2699. So I'll rebase this PR once the other one is merged. I've chosen to open two separated PRs as they are fixing two different issues.

Fixes: #2691