### PR TITLE
Videoroom API "list" endpoint: update docs, add is_private

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -362,8 +362,7 @@ room-<unique room ID>: {
  *
 \verbatim
 {
-	"request" : "list",
-	"admin_key" : "..."
+	"request" : "list"
 }
 \endverbatim
  *

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -357,14 +357,13 @@ room-<unique room ID>: {
 \endverbatim
  *
  * To get a list of the available rooms you can make use of the \c list request.
- *
  * \c admin_key is optional. If included and correct, rooms configured/created
  * as private will be included in the list as well.
  *
 \verbatim
 {
 	"request" : "list",
-	"admin_key" : "..." // optional
+	"admin_key" : "..."
 }
 \endverbatim
  *
@@ -378,29 +377,29 @@ room-<unique room ID>: {
 			"room" : <unique numeric ID>,
 			"description" : "<Name of the room>",
 			"pin_required" : <true|false, whether a PIN is required to join this room>,
-			"is_private" : <whether this room is 'private' (as in hidden) or not>,
+			"is_private" : <true|false, whether this room is 'private' (as in hidden) or not>,
 			"max_publishers" : <how many publishers can actually publish via WebRTC at the same time>,
 			"bitrate" : <bitrate cap that should be forced (via REMB) on all publishers by default>,
 			"bitrate_cap" : <true|false, whether the above cap should act as a limit to dynamic bitrate changes by publishers (optional)>,
 			"fir_freq" : <how often a keyframe request is sent via PLI/FIR to active publishers>,
-			"require_pvtid": <true|false whether subscriptions in this room require a private_id>,
-			"require_e2ee": <true|false whether end-to-end encrypted publishers are required>,
-			"notify_joining": <true|false whether an event is sent to notify all participants if a new participant joins the room>,
+			"require_pvtid": <true|false, whether subscriptions in this room require a private_id>,
+			"require_e2ee": <true|false, whether end-to-end encrypted publishers are required>,
+			"notify_joining": <true|false, whether an event is sent to notify all participants if a new participant joins the room>,
 			"audiocodec" : "<comma separated list of allowed audio codecs>",
 			"videocodec" : "<comma separated list of allowed video codecs>",
-			"opus_fec": <true|false whether inband FEC must be negotiated (note: only available for Opus) (optional)>,
-			"video_svc": <true|false whether SVC must be done for video (note: only available for VP9 right now) (optional)>,
+			"opus_fec": <true|false, whether inband FEC must be negotiated (note: only available for Opus) (optional)>,
+			"video_svc": <true|false, whether SVC must be done for video (note: only available for VP9 right now) (optional)>,
 			"record" : <true|false, whether the room is being recorded>,
 			"rec_dir" : "<if recording, the path where the .mjr files are being saved>",
 			"lock_record" : <true|false, whether the room recording state can only be changed providing the secret>,
 			"num_participants" : <count of the participants (publishers, active or not; not subscribers)>
-			"audiolevel_ext": <true|false whether the ssrc-audio-level extension must be negotiated or not for new publishers>,
-			"audiolevel_event": <true|false whether to emit event to other users about audiolevel>,
+			"audiolevel_ext": <true|false, whether the ssrc-audio-level extension must be negotiated or not for new publishers>,
+			"audiolevel_event": <true|false, whether to emit event to other users about audiolevel>,
 			"audio_active_packets": <amount of packets with audio level for checkup (optional, only if audiolevel_event is true)>,
 			"audio_level_average": <average audio level (optional, only if audiolevel_event is true)>,
-			"videoorient_ext": <true|false whether the video-orientation extension must be negotiated or not for new publishers>,
-			"playoutdelay_ext": <true|false whether the playout-delay extension must be negotiated or not for new publishers>,
-			"transport_wide_cc_ext": <true|false whether the transport wide cc extension must be negotiated or not for new publishers>
+			"videoorient_ext": <true|false, whether the video-orientation extension must be negotiated or not for new publishers>,
+			"playoutdelay_ext": <true|false, whether the playout-delay extension must be negotiated or not for new publishers>,
+			"transport_wide_cc_ext": <true|false, whether the transport wide cc extension must be negotiated or not for new publishers>
 		},
 		// Other rooms
 	]

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -386,6 +386,8 @@ room-<unique room ID>: {
 			"record_dir" : "<if recording, the path where the .mjr files are being saved>",
 			"lock_record" : <true|false, whether the room recording state can only be changed providing the secret>,
 			"num_participants" : <count of the participants (publishers, active or not; not subscribers)>
+			"is_private" : <whether this room is 'private' (as in hidden) or not>
+			...
 		},
 		// Other rooms
 	]
