### PR TITLE
Add configurable expected loss to AudioBridge to actually send FEC

### DIFF
--- a/conf/janus.plugin.audiobridge.jcfg.sample
+++ b/conf/janus.plugin.audiobridge.jcfg.sample
@@ -11,6 +11,7 @@
 # audio_active_packets = 100 (number of packets with audio level, default=100, 2 seconds)
 # audio_level_average = 25 (average value of audio level, 127=muted, 0='too loud', default=25)
 # default_prebuffering = number of packets to buffer before decoding each particiant (default=6)
+# default_expectedloss = percent of packets we expect participants may miss, to help with FEC (default=0)
 # record = true|false (whether this room should be recorded, default=false)
 # record_file = "/path/to/recording.wav" (where to save the recording)
 # record_dir = "/path/to/" (path to save the recording to, makes record_file a relative path if provided)

--- a/conf/janus.plugin.audiobridge.jcfg.sample
+++ b/conf/janus.plugin.audiobridge.jcfg.sample
@@ -12,6 +12,7 @@
 # audio_level_average = 25 (average value of audio level, 127=muted, 0='too loud', default=25)
 # default_prebuffering = number of packets to buffer before decoding each particiant (default=6)
 # default_expectedloss = percent of packets we expect participants may miss, to help with FEC (default=0, max=20; automatically used for forwarders too)
+# default_bitrate = default bitrate in bps to use for the all participants (default=auto, libopus decides; automatically used for forwarders too)
 # record = true|false (whether this room should be recorded, default=false)
 # record_file = "/path/to/recording.wav" (where to save the recording)
 # record_dir = "/path/to/" (path to save the recording to, makes record_file a relative path if provided)

--- a/conf/janus.plugin.audiobridge.jcfg.sample
+++ b/conf/janus.plugin.audiobridge.jcfg.sample
@@ -11,7 +11,7 @@
 # audio_active_packets = 100 (number of packets with audio level, default=100, 2 seconds)
 # audio_level_average = 25 (average value of audio level, 127=muted, 0='too loud', default=25)
 # default_prebuffering = number of packets to buffer before decoding each particiant (default=6)
-# default_expectedloss = percent of packets we expect participants may miss, to help with FEC (default=0)
+# default_expectedloss = percent of packets we expect participants may miss, to help with FEC (default=0; automatically used for forwarders too)
 # record = true|false (whether this room should be recorded, default=false)
 # record_file = "/path/to/recording.wav" (where to save the recording)
 # record_dir = "/path/to/" (path to save the recording to, makes record_file a relative path if provided)

--- a/conf/janus.plugin.audiobridge.jcfg.sample
+++ b/conf/janus.plugin.audiobridge.jcfg.sample
@@ -11,7 +11,7 @@
 # audio_active_packets = 100 (number of packets with audio level, default=100, 2 seconds)
 # audio_level_average = 25 (average value of audio level, 127=muted, 0='too loud', default=25)
 # default_prebuffering = number of packets to buffer before decoding each particiant (default=6)
