### PR TITLE
Handle sdp in 180 sip message same as 183

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -5604,8 +5604,8 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 
 			gboolean in_progress = FALSE;
 			if(status < 200) {
-				/* Not ready yet, either notify the user (e.g., "ringing") or handle early media (if it's a 183) */
-				if(status == 180) {
+				/* Not ready yet, either notify the user (e.g., "ringing") or handle early media */
+				if(status == 180 || status == 183) {
                     /* If's a Session Progress: check if there's an SDP, and if so, treat it like a 200 */
                     if(sip->sip_payload && sip->sip_payload->pl_data) {
                         in_progress = TRUE;
@@ -5626,11 +5626,6 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
                         json_decref(ringing);
                         break;
                     }
-				} else if(status == 183) {
-					/* If's a Session Progress: check if there's an SDP, and if so, treat it like a 200 */
-					if(!sip->sip_payload || !sip->sip_payload->pl_data)
-						break;
-					in_progress = TRUE;
 				} else {
 					/* Nothing to do, let's wait for a 200 OK */
 					break;

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -5606,21 +5606,26 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			if(status < 200) {
 				/* Not ready yet, either notify the user (e.g., "ringing") or handle early media (if it's a 183) */
 				if(status == 180) {
-					/* Ringing, notify the application */
-					json_t *ringing = json_object();
-					json_object_set_new(ringing, "sip", json_string("event"));
-					json_t *result = json_object();
-					json_object_set_new(result, "event", json_string("ringing"));
-					if(session->incoming_header_prefixes) {
-						json_t *headers = janus_sip_get_incoming_headers(sip, session);
-						json_object_set_new(result, "headers", headers);
-					}
-					json_object_set_new(ringing, "result", result);
-					json_object_set_new(ringing, "call_id", json_string(session->callid));
-					int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, ringing, NULL);
-					JANUS_LOG(LOG_VERB, "  >> Pushing event to peer: %d (%s)\n", ret, janus_get_api_error(ret));
-					json_decref(ringing);
-					break;
+                    /* If's a Session Progress: check if there's an SDP, and if so, treat it like a 200 */
+                    if(sip->sip_payload && sip->sip_payload->pl_data) {
+                        in_progress = TRUE;
+                    } else {
+                        /* Ringing, notify the application */
+                        json_t *ringing = json_object();
+                        json_object_set_new(ringing, "sip", json_string("event"));
+                        json_t *result = json_object();
+                        json_object_set_new(result, "event", json_string("ringing"));
+                        if(session->incoming_header_prefixes) {
+                            json_t *headers = janus_sip_get_incoming_headers(sip, session);
+                            json_object_set_new(result, "headers", headers);
+                        }
+                        json_object_set_new(ringing, "result", result);
+                        json_object_set_new(ringing, "call_id", json_string(session->callid));
+                        int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, ringing, NULL);
+                        JANUS_LOG(LOG_VERB, "  >> Pushing event to peer: %d (%s)\n", ret, janus_get_api_error(ret));
+                        json_decref(ringing);
+                        break;
+                    }
 				} else if(status == 183) {
 					/* If's a Session Progress: check if there's an SDP, and if so, treat it like a 200 */
 					if(!sip->sip_payload || !sip->sip_payload->pl_data)

--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -5606,26 +5606,26 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 			if(status < 200) {
 				/* Not ready yet, either notify the user (e.g., "ringing") or handle early media */
 				if(status == 180 || status == 183) {
-                    /* If's a Session Progress: check if there's an SDP, and if so, treat it like a 200 */
-                    if(sip->sip_payload && sip->sip_payload->pl_data) {
-                        in_progress = TRUE;
-                    } else {
-                        /* Ringing, notify the application */
-                        json_t *ringing = json_object();
-                        json_object_set_new(ringing, "sip", json_string("event"));
-                        json_t *result = json_object();
-                        json_object_set_new(result, "event", json_string("ringing"));
-                        if(session->incoming_header_prefixes) {
-                            json_t *headers = janus_sip_get_incoming_headers(sip, session);
-                            json_object_set_new(result, "headers", headers);
-                        }
-                        json_object_set_new(ringing, "result", result);
-                        json_object_set_new(ringing, "call_id", json_string(session->callid));
-                        int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, ringing, NULL);
-                        JANUS_LOG(LOG_VERB, "  >> Pushing event to peer: %d (%s)\n", ret, janus_get_api_error(ret));
-                        json_decref(ringing);
-                        break;
-                    }
+					/* If's a Session Progress: check if there's an SDP, and if so, treat it like a 200 */
+					if(sip->sip_payload && sip->sip_payload->pl_data) {
+						in_progress = TRUE;
+					} else {
+						/* Ringing, notify the application */
+						json_t *ringing = json_object();
+						json_object_set_new(ringing, "sip", json_string("event"));
+						json_t *result = json_object();
+						json_object_set_new(result, "event", json_string("ringing"));
+						if(session->incoming_header_prefixes) {
+							json_t *headers = janus_sip_get_incoming_headers(sip, session);
+							json_object_set_new(result, "headers", headers);
+						}
+						json_object_set_new(ringing, "result", result);
+						json_object_set_new(ringing, "call_id", json_string(session->callid));
+						int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, ringing, NULL);
+						JANUS_LOG(LOG_VERB, "  >> Pushing event to peer: %d (%s)\n", ret, janus_get_api_error(ret));
+						json_decref(ringing);
+						break;
+					}
 				} else {
 					/* Nothing to do, let's wait for a 200 OK */
 					break;


### PR DESCRIPTION
183 is not always with SDP and 180 is not always without SDP. 
In general, 180 with SDP is used for the distinctive ring tone and 183 with SDP for announcement. 
We need to treat 180 and 183 the same and only make a difference whether there is SDP (early media) or not.

Nice writeup here: https://thanhloi2603.wordpress.com/2017/08/05/sip-180-vs-183-vs-early-media/

According to https://datatracker.ietf.org/doc/html/rfc3261#section-21.1.5:
“The Reason-Phrase, header fields, or message body MAY be used to convey more details about the call progress.”

This RFC sums up how to handle 180 (and 183): https://datatracker.ietf.org/doc/html/rfc3960 