### PR TITLE
Ext orientation video recording sip

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4141,8 +4141,8 @@ static void *janus_sip_handler(void *data) {
 			char custom_headers[2048];
 			janus_sip_parse_custom_headers(root, (char *)&custom_headers, sizeof(custom_headers));
 			nua_respond(session->stack->s_nh_i, response_code, sip_status_phrase(response_code),
-				    TAG_IF(strlen(custom_headers) > 0, SIPTAG_HEADER_STR(custom_headers)),
-				    TAG_END());
+					TAG_IF(strlen(custom_headers) > 0, SIPTAG_HEADER_STR(custom_headers)),
+					TAG_END());
 			janus_mutex_lock(&session->mutex);
 			/* Also notify event handlers */
 			if(notify_events && gateway->events_is_enabled()) {
@@ -4491,10 +4491,10 @@ static void *janus_sip_handler(void *data) {
 							}
 						}
 
-                        /* If the video-orientation extension has been negotiated, mark it in the recording */
-                        if (session->media.video_orientation_extension_id > 0) {
-                        	janus_recorder_add_extmap(session->vrc_peer, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
-                        }
+						/* If the video-orientation extension has been negotiated, mark it in the recording */
+						if (session->media.video_orientation_extension_id > 0) {
+							janus_recorder_add_extmap(session->vrc_peer, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
+						}
 						/* TODO We should send a FIR/PLI to this peer... */
 					}
 				}
@@ -4553,10 +4553,10 @@ static void *janus_sip_handler(void *data) {
 							}
 						}
 
