### PR TITLE
Added option to print extended header in janus-pp-rec (inspired by #2838)

### DIFF
--- a/postprocessing/janus-pp-rec.1
+++ b/postprocessing/janus-pp-rec.1
@@ -30,6 +30,9 @@ Only parse .mjr header  (default=off)
 .BR \-p ", " \-\-parse
 Only parse and re-order packets  (default=off)
 .TP
+.BR \-e ", " \-\-extended-json
+Only print extended JSON report (automatically enables --json)  (default=off)
+.TP
 .BR \-m ", " \-\-metadata=metadata
 Save this metadata string in the target file
 .TP

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -1212,7 +1212,8 @@ int main(int argc, char *argv[])
 			JANUS_LOG(LOG_VERB, "[%10lu][%4d] seq=%"SCNu16", ts=%"SCNu64", time=%.2fs pts=%.2fs\n",
 				tmp->offset, tmp->len, tmp->seq, tmp->ts, ts, pts);
 		} else {
-			JANUS_LOG(LOG_VERB, "[%10lu][%4d] time=%"SCNu64"s\n", tmp->offset, tmp->len, tmp->ts);
+			ts = (double)tmp->ts/G_USEC_PER_SEC;
+			JANUS_LOG(LOG_VERB, "[%10lu][%4d] time=%.2fs\n", tmp->offset, tmp->len, ts);
 		}
 		tmp = tmp->next;
 	}

--- a/postprocessing/janus-pp-rec.c
+++ b/postprocessing/janus-pp-rec.c
@@ -56,6 +56,8 @@ Usage: janus-pp-rec [OPTIONS] source.mjr
   -j, --json                    Only print JSON header  (default=off)
   -H, --header                  Only parse .mjr header  (default=off)
   -p, --parse                   Only parse and re-order packets  (default=off)
+  -e, --extended-report         Only print extended report (automatically
+                                  enables --header)  (default=off)
   -m, --metadata=metadata       Save this metadata string in the target file
   -i, --ignore-first=count      Number of first packets to ignore when
                                   processing, e.g., in case they're cause of
@@ -255,13 +257,19 @@ int main(int argc, char *argv[])
 	}
 
 	/* If we're asked to print the JSON header as it is, we must not print anything else */
-	gboolean jsonheader_only = FALSE, header_only = FALSE, parse_only = FALSE;
+	gboolean jsonheader_only = FALSE, header_only = FALSE, parse_only = FALSE, extjson_only = FALSE;
 	if(args_info.json_given)
 		jsonheader_only = TRUE;
 	if(args_info.header_given && !jsonheader_only)
 		header_only = TRUE;
 	if(args_info.parse_given && !jsonheader_only && !header_only)
 		parse_only = TRUE;
+	if(args_info.extended_json_given) {
+		jsonheader_only = FALSE;
+		header_only = FALSE;
+		parse_only = TRUE;
+		extjson_only = TRUE;
+	}
 
 	/* We support both command line arguments and, for backwards compatibility, env variables in some cases */
 	if(args_info.debug_level_given || (g_getenv("JANUS_PPREC_DEBUG") != NULL)) {
@@ -281,6 +289,9 @@ int main(int argc, char *argv[])
 		if(val >= 0)
 			ignore_first_packets = val;
 	}
