### PR TITLE
Solve the media state flag is missing in case of fast renegotiations

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -667,22 +667,39 @@ static int janus_seq_in_range(guint16 seqn, guint16 start, guint16 len) {
 	return (s <= n && n < e) || (s <= nh && nh < e);
 }
 
-/* Checks wether based on the conditions in the stats an update to the mediastate needs to get dispatched
+/* Checks whether based on the conditions in the stats an update to the mediastate needs to get dispatched
  * stats - the stats object we are inspecting
  * now - the current monotonic time
  * targetstate - the state we would like to travers to
  * returns true in case the mediastate shall get send
  */
-gboolean janus_ice_event_check_send_mediastate(janus_ice_stats_info *stats, gint64 now, janus_ice_media_state targetstate) {
+static gboolean janus_ice_event_check_send_mediastate(janus_ice_stats_info *stats, gint64 now, janus_ice_media_state targetstate) {
 	if(targetstate == JANUS_ICE_MEDIA_STATE_UP) {
-		if(stats->bytes == 0 || stats->notified_lastsec || stats->last_notified != JANUS_ICE_MEDIA_STATE_UP)
+		// This method is called when the stream has receive data which is about to get updated within the stats
+		if(stats->bytes == 0) {
+			// First data is beeing received (bytes currently pointing to 0 as we are right after init)
 			return TRUE;
+		} else if(stats->temporarily_down) {
+			// Was notified as temporarily down before
+			return TRUE;
+		} else if(stats->last_notified == JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG && now > stats->send_update_after) {
+			// A SDP change changed the transport for this media (inactive or active again) thus we retransmit the status after time
+			return TRUE;
+		}
 	} else if(targetstate == JANUS_ICE_MEDIA_STATE_DOWN) {
 		gint64 last = stats->updated;
-		if((!stats->notified_lastsec || stats->last_notified != JANUS_ICE_MEDIA_STATE_DOWN) &&
-				last && !stats->bytes_lastsec && !stats->bytes_lastsec_temp &&
-					now-last >= (gint64)no_media_timer*G_USEC_PER_SEC) {
-			return TRUE;
+		if(last && !stats->bytes_lastsec && !stats->bytes_lastsec_temp && now-last >= (gint64)no_media_timer*G_USEC_PER_SEC) {
+			// The stream is currently not receiving any media
+			if(!stats->temporarily_down) {
+				// Was not notified as temporarily down before
+				return true;
+			} else if(stats->last_notified == JANUS_ICE_MEDIA_STATE_UNKNOWN || stats->last_notified == JANUS_ICE_MEDIA_STATE_UP) {
+				// The media state is currently unknown (after init) or notified as up
+				return TRUE;
+			} else if(stats->last_notified == JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG && now > stats->send_update_after) {
+				// A SDP change changed the transport for this media (inactive or active again) thus we retransmit the status after time
+				return TRUE;
+			}
 		}
 	}
 	return FALSE;
@@ -2753,7 +2770,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 					if(!video) {
 						if(janus_ice_event_check_send_mediastate(&component->in_stats.audio, now, JANUS_ICE_MEDIA_STATE_UP)) {
 							/* We either received our first audio packet, or we started receiving it again after missing more than a second */
-							component->in_stats.audio.notified_lastsec = FALSE;
+							component->in_stats.audio.temporarily_down = FALSE;
 							component->in_stats.audio.last_notified = JANUS_ICE_MEDIA_STATE_UP;
 							janus_ice_notify_media(handle, FALSE, 0, TRUE);
 						}
@@ -2773,7 +2790,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 					} else {
 						if(janus_ice_event_check_send_mediastate(&component->in_stats.video[vindex], now, JANUS_ICE_MEDIA_STATE_UP)) {
 							/* We either received our first video packet, or we started receiving it again after missing more than a second */
-							component->in_stats.video[vindex].notified_lastsec = FALSE;
+							component->in_stats.video[vindex].temporarily_down = FALSE;
 							component->in_stats.video[vindex].last_notified = JANUS_ICE_MEDIA_STATE_UP;
 							janus_ice_notify_media(handle, TRUE, vindex, TRUE);
 						}
@@ -4182,7 +4199,7 @@ static gboolean janus_ice_outgoing_stats_handle(gpointer user_data) {
 		/* Audio */
 		if(janus_ice_event_check_send_mediastate(&component->in_stats.audio, now, JANUS_ICE_MEDIA_STATE_DOWN)) {
 			/* We missed more than no_second_timer seconds of audio! */
-			component->in_stats.audio.notified_lastsec = TRUE;
+			component->in_stats.audio.temporarily_down = TRUE;
 			component->in_stats.audio.last_notified = JANUS_ICE_MEDIA_STATE_DOWN;
 			JANUS_LOG(LOG_WARN, "[%"SCNu64"] Didn't receive audio for more than %d seconds...\n", handle->handle_id, no_media_timer);
 			janus_ice_notify_media(handle, FALSE, 0, FALSE);
@@ -4192,7 +4209,7 @@ static gboolean janus_ice_outgoing_stats_handle(gpointer user_data) {
 		for(vindex=0; vindex<3; vindex++) {
 			if(janus_ice_event_check_send_mediastate(&component->in_stats.video[vindex], now, JANUS_ICE_MEDIA_STATE_DOWN)) {
 				/* We missed more than no_second_timer seconds of this video stream! */
-				component->in_stats.video[vindex].notified_lastsec = TRUE;
+				component->in_stats.video[vindex].temporarily_down = TRUE;
 				component->in_stats.video[vindex].last_notified = JANUS_ICE_MEDIA_STATE_DOWN;
 				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Didn't receive video #%d for more than a second...\n", handle->handle_id, vindex);
 				janus_ice_notify_media(handle, TRUE, vindex, FALSE);

--- a/ice.c
+++ b/ice.c
@@ -2772,6 +2772,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 							/* We either received our first audio packet, or we started receiving it again after missing more than a second */
 							component->in_stats.audio.temporarily_down = FALSE;
 							component->in_stats.audio.last_notified = JANUS_ICE_MEDIA_STATE_UP;
+							component->in_stats.audio.send_update_after = 0;
 							janus_ice_notify_media(handle, FALSE, 0, TRUE);
 						}
 						/* Overall audio data */
@@ -2792,6 +2793,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 							/* We either received our first video packet, or we started receiving it again after missing more than a second */
 							component->in_stats.video[vindex].temporarily_down = FALSE;
 							component->in_stats.video[vindex].last_notified = JANUS_ICE_MEDIA_STATE_UP;
+							component->in_stats.video[vindex].send_update_after = 0;
 							janus_ice_notify_media(handle, TRUE, vindex, TRUE);
 						}
 						/* Overall video data for this SSRC */
@@ -4201,6 +4203,7 @@ static gboolean janus_ice_outgoing_stats_handle(gpointer user_data) {
 			/* We missed more than no_second_timer seconds of audio! */
 			component->in_stats.audio.temporarily_down = TRUE;
 			component->in_stats.audio.last_notified = JANUS_ICE_MEDIA_STATE_DOWN;
+			component->in_stats.audio.send_update_after = 0;
 			JANUS_LOG(LOG_WARN, "[%"SCNu64"] Didn't receive audio for more than %d seconds...\n", handle->handle_id, no_media_timer);
 			janus_ice_notify_media(handle, FALSE, 0, FALSE);
 		}
@@ -4211,6 +4214,7 @@ static gboolean janus_ice_outgoing_stats_handle(gpointer user_data) {
 				/* We missed more than no_second_timer seconds of this video stream! */
 				component->in_stats.video[vindex].temporarily_down = TRUE;
 				component->in_stats.video[vindex].last_notified = JANUS_ICE_MEDIA_STATE_DOWN;
+				component->in_stats.video[vindex].send_update_after = 0;
 				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Didn't receive video #%d for more than a second...\n", handle->handle_id, vindex);
 				janus_ice_notify_media(handle, TRUE, vindex, FALSE);
 			}

--- a/ice.c
+++ b/ice.c
@@ -682,7 +682,7 @@ static gboolean janus_ice_event_check_send_mediastate(janus_ice_stats_info *stat
 		} else if(stats->last_notified == JANUS_ICE_MEDIA_STATE_DOWN) {
 			// Was notified as temporarily down before
 			return TRUE;
-		} else if(stats->last_notified == JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG && now > stats->send_update_after) {
+		} else if(stats->last_notified == JANUS_ICE_MEDIA_STATE_UPDATE_PENDING && now > stats->send_update_after) {
 			// A SDP change changed the transport for this media (inactive or active again) thus we retransmit the status after time
 			return TRUE;
 		}
@@ -693,7 +693,7 @@ static gboolean janus_ice_event_check_send_mediastate(janus_ice_stats_info *stat
 			if(stats->last_notified == JANUS_ICE_MEDIA_STATE_UNKNOWN || stats->last_notified == JANUS_ICE_MEDIA_STATE_UP) {
 				// The media state is currently unknown (after init) or notified as up
 				return TRUE;
-			} else if(stats->last_notified == JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG && now > stats->send_update_after) {
+			} else if(stats->last_notified == JANUS_ICE_MEDIA_STATE_UPDATE_PENDING && now > stats->send_update_after) {
 				// A SDP change changed the transport for this media (inactive or active again) thus we retransmit the status after time
 				return TRUE;
 			}

--- a/ice.h
+++ b/ice.h
@@ -284,7 +284,7 @@ typedef struct janus_ice_stats_info {
 	/*! \brief Time we last updated the last second counter */
 	gint64 updated;
 	/*! \brief Whether or not we notified about lastsec issues already */
-	gboolean notified_lastsec;
+	gboolean temporarily_down;
 	/*! \brief This is the state we have notified before */
 	janus_ice_media_state last_notified;
 	/*! \brief Stores the timestamp when the media state has to get resend if last_notified is set to JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG */

--- a/ice.h
+++ b/ice.h
@@ -262,9 +262,14 @@ typedef struct janus_ice_trickle janus_ice_trickle;
 
 /*! \brief The information about the media state (are we sending receiving, are we down or are we unknown (after an sdp exchange) */
 typedef enum janus_ice_media_state {
+	/* Default state if the object is initialized */
 	JANUS_ICE_MEDIA_STATE_UNKNOWN = 0,
+	/* Media is currently transported, the api signalled media receiving: true */
 	JANUS_ICE_MEDIA_STATE_UP = 1,
-	JANUS_ICE_MEDIA_STATE_DOWN = 2
+	/* Media is currently not transported, the api signalled media receiving: false */
+	JANUS_ICE_MEDIA_STATE_DOWN = 2,
+	/* The SDP has changed an forces an update or resend of the status after time */
+	JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG = 3,
 } janus_ice_media_state;
 
 /*! \brief Janus media statistics
@@ -282,6 +287,8 @@ typedef struct janus_ice_stats_info {
 	gboolean notified_lastsec;
 	/*! \brief This is the state we have notified before */
 	janus_ice_media_state last_notified;
+	/*! \brief Stores the timestamp when the media state has to get resend if last_notified is set to JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG */
+	gint64 send_update_after;
 	/*! \brief Number of NACKs sent or received */
 	guint32 nacks;
 } janus_ice_stats_info;

--- a/ice.h
+++ b/ice.h
@@ -260,6 +260,12 @@ typedef struct janus_ice_trickle janus_ice_trickle;
 #define JANUS_ICE_HANDLE_WEBRTC_NEW_DATACHAN_SDP	(1 << 20)
 #define JANUS_ICE_HANDLE_WEBRTC_E2EE				(1 << 21)
 
+/*! \brief The information about the media state (are we sending receiving, are we down or are we unknown (after an sdp exchange) */
+typedef enum janus_ice_media_state {
+	JANUS_ICE_MEDIA_STATE_UNKNOWN = 0,
+	JANUS_ICE_MEDIA_STATE_UP = 1,
+	JANUS_ICE_MEDIA_STATE_DOWN = 2
+} janus_ice_media_state;
 
 /*! \brief Janus media statistics
  * \note To improve with more stuff */
@@ -274,6 +280,8 @@ typedef struct janus_ice_stats_info {
 	gint64 updated;
 	/*! \brief Whether or not we notified about lastsec issues already */
 	gboolean notified_lastsec;
+	/*! \brief This is the state we have notified before */
+	janus_ice_media_state last_notified;
 	/*! \brief Number of NACKs sent or received */
 	guint32 nacks;
 } janus_ice_stats_info;

--- a/ice.h
+++ b/ice.h
@@ -283,8 +283,6 @@ typedef struct janus_ice_stats_info {
 	guint32 bytes_lastsec, bytes_lastsec_temp;
 	/*! \brief Time we last updated the last second counter */
 	gint64 updated;
-	/*! \brief Whether or not we notified about lastsec issues already */
-	gboolean temporarily_down;
 	/*! \brief This is the state we have notified before */
 	janus_ice_media_state last_notified;
 	/*! \brief Stores the timestamp when the media state has to get resend if last_notified is set to JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG */

--- a/ice.h
+++ b/ice.h
@@ -269,7 +269,7 @@ typedef enum janus_ice_media_state {
 	/* Media is currently not transported, the api signalled media receiving: false */
 	JANUS_ICE_MEDIA_STATE_DOWN = 2,
 	/* The SDP has changed an forces an update or resend of the status after time */
-	JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG = 3,
+	JANUS_ICE_MEDIA_STATE_UPDATE_PENDING = 3,
 } janus_ice_media_state;
 
 /*! \brief Janus media statistics

--- a/sdp.c
+++ b/sdp.c
@@ -180,6 +180,7 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean rids_hml
 						stream->audio_rtcp_ctx->tb = 48000;	/* May change later */
 					}
 				}
+				gboolean audio_recv_old = stream->audio_recv;
 				switch(m->direction) {
 					case JANUS_SDP_INACTIVE:
 					case JANUS_SDP_INVALID:
@@ -202,6 +203,13 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean rids_hml
 						stream->audio_send = TRUE;
 						stream->audio_recv = TRUE;
 						break;
+				}
+				if(audio_recv_old != stream->audio_recv) {
+					/* The audio state has changed
+	 				 * -> we need to rest the last notified so that the media state is properly signalled again */
+					stream->component->in_stats.audio.last_notified = JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG;
+					/* returns uSeconds -> +2000000 = 2 seconds */
+					stream->component->in_stats.audio.send_update_after = janus_get_monotonic_time() + 2000000;
 				}
 				if(m->ptypes != NULL) {
 					g_list_free(stream->audio_payload_types);
@@ -230,6 +238,7 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean rids_hml
 						stream->video_rtcp_ctx[0]->tb = 90000;	/* May change later */
 					}
 				}
+				gboolean video_recv_old = stream->video_recv;
 				switch(m->direction) {
 					case JANUS_SDP_INACTIVE:
 					case JANUS_SDP_INVALID:
@@ -252,6 +261,13 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean rids_hml
 						stream->video_send = TRUE;
 						stream->video_recv = TRUE;
 						break;
+				}
+				if(video_recv_old != stream->video_recv) {
+					/* The video state has changed
+	 				 * -> we need to rest the last notified so that the media state is properly signalled again */
+					stream->component->in_stats.video[0].last_notified = JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG;
+					/* returns uSeconds -> +2000000 = 2 seconds */
+					stream->component->in_stats.video[0].send_update_after = janus_get_monotonic_time() + 2000000;
 				}
 				if(m->ptypes != NULL) {
 					g_list_free(stream->video_payload_types);

--- a/sdp.c
+++ b/sdp.c
@@ -207,7 +207,7 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean rids_hml
 				if(audio_recv_old != stream->audio_recv) {
 					/* The audio state has changed
 	 				 * -> we need to rest the last notified so that the media state is properly signalled again */
-					stream->component->in_stats.audio.last_notified = JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG;
+					stream->component->in_stats.audio.last_notified = JANUS_ICE_MEDIA_STATE_UPDATE_PENDING;
 					/* returns uSeconds -> +2000000 = 2 seconds */
 					stream->component->in_stats.audio.send_update_after = janus_get_monotonic_time() + 2000000;
 				}
@@ -265,7 +265,7 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean rids_hml
 				if(video_recv_old != stream->video_recv) {
 					/* The video state has changed
 	 				 * -> we need to rest the last notified so that the media state is properly signalled again */
-					stream->component->in_stats.video[0].last_notified = JANUS_ICE_MEDIA_STATE_UPDATE_PENDIG;
+					stream->component->in_stats.video[0].last_notified = JANUS_ICE_MEDIA_STATE_UPDATE_PENDING;
 					/* returns uSeconds -> +2000000 = 2 seconds */
 					stream->component->in_stats.video[0].send_update_after = janus_get_monotonic_time() + 2000000;
 				}


### PR DESCRIPTION
This is an idea how to retransmit the media state in case the connection is renegotiating.
I don´t know where the sdp is handshaked so how it would be possible to set the flag to unknown.