### PR TITLE
add the token used to join the room to the info sent to event handlers

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -6366,15 +6366,16 @@ static void *janus_videoroom_handler(void *data) {
 				/* Also notify event handlers */
 				if(notify_events && gateway->events_is_enabled()) {
 					json_t *info = json_object();
-					json_t *token = json_object_get(root, "token");
 					json_object_set_new(info, "event", json_string("joined"));
 					json_object_set_new(info, "room", string_ids ? json_string(publisher->room->room_id_str) :
 					json_integer(publisher->room->room_id));
 					json_object_set_new(info, "id", string_ids ? json_string(user_id_str) : json_integer(user_id));
 					json_object_set_new(info, "private_id", json_integer(publisher->pvt_id));
-                    if (publisher->room->check_allowed)
-    					json_object_set_new(info, "token", token);
-					if(display_text != NULL)
+                    if(publisher->room->check_allowed) {
+                        const char *token = json_string_value(json_object_get(root, "token"));
+                        json_object_set_new(info, "token", json_string(token));
+                    }
+                    if(display_text != NULL)
 						json_object_set_new(info, "display", json_string(display_text));
 					if(publisher->user_audio_active_packets)
 						json_object_set_new(info, "audio_active_packets", json_integer(publisher->user_audio_active_packets));

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -6372,7 +6372,8 @@ static void *janus_videoroom_handler(void *data) {
 					json_integer(publisher->room->room_id));
 					json_object_set_new(info, "id", string_ids ? json_string(user_id_str) : json_integer(user_id));
 					json_object_set_new(info, "private_id", json_integer(publisher->pvt_id));
-					json_object_set_new(info, "token", token);
+                    if (publisher->room->check_allowed)
+    					json_object_set_new(info, "token", token);
 					if(display_text != NULL)
 						json_object_set_new(info, "display", json_string(display_text));
 					if(publisher->user_audio_active_packets)

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -6366,11 +6366,13 @@ static void *janus_videoroom_handler(void *data) {
 				/* Also notify event handlers */
 				if(notify_events && gateway->events_is_enabled()) {
 					json_t *info = json_object();
+					json_t *token = json_object_get(root, "token");
 					json_object_set_new(info, "event", json_string("joined"));
 					json_object_set_new(info, "room", string_ids ? json_string(publisher->room->room_id_str) :
 					json_integer(publisher->room->room_id));
 					json_object_set_new(info, "id", string_ids ? json_string(user_id_str) : json_integer(user_id));
 					json_object_set_new(info, "private_id", json_integer(publisher->pvt_id));
+					json_object_set_new(info, "token", token);
 					if(display_text != NULL)
 						json_object_set_new(info, "display", json_string(display_text));
 					if(publisher->user_audio_active_packets)


### PR DESCRIPTION
all in  the title, use cases can be similar to the one mentioned in [this google grp dicussion](https://groups.google.com/g/meetecho-janus/c/9maXG4mjNdw)