### PR TITLE
[janus-pp-rec] activate keyframe logic for VP9

### DIFF
--- a/postprocessing/pp-webm.c
+++ b/postprocessing/pp-webm.c
@@ -473,6 +473,7 @@ int janus_pp_webm_process(FILE *file, janus_pp_frame_packet *list, gboolean vp8,
 					uint8_t ybit = (vp9pd & 0x10);
 					uint8_t gbit = (vp9pd & 0x08);
 					if(ybit) {
+						keyFrame = 1;
 						/* Iterate on all spatial layers and get resolution */
 						buffer++;
 						len--;


### PR DESCRIPTION
Hi, 

When post-processing vp9 stream into a webm file, it happens that the generated file miss keyframes flag, and make the file difficult to seek for some tools (tested with chrome 91).

Activating it allow the file to be seekable.

Regard,

Matthieu