### PR TITLE
Fix sample event handler behaviour

### DIFF
--- a/events/janus_sampleevh.c
+++ b/events/janus_sampleevh.c
@@ -733,6 +733,7 @@ static void *janus_sampleevh_handler(void *data) {
 			curl_easy_setopt(curl, CURLOPT_PASSWORD, backend_pwd);
 		}
 		janus_mutex_unlock(&evh_mutex);
+		headers = curl_slist_append(headers, "Content-Type: application/json");
 		/* Check if we need to compress the data */
 		if(compress) {
 			compressed_len = janus_gzip_compress(compression,
@@ -748,10 +749,8 @@ static void *janus_sampleevh_handler(void *data) {
 				output = NULL;
 				continue;
 			}
+			headers = curl_slist_append(headers, "Content-Encoding: gzip");
 		}
-		headers = curl_slist_append(headers, compress ? "Accept: application/gzip": "Accept: application/json");
-		headers = curl_slist_append(headers, compress ? "Content-Type: application/gzip" : "Content-Type: application/json");
-		headers = curl_slist_append(headers, "charsets: utf-8");
 		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, compress ? compressed_text : event_text);
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, compress ? compressed_len : strlen(event_text));

--- a/utils.c
+++ b/utils.c
@@ -1190,7 +1190,7 @@ size_t janus_gzip_compress(int compression, char *text, size_t tlen, char *compr
 	zs.zfree = Z_NULL;
 	zs.opaque = Z_NULL;
 	zs.next_in = (Bytef *)text;
-	zs.avail_in = (uInt)tlen+1;
+	zs.avail_in = (uInt)tlen;
 	zs.next_out = (Bytef *)compressed;
 	zs.avail_out = (uInt)zlen;
 	int res = deflateInit2(&zs, compression, Z_DEFLATED, 15 | 16, 8, Z_DEFAULT_STRATEGY);


### PR DESCRIPTION
This pull request makes some breaking changes but the new behaviour is arguably more correct

### Remove a trailing null in gzipped messages using janus_gzip_compress

The trailing null in a string is not logically part of the string contents. It should not be included in gzip message body.

The only two places in the code that use this function are the sample and gelf event handlers

### Use standard HTTP headers in messages sent by the sample event handler

- The `Accept` header is not relevant since we ignore the HTTP response
- The standard method to signal a gzipped message body is not to modify `Content-Type` but to use `Content-Encoding: gzip`
- charsets is not a standard HTTP header. utf8 is implied by JSON