### PR TITLE
Fix error message when creating a session

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -968,7 +968,7 @@ function Janus(gatewayCallbacks) {
 				if(errorThrown === "")
 					callbacks.error(textStatus + ": Is the server down?");
 				else if (errorThrown && errorThrown.error)
-					callbacks.error(textStatus + ": " + errorThrown.error.stack);
+					callbacks.error(textStatus + ": " + errorThrown.error.message);
 				else
 					callbacks.error(textStatus + ": " + errorThrown);
 			}

--- a/html/janus.js
+++ b/html/janus.js
@@ -967,8 +967,10 @@ function Janus(gatewayCallbacks) {
 				}
 				if(errorThrown === "")
 					callbacks.error(textStatus + ": Is the server down?");
-				else
+				else if (errorThrown && errorThrown.error)
 					callbacks.error(textStatus + ": " + errorThrown.error.stack);
+				else
+					callbacks.error(textStatus + ": " + errorThrown);
 			}
 		});
 	}

--- a/html/janus.js
+++ b/html/janus.js
@@ -968,7 +968,7 @@ function Janus(gatewayCallbacks) {
 				if(errorThrown === "")
 					callbacks.error(textStatus + ": Is the server down?");
 				else
-					callbacks.error(textStatus + ": " + errorThrown);
+					callbacks.error(textStatus + ": " + errorThrown.error.stack);
 			}
 		});
 	}


### PR DESCRIPTION
On the createSession function, the error callback is called like this:

```js
  callbacks.error(textStatus + ": " + errorThrown);
```

But errorThrown isn't a string. So if I try do something like:

```js
 new Janus({
          server: 'http://localhost:8088/janus',
          iceServers: [
            {
              urls: 'stun:stun.l.google.com:19302',
            },
          ],
          success: () => {
              ...
          },
          error: (error) => {
            console.warn(error);
          },
        });
      },
    });

```

If the connection fails for any reason, the message could be something like this:

`Probably a network error, is the server down?: [object Object]`

I believe it happens on another parts of the code. But I couldn't  test them yet.

PS: Sorry about my rusty English.