-                        /* If the video-orientation extension has been negotiated, mark it in the recording */
-                        if (session->media.video_orientation_extension_id > 0) {
-                            janus_recorder_add_extmap(session->vrc, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
-                        }
+						/* If the video-orientation extension has been negotiated, mark it in the recording */
+						if (session->media.video_orientation_extension_id > 0) {
+							janus_recorder_add_extmap(session->vrc, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
+						}
 
 						/* Send a PLI */
 						JANUS_LOG(LOG_VERB, "Recording video, sending a PLI to kickstart it\n");

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4493,9 +4493,7 @@ static void *janus_sip_handler(void *data) {
 
                         /* If the video-orientation extension has been negotiated, mark it in the recording */
                         if (session->media.video_orientation_extension_id > 0) {
-                            if (!janus_recorder_add_extmap(session->vrc_peer, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION)) {
-                                JANUS_LOG(LOG_WARN, "Failed to add video orientation extension id to peer extmap!\n");
-                            }
+                            janus_recorder_add_extmap(session->vrc_peer, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
                         }
 						/* TODO We should send a FIR/PLI to this peer... */
 					}
@@ -4557,9 +4555,7 @@ static void *janus_sip_handler(void *data) {
 
                         /* If the video-orientation extension has been negotiated, mark it in the recording */
                         if (session->media.video_orientation_extension_id > 0) {
-                            if (!janus_recorder_add_extmap(session->vrc, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION)) {
-                                JANUS_LOG(LOG_WARN, "Failed to add video orientation extension id to user extmap!\n");
-                            }
+                            janus_recorder_add_extmap(session->vrc, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
                         }
 
 						/* Send a PLI */

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4492,9 +4492,8 @@ static void *janus_sip_handler(void *data) {
 						}
 
 						/* If the video-orientation extension has been negotiated, mark it in the recording */
-						if (session->media.video_orientation_extension_id > 0) {
+						if (session->media.video_orientation_extension_id > 0)
 							janus_recorder_add_extmap(session->vrc_peer, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
-						}
 						/* TODO We should send a FIR/PLI to this peer... */
 					}
 				}
@@ -4554,9 +4553,8 @@ static void *janus_sip_handler(void *data) {
 						}
 
 						/* If the video-orientation extension has been negotiated, mark it in the recording */
-						if (session->media.video_orientation_extension_id > 0) {
+						if (session->media.video_orientation_extension_id > 0)
 							janus_recorder_add_extmap(session->vrc, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
-						}
 
 						/* Send a PLI */
 						JANUS_LOG(LOG_VERB, "Recording video, sending a PLI to kickstart it\n");

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4493,7 +4493,7 @@ static void *janus_sip_handler(void *data) {
 
                         /* If the video-orientation extension has been negotiated, mark it in the recording */
                         if (session->media.video_orientation_extension_id > 0) {
-                            janus_recorder_add_extmap(session->vrc_peer, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
+                        	janus_recorder_add_extmap(session->vrc_peer, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
                         }
 						/* TODO We should send a FIR/PLI to this peer... */
 					}

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4141,8 +4141,8 @@ static void *janus_sip_handler(void *data) {
 			char custom_headers[2048];
 			janus_sip_parse_custom_headers(root, (char *)&custom_headers, sizeof(custom_headers));
 			nua_respond(session->stack->s_nh_i, response_code, sip_status_phrase(response_code),
-					TAG_IF(strlen(custom_headers) > 0, SIPTAG_HEADER_STR(custom_headers)),
-					TAG_END());
+				    TAG_IF(strlen(custom_headers) > 0, SIPTAG_HEADER_STR(custom_headers)),
+				    TAG_END());
 			janus_mutex_lock(&session->mutex);
 			/* Also notify event handlers */
 			if(notify_events && gateway->events_is_enabled()) {

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4524,6 +4524,11 @@ static void *janus_sip_handler(void *data) {
 						}
 					}
 					if(record_video) {
+						/* If the video-orientation extension has been negotiated, mark it in the recording */
+						if (session->media.video_orientation_extension_id > 0) {
+							janus_recorder_add_extmap(session->vrc, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
+						}
+
 						memset(filename, 0, 255);
 						if(recording_base) {
 							/* Use the filename and path we have been provided */

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4525,8 +4525,10 @@ static void *janus_sip_handler(void *data) {
 					}
 					if(record_video) {
 						/* If the video-orientation extension has been negotiated, mark it in the recording */
-						if (session->media.video_orientation_extension_id > 0) {
+                        JANUS_LOG(LOG_INFO, "Checking video orientation extension id! %d\n", session->media.video_orientation_extension_id);
+                        if (session->media.video_orientation_extension_id > 0) {
 							janus_recorder_add_extmap(session->vrc, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
+							janus_recorder_add_extmap(session->vrc_peer, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
 						}
 
 						memset(filename, 0, 255);

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -4490,6 +4490,13 @@ static void *janus_sip_handler(void *data) {
 								JANUS_LOG(LOG_ERR, "Couldn't open an video recording file for this peer!\n");
 							}
 						}
+
+                        /* If the video-orientation extension has been negotiated, mark it in the recording */
+                        if (session->media.video_orientation_extension_id > 0) {
+                            if (!janus_recorder_add_extmap(session->vrc_peer, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION)) {
+                                JANUS_LOG(LOG_WARN, "Failed to add video orientation extension id to peer extmap!\n");
+                            }
+                        }
 						/* TODO We should send a FIR/PLI to this peer... */
 					}
 				}
@@ -4524,13 +4531,6 @@ static void *janus_sip_handler(void *data) {
 						}
 					}
 					if(record_video) {
-						/* If the video-orientation extension has been negotiated, mark it in the recording */
-                        JANUS_LOG(LOG_INFO, "Checking video orientation extension id! %d\n", session->media.video_orientation_extension_id);
-                        if (session->media.video_orientation_extension_id > 0) {
-							janus_recorder_add_extmap(session->vrc, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
-							janus_recorder_add_extmap(session->vrc_peer, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
-						}
-
 						memset(filename, 0, 255);
 						if(recording_base) {
 							/* Use the filename and path we have been provided */
@@ -4554,6 +4554,14 @@ static void *janus_sip_handler(void *data) {
 								JANUS_LOG(LOG_ERR, "Couldn't open an video recording file for this user!\n");
 							}
 						}
+
+                        /* If the video-orientation extension has been negotiated, mark it in the recording */
+                        if (session->media.video_orientation_extension_id > 0) {
+                            if (!janus_recorder_add_extmap(session->vrc, session->media.video_orientation_extension_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION)) {
+                                JANUS_LOG(LOG_WARN, "Failed to add video orientation extension id to user extmap!\n");
+                            }
+                        }
+
 						/* Send a PLI */
 						JANUS_LOG(LOG_VERB, "Recording video, sending a PLI to kickstart it\n");
 						gateway->send_pli(session->handle);


### PR DESCRIPTION
Similar to what was done in https://github.com/meetecho/janus-gateway/pull/2527

We add the orientation extension id in the MJR header so it can be read & applied when processing the video afterwards.