### PR TITLE
Add ability to specify recordings folder in AudioBridge

### DIFF
--- a/conf/janus.plugin.audiobridge.jcfg.sample
+++ b/conf/janus.plugin.audiobridge.jcfg.sample
@@ -13,6 +13,7 @@
 # default_prebuffering = number of packets to buffer before decoding each particiant (default=6)
 # record = true|false (whether this room should be recorded, default=false)
 # record_file = "/path/to/recording.wav" (where to save the recording)
+# record_dir = "/path/to/" (path to save the recording to, makes record_file a relative path if provided)
 # allow_rtp_participants = true|false (whether participants should be allowed to join
 #		via plain RTP as well, rather than just WebRTC, default=false)
 #
@@ -71,5 +72,6 @@ room-1234: {
 	secret = "adminpwd"
 	sampling_rate = 16000
 	record = false
-	#record_file = "/path/to/recording.wav"
+	#record_dir = "/path/to/"
+	#record_file = "recording.wav"
 }


### PR DESCRIPTION
This extends the `enable_recording` feature added by @rajneeshksoni to the AudioBridge plugin in #2674, by adding an additional property, called `record_dir`, where you can specify where the `.wav` recordings should be stored. It's available both in room creation (API or jcfg file) and when using `enable_recording`: when provided, it makes `record_file` a relative path. Notice this only impacts `.wav` recordings, and not the individual recording via `.mjr` that we do support in the AudioBridge: it may make sense to enforce it for those too, but maybe later.

Tested briefly but it seems to be working for me, feedback welcome.