### PR TITLE
Change automatic allocation on static loops from round robin to least loaded

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -1372,7 +1372,12 @@ gint janus_ice_handle_attach_plugin(void *core_session, janus_ice_handle *handle
 			GSList *l = event_loops;
 			while(l) {
 				janus_ice_static_event_loop *el = (janus_ice_static_event_loop *)l->data;
-				if(handles == -1 || (loop == NULL && el->handles == 0) || el->handles < handles) {
+				if(el->handles == 0) {
+					/* Best option, stop here */
+					loop = el;
+					break;
+				}
+				if(handles == -1 || el->handles < handles) {
 					handles = el->handles;
 					loop = el;
 				}

--- a/ice.c
+++ b/ice.c
@@ -231,6 +231,23 @@ void janus_ice_set_static_event_loops(int loops, gboolean allow_api) {
 		allow_loop_indication ? "will" : "will NOT");
 	return;
 }
+json_t *janus_ice_static_event_loops_info(void) {
+	json_t *list = json_array();
+	if(static_event_loops < 1)
+		return list;
+	janus_mutex_lock(&event_loops_mutex);
+	GSList *l = event_loops;
+	while(l) {
+		janus_ice_static_event_loop *loop = (janus_ice_static_event_loop *)l->data;
+		json_t *info = json_object();
+		json_object_set_new(info, "id", json_integer(loop->id));
+		json_object_set_new(info, "handles", json_integer(loop->handles));
+		json_array_append_new(list, info);
+		l = l->next;
+	}
+	janus_mutex_unlock(&event_loops_mutex);
+	return list;
+}
 void janus_ice_stop_static_event_loops(void) {
 	if(static_event_loops < 1)
 		return;

--- a/ice.h
+++ b/ice.h
@@ -346,6 +346,8 @@ struct janus_ice_handle {
 	GMainContext *mainctx;
 	/*! \brief GLib loop for the handle and libnice */
 	GMainLoop *mainloop;
+	/*! \brief In case static event loops are used, opaque pointer to the loop */
+	void *static_event_loop;
 	/*! \brief GLib thread for the handle and libnice */
 	GThread *thread;
 	/*! \brief GLib sources for outgoing traffic, recurring RTCP, and stats (and optionally TWCC) */

--- a/ice.h
+++ b/ice.h
@@ -762,6 +762,10 @@ int janus_ice_get_static_event_loops(void);
 /*! \brief Method to check whether loop indication via API is allowed
  * @returns true if allowed, false otherwise */
 gboolean janus_ice_is_loop_indication_allowed(void);
+/*! \brief Helper method to return a summary of the static loops activity
+ * @note This is only used by the Admin API
+ * @returns a json_t array with the required info */
+json_t *janus_ice_static_event_loops_info(void);
 /*! \brief Method to stop all the static event loops, if enabled
  * @note This will wait for the related threads to exit, and so may delay the shutdown process */
 void janus_ice_stop_static_event_loops(void);

--- a/janus.c
+++ b/janus.c
@@ -2676,6 +2676,16 @@ int janus_process_incoming_admin_request(janus_request *request) {
 			/* Send the success reply */
 			ret = janus_process_success(request, reply);
 			goto jsondone;
+		} else if(!strcasecmp(message_text, "loops_info")) {
+			/* Query the Janus core to see how many handles each static loop is
+			 * handling: will return an empty list if static loops are disabled */
+			json_t *list = janus_ice_static_event_loops_info();
+			/* Prepare JSON reply */
+			json_t *reply = janus_create_message("success", 0, transaction_text);
+			json_object_set_new(reply, "loops", list);
+			/* Send the success reply */
+			ret = janus_process_success(request, reply);
+			goto jsondone;
 		} else {
 			/* No message we know of */
 			ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_INVALID_REQUEST_PATH, "Unhandled request '%s' at this path", message_text);

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -2273,7 +2273,10 @@ const token = getJanusToken('janus', ['janus.plugin.videoroom']);
  * - \c ping: a simple ping/pong mechanism for the Admin API, that returns
  * a \c pong back that the client can use as a healthcheck or to measure
  * the protocol round-trip time; together with the \c info request introduced
- * above, it's the only one that doesn't require a secret.
+ * above, it's the only one that doesn't require a secret;
+ * - \c loops_info: returns a summary of how many handles each static
+ * event loop is currently responsible for, in case static event loops
+ * are in use (returns an empty array otherwise).
  *
  * \subsection adminreqc Configuration-related requests
  * - \c get_status: returns the current value for the settings that can be


### PR DESCRIPTION
When using static event loops instead of one thread/loop per handle, the default policy was a round robin: if you wanted more control on which loop to put a new handle, you'd have to use the manual mode via API. This PR changes the default from round robin to picking the loop that's handling less handles instead, which should result in a more balanced loop workload (especially considering that round robin doesn't take into account previous handles may leave in the meanwhile).

This is still not an optimal solution, as different handles may keep their loop busy in different ways, but since the core has no way to know how a handle will be used, there's not much we can do about that. This should still be better than what we have now.

Feedback welcome as I plan to merge soon.