### PR TITLE
Fix syntax error in VideoRoom

### DIFF
--- a/conf/janus.plugin.videoroom.jcfg.sample
+++ b/conf/janus.plugin.videoroom.jcfg.sample
@@ -6,7 +6,7 @@
 # require_pvtid = true|false (whether subscriptions are required to provide a valid private_id
 #			to associate with a publisher, default=false)
 # signed_tokens = true|false (whether access to the room requires signed tokens; default=false,
-			only works if signed tokens are used in the core as well)
+#			only works if signed tokens are used in the core as well)
 # publishers = <max number of concurrent senders> (e.g., 6 for a video
 #              conference or 1 for a webinar)
 # bitrate = <max video bitrate for senders> (e.g., 128000)


### PR DESCRIPTION
This fixes the bad comment (missing #) in [janus.plugin.videoroom.jcfg.sample](https://github.com/meetecho/janus-gateway/blob/98eaaef2216b596844b06e0d655ee6d237fe5e83/conf/janus.plugin.videoroom.jcfg.sample#L9) that was introduced a few days ago in #2825, causing a syntax error with VideoRoom.