### PR TITLE
Add pause/resume recording functionality to Record&Play and SIP plugins

### DIFF
--- a/html/recordplaytest.html
+++ b/html/recordplaytest.html
@@ -92,8 +92,7 @@
 								<h3 class="panel-title">
 									<span id="videotitle">Remote Video</span>
 									<button class="btn-xs btn-danger pull-right" autocomplete="off" id="stop">Stop</button>
-									<button class="btn-xs btn-primary pull-right" hidden autocomplete="off" id="resume">Resume</button>
-									<button class="btn-xs btn-primary pull-right" autocomplete="off" id="pause">Pause</button>
+									<button class="btn-xs btn-primary pull-right" autocomplete="off" id="pause-resume">Pause</button>
 								</h3>
 							</div>
 							<div class="panel-body" id="videobox"></div>

--- a/html/recordplaytest.html
+++ b/html/recordplaytest.html
@@ -89,7 +89,12 @@
 					<div class="col-md-6 hide" id="video">
 						<div class="panel panel-default">
 							<div class="panel-heading">
-								<h3 class="panel-title"><span id="videotitle">Remote Video</span> <button class="btn-xs btn-danger pull-right" autocomplete="off" id="stop">Stop</button></h3>
+								<h3 class="panel-title">
+									<span id="videotitle">Remote Video</span>
+									<button class="btn-xs btn-danger pull-right" autocomplete="off" id="stop">Stop</button>
+									<button class="btn-xs btn-primary pull-right" hidden autocomplete="off" id="resume">Resume</button>
+									<button class="btn-xs btn-primary pull-right" autocomplete="off" id="pause">Pause</button>
+								</h3>
 							</div>
 							<div class="panel-body" id="videobox"></div>
 						</div>

--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -497,18 +497,15 @@ function startRecording() {
 					recordplay.hangup();
 				}
 			});
-
-			$('#pause').on('click', () => {
+		$('#pause-resume').unbind('click').on('click', function() {
+			if($(this).text() === 'Pause') {
 				recordplay.send({message: {request: 'pause'}});
-				$('#pause').attr('hidden', true);
-				$('#resume').attr('hidden', false);
-			});
-
-			$('#resume').on('click', () => {
+				$(this).text('Resume');
+			} else {
 				recordplay.send({message: {request: 'resume'}});
-				$('#pause').attr('hidden', false);
-				$('#resume').attr('hidden', true);
-			});
+				$(this).text('Pause');
+			}
+		});
 	});
 }
 

--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -453,6 +453,7 @@ function startRecording() {
 		$('#list').unbind('click').attr('disabled', true);
 		$('#recset').attr('disabled', true);
 		$('#recslist').attr('disabled', true);
+		$('#pause-resume').removeClass('hide');
 
 		// bitrate and keyframe interval can be set at any time:
 		// before, after, during recording
@@ -524,6 +525,7 @@ function startPlayout() {
 	$('#list').unbind('click').attr('disabled', true);
 	$('#recset').attr('disabled', true);
 	$('#recslist').attr('disabled', true);
+	$('#pause-resume').addClass('hide');
 	var play = { request: "play", id: parseInt(selectedRecording) };
 	recordplay.send({ message: play });
 }

--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -497,6 +497,18 @@ function startRecording() {
 					recordplay.hangup();
 				}
 			});
