### PR TITLE
Make rtp port range variables static in ice to prevent clashes with plugins

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -332,8 +332,8 @@ int janus_ice_get_event_stats_period(void) {
 
 
 /* RTP/RTCP port range */
-uint16_t rtp_range_min = 0;
-uint16_t rtp_range_max = 0;
+static uint16_t rtp_range_min = 0;
+static uint16_t rtp_range_max = 0;
 
 
 #define JANUS_ICE_PACKET_AUDIO	0


### PR DESCRIPTION
Our custom plugin was not using a storage class specifier on rtp_range_min and rtp_range_max. This led to a clash with the ice handling code which is also not using a storage class specifier, hence defaulting to extern.

This change is to explicitly add a static specifier hence removing potential clashes for other plugin developers.