-# default_expectedloss = percent of packets we expect participants may miss, to help with FEC (default=0; automatically used for forwarders too)
+# default_expectedloss = percent of packets we expect participants may miss, to help with FEC (default=0, max=20; automatically used for forwarders too)
 # record = true|false (whether this room should be recorded, default=false)
 # record_file = "/path/to/recording.wav" (where to save the recording)
 # record_dir = "/path/to/" (path to save the recording to, makes record_file a relative path if provided)

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -39,7 +39,7 @@ room-<unique room ID>: {
 	audio_active_packets = 100 (number of packets with audio level, default=100, 2 seconds)
 	audio_level_average = 25 (average value of audio level, 127=muted, 0='too loud', default=25)
 	default_prebuffering = number of packets to buffer before decoding each participant (default=DEFAULT_PREBUFFERING)
-	default_expectedloss = percent of packets we expect participants may miss, to help with FEC (default=0; automatically used for forwarders too)
+	default_expectedloss = percent of packets we expect participants may miss, to help with FEC (default=0, max=20; automatically used for forwarders too)
 	record = true|false (whether this room should be recorded, default=false)
 	record_file = /path/to/recording.wav (where to save the recording)
 	record_dir = /path/to/ (path to save the recording to, makes record_file a relative path if provided)
@@ -2489,7 +2489,7 @@ int janus_audiobridge_init(janus_callbacks *callback, const char *config_path) {
 			audiobridge->default_expectedloss = 0;
 			if(default_expectedloss != NULL && default_expectedloss->value != NULL) {
 				int expectedloss = atoi(default_expectedloss->value);
-				if(expectedloss < 0 || expectedloss > 100) {
+				if(expectedloss < 0 || expectedloss > 20) {
 					JANUS_LOG(LOG_WARN, "Invalid expectedloss value provided, using default: 0\n");
 				} else {
 					audiobridge->default_expectedloss = expectedloss;
@@ -3096,7 +3096,7 @@ static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_s
 		audiobridge->default_expectedloss = 0;
 		if(default_expectedloss != NULL) {
 			int expectedloss = json_integer_value(default_expectedloss);
-			if(expectedloss > 100) {
+			if(expectedloss > 20) {
 				JANUS_LOG(LOG_WARN, "Invalid expectedloss value provided, using default: 0\n");
 			} else {
 				audiobridge->default_expectedloss = expectedloss;

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -693,7 +693,7 @@ room-<unique room ID>: {
 	"prebuffer" : <number of packets to buffer before decoding this participant (default=room value, or DEFAULT_PREBUFFERING)>,
 	"bitrate" : <bitrate to use for the Opus stream in bps; optional, default=0 (libopus decides)>,
 	"quality" : <0-10, Opus-related complexity to use, the higher the value, the better the quality (but more CPU); optional, default is 4>,
-	"expected_loss" : <0-100, a percentage of the expected loss, only needed in case FEC is used; optional, default is 0 (FEC disabled even when negotiated) or the room default>,
+	"expected_loss" : <0-20, a percentage of the expected loss (capped at 20%), only needed in case FEC is used; optional, default is 0 (FEC disabled even when negotiated) or the room default>,
 	"volume" : <percent value, <100 reduces volume, >100 increases volume; optional, default is 100 (no volume change)>,
 	"spatial_position" : <in case spatial audio is enabled for the room, panning of this participant (0=left, 50=center, 100=right)>,
 	"secret" : "<room management password; optional, if provided the user is an admin and can't be globally muted with mute_room>",
@@ -883,7 +883,7 @@ room-<unique room ID>: {
 	"muted" : <true|false, whether to start unmuted or muted>,
 	"bitrate" : <bitrate to use for the Opus stream in bps; optional, default=0 (libopus decides)>,
 	"quality" : <0-10, Opus-related complexity to use, higher is higher quality; optional, default is 4>,
-	"expected_loss" : <0-100, a percentage of the expected loss, only needed in case FEC is used; optional, default is 0 (FEC disabled even when negotiated) or the room default>
+	"expected_loss" : <0-20, a percentage of the expected loss (capped at 20%), only needed in case FEC is used; optional, default is 0 (FEC disabled even when negotiated) or the room default>
 }
 \endverbatim
  *
@@ -5972,12 +5972,12 @@ static void *janus_audiobridge_handler(void *data) {
 				goto error;
 			}
 			int expected_loss = exploss ? json_integer_value(exploss) : audiobridge->default_expectedloss;
-			if(expected_loss > 100) {
+			if(expected_loss > 20) {
 				janus_mutex_unlock(&audiobridge->mutex);
 				janus_refcount_decrease(&audiobridge->ref);
-				JANUS_LOG(LOG_ERR, "Invalid element (expected_loss should be a positive integer between 0 and 100)\n");
+				JANUS_LOG(LOG_ERR, "Invalid element (expected_loss should be a positive integer between 0 and 20)\n");
 				error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT;
-				g_snprintf(error_cause, 512, "Invalid element (expected_loss should be a positive integer between 0 and 100)");
+				g_snprintf(error_cause, 512, "Invalid element (expected_loss should be a positive integer between 0 and 20)");
 				goto error;
 			}
 			janus_audiocodec codec = JANUS_AUDIOCODEC_OPUS;
@@ -6479,10 +6479,10 @@ static void *janus_audiobridge_handler(void *data) {
 			}
 			if(exploss) {
 				int expected_loss = json_integer_value(exploss);
-				if(expected_loss > 100) {
-					JANUS_LOG(LOG_ERR, "Invalid element (expected_loss should be a positive integer between 0 and 100)\n");
+				if(expected_loss > 20) {
+					JANUS_LOG(LOG_ERR, "Invalid element (expected_loss should be a positive integer between 0 and 20)\n");
 					error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT;
-					g_snprintf(error_cause, 512, "Invalid element (expected_loss should be a positive integer between 0 and 100)");
+					g_snprintf(error_cause, 512, "Invalid element (expected_loss should be a positive integer between 0 and 20)");
 					goto error;
 				}
 				participant->expected_loss = expected_loss;
@@ -6793,13 +6793,13 @@ static void *janus_audiobridge_handler(void *data) {
 				goto error;
 			}
 			int expected_loss = exploss ? json_integer_value(exploss) : audiobridge->default_expectedloss;
-			if(expected_loss > 100) {
+			if(expected_loss > 20) {
 				janus_mutex_unlock(&audiobridge->mutex);
 				janus_refcount_decrease(&audiobridge->ref);
 				janus_mutex_unlock(&rooms_mutex);
-				JANUS_LOG(LOG_ERR, "Invalid element (expected_loss should be a positive integer between 0 and 100)\n");
+				JANUS_LOG(LOG_ERR, "Invalid element (expected_loss should be a positive integer between 0 and 20)\n");
 				error_code = JANUS_AUDIOBRIDGE_ERROR_INVALID_ELEMENT;
-				g_snprintf(error_cause, 512, "Invalid element (expected_loss should be a positive integer between 0 and 100)");
+				g_snprintf(error_cause, 512, "Invalid element (expected_loss should be a positive integer between 0 and 20)");
 				goto error;
 			}
 			guint64 user_id = 0;


### PR DESCRIPTION
While we've been supporting Opus FEC in the AudioBridge for a while, we were not actually using it properly on the way out, that is, on streams encoded by the AudioBridge itself. In fact, the libopus documentation explains that, even when you tell the encoder to use FEC, no FEC will actually be added to packets out of the box: in order for that to happen, you also need to tell the encoder the percentage of packets you expect to be lost after they're sent, so that the encoder can add enough info to help compensate such a loss.

This patch tries to address exactly that. More specifically, it adds new settings you can configure for participants (at join time and dynamically, using "configure") to modify this expected loss property. If FEC is negotiated and `expected_loss` for a participant is set, e.g., to `10`, then the encoder for that participant will indeed add FEC info to packets. I tested this by checking the stats in webrtc-internals, which shows the number of FEC packets that have been received and used: as expected, under normal circumstancies (no losses) I saw many FEC packets being received, and all of them discarded since they were not needed; simulating some loss with iptables did show some of them being used, and I could hear the audio sounding "better".

The PR also adds a per-room default expected loss property: if you don't set anything, it will be 0 (so no FEC added even if negotiated), but you can set it to something higher than that so that by default participants can be configured with some FEC without the need for a per-participant setting. This per-room default is also automatically used for RTP forwarders, which helps when you're actually broadcasting a mixer room somewhere else (e.g., via the Streaming plugin), as that way you'll have some FEC info the subscribers can take advantage of too. Notice we don't have a per-forwarder FEC/loss setting since encoders are shared when forwarders are used, which means we can't set expected loss X on one and Y on another.

I only tested this briefly, so I'm looking forward to feedback from you in case you decide to experiment with this (which you should if you'd like better audio quality in the AudioBridge).