### PR TITLE
fix ssrc header of transport-cc

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -3617,7 +3617,21 @@ static gint rtcp_transport_wide_cc_stats_comparator(gconstpointer item1, gconstp
 static gboolean janus_ice_outgoing_transport_wide_cc_feedback(gpointer user_data) {
 	janus_ice_handle *handle = (janus_ice_handle *)user_data;
 	janus_ice_peerconnection *pc = handle->pc;
-	janus_ice_peerconnection_medium *medium = pc ? g_hash_table_lookup(pc->media_bytype, GINT_TO_POINTER(JANUS_MEDIA_VIDEO)) : NULL;
+
+	janus_ice_peerconnection_medium *medium;
+	if (pc) {
+		/* Find inbound video medium */
+		GHashTableIter iter;
+		gpointer value;
+		g_hash_table_iter_init(&iter, pc->media_bymid);
+		while (g_hash_table_iter_next(&iter, NULL, &value)) {
+			janus_ice_peerconnection_medium *m = value;
+			if (m->type == JANUS_MEDIA_VIDEO && m->recv) {
+				medium = m;
+			}
+		}
+	}
+
 	if(pc && pc->do_transport_wide_cc && medium) {
 		/* Create a transport wide feedback message */
 		size_t size = 1300;

--- a/ice.c
+++ b/ice.c
@@ -3618,16 +3618,17 @@ static gboolean janus_ice_outgoing_transport_wide_cc_feedback(gpointer user_data
 	janus_ice_handle *handle = (janus_ice_handle *)user_data;
 	janus_ice_peerconnection *pc = handle->pc;
 
-	janus_ice_peerconnection_medium *medium;
-	if (pc) {
+	janus_ice_peerconnection_medium *medium = NULL;
+	if(pc) {
 		/* Find inbound video medium */
 		GHashTableIter iter;
 		gpointer value;
 		g_hash_table_iter_init(&iter, pc->media_bymid);
 		while (g_hash_table_iter_next(&iter, NULL, &value)) {
 			janus_ice_peerconnection_medium *m = value;
-			if (m->type == JANUS_MEDIA_VIDEO && m->recv) {
+			if(m && m->type == JANUS_MEDIA_VIDEO && m->recv) {
 				medium = m;
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
If peerconnection contains one send-only video stream and one or more recv-only video stream, for example:

- mid-0 = sendrecv audio
- mid-1 = sendonly video
- mid-2 = recvonly video

`pc->media_bytype` only hold mid-0 and mid-2 medium, and `g_hash_table_lookup(pc->media_bytype, GINT_TO_POINTER(JANUS_MEDIA_VIDEO))` will return mid-2 medium. This cause rtcp report sending with ssrc=0.

Remote peer will slow down RTP transmission because no correct rtcp report send back to it.