+	/* If we're just printing the JSON header (extended or not), disable debugging */
+	if(jsonheader_only || extjson_only)
+		janus_log_level = LOG_NONE;
 
 	int match_pt = -1;
 	if(args_info.payload_type_given) {
@@ -437,6 +448,7 @@ int main(int argc, char *argv[])
 	/* Pre-parse */
 	if(!jsonheader_only)
 		JANUS_LOG(LOG_INFO, "Pre-parsing file to generate ordered index...\n");
+	json_t *info = NULL;
 	gboolean has_timestamps = FALSE;
 	gboolean parsed_header = FALSE;
 	gboolean video = FALSE, data = FALSE, textdata = FALSE;
@@ -544,14 +556,14 @@ int main(int argc, char *argv[])
 				bytes = fread(prebuffer, sizeof(char), len, file);
 				parsed_header = TRUE;
 				prebuffer[len] = '\0';
-				if(jsonheader_only) {
+				if(jsonheader_only && !extjson_only) {
 					/* Print the header as it is and exit */
 					JANUS_PRINT("%s\n", prebuffer);
 					cmdline_parser_free(&args_info);
 					exit(0);
 				}
 				json_error_t error;
-				json_t *info = json_loads(prebuffer, 0, &error);
+				info = json_loads(prebuffer, 0, &error);
 				if(!info) {
 					JANUS_LOG(LOG_ERR, "JSON error: on line %d: %s\n", error.line, error.text);
 					JANUS_LOG(LOG_WARN, "Error parsing info header...\n");
@@ -590,6 +602,7 @@ int main(int argc, char *argv[])
 				json_t *codec = json_object_get(info, "c");
 				if(!codec || !json_is_string(codec)) {
 					JANUS_LOG(LOG_WARN, "Missing recording codec in info header...\n");
+					json_decref(info);
 					cmdline_parser_free(&args_info);
 					exit(1);
 				}
@@ -769,7 +782,11 @@ int main(int argc, char *argv[])
 				/* Save the original string as a metadata to save in the media container, if possible */
 				if(metadata == NULL)
 					metadata = g_strdup(prebuffer);
-				json_decref(info);
+				/* Unless we need the extended report, get rid of the JSON object */
+				if(!extjson_only) {
+					json_decref(info);
+					info = NULL;
+				}
 			}
 		} else {
 			JANUS_LOG(LOG_ERR, "Invalid header...\n");
@@ -792,8 +809,17 @@ int main(int argc, char *argv[])
 			strcasecmp(extension, "srt") && (!data || (data && textdata))) {
 		/* Unsupported extension? */
 		JANUS_LOG(LOG_ERR, "Unsupported extension '%s'\n", extension);
+		if(info)
+			json_decref(info);
 		cmdline_parser_free(&args_info);
 		exit(1);
+	}
+
+	/* In case we need an extended report */
+	json_t *report = NULL, *rotations = NULL;
+	if(extjson_only) {
+		report = json_object();
+		json_object_set_new(info, "extended", report);
 	}
 
 	/* Now let's parse the frames and order them */
@@ -954,7 +980,8 @@ int main(int argc, char *argv[])
 			if(video_orient_extmap_id > 0) {
 				janus_pp_rtp_header_extension_parse_video_orientation(prebuffer, len, video_orient_extmap_id, &rotation);
 				if(rotation != -1 && rotation != last_rotation) {
-					last_rotation = rotation;
+					if(!extjson_only)
+						last_rotation = rotation;
 					rotated++;
 				}
 			}
@@ -1148,11 +1175,24 @@ int main(int argc, char *argv[])
 				list = p;
 			}
 		}
+		/* Add to the extended header, if that's what we're doing */
+		if(extjson_only && p->rotation != -1 && p->rotation != last_rotation) {
+			last_rotation = p->rotation;
+			if(rotations == NULL)
+				rotations = json_array();
+			double ts = (double)(p->ts - list->ts)/(double)90000;
+			json_t *r = json_object();
+			json_object_set_new(r, "ts", json_real(ts));
+			json_object_set_new(r, "rotation", json_integer(p->rotation));
+			json_array_append_new(rotations, r);
+		}
 		/* Skip data for now */
 		offset += len;
 		count++;
 	}
 	if(!working) {
+		if(info)
+			json_decref(info);
 		cmdline_parser_free(&args_info);
 		exit(0);
 	}
@@ -1163,12 +1203,17 @@ int main(int argc, char *argv[])
 	int rate = video ? 90000 : 48000;
 	if(g711 || g722)
 		rate = 8000;
