### PR TITLE
CC-2239 Allow media statistic events to get dispatched as on event per stream instead of dedicated ones per media

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -423,9 +423,13 @@ loggers: {
 # especially if you have many PeerConnections active. To change this,
 # just set 'stats_period' to the number of seconds that should pass in
 # between statistics for each handle. Setting it to 0 disables them (but
-# not other media-related events).
+# not other media-related events). By default janus sends single media
+# statistic events per media (audio, video and the simulcast layers each
+# as one event.) If you prefer to receive one event containing all media
+# stats in one event set combine_media_stats to true.
 events: {
 	#broadcast = true
+	#combine_media_stats = true
 	#disable = "libjanus_sampleevh.so"
 	#stats_period = 5
 }

--- a/ice.c
+++ b/ice.c
@@ -350,6 +350,14 @@ int janus_ice_get_event_stats_period(void) {
 	return janus_ice_event_stats_period;
 }
 
+/* How to handle media statistic events (one per media or one per peerConnection) */
+static gboolean janus_ice_event_combine_media_stats_to_one_event = false;
+void janus_ice_set_combine_media_stats_to_one_event(gboolean combine_media_stats_to_one_event) {
+	janus_ice_event_combine_media_stats_to_one_event = combine_media_stats_to_one_event;
+}
+gboolean janus_ice_get_combine_media_stats_to_one_event(void) {
+	return janus_ice_event_combine_media_stats_to_one_event;
+}
 
 /* RTP/RTCP port range */
 uint16_t rtp_range_min = 0;
@@ -4173,73 +4181,97 @@ static gboolean janus_ice_outgoing_stats_handle(gpointer user_data) {
 	handle->last_event_stats++;
 	if(janus_ice_event_stats_period > 0 && handle->last_event_stats >= janus_ice_event_stats_period) {
 		handle->last_event_stats = 0;
-		/* Audio */
-		if(janus_events_is_enabled() && janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AUDIO)) {
-			if(stream && stream->audio_rtcp_ctx) {
-				json_t *info = json_object();
-				json_object_set_new(info, "media", json_string("audio"));
-				json_object_set_new(info, "base", json_integer(stream->audio_rtcp_ctx->tb));
-				json_object_set_new(info, "rtt", json_integer(janus_rtcp_context_get_rtt(stream->audio_rtcp_ctx)));
-				json_object_set_new(info, "lost", json_integer(janus_rtcp_context_get_lost_all(stream->audio_rtcp_ctx, FALSE)));
-				json_object_set_new(info, "lost-by-remote", json_integer(janus_rtcp_context_get_lost_all(stream->audio_rtcp_ctx, TRUE)));
-				json_object_set_new(info, "jitter-local", json_integer(janus_rtcp_context_get_jitter(stream->audio_rtcp_ctx, FALSE)));
-				json_object_set_new(info, "jitter-remote", json_integer(janus_rtcp_context_get_jitter(stream->audio_rtcp_ctx, TRUE)));
-				json_object_set_new(info, "in-link-quality", json_integer(janus_rtcp_context_get_in_link_quality(stream->audio_rtcp_ctx)));
-				json_object_set_new(info, "in-media-link-quality", json_integer(janus_rtcp_context_get_in_media_link_quality(stream->audio_rtcp_ctx)));
-				json_object_set_new(info, "out-link-quality", json_integer(janus_rtcp_context_get_out_link_quality(stream->audio_rtcp_ctx)));
-				json_object_set_new(info, "out-media-link-quality", json_integer(janus_rtcp_context_get_out_media_link_quality(stream->audio_rtcp_ctx)));
-				if(stream->component) {
-					json_object_set_new(info, "packets-received", json_integer(stream->component->in_stats.audio.packets));
-					json_object_set_new(info, "packets-sent", json_integer(stream->component->out_stats.audio.packets));
-					json_object_set_new(info, "bytes-received", json_integer(stream->component->in_stats.audio.bytes));
-					json_object_set_new(info, "bytes-sent", json_integer(stream->component->out_stats.audio.bytes));
-					json_object_set_new(info, "bytes-received-lastsec", json_integer(stream->component->in_stats.audio.bytes_lastsec));
-					json_object_set_new(info, "bytes-sent-lastsec", json_integer(stream->component->out_stats.audio.bytes_lastsec));
-					json_object_set_new(info, "nacks-received", json_integer(stream->component->in_stats.audio.nacks));
-					json_object_set_new(info, "nacks-sent", json_integer(stream->component->out_stats.audio.nacks));
-					json_object_set_new(info, "retransmissions-received", json_integer(stream->audio_rtcp_ctx->retransmitted));
-				}
-				janus_events_notify_handlers(JANUS_EVENT_TYPE_MEDIA, JANUS_EVENT_SUBTYPE_MEDIA_STATS,
-					session->session_id, handle->handle_id, handle->opaque_id, info);
-			}
-		}
-		/* Do the same for video */
-		if(janus_events_is_enabled() && janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO)) {
-			int vindex=0;
-			for(vindex=0; vindex<3; vindex++) {
-				if(stream && stream->video_rtcp_ctx[vindex]) {
+		if(janus_events_is_enabled()) {
+			/* Shall janus send dedicated events per media or one per peerConnection */
+			json_t *combinedEvent = NULL;
+			if(janus_ice_get_combine_media_stats_to_one_event())
+				combinedEvent = json_object();
+
+			/* Audio */
+			if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AUDIO)) {
+				if(stream && stream->audio_rtcp_ctx) {
 					json_t *info = json_object();
-					if(vindex == 0)
-						json_object_set_new(info, "media", json_string("video"));
-					else if(vindex == 1)
-						json_object_set_new(info, "media", json_string("video-sim1"));
-					else
-						json_object_set_new(info, "media", json_string("video-sim2"));
-					json_object_set_new(info, "base", json_integer(stream->video_rtcp_ctx[vindex]->tb));
-					if(vindex == 0)
-						json_object_set_new(info, "rtt", json_integer(janus_rtcp_context_get_rtt(stream->video_rtcp_ctx[vindex])));
-					json_object_set_new(info, "lost", json_integer(janus_rtcp_context_get_lost_all(stream->video_rtcp_ctx[vindex], FALSE)));
-					json_object_set_new(info, "lost-by-remote", json_integer(janus_rtcp_context_get_lost_all(stream->video_rtcp_ctx[vindex], TRUE)));
-					json_object_set_new(info, "jitter-local", json_integer(janus_rtcp_context_get_jitter(stream->video_rtcp_ctx[vindex], FALSE)));
-					json_object_set_new(info, "jitter-remote", json_integer(janus_rtcp_context_get_jitter(stream->video_rtcp_ctx[vindex], TRUE)));
-					json_object_set_new(info, "in-link-quality", json_integer(janus_rtcp_context_get_in_link_quality(stream->video_rtcp_ctx[vindex])));
-					json_object_set_new(info, "in-media-link-quality", json_integer(janus_rtcp_context_get_in_media_link_quality(stream->video_rtcp_ctx[vindex])));
-					json_object_set_new(info, "out-link-quality", json_integer(janus_rtcp_context_get_out_link_quality(stream->video_rtcp_ctx[vindex])));
-					json_object_set_new(info, "out-media-link-quality", json_integer(janus_rtcp_context_get_out_media_link_quality(stream->video_rtcp_ctx[vindex])));
+					if(!combinedEvent)
+						json_object_set_new(info, "media", json_string("audio"));
+					json_object_set_new(info, "base", json_integer(stream->audio_rtcp_ctx->tb));
+					json_object_set_new(info, "rtt", json_integer(janus_rtcp_context_get_rtt(stream->audio_rtcp_ctx)));
+					json_object_set_new(info, "lost", json_integer(janus_rtcp_context_get_lost_all(stream->audio_rtcp_ctx, FALSE)));
+					json_object_set_new(info, "lost-by-remote", json_integer(janus_rtcp_context_get_lost_all(stream->audio_rtcp_ctx, TRUE)));
+					json_object_set_new(info, "jitter-local", json_integer(janus_rtcp_context_get_jitter(stream->audio_rtcp_ctx, FALSE)));
+					json_object_set_new(info, "jitter-remote", json_integer(janus_rtcp_context_get_jitter(stream->audio_rtcp_ctx, TRUE)));
+					json_object_set_new(info, "in-link-quality", json_integer(janus_rtcp_context_get_in_link_quality(stream->audio_rtcp_ctx)));
+					json_object_set_new(info, "in-media-link-quality", json_integer(janus_rtcp_context_get_in_media_link_quality(stream->audio_rtcp_ctx)));
+					json_object_set_new(info, "out-link-quality", json_integer(janus_rtcp_context_get_out_link_quality(stream->audio_rtcp_ctx)));
+					json_object_set_new(info, "out-media-link-quality", json_integer(janus_rtcp_context_get_out_media_link_quality(stream->audio_rtcp_ctx)));
 					if(stream->component) {
-						json_object_set_new(info, "packets-received", json_integer(stream->component->in_stats.video[vindex].packets));
-						json_object_set_new(info, "packets-sent", json_integer(stream->component->out_stats.video[vindex].packets));
-						json_object_set_new(info, "bytes-received", json_integer(stream->component->in_stats.video[vindex].bytes));
-						json_object_set_new(info, "bytes-sent", json_integer(stream->component->out_stats.video[vindex].bytes));
-						json_object_set_new(info, "bytes-received-lastsec", json_integer(stream->component->in_stats.video[vindex].bytes_lastsec));
-						json_object_set_new(info, "bytes-sent-lastsec", json_integer(stream->component->out_stats.video[vindex].bytes_lastsec));
-						json_object_set_new(info, "nacks-received", json_integer(stream->component->in_stats.video[vindex].nacks));
-						json_object_set_new(info, "nacks-sent", json_integer(stream->component->out_stats.video[vindex].nacks));
-						json_object_set_new(info, "retransmissions-received", json_integer(stream->video_rtcp_ctx[vindex]->retransmitted));
+						json_object_set_new(info, "packets-received", json_integer(stream->component->in_stats.audio.packets));
+						json_object_set_new(info, "packets-sent", json_integer(stream->component->out_stats.audio.packets));
+						json_object_set_new(info, "bytes-received", json_integer(stream->component->in_stats.audio.bytes));
+						json_object_set_new(info, "bytes-sent", json_integer(stream->component->out_stats.audio.bytes));
+						json_object_set_new(info, "bytes-received-lastsec", json_integer(stream->component->in_stats.audio.bytes_lastsec));
+						json_object_set_new(info, "bytes-sent-lastsec", json_integer(stream->component->out_stats.audio.bytes_lastsec));
+						json_object_set_new(info, "nacks-received", json_integer(stream->component->in_stats.audio.nacks));
+						json_object_set_new(info, "nacks-sent", json_integer(stream->component->out_stats.audio.nacks));
+						json_object_set_new(info, "retransmissions-received", json_integer(stream->audio_rtcp_ctx->retransmitted));
 					}
-					janus_events_notify_handlers(JANUS_EVENT_TYPE_MEDIA, JANUS_EVENT_SUBTYPE_MEDIA_STATS,
-						session->session_id, handle->handle_id, handle->opaque_id, info);
+					if(combinedEvent)
+						json_object_set(combinedEvent, "audio", info);
+					else {
+						janus_events_notify_handlers(JANUS_EVENT_TYPE_MEDIA, JANUS_EVENT_SUBTYPE_MEDIA_STATS,
+							session->session_id, handle->handle_id, handle->opaque_id, info);
+					}
 				}
+			}
+			/* Do the same for video */
+			if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO)) {
+				int vindex=0;
+				for(vindex=0; vindex<3; vindex++) {
+					if(stream && stream->video_rtcp_ctx[vindex]) {
+						json_t *info = json_object();
+						const char* szElement = NULL;
+						if(vindex == 0)
+							szElement = "video";
+						else if(vindex == 1)
+							szElement = "video-sim1";
+						else
+							szElement = "video-sim2";
+						if(!combinedEvent)
+							json_object_set_new(info, "media", json_string(szElement));
+						json_object_set_new(info, "base", json_integer(stream->video_rtcp_ctx[vindex]->tb));
+						if(vindex == 0)
+							json_object_set_new(info, "rtt", json_integer(janus_rtcp_context_get_rtt(stream->video_rtcp_ctx[vindex])));
+						json_object_set_new(info, "lost", json_integer(janus_rtcp_context_get_lost_all(stream->video_rtcp_ctx[vindex], FALSE)));
+						json_object_set_new(info, "lost-by-remote", json_integer(janus_rtcp_context_get_lost_all(stream->video_rtcp_ctx[vindex], TRUE)));
+						json_object_set_new(info, "jitter-local", json_integer(janus_rtcp_context_get_jitter(stream->video_rtcp_ctx[vindex], FALSE)));
+						json_object_set_new(info, "jitter-remote", json_integer(janus_rtcp_context_get_jitter(stream->video_rtcp_ctx[vindex], TRUE)));
+						json_object_set_new(info, "in-link-quality", json_integer(janus_rtcp_context_get_in_link_quality(stream->video_rtcp_ctx[vindex])));
+						json_object_set_new(info, "in-media-link-quality", json_integer(janus_rtcp_context_get_in_media_link_quality(stream->video_rtcp_ctx[vindex])));
+						json_object_set_new(info, "out-link-quality", json_integer(janus_rtcp_context_get_out_link_quality(stream->video_rtcp_ctx[vindex])));
+						json_object_set_new(info, "out-media-link-quality", json_integer(janus_rtcp_context_get_out_media_link_quality(stream->video_rtcp_ctx[vindex])));
+						if(stream->component) {
+							json_object_set_new(info, "packets-received", json_integer(stream->component->in_stats.video[vindex].packets));
+							json_object_set_new(info, "packets-sent", json_integer(stream->component->out_stats.video[vindex].packets));
+							json_object_set_new(info, "bytes-received", json_integer(stream->component->in_stats.video[vindex].bytes));
+							json_object_set_new(info, "bytes-sent", json_integer(stream->component->out_stats.video[vindex].bytes));
+							json_object_set_new(info, "bytes-received-lastsec", json_integer(stream->component->in_stats.video[vindex].bytes_lastsec));
+							json_object_set_new(info, "bytes-sent-lastsec", json_integer(stream->component->out_stats.video[vindex].bytes_lastsec));
+							json_object_set_new(info, "nacks-received", json_integer(stream->component->in_stats.video[vindex].nacks));
+							json_object_set_new(info, "nacks-sent", json_integer(stream->component->out_stats.video[vindex].nacks));
+							json_object_set_new(info, "retransmissions-received", json_integer(stream->video_rtcp_ctx[vindex]->retransmitted));
+						}
+						if(combinedEvent)
+							json_object_set(combinedEvent, szElement, info);
+						else {
+							janus_events_notify_handlers(JANUS_EVENT_TYPE_MEDIA, JANUS_EVENT_SUBTYPE_MEDIA_STATS,
+								session->session_id, handle->handle_id, handle->opaque_id, info);
+						}
+					}
+				}
+			}
+
+			if(combinedEvent) {
+				janus_events_notify_handlers(JANUS_EVENT_TYPE_MEDIA, JANUS_EVENT_SUBTYPE_MEDIA_STATS,
+					session->session_id, handle->handle_id, handle->opaque_id, combinedEvent);
 			}
 		}
 	}

