### PR TITLE
Remove distinction between simulcast and simulcast2 in janus.js

### DIFF
--- a/html/canvas.js
+++ b/html/canvas.js
@@ -60,7 +60,6 @@ var audioenabled = false;
 var videoenabled = false;
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
-var doSimulcast2 = (getQueryStringValue("simulcast2") === "yes" || getQueryStringValue("simulcast2") === "true");
 var acodec = (getQueryStringValue("acodec") !== "" ? getQueryStringValue("acodec") : null);
 var vcodec = (getQueryStringValue("vcodec") !== "" ? getQueryStringValue("vcodec") : null);
 var vprofile = (getQueryStringValue("vprofile") !== "" ? getQueryStringValue("vprofile") : null);
@@ -465,7 +464,6 @@ function createCanvas() {
 						// pass a ?simulcast=true when opening this demo page: it will turn
 						// the following 'simulcast' property to pass to janus.js to true
 						simulcast: doSimulcast,
-						simulcast2: doSimulcast2,
 						success: function(jsep) {
 							Janus.debug("Got SDP!", jsep);
 							echotest.send({ message: body, jsep: jsep });

--- a/html/devicetest.js
+++ b/html/devicetest.js
@@ -64,7 +64,6 @@ var audioenabled = false;
 var videoenabled = false;
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
-var doSimulcast2 = (getQueryStringValue("simulcast2") === "yes" || getQueryStringValue("simulcast2") === "true");
 var acodec = (getQueryStringValue("acodec") !== "" ? getQueryStringValue("acodec") : null);
 var vcodec = (getQueryStringValue("vcodec") !== "" ? getQueryStringValue("vcodec") : null);
 var vprofile = (getQueryStringValue("vprofile") !== "" ? getQueryStringValue("vprofile") : null);
@@ -175,7 +174,6 @@ function restartCapture() {
 			// pass a ?simulcast=true when opening this demo page: it will turn
 			// the following 'simulcast' property to pass to janus.js to true
 			simulcast: doSimulcast,
-			simulcast2: doSimulcast2,
 			success: function(jsep) {
 				Janus.debug("Got SDP!", jsep);
 				echotest.send({ message: body, jsep: jsep });

--- a/html/e2etest.js
+++ b/html/e2etest.js
@@ -61,7 +61,6 @@ var audioenabled = false;
 var videoenabled = false;
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
-var doSimulcast2 = (getQueryStringValue("simulcast2") === "yes" || getQueryStringValue("simulcast2") === "true");
 var acodec = (getQueryStringValue("acodec") !== "" ? getQueryStringValue("acodec") : null);
 var vcodec = (getQueryStringValue("vcodec") !== "" ? getQueryStringValue("vcodec") : null);
 var simulcastStarted = false;
@@ -643,7 +642,6 @@ function promptCryptoKey() {
 				// pass a ?simulcast=true when opening this demo page: it will turn
 				// the following 'simulcast' property to pass to janus.js to true.
 				simulcast: doSimulcast,
-				simulcast2: doSimulcast2,
 				// Since we want to use Insertable Streams,
 				// we specify the transform functions to use
 				senderTransforms: senderTransforms,

--- a/html/echotest.js
+++ b/html/echotest.js
@@ -61,7 +61,6 @@ var audioenabled = false;
 var videoenabled = false;
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
-var doSimulcast2 = (getQueryStringValue("simulcast2") === "yes" || getQueryStringValue("simulcast2") === "true");
 var doSvc = getQueryStringValue("svc");
 if(doSvc === "")
 	doSvc = null;
@@ -132,7 +131,6 @@ $(document).ready(function() {
 											// pass a ?simulcast=true when opening this demo page: it will turn
 											// the following 'simulcast' property to pass to janus.js to true
 											simulcast: doSimulcast,
-											simulcast2: doSimulcast2,
 											svc: (vcodec === 'av1' && doSvc) ? doSvc : null,
 											customizeSdp: function(jsep) {
 												// If DTX is enabled, munge the SDP

--- a/html/multiopus.js
+++ b/html/multiopus.js
@@ -60,7 +60,6 @@ var audioenabled = false;
 var videoenabled = false;
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
-var doSimulcast2 = (getQueryStringValue("simulcast2") === "yes" || getQueryStringValue("simulcast2") === "true");
 var acodec = "multiopus";
 var vcodec = (getQueryStringValue("vcodec") !== "" ? getQueryStringValue("vcodec") : null);
 var vprofile = (getQueryStringValue("vprofile") !== "" ? getQueryStringValue("vprofile") : null);
@@ -139,7 +138,6 @@ $(document).ready(function() {
 											// pass a ?simulcast=true when opening this demo page: it will turn
 											// the following 'simulcast' property to pass to janus.js to true
 											simulcast: doSimulcast,
-											simulcast2: doSimulcast2,
 											customizeSdp(jsep) {
 												// Offer multiopus
 												jsep.sdp = jsep.sdp

--- a/html/mvideoroomtest.js
+++ b/html/mvideoroomtest.js
@@ -67,7 +67,6 @@ var localTracks = {}, localVideos = 0, remoteTracks = {};
 var bitrateTimer = [], simulcastStarted = {};
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
-var doSimulcast2 = (getQueryStringValue("simulcast2") === "yes" || getQueryStringValue("simulcast2") === "true");
 var acodec = (getQueryStringValue("acodec") !== "" ? getQueryStringValue("acodec") : null);
 var vcodec = (getQueryStringValue("vcodec") !== "" ? getQueryStringValue("vcodec") : null);
 var subscriber_mode = (getQueryStringValue("subscriber-mode") === "yes" || getQueryStringValue("subscriber-mode") === "true");
@@ -481,7 +480,6 @@ function publishOwnFeed(useAudio) {
 			// pass a ?simulcast=true when opening this demo page: it will turn
 			// the following 'simulcast' property to pass to janus.js to true
 			simulcast: doSimulcast,
-			simulcast2: doSimulcast2,
 			success: function(jsep) {
 				Janus.debug("Got publisher SDP!");
 				Janus.debug(jsep);

--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -68,7 +68,6 @@ var acodec = (getQueryStringValue("acodec") !== "" ? getQueryStringValue("acodec
 var vcodec = (getQueryStringValue("vcodec") !== "" ? getQueryStringValue("vcodec") : null);
 var vprofile = (getQueryStringValue("vprofile") !== "" ? getQueryStringValue("vprofile") : null);
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
-var doSimulcast2 = (getQueryStringValue("simulcast2") === "yes" || getQueryStringValue("simulcast2") === "true");
 var doOpusred = (getQueryStringValue("opusred") === "yes" || getQueryStringValue("opusred") === "true");
 var recordData = (getQueryStringValue("data") !== "" ? getQueryStringValue("data") : null);
 if(recordData !== "text" && recordData !== "binary")

--- a/html/videocalltest.js
+++ b/html/videocalltest.js
@@ -64,7 +64,6 @@ var myusername = null;
 var yourusername = null;
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
-var doSimulcast2 = (getQueryStringValue("simulcast2") === "yes" || getQueryStringValue("simulcast2") === "true");
 var simulcastStarted = false;
 
 $(document).ready(function() {

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -66,7 +66,6 @@ var feeds = [], feedStreams = {};
 var bitrateTimer = [];
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
-var doSimulcast2 = (getQueryStringValue("simulcast2") === "yes" || getQueryStringValue("simulcast2") === "true");
 var acodec = (getQueryStringValue("acodec") !== "" ? getQueryStringValue("acodec") : null);
 var vcodec = (getQueryStringValue("vcodec") !== "" ? getQueryStringValue("vcodec") : null);
 var doDtx = (getQueryStringValue("dtx") === "yes" || getQueryStringValue("dtx") === "true");
@@ -485,7 +484,6 @@ function publishOwnFeed(useAudio) {
 			// pass a ?simulcast=true when opening this demo page: it will turn
 			// the following 'simulcast' property to pass to janus.js to true
 			simulcast: doSimulcast,
-			simulcast2: doSimulcast2,
 			customizeSdp: function(jsep) {
 				// If DTX is enabled, munge the SDP
 				if(doDtx) {


### PR DESCRIPTION
For a long time `janus.js` has supported two different ways to enable simulcast:

1. `simulcast: true`, which on Chrome enabled simulcast using the old SDP munging approach, and on Firefox its custom rid approach;
2. `simulcast2: true`, which on Chrome enabled simulcast using the standard rid approach.

This was initially done to account for the different ways simulcast could be enabled in browsers, as explained in this [blog post](https://www.meetecho.com/blog/simulcast-janus-ssrc/) I wrote at the time.

This patch gets rid of this distinction, and assumes `simulcast: true` is all you need to enable simulcast in a web page: `janus.js` then automatically enables the right mechanism depending on the browser (munging on very old versions of Chrome, custom-rid for Firefox, standard-rid otherwise). `simulcast2: true` is still accepted for backwards compatibility, but it's considered an alias of `simulcast: true` internally. Notice there's no way to force simulcast via SDP munging now: I don't see a reason for having it, since `janus.js` is only useful if you're talking to Janus, and Janus is perfectly capable of handling both mechanisms just fine.

Planning to merge soon, so feedback welcome before I hit the button.