+	double ts = 0.0, pts = 0.0;
 	while(tmp) {
 		count++;
-		if(!data)
-			JANUS_LOG(LOG_VERB, "[%10lu][%4d] seq=%"SCNu16", ts=%"SCNu64", time=%.2fs pts=%.2fs\n", tmp->offset, tmp->len, tmp->seq, tmp->ts, (double)(tmp->ts-list->ts)/(double)rate, (double)tmp->p_ts/1000);
-		else
+		if(!data) {
+			ts = (double)(tmp->ts - list->ts)/(double)rate;
+			pts = (double)tmp->p_ts/1000;
+			JANUS_LOG(LOG_VERB, "[%10lu][%4d] seq=%"SCNu16", ts=%"SCNu64", time=%.2fs pts=%.2fs\n",
+				tmp->offset, tmp->len, tmp->seq, tmp->ts, ts, pts);
+		} else {
 			JANUS_LOG(LOG_VERB, "[%10lu][%4d] time=%"SCNu64"s\n", tmp->offset, tmp->len, tmp->ts);
+		}
 		tmp = tmp->next;
 	}
 	JANUS_LOG(LOG_INFO, "Counted %"SCNu32" frame packets\n", count);
@@ -1180,35 +1225,64 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	if(extjson_only) {
+		json_object_set_new(report, "packets", json_integer(count));
+		json_object_set_new(report, "duration", json_real(ts));
+		if(rotations)
+			json_object_set_new(report, "rotations", rotations);
+	}
+
 	if(video) {
 		/* Look for maximum width and height, if possible, and for the average framerate */
+		json_t *codec_info = NULL;
+		if(extjson_only) {
+			codec_info = json_object();
+			json_object_set_new(report, "codec", codec_info);
+		}
 		if(vp8 || vp9) {
-			if(janus_pp_webm_preprocess(file, list, vp8) < 0) {
+			if(janus_pp_webm_preprocess(file, list, vp8, codec_info) < 0) {
 				JANUS_LOG(LOG_ERR, "Error pre-processing %s RTP frames...\n", vp8 ? "VP8" : "VP9");
+				if(info)
+					json_decref(info);
 				cmdline_parser_free(&args_info);
 				exit(1);
 			}
 		} else if(h264) {
-			if(janus_pp_h264_preprocess(file, list) < 0) {
+			if(janus_pp_h264_preprocess(file, list, codec_info) < 0) {
 				JANUS_LOG(LOG_ERR, "Error pre-processing H.264 RTP frames...\n");
+				if(info)
+					json_decref(info);
 				cmdline_parser_free(&args_info);
 				exit(1);
 			}
 		} else if(av1) {
-			if(janus_pp_av1_preprocess(file, list) < 0) {
+			if(janus_pp_av1_preprocess(file, list, codec_info) < 0) {
 				JANUS_LOG(LOG_ERR, "Error pre-processing AV1 RTP frames...\n");
+				if(info)
+					json_decref(info);
 				cmdline_parser_free(&args_info);
 				exit(1);
 			}
 		} else if(h265) {
-			if(janus_pp_h265_preprocess(file, list) < 0) {
+			if(janus_pp_h265_preprocess(file, list, codec_info) < 0) {
 				JANUS_LOG(LOG_ERR, "Error pre-processing H.265 RTP frames...\n");
+				if(info)
+					json_decref(info);
 				cmdline_parser_free(&args_info);
 				exit(1);
 			}
 		}
 	}
 
+	if(extjson_only) {
+		/* Print the extended header and leave */
+		char *info_text = json_dumps(info, JSON_COMPACT | JSON_PRESERVE_ORDER);
+		JANUS_PRINT("%s\n", info_text);
+		free(info_text);
+		json_decref(info);
+		cmdline_parser_free(&args_info);
+		exit(0);
+	}
 	if(parse_only) {
 		/* We only needed to parse and re-order the packets, we're done here */
 		JANUS_LOG(LOG_INFO, "Parsing and reordering completed, bye!\n");

--- a/postprocessing/janus-pp-rec.ggo
+++ b/postprocessing/janus-pp-rec.ggo
@@ -4,6 +4,7 @@ option "file-extensions" F "Only print the supported target file extensions per 
 option "json" j "Only print JSON header" flag off
 option "header" H "Only parse .mjr header" flag off
 option "parse" p "Only parse and re-order packets" flag off
+option "extended-json" e "Only print extended JSON report (automatically enables --json)" flag off
 option "metadata" m "Save this metadata string in the target file" string typestr="metadata" optional
 option "ignore-first" i "Number of first packets to ignore when processing, e.g., in case they're cause of issues (default=0)" int typestr="count" optional
 option "payload-type" P "Ignore all RTP packets that don't match the specified payload type (default=none)" int typestr="pt" optional

--- a/postprocessing/pp-av1.h
+++ b/postprocessing/pp-av1.h
@@ -13,13 +13,14 @@
 #define JANUS_PP_AV1
 
 #include <stdio.h>
+#include <jansson.h>
 
 #include "pp-rtp.h"
 
 /* AV1 stuff */
 const char **janus_pp_av1_get_extensions(void);
 int janus_pp_av1_create(char *destination, char *metadata, gboolean faststart, const char *extension);
-int janus_pp_av1_preprocess(FILE *file, janus_pp_frame_packet *list);
+int janus_pp_av1_preprocess(FILE *file, janus_pp_frame_packet *list, json_t *info);
 int janus_pp_av1_process(FILE *file, janus_pp_frame_packet *list, int *working);
 void janus_pp_av1_close(void);
 

--- a/postprocessing/pp-h264.c
+++ b/postprocessing/pp-h264.c
@@ -225,9 +225,11 @@ static void janus_pp_h264_parse_sps(char *buffer, int *width, int *height) {
 }
 
 
-int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list) {
+int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list, json_t *info) {
 	if(!file || !list)
 		return -1;
+	json_t *resolutions = NULL;
+	int last_width = -1, last_height = -1;
 	janus_pp_frame_packet *tmp = list;
 	int bytes = 0, min_ts_diff = 0, max_ts_diff = 0;
 	int rotation = -1;
@@ -269,6 +271,20 @@ int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list) {
 				max_width = width;
 				max_height = height;
 			}
+			if(info && (last_width != width || last_height != height)) {
+				last_width = width;
+				last_height = height;
+				if(resolutions == NULL) {
+					resolutions = json_array();
+					json_object_set_new(info, "resolution", resolutions);
+				}
+				json_t *resolution = json_object();
+				double ts = (double)(tmp->ts-list->ts)/(double)90000;
+				json_object_set_new(resolution, "ts", json_real(ts));
+				json_object_set_new(resolution, "width", json_integer(width));
+				json_object_set_new(resolution, "height", json_integer(height));
+				json_array_append_new(resolutions, resolution);
+			}
 		} else if((prebuffer[0] & 0x1F) == 24) {
 			/* May we find an SPS in this STAP-A? */
 			JANUS_LOG(LOG_HUGE, "Parsing STAP-A...\n");
@@ -290,6 +306,20 @@ int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list) {
 					if(width*height > max_width*max_height) {
 						max_width = width;
 						max_height = height;
+					}
+					if(info && (last_width != width || last_height != height)) {
+						last_width = width;
+						last_height = height;
+						if(resolutions == NULL) {
+							resolutions = json_array();
+							json_object_set_new(info, "resolution", resolutions);
+						}
+						json_t *resolution = json_object();
+						double ts = (double)(tmp->ts-list->ts)/(double)90000;
+						json_object_set_new(resolution, "ts", json_real(ts));
+						json_object_set_new(resolution, "width", json_integer(width));
+						json_object_set_new(resolution, "height", json_integer(height));
+						json_array_append_new(resolutions, resolution);
 					}
 				}
 				buffer += psize;

--- a/postprocessing/pp-h264.h
+++ b/postprocessing/pp-h264.h
@@ -13,13 +13,14 @@
 #define JANUS_PP_H264
 
 #include <stdio.h>
+#include <jansson.h>
 
 #include "pp-rtp.h"
 
 /* H.264 stuff */
 const char **janus_pp_h264_get_extensions(void);
 int janus_pp_h264_create(char *destination, char *metadata, gboolean faststart, const char *extension);
-int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list);
+int janus_pp_h264_preprocess(FILE *file, janus_pp_frame_packet *list, json_t *info);
 int janus_pp_h264_process(FILE *file, janus_pp_frame_packet *list, int *working);
 void janus_pp_h264_close(void);
 

--- a/postprocessing/pp-h265.c
+++ b/postprocessing/pp-h265.c
@@ -226,9 +226,11 @@ static void janus_pp_h265_parse_sps(char *buffer, int *width, int *height) {
 	*height = janus_pp_h265_eg_decode(base, &offset);
 }
 
-int janus_pp_h265_preprocess(FILE *file, janus_pp_frame_packet *list) {
+int janus_pp_h265_preprocess(FILE *file, janus_pp_frame_packet *list, json_t *info) {
 	if(!file || !list)
 		return -1;
+	json_t *resolutions = NULL;
+	int last_width = -1, last_height = -1;
 	janus_pp_frame_packet *tmp = list;
 	int bytes = 0, min_ts_diff = 0, max_ts_diff = 0;
 	int rotation = -1;
@@ -312,6 +314,20 @@ int janus_pp_h265_preprocess(FILE *file, janus_pp_frame_packet *list) {
 				max_width = width;
 				max_height = height;
 			}
+			if(info && (last_width != width || last_height != height)) {
+				last_width = width;
+				last_height = height;
+				if(resolutions == NULL) {
+					resolutions = json_array();
+					json_object_set_new(info, "resolution", resolutions);
+				}
+				json_t *resolution = json_object();
+				double ts = (double)(tmp->ts-list->ts)/(double)90000;
+				json_object_set_new(resolution, "ts", json_real(ts));
+				json_object_set_new(resolution, "width", json_integer(width));
+				json_object_set_new(resolution, "height", json_integer(height));
+				json_array_append_new(resolutions, resolution);
+			}
 		} else if(type == 34) {
 			/* PPS */
 			JANUS_LOG(LOG_HUGE, "[PPS] %u/%u/%u/%u\n", fbit, type, lid, tid);
@@ -363,6 +379,20 @@ int janus_pp_h265_preprocess(FILE *file, janus_pp_frame_packet *list) {
 						if(width*height > max_width*max_height) {
 							max_width = width;
 							max_height = height;
+						}
+						if(info && (last_width != width || last_height != height)) {
+							last_width = width;
+							last_height = height;
+							if(resolutions == NULL) {
+								resolutions = json_array();
+								json_object_set_new(info, "resolution", resolutions);
+							}
+							json_t *resolution = json_object();
+							double ts = (double)(tmp->ts-list->ts)/(double)90000;
+							json_object_set_new(resolution, "ts", json_real(ts));
+							json_object_set_new(resolution, "width", json_integer(width));
+							json_object_set_new(resolution, "height", json_integer(height));
+							json_array_append_new(resolutions, resolution);
 						}
 						break;
 					case 34:

--- a/postprocessing/pp-h265.h
+++ b/postprocessing/pp-h265.h
@@ -13,13 +13,14 @@
 #define JANUS_PP_H265
 
 #include <stdio.h>
+#include <jansson.h>
 
 #include "pp-rtp.h"
 
 /* H.265 stuff */
 const char **janus_pp_h265_get_extensions(void);
 int janus_pp_h265_create(char *destination, char *metadata, gboolean faststart, const char *extension);
-int janus_pp_h265_preprocess(FILE *file, janus_pp_frame_packet *list);
+int janus_pp_h265_preprocess(FILE *file, janus_pp_frame_packet *list, json_t *info);
 int janus_pp_h265_process(FILE *file, janus_pp_frame_packet *list, int *working);
 void janus_pp_h265_close(void);
 

--- a/postprocessing/pp-webm.c
+++ b/postprocessing/pp-webm.c
@@ -91,9 +91,11 @@ int janus_pp_webm_create(char *destination, char *metadata, gboolean vp8, const 
 	return 0;
 }
 
-int janus_pp_webm_preprocess(FILE *file, janus_pp_frame_packet *list, gboolean vp8) {
+int janus_pp_webm_preprocess(FILE *file, janus_pp_frame_packet *list, gboolean vp8, json_t *info) {
 	if(!file || !list)
 		return -1;
+	json_t *resolutions = NULL;
+	int last_width = -1, last_height = -1;
 	janus_pp_frame_packet *tmp = list;
 	int bytes = 0, min_ts_diff = 0, max_ts_diff = 0;
 	int rotation = -1;
@@ -192,6 +194,20 @@ int janus_pp_webm_preprocess(FILE *file, janus_pp_frame_packet *list, gboolean v
 							max_width = vp8w;
 							max_height = vp8h;
 						}
+						if(info && (last_width != vp8w || last_height != vp8h)) {
+							last_width = vp8w;
+							last_height = vp8h;
+							if(resolutions == NULL) {
+								resolutions = json_array();
+								json_object_set_new(info, "resolution", resolutions);
+							}
+							json_t *resolution = json_object();
+							double ts = (double)(tmp->ts-list->ts)/(double)90000;
+							json_object_set_new(resolution, "ts", json_real(ts));
+							json_object_set_new(resolution, "width", json_integer(vp8w));
+							json_object_set_new(resolution, "height", json_integer(vp8h));
+							json_array_append_new(resolutions, resolution);
+						}
 					}
 				}
 			}
@@ -265,6 +281,20 @@ int janus_pp_webm_preprocess(FILE *file, janus_pp_frame_packet *list, gboolean v
 						if(width*height > max_width*max_height) {
 							max_width = width;
 							max_height = height;
+						}
+						if(info && (last_width != width || last_height != height)) {
+							last_width = width;
+							last_height = height;
+									if(resolutions == NULL) {
+								resolutions = json_array();
+								json_object_set_new(info, "resolution", resolutions);
+							}
+							json_t *resolution = json_object();
+							double ts = (double)(tmp->ts-list->ts)/(double)90000;
+							json_object_set_new(resolution, "ts", json_real(ts));
+							json_object_set_new(resolution, "width", json_integer(width));
+							json_object_set_new(resolution, "height", json_integer(height));
+							json_array_append_new(resolutions, resolution);
 						}
 					}
 				}

--- a/postprocessing/pp-webm.h
+++ b/postprocessing/pp-webm.h
@@ -13,13 +13,14 @@
 #define JANUS_PP_WEBM
 
 #include <stdio.h>
+#include <jansson.h>
 
 #include "pp-rtp.h"
 
 /* WebM stuff */
 const char **janus_pp_webm_get_extensions(void);
 int janus_pp_webm_create(char *destination, char *metadata, gboolean vp8, const char *extension);
-int janus_pp_webm_preprocess(FILE *file, janus_pp_frame_packet *list, gboolean vp8);
+int janus_pp_webm_preprocess(FILE *file, janus_pp_frame_packet *list, gboolean vp8, json_t *info);
 int janus_pp_webm_process(FILE *file, janus_pp_frame_packet *list, gboolean vp8, int *working);
 void janus_pp_webm_close(void);
 


### PR DESCRIPTION
This PR is inspired by the excellent work @adnanel did in #2838, but using a slightly different approach, and broadening the scope a bit. Specifically, it adds a new command line option to `janus-pp-rec` (`-e` or `--extended-json`) which, if set, only prints the JSON header, but enriched with information it parses from the MJR file itself. An example (with artificial intendation, since the tool prints compact JSON) is the following:

```
{
   "t": "v",
   "c": "vp8",
   "x": {
      "13": "urn:3gpp:video-orientation"
   },
   "s": 1612369719662379,
   "u": 1612369719904395,
   "extended": {
      "packets": 1427,
      "duration": 29.850000000000001,
      "rotations": [
         {
            "ts": 0.0,
            "rotation": 0
         }
      ],
      "codec": {
         "resolution": [
            {
               "ts": 0.0,
               "width": 480,
               "height": 270
            },
            {
               "ts": 13.85,
               "width": 720,
               "height": 405
            },
            {
               "ts": 17.850000000000001,
               "width": 960,
               "height": 540
            },
            {
               "ts": 25.901,
               "width": 1440,
               "height": 810
            }
         ]
      }
   }
}
```
where as you can see, besides the "usual" fields already present in the header, there's a new `extended` object that contains additional information. At the moment, the information I've added are the number of packets in the MJR file, the estimated duration of the recording, the rotations we detected (which was the main purpose of #2838 itself) and, for video files, the resolution changes we detected as well. In the future we may add other information, here, depending on what people think might be useful.

Please let me know what you think about this, as I plan to merge soon.