### PR TITLE
0.x: videoroom: always default {min,max}_delay to -1

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -6302,6 +6302,8 @@ static void *janus_videoroom_handler(void *data) {
 				publisher->audio_level_extmap_id = 0;
 				publisher->video_orient_extmap_id = 0;
 				publisher->playout_delay_extmap_id = 0;
+				publisher->min_delay = -1;	/* We'll deal with this later */
+				publisher->max_delay = -1;	/* We'll deal with this later */
 				publisher->remb_startup = 4;
 				publisher->remb_latest = 0;
 				publisher->fir_latest = 0;


### PR DESCRIPTION
This was defaulting to 0 since publishers are allocated with g_malloc0.