### PR TITLE
Send receiving:false notifications right after renegotiating (see #2807 and #2808)

### DIFF
--- a/ice.h
+++ b/ice.h
@@ -697,6 +697,9 @@ void janus_ice_relay_sctp(janus_ice_handle *handle, char *buffer, int length);
 /*! \brief Plugin SCTP/DataChannel callback, called by the SCTP stack when data can be written
  * @param[in] handle The Janus ICE handle associated with the peer */
 void janus_ice_notify_data_ready(janus_ice_handle *handle);
+/*! \brief Core SDP callback, called by the SDP stack when a stream has been paused by a negotiation
+ * @param[in] handle The Janus ICE handle associated with the peer */
+void janus_ice_notify_media_stopped(janus_ice_handle *handle);
 ///@}
 
 

--- a/sdp.c
+++ b/sdp.c
@@ -180,6 +180,7 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean rids_hml
 						stream->audio_rtcp_ctx->tb = 48000;	/* May change later */
 					}
 				}
+				gboolean receiving = (stream->audio_recv == TRUE);
 				switch(m->direction) {
 					case JANUS_SDP_INACTIVE:
 					case JANUS_SDP_INVALID:
@@ -203,6 +204,8 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean rids_hml
 						stream->audio_recv = TRUE;
 						break;
 				}
+				if(receiving != stream->audio_recv)
+					janus_ice_notify_media_stopped(handle);
 				if(m->ptypes != NULL) {
 					g_list_free(stream->audio_payload_types);
 					stream->audio_payload_types = g_list_copy(m->ptypes);
@@ -230,6 +233,7 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean rids_hml
 						stream->video_rtcp_ctx[0]->tb = 90000;	/* May change later */
 					}
 				}
+				gboolean receiving = (stream->video_recv == TRUE);
 				switch(m->direction) {
 					case JANUS_SDP_INACTIVE:
 					case JANUS_SDP_INVALID:
@@ -253,6 +257,8 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean rids_hml
 						stream->video_recv = TRUE;
 						break;
 				}
+				if(receiving != stream->video_recv)
+					janus_ice_notify_media_stopped(handle);
 				if(m->ptypes != NULL) {
 					g_list_free(stream->video_payload_types);
 					stream->video_payload_types = g_list_copy(m->ptypes);
@@ -1328,6 +1334,7 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 				stream->audio_ssrc = 0;
 			}
 			if(audio == 1) {
+				gboolean receiving = (stream->audio_recv == TRUE);
 				switch(m->direction) {
 					case JANUS_SDP_INACTIVE:
 						stream->audio_send = FALSE;
@@ -1348,6 +1355,8 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 						stream->audio_recv = TRUE;
 						break;
 				}
+				if(receiving != stream->audio_recv)
+					janus_ice_notify_media_stopped(handle);
 			}
 		} else if(m->type == JANUS_SDP_VIDEO) {
 			video++;
@@ -1361,6 +1370,7 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 				stream->video_ssrc = 0;
 			}
 			if(video == 1) {
+				gboolean receiving = (stream->video_recv == TRUE);
 				switch(m->direction) {
 					case JANUS_SDP_INACTIVE:
 						stream->video_send = FALSE;
@@ -1381,6 +1391,8 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 						stream->video_recv = TRUE;
 						break;
 				}
+				if(receiving != stream->video_recv)
+					janus_ice_notify_media_stopped(handle);
 				if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX)) {
 					/* Add RFC4588 stuff */
 					if(stream->rtx_payload_types && g_hash_table_size(stream->rtx_payload_types) > 0) {


### PR DESCRIPTION
This PR should address #2807, and is an alternative approach to #2808. Specifically, it tries to ensure that any time Janus is aware of a renegotiation that disables incoming media, a `receiving:false` notification for that medium is sent right away (a bit like we do when we start receiving media after a while, on the first incoming packet). As such, it also implicitly addresses the missing `receiving:true` notification when a further renegotiation adds incoming media back in (triggered again by the first incoming packet). This should also be easier to port to multistream, since it makes use of a generic event the loop can intercept and operate upon.

I tested this with the EchoTest plugin, by replicating a quick removeVideo/addVideo transition, and it seems to be working as expected. That said, further testing should be done. Pinging @JanFellner as the main reporter of both issue and original PR.