### PR TITLE
Use the same version number for npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janus-gateway",
-  "version": "0.7.5",
+  "version": "1.0.0",
   "description": "A javascript library for interacting with the C based Janus WebRTC Server",
   "main": "html/janus.js",
   "repository": {


### PR DESCRIPTION
I noticed that the package.json still includes version `0.7.5`, while the main repo is at `0.11.8` right now. I feel those should be matching? (I may be wrong, but there's only one way to find out!)