### PR TITLE
Multistream add orient extmap

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -7000,8 +7000,8 @@ static void janus_videoroom_recorder_create(janus_videoroom_publisher_stream *ps
 			}
 		}
 		/* If the video-orientation extension has been negotiated, mark it in the recording */
-		if(participant->video_orient_extmap_id > 0)
-			janus_recorder_add_extmap(rc, participant->video_orient_extmap_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
+		if(ps->video_orient_extmap_id > 0)
+			janus_recorder_add_extmap(rc, ps->video_orient_extmap_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
 		/* If media is encrypted, mark it in the recording */
 		if(ps->type != JANUS_VIDEOROOM_MEDIA_DATA && participant->e2ee)
 			janus_recorder_encrypted(rc);

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -6999,6 +6999,9 @@ static void janus_videoroom_recorder_create(janus_videoroom_publisher_stream *ps
 					janus_videoroom_media_str(ps->type));
 			}
 		}
+		/* If the video-orientation extension has been negotiated, mark it in the recording */
+		if(participant->video_orient_extmap_id > 0)
+			janus_recorder_add_extmap(rc, participant->video_orient_extmap_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
 		/* If media is encrypted, mark it in the recording */
 		if(ps->type != JANUS_VIDEOROOM_MEDIA_DATA && participant->e2ee)
 			janus_recorder_encrypted(rc);


### PR DESCRIPTION
Similar to what was done in #2836 and #2527.

For videoroom on multistream branch, we add the orientation extension id in the MJR header so it can be read & applied when processing the video afterwards.