+
+			$('#pause').on('click', () => {
+				recordplay.send({message: {request: 'pause'}});
+				$('#pause').attr('hidden', true);
+				$('#resume').attr('hidden', false);
+			});
+
+			$('#resume').on('click', () => {
+				recordplay.send({message: {request: 'resume'}});
+				$('#pause').attr('hidden', false);
+				$('#resume').attr('hidden', true);
+			});
 	});
 }
 

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -2010,17 +2010,16 @@ playdone:
 			gateway->close_pc(session->handle);
 		} else if (!strcasecmp(request_text, "pause") || !strcasecmp(request_text, "resume")) {
 			JANUS_LOG(LOG_VERB, "Record&Play: Got pause/resume request\n");
-			int pause = !strcasecmp(request_text, "pause");
-			result = json_object();
-			json_object_set_new(result, "status", json_string(pause ? "paused" : "resumed"));
 			if(session->recording) {
+				gboolean pause = !strcasecmp(request_text, "pause");
+				result = json_object();
+				json_object_set_new(result, "status", json_string(pause ? "paused" : "resumed"));
 				json_object_set_new(result, "id", json_integer(session->recording->id));
 				/* Also notify event handlers */
 				if(notify_events && gateway->events_is_enabled()) {
 					json_t *info = json_object();
 					json_object_set_new(info, "event", json_string(pause ? "paused" : "resumed"));
-					if(session->recording)
-						json_object_set_new(info, "id", json_integer(session->recording->id));
+					json_object_set_new(info, "id", json_integer(session->recording->id));
 					gateway->notify_event(&janus_recordplay_plugin, session->handle, info);
 				}
 				if(pause) {
@@ -2033,6 +2032,8 @@ playdone:
 					janus_recorder_resume(session->drc);
 					gateway->send_pli(session->handle);
 				}
+			} else {
+				JANUS_LOG(LOG_VERB, "Record&Play: Not recording, ignoring pause/resume request\n");
 			}
 		} else {
 			JANUS_LOG(LOG_ERR, "Unknown request '%s'\n", request_text);

--- a/plugins/janus_recordplay.c
+++ b/plugins/janus_recordplay.c
@@ -418,6 +418,7 @@ typedef struct janus_recordplay_recording {
 	char *offer;				/* The SDP offer that will be sent to watchers */
 	gboolean e2ee;				/* Whether media in the recording is encrypted, e.g., using Insertable Streams */
 	GList *viewers;				/* List of users watching this recording */
+	volatile gint paused;		/* Whether this recording is paused */
 	volatile gint completed;	/* Whether this recording was completed or still going on */
 	volatile gint destroyed;	/* Whether this recording has been marked as destroyed */
 	janus_refcount ref;			/* Reference counter */
@@ -1635,6 +1636,7 @@ static void *janus_recordplay_handler(void *data) {
 			rec->acodec = JANUS_AUDIOCODEC_NONE;
 			rec->vcodec = JANUS_VIDEOCODEC_NONE;
 			rec->e2ee = e2ee;
+			g_atomic_int_set(&rec->paused, 0);
 			g_atomic_int_set(&rec->destroyed, 0);
 			g_atomic_int_set(&rec->completed, 0);
 			janus_refcount_init(&rec->ref, janus_recordplay_recording_free);
@@ -2012,25 +2014,29 @@ playdone:
 			JANUS_LOG(LOG_VERB, "Record&Play: Got pause/resume request\n");
 			if(session->recording) {
 				gboolean pause = !strcasecmp(request_text, "pause");
-				result = json_object();
-				json_object_set_new(result, "status", json_string(pause ? "paused" : "resumed"));
-				json_object_set_new(result, "id", json_integer(session->recording->id));
-				/* Also notify event handlers */
-				if(notify_events && gateway->events_is_enabled()) {
-					json_t *info = json_object();
-					json_object_set_new(info, "event", json_string(pause ? "paused" : "resumed"));
-					json_object_set_new(info, "id", json_integer(session->recording->id));
-					gateway->notify_event(&janus_recordplay_plugin, session->handle, info);
-				}
-				if(pause) {
-					janus_recorder_pause(session->arc);
-					janus_recorder_pause(session->vrc);
-					janus_recorder_pause(session->drc);
+				if (g_atomic_int_compare_and_exchange(&session->recording->paused, !pause, pause)) {
+					result = json_object();
+					json_object_set_new(result, "status", json_string(pause ? "paused" : "resumed"));
+					json_object_set_new(result, "id", json_integer(session->recording->id));
+					/* Also notify event handlers */
+					if(notify_events && gateway->events_is_enabled()) {
+						json_t *info = json_object();
+						json_object_set_new(info, "event", json_string(pause ? "paused" : "resumed"));
+						json_object_set_new(info, "id", json_integer(session->recording->id));
+						gateway->notify_event(&janus_recordplay_plugin, session->handle, info);
+					}
+					if(pause) {
+						janus_recorder_pause(session->arc);
+						janus_recorder_pause(session->vrc);
+						janus_recorder_pause(session->drc);
+					} else {
+						janus_recorder_resume(session->arc);
+						janus_recorder_resume(session->vrc);
+						janus_recorder_resume(session->drc);
+						gateway->send_pli(session->handle);
+					}
 				} else {
-					janus_recorder_resume(session->arc);
-					janus_recorder_resume(session->vrc);
-					janus_recorder_resume(session->drc);
-					gateway->send_pli(session->handle);
+					JANUS_LOG(LOG_VERB, "Record&Play: Tried to pause/resume recording of same state, ignoring\n");
 				}
 			} else {
 				JANUS_LOG(LOG_VERB, "Record&Play: Not recording, ignoring pause/resume request\n");
@@ -2231,6 +2237,7 @@ void janus_recordplay_update_recordings_list(void) {
 		if(janus_recordplay_generate_offer(rec) < 0) {
 			JANUS_LOG(LOG_WARN, "Could not generate offer for recording %"SCNu64"...\n", rec->id);
 		}
+		g_atomic_int_set(&rec->paused, 0);
 		g_atomic_int_set(&rec->destroyed, 0);
 		g_atomic_int_set(&rec->completed, 1);
 		janus_refcount_init(&rec->ref, janus_recordplay_recording_free);

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4374,27 +4374,10 @@ static void *janus_sip_handler(void *data) {
 			record_peer_audio = peer_audio ? json_is_true(peer_audio) : FALSE;
 			json_t *peer_video = json_object_get(root, "peer_video");
 			record_peer_video = peer_video ? json_is_true(peer_video) : FALSE;
-			gint update_bitmap =
-				record_audio |
-				record_video << 1 |
-				record_peer_audio << 2 |
-				record_peer_video << 3;
-			if(!update_bitmap) {
+			if(!record_audio && !record_video && !record_peer_audio && !record_peer_video) {
 				JANUS_LOG(LOG_ERR, "Invalid request (at least one of audio, video, peer_audio and peer_video should be true)\n");
 				error_code = JANUS_SIP_ERROR_RECORDING_ERROR;
 				g_snprintf(error_cause, 512, "Invalid request (at least one of audio, video, peer_audio and peer_video should be true)");
-				goto error;
-			}
-			gint recorder_bitmap =
-				g_atomic_int_get(&session->arc->paused) |
-				g_atomic_int_get(&session->vrc->paused) << 1 |
-				g_atomic_int_get(&session->arc_peer->paused) << 2 |
-				g_atomic_int_get(&session->vrc_peer->paused) << 3;
-			if ((!strcasecmp(action_text, "pause") && !(~recorder_bitmap & update_bitmap)) ||
-				(!strcasecmp(action_text, "resume") && !(recorder_bitmap & update_bitmap))) {
-				JANUS_LOG(LOG_ERR, "Invalid pause/resume request (at least one of audio, video, peer_audio and peer_video should change recorder state)\n");
-				error_code = JANUS_SIP_ERROR_RECORDING_ERROR;
-				g_snprintf(error_cause, 512, "Invalid pause/resume request (at least one of audio, video, peer_audio and peer_video should change recorder state)");
 				goto error;
 			}
 			json_t *recfile = json_object_get(root, "filename");
@@ -4521,26 +4504,25 @@ static void *janus_sip_handler(void *data) {
 					}
 				}
 			} else if(!strcasecmp(action_text, "pause")) {
-				gint pause_bitmap = ~recorder_bitmap & update_bitmap;
-				if(pause_bitmap & 1)
+				if(record_audio)
 					janus_recorder_pause(session->arc);
-				if(pause_bitmap & 2)
+				if(record_video)
 					janus_recorder_pause(session->vrc);
-				if(pause_bitmap & 4)
+				if(record_peer_audio)
 					janus_recorder_pause(session->arc_peer);
-				if(pause_bitmap & 8)
+				if(record_peer_video)
 					janus_recorder_pause(session->vrc_peer);
 			} else if(!strcasecmp(action_text, "resume")) {
-				gint resume_bitmap = recorder_bitmap & update_bitmap;
-				if(resume_bitmap & 1)
+				gboolean send_pli = FALSE;
+				if(record_audio)
 					janus_recorder_resume(session->arc);
-				if(resume_bitmap & 2)
-					janus_recorder_resume(session->vrc);
-				if(resume_bitmap & 4)
+				if(record_video && !janus_recorder_resume(session->vrc))
+					send_pli = TRUE;
+				if(record_peer_audio)
 					janus_recorder_resume(session->arc_peer);
-				if(resume_bitmap & 8)
-					janus_recorder_resume(session->vrc_peer);
-				if(resume_bitmap & 10)
+				if(record_peer_video && !janus_recorder_resume(session->vrc_peer))
+					send_pli = TRUE;
+				if(send_pli)
 					gateway->send_pli(session->handle);
 			} else {
 				/* Stop recording something: notice that this never returns an error, even when we were not recording anything */

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4513,17 +4513,14 @@ static void *janus_sip_handler(void *data) {
 				if(record_peer_video)
 					janus_recorder_pause(session->vrc_peer);
 			} else if(!strcasecmp(action_text, "resume")) {
-				gboolean send_pli = FALSE;
 				if(record_audio)
 					janus_recorder_resume(session->arc);
 				if(record_video && !janus_recorder_resume(session->vrc))
-					send_pli = TRUE;
+					gateway->send_pli(session->handle);
 				if(record_peer_audio)
 					janus_recorder_resume(session->arc_peer);
-				if(record_peer_video && !janus_recorder_resume(session->vrc_peer))
-					send_pli = TRUE;
-				if(send_pli)
-					gateway->send_pli(session->handle);
+				if(record_peer_video)
+					janus_recorder_resume(session->vrc_peer);
 			} else {
 				/* Stop recording something: notice that this never returns an error, even when we were not recording anything */
 				janus_sip_recorder_close(session, record_audio, record_peer_audio, record_video, record_peer_video);

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4358,7 +4358,7 @@ static void *janus_sip_handler(void *data) {
 			json_t *action = json_object_get(root, "action");
 			const char *action_text = json_string_value(action);
 			if(strcasecmp(action_text, "start") && strcasecmp(action_text, "stop") &&
-				strcasecmp(action_text, "pause") && strcasecmp(action_text, "resume")) {
+					strcasecmp(action_text, "pause") && strcasecmp(action_text, "resume")) {
 				JANUS_LOG(LOG_ERR, "Invalid action (should be start|stop|pause|resume)\n");
 				error_code = JANUS_SIP_ERROR_INVALID_ELEMENT;
 				g_snprintf(error_cause, 512, "Invalid action (should be start|stop|pause|resume)");
@@ -4504,34 +4504,25 @@ static void *janus_sip_handler(void *data) {
 					}
 				}
 			} else if(!strcasecmp(action_text, "pause")) {
-				if(record_audio) {
-					janus_recorder_pause(&session->arc);
-				}
-				if(record_video) {
-					janus_recorder_pause(&session->vrc);
-				}
-				if(record_peer_audio) {
-					janus_recorder_pause(&session->arc_peer);
-				}
-				if(record_peer_video) {
-					janus_recorder_pause(&session->vrc_peer);
-				}
+				if(record_audio)
+					janus_recorder_pause(session->arc);
+				if(record_video)
+					janus_recorder_pause(session->vrc);
+				if(record_peer_audio)
+					janus_recorder_pause(session->arc_peer);
+				if(record_peer_video)
+					janus_recorder_pause(session->vrc_peer);
 			} else if(!strcasecmp(action_text, "resume")) {
-				if(record_audio) {
-					janus_recorder_resume(&session->arc);
-				}
-				if(record_video) {
-					janus_recorder_resume(&session->vrc);
-				}
-				if(record_peer_audio) {
-					janus_recorder_resume(&session->arc_peer);
-				}
-				if(record_peer_video) {
-					janus_recorder_resume(&session->vrc_peer);
-				}
-				if(record_video || record_peer_video) {
-					gateway->send_pli(&session->handle);
-				}
+				if(record_audio)
+					janus_recorder_resume(session->arc);
+				if(record_video)
+					janus_recorder_resume(session->vrc);
+				if(record_peer_audio)
+					janus_recorder_resume(session->arc_peer);
+				if(record_peer_video)
+					janus_recorder_resume(session->vrc_peer);
+				if(record_video || record_peer_video)
+					gateway->send_pli(session->handle);
 			} else {
 				/* Stop recording something: notice that this never returns an error, even when we were not recording anything */
 				janus_sip_recorder_close(session, record_audio, record_peer_audio, record_video, record_peer_video);

--- a/record.h
+++ b/record.h
@@ -61,7 +61,7 @@ typedef struct janus_recorder {
 	volatile int header;
 	/*! \brief Whether this recorder instance can be used for writing or not */
 	volatile int writable;
-	/*! \brief Whether writing RTP packets is paused */
+	/*! \brief Whether writing s/RTP packets/data is paused */
 	volatile int paused;
 	/*! \brief RTP switching context for rewriting RTP headers */
 	janus_rtp_switching_context context;

--- a/record.h
+++ b/record.h
@@ -27,6 +27,7 @@
 
 #include "mutex.h"
 #include "refcount.h"
+#include "rtp.h"
 
 
 /*! \brief Media types we can record */
@@ -60,8 +61,10 @@ typedef struct janus_recorder {
 	volatile int header;
 	/*! \brief Whether this recorder instance can be used for writing or not */
 	volatile int writable;
-	/*! \brief Whether recorder instance is paused or not */
-	volatile int paused;
+	/*! \brief Pause start timestamp */
+	gint64 paused;
+	/*! \brief RTP switching context for rewriting RTP headers */
+	janus_rtp_switching_context context;
 	/*! \brief Mutex to lock/unlock this recorder instance */
 	janus_mutex mutex;
 	/*! \brief Atomic flag to check if this instance has been destroyed */

--- a/record.h
+++ b/record.h
@@ -60,6 +60,8 @@ typedef struct janus_recorder {
 	volatile int header;
 	/*! \brief Whether this recorder instance can be used for writing or not */
 	volatile int writable;
+	/*! \brief Whether recorder instance is paused or not */
+	volatile int paused;
 	/*! \brief Mutex to lock/unlock this recorder instance */
 	janus_mutex mutex;
 	/*! \brief Atomic flag to check if this instance has been destroyed */
@@ -92,6 +94,16 @@ janus_recorder *janus_recorder_create(const char *dir, const char *codec, const 
  * @param[in] filename Filename to use for the recording
  * @returns A valid janus_recorder instance in case of success, NULL otherwise */
 janus_recorder *janus_recorder_create_full(const char *dir, const char *codec, const char *fmtp, const char *filename);
+/*! \brief Pause recording packets
+ * \note This is to allow pause and resume recorder functionality.
+ * @param[in] recorder The janus_recorder to pause
+ * @returns 0 in case of success, a negative integer otherwise */
+int janus_recorder_pause(janus_recorder *recorder);
+/*! \brief Resume recording packets
+ * \note This is to allow pause and resume recorder functionality.
+ * @param[in] recorder The janus_recorder to resume
+ * @returns 0 in case of success, a negative integer otherwise */
+int janus_recorder_resume(janus_recorder *recorder);
 /*! \brief Add an RTP extension to this recording
  * \note This will only be possible BEFORE the first frame is written, as it needs to
  * be reflected in the .mjr header: doing this after that will return an error.

--- a/record.h
+++ b/record.h
@@ -61,8 +61,8 @@ typedef struct janus_recorder {
 	volatile int header;
 	/*! \brief Whether this recorder instance can be used for writing or not */
 	volatile int writable;
-	/*! \brief Pause start timestamp */
-	gint64 paused;
+	/*! \brief Whether writing RTP packets is paused */
+	volatile int paused;
 	/*! \brief RTP switching context for rewriting RTP headers */
 	janus_rtp_switching_context context;
 	/*! \brief Mutex to lock/unlock this recorder instance */

--- a/rtp.c
+++ b/rtp.c
@@ -608,7 +608,7 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 		}
 		if(context->v_ts_reset) {
 			/* Video timestamp was paused for a while */
-			JANUS_LOG(LOG_VERB, "Video RTP timestamp reset requested");
+			JANUS_LOG(LOG_HUGE, "Video RTP timestamp reset requested");
 			context->v_ts_reset = FALSE;
 			context->v_base_ts_prev = context->v_last_ts;
 			context->v_base_ts = timestamp;
@@ -620,12 +620,12 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 					time_diff = 1;
 				context->v_base_ts_prev += (guint32)time_diff;
 				context->v_last_ts += (guint32)time_diff;
-				JANUS_LOG(LOG_VERB, "Computed offset for video RTP timestamp: %"SCNu32"\n", (guint32)time_diff);
+				JANUS_LOG(LOG_HUGE, "Computed offset for video RTP timestamp: %"SCNu32"\n", (guint32)time_diff);
 			}
 		}
 		if(context->v_seq_reset) {
 			/* Video sequence number was paused for a while */
-			JANUS_LOG(LOG_VERB, "Video RTP sequence number reset requested");
+			JANUS_LOG(LOG_HUGE, "Video RTP sequence number reset requested");
 			context->v_seq_reset = FALSE;
 			context->v_base_seq_prev = context->v_last_seq;
 			context->v_base_seq = seq;
@@ -653,7 +653,7 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 		}
 		if(context->a_ts_reset) {
 			/* Audio timestamp was paused for a while */
-			JANUS_LOG(LOG_VERB, "Audio RTP timestamp reset requested");
+			JANUS_LOG(LOG_HUGE, "Audio RTP timestamp reset requested");
 			context->a_ts_reset = FALSE;
 			context->a_base_ts_prev = context->a_last_ts;
 			context->a_base_ts = timestamp;
@@ -669,12 +669,12 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 				context->a_base_ts_prev += (guint32)time_diff;
 				context->a_prev_ts += (guint32)time_diff;
 				context->a_last_ts += (guint32)time_diff;
-				JANUS_LOG(LOG_VERB, "Computed offset for audio RTP timestamp: %"SCNu32"\n", (guint32)time_diff);
+				JANUS_LOG(LOG_HUGE, "Computed offset for audio RTP timestamp: %"SCNu32"\n", (guint32)time_diff);
 			}
 		}
 		if(context->a_seq_reset) {
 			/* Audio sequence number was paused for a while */
-			JANUS_LOG(LOG_VERB, "Audio RTP sequence number reset requested");
+			JANUS_LOG(LOG_HUGE, "Audio RTP sequence number reset requested");
 			context->a_seq_reset = FALSE;
 			context->a_base_seq_prev = context->a_last_seq;
 			context->a_base_seq = seq;

--- a/rtp.c
+++ b/rtp.c
@@ -595,7 +595,6 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 	uint32_t ssrc = ntohl(header->ssrc);
 	uint32_t timestamp = ntohl(header->timestamp);
 	uint16_t seq = ntohs(header->seq_number);
-	gint64 ts_diff = 0;
 	if(video) {
 		if(ssrc != context->v_last_ssrc) {
 			/* Video SSRC changed: update both sequence number and timestamp */
@@ -624,9 +623,6 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 				JANUS_LOG(LOG_VERB, "Computed offset for video RTP timestamp: %"SCNu32"\n", (guint32)time_diff);
 			}
 		}
-		if(context->v_time_offset != 0) {
-			ts_diff = (context->v_time_offset*90)/1000; 	/* We're assuming 90khz here */
-		}
 		if(context->v_seq_reset) {
 			/* Video sequence number was paused for a while */
 			JANUS_LOG(LOG_VERB, "Video RTP sequence number reset requested");
@@ -636,7 +632,7 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 		}
 		/* Compute a coherent timestamp and sequence number */
 		context->v_prev_ts = context->v_last_ts;
-		context->v_last_ts = (guint32)((timestamp-context->v_base_ts) + context->v_base_ts_prev + ts_diff);
+		context->v_last_ts = (timestamp-context->v_base_ts) + context->v_base_ts_prev;
 		context->v_prev_seq = context->v_last_seq;
 		context->v_last_seq = (seq-context->v_base_seq)+context->v_base_seq_prev+1;
 		/* Update the timestamp and sequence number in the RTP packet */
@@ -676,12 +672,6 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 				JANUS_LOG(LOG_VERB, "Computed offset for audio RTP timestamp: %"SCNu32"\n", (guint32)time_diff);
 			}
 		}
-		if(context->a_time_offset != 0) {
-			int akhz = 48;
-			if(header->type == 0 || header->type == 8 || header->type == 9)
-				akhz = 8;	/* We're assuming 48khz here (Opus), unless it's G.711/G.722 (8khz) */
-			ts_diff = (context->a_time_offset*90)/1000; 	/* We're assuming 90khz here */
-		}
 		if(context->a_seq_reset) {
 			/* Audio sequence number was paused for a while */
 			JANUS_LOG(LOG_VERB, "Audio RTP sequence number reset requested");
@@ -691,7 +681,7 @@ void janus_rtp_header_update(janus_rtp_header *header, janus_rtp_switching_conte
 		}
 		/* Compute a coherent timestamp and sequence number */
 		context->a_prev_ts = context->a_last_ts;
-		context->a_last_ts = (guint32)((timestamp-context->a_base_ts) + context->a_base_ts_prev + ts_diff);
+		context->a_last_ts = (timestamp-context->a_base_ts) + context->a_base_ts_prev;
 		context->a_prev_seq = context->a_last_seq;
 		context->a_last_seq = (seq-context->a_base_seq)+context->a_base_seq_prev+1;
 		/* Update the timestamp and sequence number in the RTP packet */

--- a/rtp.h
+++ b/rtp.h
@@ -232,8 +232,8 @@ typedef struct janus_rtp_switching_context {
 			v_seq_offset;
 	gint32 a_prev_delay, a_active_delay, a_ts_offset,
 			v_prev_delay, v_active_delay, v_ts_offset;
-	gint64 a_last_time, a_reference_time, a_start_time, a_evaluating_start_time, a_time_offset,
-			v_last_time, v_reference_time, v_start_time, v_evaluating_start_time, v_time_offset;
+	gint64 a_last_time, a_reference_time, a_start_time, a_evaluating_start_time,
+			v_last_time, v_reference_time, v_start_time, v_evaluating_start_time;
 } janus_rtp_switching_context;
 
 /*! \brief Set (or reset) the context fields to their default values

--- a/rtp.h
+++ b/rtp.h
@@ -226,14 +226,14 @@ typedef struct janus_rtp_switching_context {
 			v_last_ssrc, v_last_ts, v_base_ts, v_base_ts_prev, v_prev_ts, v_target_ts, v_start_ts;
 	uint16_t a_last_seq, a_prev_seq, a_base_seq, a_base_seq_prev,
 			v_last_seq, v_prev_seq, v_base_seq, v_base_seq_prev;
-	gboolean a_seq_reset, a_new_ssrc,
-			v_seq_reset, v_new_ssrc;
+	gboolean a_ts_reset, a_seq_reset, a_new_ssrc,
+			v_ts_reset, v_seq_reset, v_new_ssrc;
 	gint16 a_seq_offset,
 			v_seq_offset;
 	gint32 a_prev_delay, a_active_delay, a_ts_offset,
 			v_prev_delay, v_active_delay, v_ts_offset;
-	gint64 a_last_time, a_reference_time, a_start_time, a_evaluating_start_time,
-			v_last_time, v_reference_time, v_start_time, v_evaluating_start_time;
+	gint64 a_last_time, a_reference_time, a_start_time, a_evaluating_start_time, a_time_offset,
+			v_last_time, v_reference_time, v_start_time, v_evaluating_start_time, v_time_offset;
 } janus_rtp_switching_context;
 
 /*! \brief Set (or reset) the context fields to their default values


### PR DESCRIPTION
This PR adds pause/resume functionality to Janus recorder, and implements signaling for it in Record&Play and SIP plugins.

This functionality is useful when relaying sensitive information during recorded meeting. It is implemented by skipping writing of RTP packets during the pause duration. On resume we request PLI to fix any video artifacts that can occur due to skipped frames in recording.