### PR TITLE
Set new remote credentials after restarting ICE (fixes #2672)

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -1520,16 +1520,16 @@ int janus_process_incoming_request(janus_request *request) {
 				}
 				if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART)) {
 					JANUS_LOG(LOG_INFO, "[%"SCNu64"] Restarting ICE...\n", handle->handle_id);
-					/* Update remote credentials for ICE */
-					if(handle->stream) {
-						nice_agent_set_remote_credentials(handle->agent, handle->stream->stream_id,
-							handle->stream->ruser, handle->stream->rpass);
-					}
 					/* FIXME We only need to do that for offers: if it's an answer, we did that already */
 					if(offer) {
 						janus_ice_restart(handle);
 					} else {
 						janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
+					}
+					/* Update remote credentials for ICE */
+					if(handle->stream) {
+						nice_agent_set_remote_credentials(handle->agent, handle->stream->stream_id,
+							handle->stream->ruser, handle->stream->rpass);
 					}
 					/* If we're full-trickling, we'll need to resend the candidates later */
 					if(janus_ice_is_full_trickle_enabled()) {


### PR DESCRIPTION
As explained in #2672, apparently new versions of libnice reset the remote credentials after invoking `nice_agent_restart`: since when receiving updated offers that include a restart we first reset the credentials, and then trigger the restart, this actually results in broken sessions, since the restart ends up not having access to remote credentials for the new STUN exchanges. This patch should address that. Notice this only changes the "browser offering the restart" scenario, since when it's Janus offering a restart, we already perform `nice_agent_restart` first, and then get the new remote credentials in an answer later on. That said, it might be a good idea to make sure that still does indeed work even for newer versions of libnice.

Despite the very small change, it's a PR and not a commit since I want to make sure this doesn't introduce regressions for restarts in current versions of libnice, so please test and provide feedback.