### PR TITLE
Fix transport-wide CC feedback when simulcast SSRCs are missing

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -3994,22 +3994,22 @@ static gboolean janus_ice_outgoing_transport_wide_cc_feedback(gpointer user_data
 				/* Pick the first valid SSRC we find across all considered mediums */
 				int i = 0;
 				for(i = 0; i < 3; i++) {
-					if(m->ssrc_peer[i] != 0)
+					if(m->ssrc_peer[i] != 0) {
+						ssrc_peer = m->ssrc_peer[i];
+						medium = m;
 						break;
+					}
 				}
 
 				/* Stop if we found a valid SSRC/medium to use */
-				if(i < 3) {
-					ssrc_peer = m->ssrc_peer[i];
-					medium = m;
+				if(medium && ssrc_peer)
 					break;
-				}
 			}
 		}
 		janus_mutex_unlock(&handle->mutex);
 	}
 
-	if(!medium) {
+	if(medium == NULL) {
 		JANUS_LOG(LOG_HUGE, "No medium with a valid peer SSRC found for transport-wide CC feedback\n");
 		return G_SOURCE_CONTINUE;
 	}


### PR DESCRIPTION
When a publisher never sends video frames for a simulcast layer (whether due to its own heuristics or the layer being disabled by the user), the SSRC for that layer will remain unknown. The TWCC feedback mechanism was always picking the first layer's SSRC, causing the report to default to an SSRC of zero if the layer never got any data.

As I understand it, being transport-wide, any SSRC going over the transport will do, so this simply goes through each simulcast layer and picks the first SSRC that exists.

The bug this PR fixes turned out to be the underlying cause of the behavior described [here](https://github.com/meetecho/janus-gateway/issues/2899#issuecomment-1047912315). In short, the lack of feedback reports with known SSRCs caused the publisher to continually downgrade the BWE for the connection, until it got low enough that the VP8 encoder fell over, causing the timestamps on frames to fall out of pace.