### PR TITLE
Fix potential Cross-site Scripting (XSS) exploits in demos

### DIFF
--- a/html/audiobridgetest.js
+++ b/html/audiobridgetest.js
@@ -178,7 +178,7 @@ $(document).ready(function() {
 												Janus.debug("Got a list of participants:", list);
 												for(var f in list) {
 													var id = list[f]["id"];
-													var display = list[f]["display"];
+													var display = escapeXmlTags(list[f]["display"]);
 													var setup = list[f]["setup"];
 													var muted = list[f]["muted"];
 													var spatial = list[f]["spatial_position"];
@@ -222,7 +222,7 @@ $(document).ready(function() {
 												Janus.debug("Got a list of participants:", list);
 												for(var f in list) {
 													var id = list[f]["id"];
-													var display = list[f]["display"];
+													var display = escapeXmlTags(list[f]["display"]);
 													var setup = list[f]["setup"];
 													var muted = list[f]["muted"];
 													var spatial = list[f]["spatial_position"];
@@ -267,7 +267,7 @@ $(document).ready(function() {
 												Janus.debug("Got a list of participants:", list);
 												for(var f in list) {
 													var id = list[f]["id"];
-													var display = list[f]["display"];
+													var display = escapeXmlTags(list[f]["display"]);
 													var setup = list[f]["setup"];
 													var muted = list[f]["muted"];
 													var spatial = list[f]["spatial_position"];
@@ -429,7 +429,7 @@ function registerUsername() {
 			return;
 		}
 		var register = { request: "join", room: myroom, display: username };
-		myusername = username;
+		myusername = escapeXmlTags(username);
 		// Check if we need to join using G.711 instead of (default) Opus
 		if(acodec === 'opus' || acodec === 'pcmu' || acodec === 'pcma')
 			register.codec = acodec;
@@ -447,4 +447,13 @@ function getQueryStringValue(name) {
 	var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
 		results = regex.exec(location.search);
 	return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+}
+
+// Helper to escape XML tags
+function escapeXmlTags(value) {
+	if(value) {
+		var escapedValue = value.replace(new RegExp('<', 'g'), '&lt');
+		escapedValue = escapedValue.replace(new RegExp('>', 'g'), '&gt');
+		return escapedValue;
+	}
 }

--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -423,11 +423,11 @@ function updateRecsList() {
 			Janus.debug("Got a list of available recordings:", list);
 			for(var mp in list) {
 				Janus.debug("  >> [" + list[mp]["id"] + "] " + list[mp]["name"] + " (" + list[mp]["date"] + ")");
-				$('#recslist').append("<li><a href='#' id='" + list[mp]["id"] + "'>" + list[mp]["name"] + " [" + list[mp]["date"] + "]" + "</a></li>");
+				$('#recslist').append("<li><a href='#' id='" + list[mp]["id"] + "'>" + escapeXmlTags(list[mp]["name"]) + " [" + list[mp]["date"] + "]" + "</a></li>");
 			}
 			$('#recslist a').unbind('click').click(function() {
 				selectedRecording = $(this).attr("id");
-				selectedRecordingInfo = $(this).text();
+				selectedRecordingInfo = escapeXmlTags($(this).text());
 				$('#recset').html($(this).html()).parent().removeClass('open');
 				$('#play').removeAttr('disabled').click(startPlayout);
 				return false;
@@ -544,4 +544,13 @@ function getQueryStringValue(name) {
 	var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
 		results = regex.exec(location.search);
 	return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+}
+
+// Helper to escape XML tags
+function escapeXmlTags(value) {
+	if(value) {
+		var escapedValue = value.replace(new RegExp('<', 'g'), '&lt');
+		escapedValue = escapedValue.replace(new RegExp('>', 'g'), '&gt');
+		return escapedValue;
+	}
 }

--- a/html/screensharingtest.js
+++ b/html/screensharingtest.js
@@ -161,7 +161,7 @@ $(document).ready(function() {
 										if(event === "joined") {
 											myid = msg["id"];
 											$('#session').html(room);
-											$('#title').html(msg["description"]);
+											$('#title').html(escapeXmlTags(msg["description"]));
 											Janus.log("Successfully joined room " + msg["room"] + " with ID " + myid);
 											if(role === "publisher") {
 												// This is our session, publish our stream
@@ -513,4 +513,13 @@ function newRemoteFeed(id, display) {
 				spinner = null;
 			}
 		});
+}
+
+// Helper to escape XML tags
+function escapeXmlTags(value) {
+	if(value) {
+		var escapedValue = value.replace(new RegExp('<', 'g'), '&lt');
+		escapedValue = escapedValue.replace(new RegExp('>', 'g'), '&gt');
+		return escapedValue;
+	}
 }

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -323,7 +323,7 @@ function updateStreamsList() {
 			Janus.debug(list);
 			for(var mp in list) {
 				Janus.debug("  >> [" + list[mp]["id"] + "] " + list[mp]["description"] + " (" + list[mp]["type"] + ")");
-				$('#streamslist').append("<li><a href='#' id='" + list[mp]["id"] + "'>" + list[mp]["description"] + " (" + list[mp]["type"] + ")" + "</a></li>");
+				$('#streamslist').append("<li><a href='#' id='" + list[mp]["id"] + "'>" + escapeXmlTags(list[mp]["description"]) + " (" + list[mp]["type"] + ")" + "</a></li>");
 			}
 			$('#streamslist a').unbind('click').click(function() {
 				selectedStream = $(this).attr("id");
@@ -345,7 +345,7 @@ function getStreamInfo() {
 	var body = { request: "info", id: parseInt(selectedStream) || selectedStream };
 	streaming.send({ message: body, success: function(result) {
 		if(result && result.info && result.info.metadata) {
-			$('#metadata').html(result.info.metadata);
+			$('#metadata').html(escapeXmlTags(result.info.metadata));
 			$('#info').removeClass('hide').show();
 		}
 	}});
@@ -392,6 +392,15 @@ function stopStream() {
 	$('#curres').empty().hide();
 	$('#simulcast').remove();
 	simulcastStarted = false;
+}
+
+// Helper to escape XML tags
+function escapeXmlTags(value) {
+	if(value) {
+		var escapedValue = value.replace(new RegExp('<', 'g'), '&lt');
+		escapedValue = escapedValue.replace(new RegExp('>', 'g'), '&gt');
+		return escapedValue;
+	}
 }
 
 // Helpers to create Simulcast-related UI, if enabled

--- a/html/textroomtest.js
+++ b/html/textroomtest.js
@@ -153,9 +153,7 @@ $(document).ready(function() {
 									var what = json["textroom"];
 									if(what === "message") {
 										// Incoming message: public or private?
-										var msg = json["text"];
-										msg = msg.replace(new RegExp('<', 'g'), '&lt');
-										msg = msg.replace(new RegExp('>', 'g'), '&gt');
+										var msg = escapeXmlTags(json["text"]);
 										var from = json["from"];
 										var dateString = getDateString(json["date"]);
 										var whisper = json["whisper"];
@@ -170,9 +168,7 @@ $(document).ready(function() {
 										}
 									} else if(what === "announcement") {
 										// Room announcement
-										var msg = json["text"];
-										msg = msg.replace(new RegExp('<', 'g'), '&lt');
-										msg = msg.replace(new RegExp('>', 'g'), '&gt');
+										var msg = escapeXmlTags(json["text"]);
 										var dateString = getDateString(json["date"]);
 										$('#chatroom').append('<p style="color: purple;">[' + dateString + '] <i>' + msg + '</i>');
 										$('#chatroom').get(0).scrollTop = $('#chatroom').get(0).scrollHeight;
@@ -180,7 +176,7 @@ $(document).ready(function() {
 										// Somebody joined
 										var username = json["username"];
 										var display = json["display"];
-										participants[username] = display ? display : username;
+										participants[username] = escapeXmlTags(display ? display : username);
 										if(username !== myid && $('#rp' + username).length === 0) {
 											// Add to the participants list
 											$('#list').append('<li id="rp' + username + '" class="list-group-item">' + participants[username] + '</li>');
@@ -282,7 +278,7 @@ function registerUsername() {
 			username: myid,
 			display: username
 		};
-		myusername = username;
+		myusername = escapeXmlTags(username);
 		transactions[transaction] = function(response) {
 			if(response["textroom"] === "error") {
 				// Something went wrong
@@ -312,7 +308,7 @@ function registerUsername() {
 			if(response.participants && response.participants.length > 0) {
 				for(var i in response.participants) {
 					var p = response.participants[i];
-					participants[p.username] = p.display ? p.display : p.username;
+					participants[p.username] = escapeXmlTags(p.display ? p.display : p.username);
 					if(p.username !== myid && $('#rp' + p.username).length === 0) {
 						// Add to the participants list
 						$('#list').append('<li id="rp' + p.username + '" class="list-group-item">' + participants[p.username] + '</li>');
@@ -417,4 +413,13 @@ function getQueryStringValue(name) {
 	var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
 		results = regex.exec(location.search);
 	return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+}
+
+// Helper to escape XML tags
+function escapeXmlTags(value) {
+	if(value) {
+		var escapedValue = value.replace(new RegExp('<', 'g'), '&lt');
+		escapedValue = escapedValue.replace(new RegExp('>', 'g'), '&gt');
+		return escapedValue;
+	}
 }

--- a/html/videocalltest.js
+++ b/html/videocalltest.js
@@ -148,7 +148,7 @@ $(document).ready(function() {
 										} else if(result["event"]) {
 											var event = result["event"];
 											if(event === 'registered') {
-												myusername = result["username"];
+												myusername = escapeXmlTags(result["username"]);
 												Janus.log("Successfully registered as " + myusername + "!");
 												$('#youok').removeClass('hide').show().html("Registered as '" + myusername + "'");
 												// Get a list of available peers, just for fun
@@ -163,7 +163,7 @@ $(document).ready(function() {
 												bootbox.alert("Waiting for the peer to answer...");
 											} else if(event === 'incomingcall') {
 												Janus.log("Incoming call from " + result["username"] + "!");
-												yourusername = result["username"];
+												yourusername = escapeXmlTags(result["username"]);
 												// Notify user
 												bootbox.hideAll();
 												incoming = bootbox.dialog({
@@ -213,7 +213,7 @@ $(document).ready(function() {
 												});
 											} else if(event === 'accepted') {
 												bootbox.hideAll();
-												var peer = result["username"];
+												var peer = escapeXmlTags(result["username"]);
 												if(!peer) {
 													Janus.log("Call started!");
 												} else {
@@ -596,6 +596,15 @@ function getQueryStringValue(name) {
 	var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
 		results = regex.exec(location.search);
 	return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+}
+
+// Helper to escape XML tags
+function escapeXmlTags(value) {
+	if(value) {
+		var escapedValue = value.replace(new RegExp('<', 'g'), '&lt');
+		escapedValue = escapedValue.replace(new RegExp('>', 'g'), '&gt');
+		return escapedValue;
+	}
 }
 
 // Helpers to create Simulcast-related UI, if enabled

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -400,7 +400,7 @@ function registerUsername() {
 			ptype: "publisher",
 			display: username
 		};
-		myusername = username;
+		myusername = escapeXmlTags(username);
 		sfutest.send({ message: register });
 	}
 }
@@ -530,7 +530,7 @@ function newRemoteFeed(id, display, audio, video) {
 							}
 						}
 						remoteFeed.rfid = msg["id"];
-						remoteFeed.rfdisplay = msg["display"];
+						remoteFeed.rfdisplay = escapeXmlTags(msg["display"]);
 						if(!remoteFeed.spinner) {
 							var target = document.getElementById('videoremote'+remoteFeed.rfindex);
 							remoteFeed.spinner = new Spinner({top:100}).spin(target);
@@ -683,6 +683,15 @@ function getQueryStringValue(name) {
 	var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
 		results = regex.exec(location.search);
 	return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+}
+
+// Helper to escape XML tags
+function escapeXmlTags(value) {
+	if(value) {
+		var escapedValue = value.replace(new RegExp('<', 'g'), '&lt');
+		escapedValue = escapedValue.replace(new RegExp('>', 'g'), '&gt');
+		return escapedValue;
+	}
 }
 
 // Helpers to create Simulcast-related UI, if enabled

--- a/html/vp9svctest.js
+++ b/html/vp9svctest.js
@@ -387,7 +387,7 @@ function registerUsername() {
 			ptype: "publisher",
 			display: username
 		};
-		myusername = username;
+		myusername = escapeXmlTags(username);
 		sfutest.send({ message: register });
 	}
 }
@@ -486,7 +486,7 @@ function newRemoteFeed(id, display, audio, video) {
 							}
 						}
 						remoteFeed.rfid = msg["id"];
-						remoteFeed.rfdisplay = msg["display"];
+						remoteFeed.rfdisplay = escapeXmlTags(msg["display"]);
 						if(!remoteFeed.spinner) {
 							var target = document.getElementById('videoremote'+remoteFeed.rfindex);
 							remoteFeed.spinner = new Spinner({top:100}).spin(target);
@@ -628,6 +628,15 @@ function newRemoteFeed(id, display, audio, video) {
 				$('#layers'+remoteFeed.rfindex).addClass('hide');
 			}
 		});
+}
+
+// Helper to escape XML tags
+function escapeXmlTags(value) {
+	if(value) {
+		var escapedValue = value.replace(new RegExp('<', 'g'), '&lt');
+		escapedValue = escapedValue.replace(new RegExp('>', 'g'), '&gt');
+		return escapedValue;
+	}
 }
 
 // Helpers to create SVC-related UI for a new viewer


### PR DESCRIPTION
This patch addresses an issue in the TextRoom demo found by @SoufElhabti (thanks!). Specifically, while we were escaping incoming messages before adding them to the page, we weren't doing the same for display names: since they would be added to the HTML as-is as well, this could cause bad things to happen. See CVE-2021-4020 for details.

This patch fixes that vulnerability in the demo, but it also got me thinking about other demos, where we do similar things with display names, descriptions, etc.  In some demos we have checks on what you can put in a display name (e.g., by enforcing alphanumeric values), but those don't protect you from users joining via other means (e.g,, a webpage accessing the same VideoRoom but without the check). As such, I've modified the other demos as well to escape those values that may need it.

I've already updated the demos online with the fix, so it shouldn't be an issue anymore for people using those. I'm planning to merge this patch soon, so please let me know if I missed some file/value.