### PR TITLE
handle host being in ignore list and enforced list

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -3630,10 +3630,11 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 			if(janus_ice_enforce_list != NULL) {
 				if(ifa->ifa_name != NULL && !janus_ice_is_enforced(ifa->ifa_name) && !janus_ice_is_enforced(host))
 					continue;
-			} else {
-				if(janus_ice_is_ignored(host))
-					continue;
 			}
+			
+			if(janus_ice_is_ignored(host))
+				continue;
+			
 			/* Ok, add interface to the ICE agent */
 			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Adding %s to the addresses to gather candidates for\n", handle->handle_id, host);
 			NiceAddress addr_local;

--- a/ice.c
+++ b/ice.c
@@ -3626,15 +3626,13 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 			/* Skip 0.0.0.0, :: and, unless otherwise configured, local scoped addresses  */
 			if(!strcmp(host, "0.0.0.0") || !strcmp(host, "::") || (!janus_ipv6_linklocal_enabled && !strncmp(host, "fe80:", 5)))
 				continue;
-			/* Check if this IP address is in the ignore/enforce list, now: the enforce list has the precedence */
+			/* Check if this IP address is in the ignore/enforce list: the enforce list has the precedence but the ignore list can then discard candidates */
 			if(janus_ice_enforce_list != NULL) {
 				if(ifa->ifa_name != NULL && !janus_ice_is_enforced(ifa->ifa_name) && !janus_ice_is_enforced(host))
 					continue;
 			}
-			
 			if(janus_ice_is_ignored(host))
 				continue;
-			
 			/* Ok, add interface to the ICE agent */
 			JANUS_LOG(LOG_VERB, "[%"SCNu64"] Adding %s to the addresses to gather candidates for\n", handle->handle_id, host);
 			NiceAddress addr_local;


### PR DESCRIPTION
If you add a eth adapter to enforced of say `eth0` and it has 3 IPs attached to it, but you want to remove one of them, you'd expect to be able to add that IP (or partial IP) to the ignore list and have it removed. Currently it doesnt work like that and doesnt allow us the flexibility over eth adapters with multiple IPs you'd expect

By making this change we get the flexibility of being able to pass in these options 

```
    --ice-enforce-list=eth0
    --ice-ignore-list=10.16.0.
```

eth0 has 3 IPs attached to it, two ipv4 and one ipv6 - one of the ipv4's being a private address. Now I can remove that private IP from being offered as a candidate

The change means I get 2 candidates instead of 3.

More control over candidates presented = win.