### PR TITLE
SIP plugin: Fix sending BYE

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -2584,7 +2584,7 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 		session->media.on_hold = FALSE;
 
 		/* Send a BYE or respond with 480 */
-		if(g_atomic_int_get(&session->established) || session->status == janus_sip_call_status_inviting)
+		if(janus_sip_call_is_established(session) || session->status == janus_sip_call_status_inviting)
 			nua_bye(session->stack->s_nh_i, TAG_END());
 		else
 			nua_respond(session->stack->s_nh_i, 480, sip_status_phrase(480), TAG_END());


### PR DESCRIPTION
Hello,
I noticed that we sometimes receive the following error from sofia sip when the call should be terminated.
`[nua_i_error]: 500 Responding to a Non-Existing Request`

After further investigation, I found out that this is happening when ICE or DTLS negotiation fails. The problem was in this condition if BYE or 480 should be sent. It should use method `janus_sip_call_is_established` because `session->established` is set to `TRUE` only when ICE and DTLS negotiation finish. 

I already tested this and it's working fine but the feedback is welcome.