### PR TITLE
Add API to force Janus to use TURN

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -304,14 +304,19 @@ nat: {
 	# You can configure a TURN server in two different ways: specifying a
 	# statically configured TURN server, and thus provide the address of the
 	# TURN server, the transport (udp/tcp/tls) to use, and a set of valid
-	# credentials to authenticate...
+	# credentials to authenticate. Notice that you should NEVER configure
+	# a TURN server for Janus unless it's really what you want! If you want
+	# *users* to use TURN, then you need to configure that on the client
+	# side, and NOT in Janus. The following TURN configuration should ONLY
+	# be enabled when Janus itself is sitting behind a restrictive firewall
+	# (e.g., it's part of a service installed on a box in a private home).
 	#turn_server = "myturnserver.com"
 	#turn_port = 3478
 	#turn_type = "udp"
 	#turn_user = "myuser"
 	#turn_pwd = "mypassword"
 
-	# ... or you can make use of the TURN REST API to get info on one or more
+	# You can also make use of the TURN REST API to get info on one or more
 	# TURN services dynamically. This makes use of the proposed standard of
 	# such an API (https://tools.ietf.org/html/draft-uberti-behave-turn-rest-00)
 	# which is currently available in both rfc5766-turn-server and coturn.
@@ -326,6 +331,11 @@ nat: {
 	#turn_rest_api_key = "anyapikeyyoumayhaveset"
 	#turn_rest_api_method = "GET"
 	#turn_rest_api_timeout = 10
+
+	# In case a TURN server is provided, you can allow applications to force
+	# Janus to use TURN (https://github.com/meetecho/janus-gateway/pull/2774).
+	# This is NOT allowed by default: only enable it if you know what you're doing.
+	#allow_force_relay = true
 
 	# You can also choose which interfaces should be explicitly used by the
 	# gateway for the purpose of ICE candidates gathering, thus excluding

--- a/html/janus.js
+++ b/html/janus.js
@@ -1390,6 +1390,8 @@ function Janus(gatewayCallbacks) {
 				request.jsep.e2ee = true;
 			if(jsep.rid_order === "hml" || jsep.rid_order === "lmh")
 				request.jsep.rid_order = jsep.rid_order;
+			if(jsep.force_relay)
+				request.jsep.force_relay = true;
 		}
 		Janus.debug("Sending message to plugin (handle=" + handleId + "):");
 		Janus.debug(request);

--- a/ice.c
+++ b/ice.c
@@ -70,6 +70,14 @@ char *janus_ice_get_turn_rest_api(void) {
 #endif
 }
 
+/* Force relay settings */
+static gboolean force_relay_allowed = FALSE;
+void janus_ice_allow_force_relay(void) {
+	force_relay_allowed = TRUE;
+}
+gboolean janus_ice_is_force_relay_allowed(void) {
+	return force_relay_allowed;
+}
 
 /* ICE-Lite status */
 static gboolean janus_ice_lite_enabled;

--- a/ice.h
+++ b/ice.h
@@ -89,6 +89,11 @@ uint16_t janus_ice_get_turn_port(void);
 /*! \brief Method to get the specified TURN REST API backend, if any
  * @returns The currently specified  TURN REST API backend, if available, or NULL if not */
 char *janus_ice_get_turn_rest_api(void);
+/*! \brief Method to enable applications to force Janus to use TURN */
+void janus_ice_allow_force_relay(void);
+/*! \brief Method to check whether applications are allowed to force Janus to use TURN
+ * @returns TRUE if they're allowed, FALSE otherwise */
+gboolean janus_ice_is_force_relay_allowed(void);
 /*! \brief Helper method to force Janus to overwrite all host candidates with the public IP
  * @param[in] keep_private_host Whether we should keep the original private host as a separate candidate, or replace it */
 void janus_ice_enable_nat_1_1(gboolean keep_private_host);


### PR DESCRIPTION
In case you configured Janus to use a TURN server (which you almost always [will NOT](https://github.com/meetecho/janus-gateway/pull/new/force-relay) want to do!), you may also sometimes want to actually force Janus to use TURN: this is what this patch allows you to do, and can be considered the Janus equivalent of the `iceTransportPolicy:"relay"` you can use in browsers, to force them to use TURN instead. Enabling it is very easy, since all you need to do is add a `force_relay:true` attribute to the JSEP object you send to Janus, whether it's an offer or answer.

Notice this only works for libnice >= 0.1.14, as that's the version the [property we use](https://libnice.freedesktop.org/libnice/NiceAgent.html#NiceAgent--force-relay) was added to. Besides, notice that this WILL cause PeerConnections to fail if: a. you didn't set any TURN server in Janus, b. Janus couldn't get a relay candidate from that server, or c. that candidate can't talk to the peer for any reason.

**VERY IMPORTANT**: Notice that you should **NOT** use this if you want **USERS** connected to Janus to use TURN. For **USERS**, you use `iceTransportPolicy:"relay"` on the client side: Janus will automatically talk to the TURN server, and does **NOT** need to be configured with TURN support itself. Janus **ONLY** needs TURN support in very specific cases, like when Janus itself is deployed behind a restrictive firewall (e.g., Janus acting as an endpoint in your home), and that's the **ONLY** time you'll need to actually be aware ths new feature exists.

I wrote this in all caps multiple times as it is a VERY common thing people get wrong all the time (main reason why we have a FAQ item for that), so I pretty much felt I had to repeat it all over again :stuck_out_tongue_winking_eye: 