### PR TITLE
Auto switch simulcast layer if REMB is too low

### DIFF
--- a/conf/janus.plugin.videoroom.jcfg.sample
+++ b/conf/janus.plugin.videoroom.jcfg.sample
@@ -55,9 +55,9 @@ general: {
 	# In case you want to use strings instead (e.g., a UUID), set string_ids to true.
 	#string_ids = true
 
-	#min_rec_bitrate_simulcast=0	# The minimum bitrate required to subscribe 
-									# higher simulcast layers. If REMB is lower than
-									# this, the subscriber will automatically switched
+	#min_rec_bitrate_simulcast=0	# The minimum bitrate required to subscribe higher
+									# simulcast layers. If REMB is lower than that, 
+									# the subscriber will automatically be switched
 									# to the lowest simulcast layer (default=64000).
 									# This can avoid creating congestion for simulcast
 									# subscribers.

--- a/conf/janus.plugin.videoroom.jcfg.sample
+++ b/conf/janus.plugin.videoroom.jcfg.sample
@@ -54,6 +54,13 @@ general: {
 	# By default, integers are used as a unique ID for both rooms and participants.
 	# In case you want to use strings instead (e.g., a UUID), set string_ids to true.
 	#string_ids = true
+
+	#min_rec_bitrate_simulcast=0	# The minimum bitrate required to subscribe 
+									# higher simulcast layers. If REMB is lower than
+									# this, the subscriber will automatically switched
+									# to the lowest simulcast layer (default=64000).
+									# This can avoid creating congestion for simulcast
+									# subscribers.
 }
 
 room-1234: {

--- a/conf/janus.plugin.videoroom.jcfg.sample
+++ b/conf/janus.plugin.videoroom.jcfg.sample
@@ -58,7 +58,7 @@ general: {
 	#min_rec_bitrate_simulcast=0	# The minimum bitrate required to subscribe higher
 									# simulcast layers. If REMB is lower than that, 
 									# the subscriber will automatically be switched
-									# to the lowest simulcast layer (default=64000).
+									# to the lowest simulcast layer (default=256000).
 									# This can avoid creating congestion for simulcast
 									# subscribers.
 }

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1502,7 +1502,7 @@ static GHashTable *rooms;
 static janus_mutex rooms_mutex = JANUS_MUTEX_INITIALIZER;
 static char *admin_key = NULL;
 static gboolean lock_rtpfwd = FALSE;
-static int simulcast_min_bitrate = 64000;
+static int simulcast_min_bitrate = 256000;
 
 typedef struct janus_videoroom_session {
 	janus_plugin_session *handle;

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -5515,6 +5515,42 @@ void janus_videoroom_incoming_rtcp(janus_plugin_session *handle, janus_plugin_rt
 		uint32_t bitrate = janus_rtcp_get_remb(buf, len);
 		if(bitrate > 0) {
 			/* FIXME We got a REMB from this subscriber, should we do something about it? */
+			JANUS_LOG(LOG_INFO, "Received REMB: %d\n", bitrate);
+
+			const target_layer = 0;
+
+			janus_mutex_lock(&session->mutex);
+			janus_videoroom_publisher *publisher = s->feed;
+			/* It is safe to use feed as the only other place sets feed to NULL
+			   is in this function and accessing to this function is synchronized
+			   by sessions_mutex */
+
+			if((publisher->ssrc[0] != 0 || publisher->rid[0] != NULL)) {
+				s->sim_context.substream_target = target_layer; //json_integer_value(sc_substream);
+				if(s->sim_context.substream_target >= 0 && s->sim_context.substream_target <= 2) {
+					JANUS_LOG(LOG_VERB, "Setting video SSRC to let through (simulcast): %"SCNu32" (index %d, was %d)\n",
+						publisher->ssrc[s->sim_context.substream_target],
+						s->sim_context.substream_target,
+						s->sim_context.substream);
+				}
+				if(s->sim_context.substream_target == s->sim_context.substream) {
+					/* No need to do anything, we're already getting the right substream, so notify the user */
+					/*
+					json_t *event = json_object();
+					json_object_set_new(event, "videoroom", json_string("event"));
+					json_object_set_new(event, "room", string_ids ? json_string(s->room_id_str) : json_integer(s->room_id));
+					json_object_set_new(event, "substream", json_integer(s->sim_context.substream));
+					gateway->push_event(handle, &janus_videoroom_plugin, NULL, event, NULL);
+					json_decref(event);
+					*/
+				} else {
+					/* Send a FIR */
+					janus_videoroom_reqpli(publisher, "Simulcasting substream change");
+				}
+			}
+
+			janus_mutex_unlock(&session->mutex);
+
 		}
 		janus_refcount_decrease_nodebug(&s->ref);
 	}


### PR DESCRIPTION
Prevent congestion by automatically switchting a subscribers simulcast layer if its REMB (Receiver Estimated Maximum Bitrate) is too low. 

Can be configured with `min_rec_bitrate_simulcast` setting in the videoroom plugin (default=256Kb/s). 

Based on `abs-send-time` branch: https://github.com/meetecho/janus-gateway/pull/2721

Might need to be further improved and become more dynamic (?) @lminiero 