### PR TITLE
Added basic history support to TextRoom plugin

### DIFF
--- a/conf/janus.plugin.textroom.jcfg.sample
+++ b/conf/janus.plugin.textroom.jcfg.sample
@@ -3,6 +3,7 @@
 # is_private = true|false (whether this room should be in the public list, default=true)
 # secret = <optional password needed for manipulating (e.g. destroying) the room>
 # pin = <optional password needed for joining the room>
+# history = <number of messages to store as a history, and send back to new participants (default=0, no history)>
 # post = <optional backend to contact via HTTP post for all incoming messages>
 #}
 
@@ -24,5 +25,6 @@ room-1234: {
 	# is_private = true
 	secret = "adminpwd"
 	# pin = "roompwd"
+	# history = 10
 	# post = "http://example.com/forward/here"
 }

--- a/html/textroomtest.js
+++ b/html/textroomtest.js
@@ -157,7 +157,7 @@ $(document).ready(function() {
 										var from = json["from"];
 										var dateString = getDateString(json["date"]);
 										var whisper = json["whisper"];
-										var sender = participants[from] ? participants[from] : json["display"];
+										var sender = participants[from] ? participants[from] : escapeXmlTags(json["display"]);
 										if(whisper === true) {
 											// Private message
 											$('#chatroom').append('<p style="color: purple;">[' + dateString + '] <b>[whisper from ' + sender + ']</b> ' + msg);

--- a/html/textroomtest.js
+++ b/html/textroomtest.js
@@ -159,13 +159,14 @@ $(document).ready(function() {
 										var from = json["from"];
 										var dateString = getDateString(json["date"]);
 										var whisper = json["whisper"];
+										var sender = participants[from] ? participants[from] : json["display"];
 										if(whisper === true) {
 											// Private message
-											$('#chatroom').append('<p style="color: purple;">[' + dateString + '] <b>[whisper from ' + participants[from] + ']</b> ' + msg);
+											$('#chatroom').append('<p style="color: purple;">[' + dateString + '] <b>[whisper from ' + sender + ']</b> ' + msg);
 											$('#chatroom').get(0).scrollTop = $('#chatroom').get(0).scrollHeight;
 										} else {
 											// Public message
-											$('#chatroom').append('<p>[' + dateString + '] <b>' + participants[from] + ':</b> ' + msg);
+											$('#chatroom').append('<p>[' + dateString + '] <b>' + sender + ':</b> ' + msg);
 											$('#chatroom').get(0).scrollTop = $('#chatroom').get(0).scrollHeight;
 										}
 									} else if(what === "announcement") {


### PR DESCRIPTION
As the title says, this PR adds basic support for history: if you configure a new room to hold a history of X messages, then incoming messages and announcements will be stored; when the queue is full, older messages are discarded. New users joining are then sent those messages as soon as they join (unless they ask not to).

I have done some basic testing and it seems to be working as expected, but you may of course want to test this more extensively if it's something you care about.