### PR TITLE
Set MTU size to play stream in NordVPN/Chrome incognito mode setup

### DIFF
--- a/src/plugins/streams/test_gstreamer1.sh
+++ b/src/plugins/streams/test_gstreamer1.sh
@@ -7,5 +7,5 @@ gst-launch-1.0 \
   videotestsrc ! \
     video/x-raw,width=320,height=240,framerate=15/1 ! \
     videoscale ! videorate ! videoconvert ! timeoverlay ! \
-    vp8enc error-resilient=1 ! \
-      rtpvp8pay ! udpsink host=127.0.0.1 port=5004
+    vp8enc keyframe-max-dist=7 error-resilient=1 ! \
+      rtpvp8pay mtu=1360 ! udpsink host=127.0.0.1 port=5004

--- a/src/plugins/streams/test_gstreamer1.sh
+++ b/src/plugins/streams/test_gstreamer1.sh
@@ -7,5 +7,5 @@ gst-launch-1.0 \
   videotestsrc ! \
     video/x-raw,width=320,height=240,framerate=15/1 ! \
     videoscale ! videorate ! videoconvert ! timeoverlay ! \
-    vp8enc keyframe-max-dist=7 error-resilient=1 ! \
-      rtpvp8pay mtu=1360 ! udpsink host=127.0.0.1 port=5004
+    vp8enc error-resilient=1 ! \
+      rtpvp8pay mtu=1200 ! udpsink host=127.0.0.1 port=5004

--- a/src/plugins/streams/test_gstreamer1_multistream.sh
+++ b/src/plugins/streams/test_gstreamer1_multistream.sh
@@ -12,5 +12,5 @@ gst-launch-1.0 \
   videotestsrc ! \
     video/x-raw,width=320,height=240,framerate=15/1 ! \
     videoscale ! videorate ! videoconvert ! timeoverlay ! \
-    vp8enc keyframe-max-dist=7 error-resilient=1 ! \
-      rtpvp8pay mtu=1360 ! udpsink host=127.0.0.1 port=5106
+    vp8enc error-resilient=1 ! \
+      rtpvp8pay mtu=1200 ! udpsink host=127.0.0.1 port=5106

--- a/src/plugins/streams/test_gstreamer1_multistream.sh
+++ b/src/plugins/streams/test_gstreamer1_multistream.sh
@@ -8,7 +8,7 @@ gst-launch-1.0 \
     video/x-raw,width=320,height=240,framerate=15/1 ! \
     videoscale ! videorate ! videoconvert ! timeoverlay ! \
     vp8enc error-resilient=1 ! \
-      rtpvp8pay ! udpsink host=127.0.0.1 port=5104 \
+      rtpvp8pay mtu=1200 ! udpsink host=127.0.0.1 port=5104 \
   videotestsrc ! \
     video/x-raw,width=320,height=240,framerate=15/1 ! \
     videoscale ! videorate ! videoconvert ! timeoverlay ! \

--- a/src/plugins/streams/test_gstreamer1_multistream.sh
+++ b/src/plugins/streams/test_gstreamer1_multistream.sh
@@ -12,5 +12,5 @@ gst-launch-1.0 \
   videotestsrc ! \
     video/x-raw,width=320,height=240,framerate=15/1 ! \
     videoscale ! videorate ! videoconvert ! timeoverlay ! \
-    vp8enc error-resilient=1 ! \
-      rtpvp8pay ! udpsink host=127.0.0.1 port=5106
+    vp8enc keyframe-max-dist=7 error-resilient=1 ! \
+      rtpvp8pay mtu=1360 ! udpsink host=127.0.0.1 port=5106


### PR DESCRIPTION
In case NordVPN(and possibly other VPNs) is used in combination with the Chrome incognito mode or Safari private mode and the streaming plugin, we can see a significant packet loss:

<img width="379" alt="image" src="https://user-images.githubusercontent.com/178517/160424939-af46815c-82f8-4979-ac2c-a9bb690633fc.png">

This can be reproduced in the official demo at https://janus.conf.meetecho.com/streamingtest.html (OPUS/VP8 live stream (sent by gstreamer script)(live), you can hear the audio, but not see the video.

You can see it working when the mtu=1360 is used at https://streaming.totodon.com/streamingtest.html by choosing the color 1280x720 (live) stream

