### PR TITLE
CC-2216 show libwebsocket version in admin dependencies

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -28,6 +28,7 @@
 #ifdef HAVE_TURNRESTAPI
 #include <curl/curl.h>
 #endif
+#include <libwebsockets.h>
 
 #include "janus.h"
 #include "version.h"
@@ -394,6 +395,7 @@ static json_t *janus_info(const char *transaction) {
 		if(curl_version && curl_version->version)
 			json_object_set_new(deps, "libcurl", json_string(curl_version->version));
 	#endif
+		json_object_set_new(deps, "libwebsocket", json_string(LWS_BUILD_HASH));
 		json_object_set_new(deps, "crypto", json_string(janus_get_ssl_version()));
 		json_object_set_new(info, "dependencies", deps);
 	}


### PR DESCRIPTION
As the libwebsocket version is currently missing in the admin dependencies i thought i just quickly add it here
Want to mention that the libwebsocket does not provide a machine parseable version "4.2.0" but only a "v4.2.0"
If we want it machine parseable a dedicated string with the major minor patch would be required.
I am just using the version string from the lib

{
"glib2":"2.64.6",
"jansson":"2.12",
"libnice":"0.1.18",
"libsrtp":"libsrtp2 2.3.0",
"libcurl":"7.68.0",
"libwebsocket":"v4.2.0",
"crypto":"OpenSSL 1.1.1 (compatible; BoringSSL)"
}