### PR TITLE
Reset rids when renegotiating SDPs (see #2927)

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -2480,6 +2480,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 								handle->handle_id, packet_ssrc, medium->mid);
 							gboolean found = FALSE;
 							/* Check if simulcasting is involved */
+							janus_mutex_lock(&handle->mutex);
 							if(medium->rid[0] == NULL || pc->rid_ext_id < 1) {
 								medium->ssrc_peer[0] = packet_ssrc;
 								found = TRUE;
@@ -2521,6 +2522,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 									}
 								}
 							}
+							janus_mutex_unlock(&handle->mutex);
 							if(found) {
 								g_hash_table_insert(pc->media_byssrc, GINT_TO_POINTER(packet_ssrc), medium);
 								janus_refcount_increase(&medium->ref);

--- a/src/janus.c
+++ b/src/janus.c
@@ -3819,6 +3819,7 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 			if(opusred_pt < 0 && medium != NULL && medium->opusred_pt > 0)
 				medium->opusred_pt = 0;
 			/* Check if rid-based simulcasting is available */
+			janus_mutex_lock(&ice_handle->mutex);
 			if(!have_rid && medium != NULL) {
 				g_free(medium->rid[0]);
 				medium->rid[0] = NULL;
@@ -3831,6 +3832,7 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 					medium->ssrc_peer_temp = 0;
 				}
 			}
+			janus_mutex_unlock(&ice_handle->mutex);
 			do_mid = do_mid || have_mid;
 			do_rid = do_rid || have_rid;
 			do_repaired_rid = do_repaired_rid || have_repaired_rid;

--- a/src/sdp.c
+++ b/src/sdp.c
@@ -367,6 +367,12 @@ int janus_sdp_process_remote(void *ice_handle, janus_sdp *remote_sdp, gboolean r
 		/* Is simulcasting enabled, using rid? (we need to check this before parsing SSRCs) */
 		tempA = m->attributes;
 		medium->rids_hml = rids_hml;
+		g_free(medium->rid[0]);
+		medium->rid[0] = NULL;
+		g_free(medium->rid[1]);
+		medium->rid[1] = NULL;
+		g_free(medium->rid[2]);
+		medium->rid[2] = NULL;
 		while(tempA) {
 			janus_sdp_attribute *a = (janus_sdp_attribute *)tempA->data;
 			if(a->name && !strcasecmp(a->name, "rid") && a->value) {


### PR DESCRIPTION
Better context is provided in #2927. This is an extended version of that PR that addresses the memory leak comment, and adds some mutexes to ensure concurrent access to rids can't cause issues during a renegotiation.