### PR TITLE
Clear rid on icerestart when simulcast

### DIFF
--- a/src/sdp.c
+++ b/src/sdp.c
@@ -367,6 +367,9 @@ int janus_sdp_process_remote(void *ice_handle, janus_sdp *remote_sdp, gboolean r
 		/* Is simulcasting enabled, using rid? (we need to check this before parsing SSRCs) */
 		tempA = m->attributes;
 		medium->rids_hml = rids_hml;
+		medium->rid[0] = NULL;
+		medium->rid[1] = NULL;
+		medium->rid[2] = NULL;
 		while(tempA) {
 			janus_sdp_attribute *a = (janus_sdp_attribute *)tempA->data;
 			if(a->name && !strcasecmp(a->name, "rid") && a->value) {


### PR DESCRIPTION
When on google chrome (98.0.4758.80) WebRTC Publisher with Simulcast.

1. Start publisher with simulcast.
```javascript
pc.addTransceiver('video', {
            direction: "sendonly",
            sendEncodings: [
                { rid: "h", active: true, scaleResolutionDownBy: 1 },
                { rid: "m", active: true, scaleResolutionDownBy: 2 },
            ],
        });
```
2. Subscribe to substream 1 (m)
3. Do iceRestart on publisher (client side only)
```javascript
pc.restartIce(); // or iptables ... -j DROP
/// Rest of createOffer({iceRestart:true}); ..... send...
```
4. Subscriber stops playback

Log from Janus:
```
[5914095661566972] Negotiation update, checking what changed...
[5914095661566972] ICE restart detected
[WARN] [5914095661566972] Too many RTP Stream IDs, ignoring 'm'...
```

It does continue playing on current master, **if** i'm subscribed to substream 0 (h), else if i'm subscribed to substream 1(m), it stops playing.

Setting them all to NULL initially when restarting makes both 0(h) and 1(m) continue to play when publisher does ice restart.