### PR TITLE
Disable slowlink events by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ or on the command line:
 	-W, --slowlink-threshold=number
                                   Number of lost packets (per s) that should
                                   trigger a 'slowlink' Janus API event to users
+                                  (default=0, feature disabled)
 	-r, --rtp-port-range=min-max  Port range to use for RTP/RTCP (only available
 								  if the installed libnice supports it)
 	-B, --twcc-period=number      How often (in ms) to send TWCC feedback back to

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -199,8 +199,8 @@ certificates: {
 # starting MTU for DTLS (1200 by default, it adapts automatically),
 # how much time, in seconds, should pass with no media (audio or
 # video) being received before Janus notifies you about this (default=1s,
-# 0 disables these events entirely), how many lost packets should trigger
-# a 'slowlink' event to users (default=4), and how often, in milliseconds,
+# 0 disables these events entirely), how many lost packets should trigger a
+# 'slowlink' event to users (default=0, disabled), and how often, in milliseconds,
 # to send the Transport Wide Congestion Control feedback information back
 # to senders, if negotiated (default=200ms). Finally, if you're using BoringSSL
 # you can customize the frequency of retransmissions: OpenSSL has a fixed

--- a/ice.c
+++ b/ice.c
@@ -489,8 +489,11 @@ uint janus_get_no_media_timer(void) {
 }
 
 /* Number of lost packets per seconds on a media stream (uplink or downlink,
- * audio or video), that should result in a slow-link event to the iser */
-#define DEFAULT_SLOWLINK_THRESHOLD	4
+ * audio or video), that should result in a slow-link event to the user.
+ * By default the feature is disabled (threshold=0), as it can be quite
+ * verbose and is often redundant information, since the same info on lost
+ * packets (in and out) can already be retrieved via client-side stats */
+#define DEFAULT_SLOWLINK_THRESHOLD	0
 static uint slowlink_threshold = DEFAULT_SLOWLINK_THRESHOLD;
 void janus_set_slowlink_threshold(uint packets) {
 	slowlink_threshold = packets;

--- a/janus.1
+++ b/janus.1
@@ -96,7 +96,7 @@ Minimum size of the NACK queue (in ms) per user for retransmissions, no matter t
 Time (in s) that should pass with no media (audio or video) being received before Janus notifies you about this
 .TP
 .BR \-W ", " \-\-slowlink-threshold=\fInumber\fR
-Number of lost packets (per s) that should trigger a 'slowlink' Janus API event to users
+Number of lost packets (per s) that should trigger a 'slowlink' Janus API event to users (default=0, feature disabled)
 .TP
 .BR \-r ", " \-\-rtp-port-range=\fImin\-max\fR
 Port range to use for RTP/RTCP

--- a/janus.ggo
+++ b/janus.ggo
@@ -25,7 +25,7 @@ option "ice-lite" I "Whether to enable the ICE Lite mode or not" flag off
 option "ice-tcp" T "Whether to enable ICE-TCP or not (warning: only works with ICE Lite)" flag off
 option "min-nack-queue" Q "Minimum size of the NACK queue (in ms) per user for retransmissions, no matter the RTT" int typestr="number" optional
 option "no-media-timer" t "Time (in s) that should pass with no media (audio or video) being received before Janus notifies you about this" int typestr="number" optional
-option "slowlink-threshold" W "Number of lost packets (per s) that should trigger a 'slowlink' Janus API event to users" int typestr="number" optional
+option "slowlink-threshold" W "Number of lost packets (per s) that should trigger a 'slowlink' Janus API event to users (default=0, feature disabled)" int typestr="number" optional
 option "rtp-port-range" r "Port range to use for RTP/RTCP" string typestr="min-max" optional
 option "twcc-period" B "How often (in ms) to send TWCC feedback back to senders, if negotiated (default=200ms)" int typestr="number" optional
 option "server-name" n "Public name of this Janus instance (default=MyJanusInstance)" string typestr="name" optional


### PR DESCRIPTION
This PR changes the default setting for the slowlink threshold, that is the value we use to decide how many lost packets per second should trigger a slowlink event via Janus API (and the related callback in plugins). Previously this value was `4`, meaning that if in or out we detected at least 4 lost packets, we'd trigger a slow link event, and would notify plugins.

We did this originally as a way to provide applications with some info they could use, e.g., to react somehow, but in practice the way it currently works just means an excessively verbose API usage (events spam), which is actually useless and redundant, since clients that have access to client stats can get the same information (actually more) and faster on their own, e,g., via getStats. As such, we decided to disable the feature by default: of course, it can still be enabled in the settings, or dynamically via Admin API, if you need it for anything.

I'm publishing this as a PR and not committing directly as it may have an impact on existing applications, e.g., people actually relying on the event for anything. This should give them time to become aware of this, and explicitly set the value in `janus.jcfg` to whatever they currently use if they weren't doing it already. I plan to merge soon anyway, so in case you have feedback on this please let us know.