@@ -3766,6 +3768,7 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 				json_object_set_new(rl, "room", string_ids ? json_string(room->room_id_str) : json_integer(room->room_id));
 				json_object_set_new(rl, "description", json_string(room->room_name));
 				json_object_set_new(rl, "pin_required", room->room_pin ? json_true() : json_false());
+				json_object_set_new(rl, "is_private", room->is_private ? json_true() : json_false());
 				json_object_set_new(rl, "max_publishers", json_integer(room->max_publishers));
 				json_object_set_new(rl, "bitrate", json_integer(room->bitrate));
 				if(room->bitrate_cap)

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -378,18 +378,29 @@ room-<unique room ID>: {
 			"room" : <unique numeric ID>,
 			"description" : "<Name of the room>",
 			"pin_required" : <true|false, whether a PIN is required to join this room>,
+			"is_private" : <whether this room is 'private' (as in hidden) or not>,
 			"max_publishers" : <how many publishers can actually publish via WebRTC at the same time>,
 			"bitrate" : <bitrate cap that should be forced (via REMB) on all publishers by default>,
-			"bitrate_cap" : <true|false, whether the above cap should act as a limit to dynamic bitrate changes by publishers>,
+			"bitrate_cap" : <true|false, whether the above cap should act as a limit to dynamic bitrate changes by publishers (optional)>,
 			"fir_freq" : <how often a keyframe request is sent via PLI/FIR to active publishers>,
+			"require_pvtid": <true|false whether subscriptions in this room require a private_id>,
+			"require_e2ee": <true|false whether end-to-end encrypted publishers are required>,
+			"notify_joining": <true|false whether an event is sent to notify all participants if a new participant joins the room>,
 			"audiocodec" : "<comma separated list of allowed audio codecs>",
 			"videocodec" : "<comma separated list of allowed video codecs>",
+			"opus_fec": <true|false whether inband FEC must be negotiated (note: only available for Opus) (optional)>,
+			"video_svc": <true|false whether SVC must be done for video (note: only available for VP9 right now) (optional)>,
 			"record" : <true|false, whether the room is being recorded>,
-			"record_dir" : "<if recording, the path where the .mjr files are being saved>",
+			"rec_dir" : "<if recording, the path where the .mjr files are being saved>",
 			"lock_record" : <true|false, whether the room recording state can only be changed providing the secret>,
 			"num_participants" : <count of the participants (publishers, active or not; not subscribers)>
-			"is_private" : <whether this room is 'private' (as in hidden) or not>
-			...
+			"audiolevel_ext": <true|false whether the ssrc-audio-level extension must be negotiated or not for new publishers>,
+			"audiolevel_event": <true|false whether to emit event to other users about audiolevel>,
+			"audio_active_packets": <amount of packets with audio level for checkup (optional, only if audiolevel_event is true)>,
+			"audio_level_average": <average audio level (optional, only if audiolevel_event is true)>,
+			"videoorient_ext": <true|false whether the video-orientation extension must be negotiated or not for new publishers>,
+			"playoutdelay_ext": <true|false whether the playout-delay extension must be negotiated or not for new publishers>,
+			"transport_wide_cc_ext": <true|false whether the transport wide cc extension must be negotiated or not for new publishers>
 		},
 		// Other rooms
 	]

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -3802,7 +3802,6 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 				json_object_set_new(rl, "record", room->record ? json_true() : json_false());
 				json_object_set_new(rl, "rec_dir", json_string(room->rec_dir));
 				json_object_set_new(rl, "lock_record", room->lock_record ? json_true() : json_false());
-				/* TODO: Should we list participants as well? or should there be a separate API call on a specific room for this? */
 				json_object_set_new(rl, "num_participants", json_integer(g_hash_table_size(room->participants)));
 				json_object_set_new(rl, "audiolevel_ext", room->audiolevel_ext ? json_true() : json_false());
 				json_object_set_new(rl, "audiolevel_event", room->audiolevel_event ? json_true() : json_false());

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -356,13 +356,15 @@ room-<unique room ID>: {
 }
 \endverbatim
  *
- * To get a list of the available rooms (excluded those configured or
- * created as private rooms) you can make use of the \c list request,
- * which has to be formatted as follows:
+ * To get a list of the available rooms you can make use of the \c list request.
+ *
+ * \c admin_key is optional. If included and correct, rooms configured/created
+ * as private will be included in the list as well.
  *
 \verbatim
 {
-	"request" : "list"
+	"request" : "list",
+	"admin_key" : "..." // optional
 }
 \endverbatim
  *


### PR DESCRIPTION
The videorooms "list" endpoint API docs have gotten quite out of sync with reality (in the C source code).

Additionally, add "is_private" to the object returned, because since commit adb77a10e, it is not always clear if a room returned in the list is private or not.