### PR TITLE
fix PCMA/PCMU RTP forwarding in audiobridge - incorrect RTP header of…

### DIFF
--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -8305,7 +8305,7 @@ static void *janus_audiobridge_mixer_thread(void *data) {
 							}
 						}
 						rtph = (janus_rtp_header *)(forwarder->codec == JANUS_AUDIOCODEC_PCMA ?
-							(rtpalaw + forwarder->group*G711_SAMPLES + 12) : (rtpulaw + forwarder->group*G711_SAMPLES + 12));
+							(rtpalaw + forwarder->group*G711_SAMPLES) : (rtpulaw + forwarder->group*G711_SAMPLES));
 						rtph->version = 2;
 						length = 160;
 					}


### PR DESCRIPTION
Fix: audiobridge plugin creates incorrect RTP packets during forwarding of PCMA/PCMU. 12 header bytes offset was moved forward and intersects with RTP payload . Wireshark shows [Malformed Packet] for such packets.