### PR TITLE
Update typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ p2m-cmdline.h
 .idea
 
 .vscode
+node_modules

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -23,7 +23,13 @@ declare namespace JanusJS {
 		Error = 'error'
 	}
 
-	interface JSEP {}
+	interface JSEP {
+		ee2e?: boolean;
+		sdp?: string;
+		type?: string;
+		rid_order?: "hml" | "lmh";
+		force_relay?: boolean;
+	}
 
 	interface InitOptions {
 		debug?: boolean | 'all' | DebugLevel[];
@@ -44,18 +50,23 @@ declare namespace JanusJS {
 		error?: (error: any) => void;
 		destroyed?: Function;
 	}
-	
+
 	interface ReconnectOptions {
 		success?: Function;
-		error?: (error: any) => void;
+		error?: (error: string) => void;
 	}
 
 	interface DestroyOptions {
-		cleanupHandles?: boolean
-		notifyDestroyed?: boolean
-		unload?: boolean
-		success?: () => void
-		error?: (error: Error | unknown) => void
+		cleanupHandles?: boolean;
+		notifyDestroyed?: boolean;
+		unload?: boolean;
+		success?: () => void;
+		error?: (error: string) => void;
+	}
+
+	interface GetInfoOptions {
+		success?: (info: any) => void;
+		error?: (error: string) => void;
 	}
 
 	enum MessageType {
@@ -74,27 +85,31 @@ declare namespace JanusJS {
 			id?: string;
 			uplink?: number;
 		};
-		error?: Error;
+		error?: string;
+		[key: string]: any;
 	}
 
-	interface PluginOptions {
-		plugin: string;
-		opaqueId?: string;
+	interface PluginCallbacks {
 		dataChannelOptions?: RTCDataChannelInit;
 		success?: (handle: PluginHandle) => void;
-		error?: (error: any) => void;
+		error?: (error: string) => void;
 		consentDialog?: (on: boolean) => void;
 		webrtcState?: (isConnected: boolean) => void;
 		iceState?: (state: 'connected' | 'failed' | 'disconnected' | 'closed') => void;
 		mediaState?: (medium: 'audio' | 'video', receiving: boolean, mid?: number) => void;
-		slowLink?: (uplink: boolean, lost: number) => void;
+		slowLink?: (uplink: boolean, lost: number, mid: string) => void;
 		onmessage?: (message: Message, jsep?: JSEP) => void;
-		onlocalstream?: (stream: MediaStream) => void;
-		onremotestream?: (stream: MediaStream) => void;
+		onlocaltrack?: (track: MediaStreamTrack, on: boolean) => void;
+		onremotetrack?: (track: MediaStreamTrack, mid: string, on: boolean) => void;
 		ondataopen?: Function;
 		ondata?: Function;
 		oncleanup?: Function;
-		detached?: Function;
+		ondetached?: Function;
+	}
+
+	interface PluginOptions extends PluginCallbacks {
+		plugin: string;
+		opaqueId?: string;
 	}
 
 	interface OfferParams {
@@ -130,37 +145,64 @@ declare namespace JanusJS {
 			[otherProps: string]: any;
 		};
 		jsep?: JSEP;
-		success?: Function;
-		error?: (error: any) => void;
+		success?: (data?: any) => void;
+		error?: (error: string) => void;
 	}
 
+	interface WebRTCInfo {
+		bitrate: {
+			bsbefore: string | null;
+			bsnow: string | null;
+			timer: string | null;
+			tsbefore: string | null;
+			tsnow: string | null;
+			value: string | null;
+		};
+		dataChannel: Array<RTCDataChannel>;
+		dataChannelOptions: RTCDataChannelInit;
+
+		dtmfSender: string | null;
+		iceDone: boolean;
+		mediaConstraints: any;
+		mySdp: {
+			sdp: string;
+			type: string;
+		};
+		myStream: MediaStream;
+		pc: RTCPeerConnection;
+		receiverTransforms: {
+			audio: TransformStream;
+			video: TransformStream;
+		};
+		remoteSdp: string;
+		remoteStream: MediaStream;
+		senderTransforms: {
+			audio: TransformStream;
+			video: TransformStream;
+		};
+		started: boolean;
+		streamExternal: boolean;
+		trickle: boolean;
+		volume: {
+			value: number;
+			timer: number;
+		};
+	}
+	interface DetachOptions {
+		success?: () => void;
+		error?: (error: string) => void;
+		noRequest?: boolean;
+	}
 	interface PluginHandle {
 		plugin: string;
 		id: string;
 		token?: string;
-		detached : boolean;
-		webrtcStuff: {
-			started: boolean,
-			myStream: MediaStream,
-			streamExternal: boolean,
-			remoteStream: MediaStream,
-			mySdp: any,
-			mediaConstraints: any,
-			pc: RTCPeerConnection,
-			dataChannelOptions: RTCDataChannelInit,
-			dataChannel: Array<RTCDataChannel>,
-			dtmfSender: any,
-			trickle: boolean,
-			iceDone: boolean,
-			volume: {
-				value: number,
-				timer: number
-			}
-		};
+		detached: boolean;
+		webrtcStuff: WebRTCInfo;
 		getId(): string;
 		getPlugin(): string;
 		send(message: PluginMessage): void;
-		createOffer(params: any): void;
+		createOffer(params: OfferParams): void;
 		createAnswer(params: any): void;
 		handleRemoteJsep(params: { jsep: JSEP }): void;
 		dtmf(params: any): void;
@@ -173,7 +215,7 @@ declare namespace JanusJS {
 		unmuteVideo(): void;
 		getBitrate(): string;
 		hangup(sendRequest?: boolean): void;
-		detach(params: any): void;
+		detach(params?: DetachOptions): void;
 	}
 
 	class Janus {
@@ -191,14 +233,17 @@ declare namespace JanusJS {
 		static attachMediaStream(element: HTMLMediaElement, stream: MediaStream): void;
 		static reattachMediaStream(to: HTMLMediaElement, from: HTMLMediaElement): void;
 
+		static stopAllTracks(stream: MediaStream): void;
+
 		constructor(options: ConstructorOptions);
 
+		attach(options: PluginOptions): void;
 		getServer(): string;
 		isConnected(): boolean;
-		getSessionId(): string;
-		attach(options: PluginOptions): void;
-		reconnect(options: ReconnectOptions): void;
-		destroy(options: DestroyOptions): void;
+		reconnect(callbacks: ReconnectOptions): void;
+		getSessionId(): number;
+		getInfo(callbacks: GetInfoOptions): void;
+		destroy(callbacks: DestroyOptions): void;
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A javascript library for interacting with the C based Janus WebRTC Server",
   "main": "html/janus.js",
+  "types": "npm/janus.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/meetecho/janus-gateway.git"


### PR DESCRIPTION
While implementing our solution basing on janus.js, our team did not notice that janus ships with (some) typings at all, so they rolled their own. This is due to using the git checkout directly, whose package.json does not mention the `types` option.

This was added now, so the types are picked up. Additionally, I updated the types with the more refined version from our team, plus changes for the multistream version of janus.js (mainly `onremotetrack` etc).

Those typings make it through our typechecks, but I reserve the option to add more stuff there as we go further!

Any feedback is valued!