### PR TITLE
send a PLI when a subscriber is resuming a previously paused stream

### DIFF
--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -9259,7 +9259,7 @@ static void *janus_videoroom_handler(void *data) {
 						gboolean oldvideo = stream->send;
 						gboolean newvideo = json_is_true(video);
 						if(!oldvideo && newvideo) {
-							/* Audio just resumed, reset the RTP sequence numbers */
+							/* Video just resumed, reset the RTP sequence numbers */
 							stream->context.seq_reset = TRUE;
 						}
 						stream->send = newvideo;
@@ -9283,6 +9283,10 @@ static void *janus_videoroom_handler(void *data) {
 							stream->context.seq_reset = TRUE;
 						}
 						stream->send = json_is_true(send);
+						if(newsend) {
+							/* Send a PLI */
+							janus_videoroom_reqpli(ps, "Restoring video for subscriber");
+						}
 					}
 					/* Next properties are for video only */
 					if(stream->type != JANUS_VIDEOROOM_MEDIA_VIDEO) {


### PR DESCRIPTION
Hi, i think i found a small issue since the multistream merge:

in the current codebase, a PLI is sent when a subscriber issues a `configure` request to start a previously paused stream, see [here](https://github.com/meetecho/janus-gateway/blob/03db74a81f6ab294cd3164211a985ed2a11dae37/src/plugins/janus_videoroom.c#L9268).

However this is only done when using the deprecated `video` parameter, and not when using `send`, causing a delay to the receiver (the stream is "frozen" until the next complete frame).

This PR is to add the PLI request also in latter case.