### PR TITLE
Feature/cc 2166 speedup eventing websocket reconnect

### DIFF
--- a/events/janus_wsevh.c
+++ b/events/janus_wsevh.c
@@ -710,6 +710,7 @@ static int janus_wsevh_callback(struct lws *wsi, enum lws_callback_reasons reaso
 			reconnect = FALSE;
 			janus_mutex_init(&ws_client->mutex);
 			lws_callback_on_writable(wsi);
+			JANUS_LOG(LOG_INFO, "WebSocketsEventHandler connected\n");
 			return 0;
 		}
 		case LWS_CALLBACK_CLIENT_CONNECTION_ERROR: {
@@ -806,11 +807,12 @@ static int janus_wsevh_callback(struct lws *wsi, enum lws_callback_reasons reaso
 #else
 		case LWS_CALLBACK_CLOSED: {
 #endif
-			JANUS_LOG(LOG_INFO, "WebSockets event handler connection closed\n");
+			reconnect_delay = 1;
+			JANUS_LOG(LOG_INFO, "Connection to WebSocketsEventHandler backend closed (next connection attempt in %ds)\n", reconnect_delay);
 			if(ws_client != NULL) {
 				/* Cleanup */
 				janus_mutex_lock(&ws_client->mutex);
-				JANUS_LOG(LOG_INFO, "Destroying WebSockets event handler client\n");
+				JANUS_LOG(LOG_INFO, "Destroying WebSocketsEventHandler client\n");
 				ws_client->wsi = NULL;
 				/* Free the shared buffers */
 				g_free(ws_client->buffer);
@@ -820,8 +822,6 @@ static int janus_wsevh_callback(struct lws *wsi, enum lws_callback_reasons reaso
 				ws_client->bufoffset = 0;
 				janus_mutex_unlock(&ws_client->mutex);
 			}
-			reconnect_delay = 1;
-			JANUS_LOG(LOG_INFO, "Connection to WebSockets event handler backend closed (next connection attempt in %ds)\n", reconnect_delay);
 			/* Check if we should reconnect */
 			ws_client = NULL;
 			wsi = NULL;

--- a/events/janus_wsevh.c
+++ b/events/janus_wsevh.c
@@ -390,7 +390,6 @@ int janus_wsevh_init(const char *config_path) {
 	info.protocols = protocols;
 	info.gid = -1;
 	info.uid = -1;
-	info.timeout_secs = 10;
 	if(secure)
 		info.options |= LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
 	context = lws_create_context(&info);

--- a/events/janus_wsevh.c
+++ b/events/janus_wsevh.c
@@ -574,7 +574,7 @@ plugin_response:
 	* The reconnect is handled in a dedicated wsl scheduler janus_wsevh_schedule_connect_attempt
 	*/
 	static void *janus_wsevh_thread(void *data) {
-	JANUS_LOG(LOG_INFO, "Joining WebSocketsEventHandler (wsl>=3.2) client thread\n");
+	JANUS_LOG(LOG_VERB, "Joining WebSocketsEventHandler (wsl>=3.2) client thread\n");
 		int n = 0;
 		while(n >= 0 && g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping))
 				n = lws_service(context, 0);
@@ -588,7 +588,7 @@ plugin_response:
 	* The reconnect is handled in the loop for wsl < 3.2
 	*/
 	static void *janus_wsevh_thread(void *data) {
-		JANUS_LOG(LOG_INFO, "Joining WebSocketsEventHandler (wsl<3.2) client thread\n");
+		JANUS_LOG(LOG_VERB, "Joining WebSocketsEventHandler (wsl<3.2) client thread\n");
 		while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
 			/* Loop until we have to stop */
 			if(!reconnect) {

--- a/events/janus_wsevh.c
+++ b/events/janus_wsevh.c
@@ -582,7 +582,7 @@ static void *janus_wsevh_thread(void *data) {
 	JANUS_LOG(LOG_VERB, "Joining WebSocketsEventHandler (lws>=3.2) client thread\n");
 	int n = 0;
 	while(n >= 0 && g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping))
-			n = lws_service(context, 0);
+		n = lws_service(context, 0);
 	lws_context_destroy(context);
 	JANUS_LOG(LOG_VERB, "Leaving WebSocketsEventHandler (lws>=3.2) client thread\n");
 	return NULL;
@@ -862,6 +862,7 @@ static void janus_wsevh_connect_attempt(lws_sorted_usec_list_t* sul) {
 		disconnected = janus_get_monotonic_time();
 		reconnect = TRUE;
 		JANUS_LOG(LOG_ERR, "WebSocketsEventHandler: Connecting to upstream websocket server %s:%d failed\n", address, port);
+		return;
 	}
 	reconnect = FALSE;
 }

--- a/events/janus_wsevh.c
+++ b/events/janus_wsevh.c
@@ -624,7 +624,7 @@ static void *janus_wsevh_thread(void *data) {
 	JANUS_LOG(LOG_VERB, "Leaving WebSocketsEventHandler (lws<3.2) client thread\n");
 	return NULL;
 }
-#endif 
+#endif
 
 /* Thread to handle incoming events */
 static void *janus_wsevh_handler(void *data) {

--- a/events/janus_wsevh.c
+++ b/events/janus_wsevh.c
@@ -577,10 +577,8 @@ plugin_response:
 }
 
 #if (LWS_LIBRARY_VERSION_MAJOR >= 3 && LWS_LIBRARY_VERSION_MINOR >= 2) || (LWS_LIBRARY_VERSION_MAJOR >= 4)
-/*
- * Websocket thread loop for websocket library newer than 3.2
- * The reconnect is handled in a dedicated lws scheduler janus_wsevh_schedule_connect_attempt
- */
+/* Websocket thread loop for websocket library newer than 3.2
+ * The reconnect is handled in a dedicated lws scheduler janus_wsevh_schedule_connect_attempt */
 static void *janus_wsevh_thread(void *data) {
 	JANUS_LOG(LOG_VERB, "Joining WebSocketsEventHandler (lws>=3.2) client thread\n");
 	int n = 0;
@@ -591,10 +589,8 @@ static void *janus_wsevh_thread(void *data) {
 	return NULL;
 }
 #else
-/*
- * Websocket thread loop for websocket library prior to (less than) 3.2
- * The reconnect is handled in the loop for lws < 3.2
- */
+/* Websocket thread loop for websocket library prior to (less than) 3.2
+ * The reconnect is handled in the loop for lws < 3.2 */
 static void *janus_wsevh_thread(void *data) {
 	JANUS_LOG(LOG_VERB, "Joining WebSocketsEventHandler (lws<3.2) client thread\n");
 	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
@@ -841,10 +837,8 @@ static int janus_wsevh_callback(struct lws *wsi, enum lws_callback_reasons reaso
 	return 0;
 }
 
-/**
- * Implements the connecting attempt to the backend websocket server
- * sets the connection result (lws_client_connect_info) to static wsi
- */
+/* Implements the connecting attempt to the backend websocket server
+ * sets the connection result (lws_client_connect_info) to static wsi */
 static void janus_wsevh_connect_attempt(lws_sorted_usec_list_t *sul) {
 	struct lws_client_connect_info i = { 0 };
 	i.host = address;
@@ -870,10 +864,8 @@ static void janus_wsevh_connect_attempt(lws_sorted_usec_list_t *sul) {
 	reconnect = FALSE;
 }
 
-/**
- * Adopts the reconnect_delay value in case of an error
- * Increases the value up to JANUS_WSEVH_MAX_RETRY_SECS
- */
+/* Adopts the reconnect_delay value in case of an error
+ * Increases the value up to JANUS_WSEVH_MAX_RETRY_SECS */
 static void janus_wsevh_calculate_reconnect_delay_on_fail(void) {
 	if(reconnect_delay == 0)
 		reconnect_delay = 1;
@@ -884,9 +876,7 @@ static void janus_wsevh_calculate_reconnect_delay_on_fail(void) {
 	}
 }
 
-/**
- * Schedules a connect attempt using the lws scheduler as 
- */
+/* Schedules a connect attempt using the lws scheduler as */
 static void janus_wsevh_schedule_connect_attempt(void) {
 	#if (LWS_LIBRARY_VERSION_MAJOR >= 3 && LWS_LIBRARY_VERSION_MINOR >= 2) || (LWS_LIBRARY_VERSION_MAJOR >= 4)
 		lws_sul_schedule(context, 0, &sul_stagger, janus_wsevh_connect_attempt, reconnect_delay * LWS_US_PER_SEC);

--- a/events/janus_wsevh.c
+++ b/events/janus_wsevh.c
@@ -82,7 +82,7 @@ static void janus_wsevh_calculate_reconnect_delay_on_fail(void);
 #if !(((LWS_LIBRARY_VERSION_MAJOR == 3 && LWS_LIBRARY_VERSION_MINOR >= 2) || LWS_LIBRARY_VERSION_MAJOR >= 4))
 	#define lws_sorted_usec_list_t void
 #endif
-static void janus_wsevh_connect_attempt(lws_sorted_usec_list_t* sul);
+static void janus_wsevh_connect_attempt(lws_sorted_usec_list_t *sul);
 
 /* Queue of events to handle */
 static GAsyncQueue *events = NULL;
@@ -578,9 +578,9 @@ plugin_response:
 
 #if (LWS_LIBRARY_VERSION_MAJOR >= 3 && LWS_LIBRARY_VERSION_MINOR >= 2) || (LWS_LIBRARY_VERSION_MAJOR >= 4)
 /*
-* Websocket thread loop for websocket library newer than 3.2
-* The reconnect is handled in a dedicated lws scheduler janus_wsevh_schedule_connect_attempt
-*/
+ * Websocket thread loop for websocket library newer than 3.2
+ * The reconnect is handled in a dedicated lws scheduler janus_wsevh_schedule_connect_attempt
+ */
 static void *janus_wsevh_thread(void *data) {
 	JANUS_LOG(LOG_VERB, "Joining WebSocketsEventHandler (lws>=3.2) client thread\n");
 	int n = 0;
@@ -592,9 +592,9 @@ static void *janus_wsevh_thread(void *data) {
 }
 #else
 /*
-* Websocket thread loop for websocket library prior to (less than) 3.2
-* The reconnect is handled in the loop for lws < 3.2
-*/
+ * Websocket thread loop for websocket library prior to (less than) 3.2
+ * The reconnect is handled in the loop for lws < 3.2
+ */
 static void *janus_wsevh_thread(void *data) {
 	JANUS_LOG(LOG_VERB, "Joining WebSocketsEventHandler (lws<3.2) client thread\n");
 	while(g_atomic_int_get(&initialized) && !g_atomic_int_get(&stopping)) {
@@ -614,7 +614,7 @@ static void *janus_wsevh_thread(void *data) {
 			}
 			ws_client = NULL;
 			janus_wsevh_connect_attempt(NULL);
-			if (!wsi) {
+			if(!wsi) {
 				janus_wsevh_calculate_reconnect_delay_on_fail();
 				JANUS_LOG(LOG_WARN, "WebSocketsEventHandler: Error attempting connection... (next retry in %ds)\n", reconnect_delay);
 			}
@@ -717,12 +717,12 @@ static int janus_wsevh_callback(struct lws *wsi, enum lws_callback_reasons reaso
 			return 0;
 		}
 		case LWS_CALLBACK_CLIENT_CONNECTION_ERROR: {
-			JANUS_LOG(LOG_ERR, "Error connecting to backend (%s)\n",
-				in ? (char *)in : "unknown error");
 			janus_wsevh_calculate_reconnect_delay_on_fail();
+			JANUS_LOG(LOG_ERR, "WebSocketsEventHandler: Error connecting to backend (%s) (next retry in %ds)\n",
+				in ? (char *)in : "unknown error",
+				reconnect_delay);
 			disconnected = janus_get_monotonic_time();
 			reconnect = TRUE;
-			JANUS_LOG(LOG_WARN, "WebSocketsEventHandler: Error attempting connection... (next retry in %ds)\n", reconnect_delay);
 			janus_wsevh_schedule_connect_attempt();
 			return 1;
 		}
@@ -842,10 +842,10 @@ static int janus_wsevh_callback(struct lws *wsi, enum lws_callback_reasons reaso
 }
 
 /**
- * Implements the connecting attempt to the upstream websocket server
+ * Implements the connecting attempt to the backend websocket server
  * sets the connection result (lws_client_connect_info) to static wsi
  */
-static void janus_wsevh_connect_attempt(lws_sorted_usec_list_t* sul) {
+static void janus_wsevh_connect_attempt(lws_sorted_usec_list_t *sul) {
 	struct lws_client_connect_info i = { 0 };
 	i.host = address;
 	i.origin = address;
@@ -858,13 +858,13 @@ static void janus_wsevh_connect_attempt(lws_sorted_usec_list_t* sul) {
 	i.ietf_version_or_minus_one = -1;
 	i.client_exts = exts;
 	i.protocol = protocols[0].name;
-	JANUS_LOG(LOG_INFO, "WebSocketsEventHandler: Connecting to upstream websocket server %s:%d...\n", address, port);
+	JANUS_LOG(LOG_INFO, "WebSocketsEventHandler: Connecting to backend websocket server %s:%d...\n", address, port);
 	wsi = lws_client_connect_via_info(&i);
 	if(!wsi) {
 		/* As we specified a callback pointer in the context the NULL result is unlikely to happen */
 		disconnected = janus_get_monotonic_time();
 		reconnect = TRUE;
-		JANUS_LOG(LOG_ERR, "WebSocketsEventHandler: Connecting to upstream websocket server %s:%d failed\n", address, port);
+		JANUS_LOG(LOG_ERR, "WebSocketsEventHandler: Connecting to backend websocket server %s:%d failed\n", address, port);
 		return;
 	}
 	reconnect = FALSE;
@@ -877,9 +877,9 @@ static void janus_wsevh_connect_attempt(lws_sorted_usec_list_t* sul) {
 static void janus_wsevh_calculate_reconnect_delay_on_fail(void) {
 	if(reconnect_delay == 0)
 		reconnect_delay = 1;
-	else if (reconnect_delay < JANUS_WSEVH_MAX_RETRY_SECS) {
+	else if(reconnect_delay < JANUS_WSEVH_MAX_RETRY_SECS) {
 		reconnect_delay += reconnect_delay;
-		if (reconnect_delay > JANUS_WSEVH_MAX_RETRY_SECS)
+		if(reconnect_delay > JANUS_WSEVH_MAX_RETRY_SECS)
 			reconnect_delay = JANUS_WSEVH_MAX_RETRY_SECS;
 	}
 }

--- a/events/janus_wsevh.c
+++ b/events/janus_wsevh.c
@@ -389,6 +389,9 @@ int janus_wsevh_init(const char *config_path) {
 	info.protocols = protocols;
 	info.gid = -1;
 	info.uid = -1;
+#if ((LWS_LIBRARY_VERSION_MAJOR == 3 && LWS_LIBRARY_VERSION_MINOR >= 2) || LWS_LIBRARY_VERSION_MAJOR >= 4)
+	info.connect_timeout_secs = 5;
+#endif
 	if(secure)
 		info.options |= LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
 	context = lws_create_context(&info);
@@ -621,7 +624,7 @@ static void *janus_wsevh_thread(void *data) {
 	JANUS_LOG(LOG_VERB, "Leaving WebSocketsEventHandler (lws<3.2) client thread\n");
 	return NULL;
 }
-#endif
+#endif 
 
 /* Thread to handle incoming events */
 static void *janus_wsevh_handler(void *data) {

--- a/events/janus_wsevh.c
+++ b/events/janus_wsevh.c
@@ -389,7 +389,7 @@ int janus_wsevh_init(const char *config_path) {
 	info.protocols = protocols;
 	info.gid = -1;
 	info.uid = -1;
-#if ((LWS_LIBRARY_VERSION_MAJOR == 3 && LWS_LIBRARY_VERSION_MINOR >= 2) || LWS_LIBRARY_VERSION_MAJOR >= 4)
+#if ((LWS_LIBRARY_VERSION_MAJOR == 4 && LWS_LIBRARY_VERSION_MINOR >= 1) || LWS_LIBRARY_VERSION_MAJOR >= 5)
 	info.connect_timeout_secs = 5;
 #endif
 	if(secure)


### PR DESCRIPTION
As followup from https://github.com/meetecho/janus-gateway/issues/2734

Changed the implementation for the reconnect from the handling inside the lws_service thread to the scheduler approach as shown in the libsocket example. (https://libwebsockets.org/git/libwebsockets/tree/minimal-examples/ws-client/minimal-ws-client-tx/minimal-ws-client.c)

The current approach is not working properly if the target is not localhost. The connection failed callback is triggered 5 seconds after the connect however the lws_service continues to sleep for 25 seconds. 

Using the lws_sul_schedule the time when the next reconnect has to happen is exactly specified, so no need to do that in the lws_service loop and the loop just does the lws_service loop.

(!) Not yet tested with wsl 3.1 want to do that now but a short feedback in the mean time would be nice.