--- a/ice.h
+++ b/ice.h
@@ -201,6 +201,14 @@ void janus_ice_set_event_stats_period(int period);
 /*! \brief Method to get the current event handler statistics period (see above)
  * @returns The current event handler stats period */
 int janus_ice_get_event_stats_period(void);
+
+/*! \brief Method to define wether the media stats shall be dispatched in one event (true) or in dedicated single events (false - default)
+ * @param[in] combine_media_stats_to_one_event true to combine media statistics in on event or false to send dedicated events */
+void janus_ice_set_combine_media_stats_to_one_event(gboolean combine_media_stats_to_one_event);
+/*! \brief Method to retrieve wether media statistic events shall be dispatched combined or in single events
+ * @returns true to combine events */
+gboolean janus_ice_get_combine_media_stats_to_one_event(void);
+
 /*! \brief Method to check whether libnice debugging has been enabled (http://nice.freedesktop.org/libnice/libnice-Debug-messages.html)
  * @returns True if libnice debugging is enabled, FALSE otherwise */
 gboolean janus_ice_is_ice_debugging_enabled(void);

--- a/janus.c
+++ b/janus.c
@@ -5195,6 +5195,15 @@ gint main(int argc, char *argv[])
 					JANUS_LOG(LOG_INFO, "Setting event handlers statistics period to %d seconds\n", period);
 				}
 			}
+
+			item = janus_config_get(config, config_events, janus_config_type_item, "combine_media_stats");
+			if(item && item->value) {
+				gboolean combine = janus_is_true(item->value);
+				janus_ice_set_combine_media_stats_to_one_event(combine);
+				if(combine)
+					JANUS_LOG(LOG_INFO, "Event handler configured to send media statistics events combined in a single event\n");
+			}
+
 			/* Any event handlers to ignore? */
 			item = janus_config_get(config, config_events, janus_config_type_item, "disable");
 			if(item && item->value)


### PR DESCRIPTION
Currently janus sends media statistics events per media, leading to 4 events for one stream if you have a simulcast stream including audio. As client on the eventing connection it is pretty laborious to determine when do i have all events. (i need to wait two iterations in order to know what the server will dispatch me next) so i cannot handle the events after i received them cause i do not know e.g. if after video i will receive simulcast layer 1 or even additionally 2.

So i added an option in the janus.jcfg to combine stream related statistics events into one. (Default is false, so no change in the behaviour until you set the flag)