### PR TITLE
Fix streaming mountpoint name generation when starting with 0

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -7058,7 +7058,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 		JANUS_LOG(LOG_VERB, "Missing name, will generate a random one...\n");
 		memset(tempname, 0, 255);
 		g_snprintf(tempname, 255, "%s", id_str);
-	} else if(atoi(name) != 0) {
+	} else if(name[0] == '0' || atoi(name) != 0) {
 		JANUS_LOG(LOG_VERB, "Names can't start with a number, prefixing it...\n");
 		memset(tempname, 0, 255);
 		g_snprintf(tempname, 255, "mp-%s", name);


### PR DESCRIPTION
Strings starting with `0` and have a following non-zero digits were ok, but not the one with `0` + letters.

```
atoi("0123abc") = 123
atoi("004abc") = 4
atoi("000abc") = 0     <--- as a result this one was missing the mp- prefix
```