### PR TITLE
Add stream description

### DIFF
--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -7104,7 +7104,7 @@ static void janus_videoroom_recorder_create(janus_videoroom_publisher_stream *ps
 			}
 		}
 		/* If the stream has a description, store it in the recording */
-		if(ps->description && rc)
+		if(ps->description)
 			janus_recorder_description(rc, ps->description);
 		/* If the video-orientation extension has been negotiated, mark it in the recording */
 		if(ps->video_orient_extmap_id > 0)

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -7103,6 +7103,9 @@ static void janus_videoroom_recorder_create(janus_videoroom_publisher_stream *ps
 					janus_videoroom_media_str(ps->type));
 			}
 		}
+		/* If the stream has a description, store it in the recording */
+		if(ps->description && rc)
+			rc->description = ps->description;
 		/* If the video-orientation extension has been negotiated, mark it in the recording */
 		if(ps->video_orient_extmap_id > 0)
 			janus_recorder_add_extmap(rc, ps->video_orient_extmap_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
@@ -10410,6 +10413,7 @@ static void *janus_videoroom_handler(void *data) {
 					while(temp) {
 						janus_videoroom_publisher_stream *ps = (janus_videoroom_publisher_stream *)temp->data;
 						janus_videoroom_recorder_create(ps);
+						AAA
 						temp = temp->next;
 					}
 					participant->recording_active = TRUE;

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -7105,7 +7105,7 @@ static void janus_videoroom_recorder_create(janus_videoroom_publisher_stream *ps
 		}
 		/* If the stream has a description, store it in the recording */
 		if(ps->description && rc)
-			rc->description = ps->description;
+			rc->description = g_strdup(ps->description);
 		/* If the video-orientation extension has been negotiated, mark it in the recording */
 		if(ps->video_orient_extmap_id > 0)
 			janus_recorder_add_extmap(rc, ps->video_orient_extmap_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -7105,7 +7105,7 @@ static void janus_videoroom_recorder_create(janus_videoroom_publisher_stream *ps
 		}
 		/* If the stream has a description, store it in the recording */
 		if(ps->description && rc)
-			rc->description = g_strdup(ps->description);
+			janus_recorder_description(rc, ps->description);
 		/* If the video-orientation extension has been negotiated, mark it in the recording */
 		if(ps->video_orient_extmap_id > 0)
 			janus_recorder_add_extmap(rc, ps->video_orient_extmap_id, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION);
@@ -8620,11 +8620,8 @@ static void *janus_videoroom_handler(void *data) {
 								desc_updated = TRUE;
 								g_free(ps->description);
 								ps->description = g_strdup(d_desc);
-								if(ps->rc) {
-									if(ps->rc->description)
-										g_free(ps->rc->description);
-									ps->rc->description = g_strdup(d_desc);
-								}
+								if(ps->rc)
+									janus_recorder_description(ps->rc, d_desc);
 							}
 						}
 					}

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -10413,7 +10413,6 @@ static void *janus_videoroom_handler(void *data) {
 					while(temp) {
 						janus_videoroom_publisher_stream *ps = (janus_videoroom_publisher_stream *)temp->data;
 						janus_videoroom_recorder_create(ps);
-						AAA
 						temp = temp->next;
 					}
 					participant->recording_active = TRUE;

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -8620,8 +8620,6 @@ static void *janus_videoroom_handler(void *data) {
 								desc_updated = TRUE;
 								g_free(ps->description);
 								ps->description = g_strdup(d_desc);
-								if(ps->rc)
-									janus_recorder_description(ps->rc, d_desc);
 							}
 						}
 					}

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -8620,6 +8620,11 @@ static void *janus_videoroom_handler(void *data) {
 								desc_updated = TRUE;
 								g_free(ps->description);
 								ps->description = g_strdup(d_desc);
+								if(ps->rc) {
+									if(ps->rc->description)
+										g_free(ps->rc->description);
+									ps->rc->description = g_strdup(d_desc);
+								}
 							}
 						}
 					}

--- a/src/record.c
+++ b/src/record.c
@@ -298,9 +298,17 @@ int janus_recorder_description(janus_recorder *recorder, const char *description
 		return -1;
 	if (!description)
 		return -1;
+	janus_mutex_lock_nodebug(&recorder->mutex);
+	if(g_atomic_int_get(&recorder->header)) {
+		/* No use setting description once it's already written in the MJR file */
+		janus_mutex_unlock_nodebug(&recorder->mutex);
+		return 0;
+	}
+
 	if(recorder->description)
 		g_free(recorder->description);
 	recorder->description = g_strdup(description);
+	janus_mutex_unlock_nodebug(&recorder->mutex);
 	return 0;
 }
 

--- a/src/record.c
+++ b/src/record.c
@@ -116,6 +116,7 @@ janus_recorder *janus_recorder_create_full(const char *dir, const char *codec, c
 	rc->file = NULL;
 	rc->codec = g_strdup(codec);
 	rc->fmtp = fmtp ? g_strdup(fmtp) : NULL;
+	rc->description = NULL;
 	rc->created = janus_get_real_time();
 	const char *rec_dir = NULL;
 	const char *rec_file = NULL;

--- a/src/record.c
+++ b/src/record.c
@@ -350,7 +350,7 @@ int janus_recorder_save_frame(janus_recorder *recorder, char *buffer, uint lengt
 		if(recorder->fmtp)
 			json_object_set_new(info, "f", json_string(recorder->fmtp));				/* Codec-specific info */
 		if(recorder->description)
-			json_object_set_new(info, "desc", json_string(recorder->description));		/* Stream description */
+			json_object_set_new(info, "d", json_string(recorder->description));		/* Stream description */
 		if(recorder->extensions) {
 			/* Add the extmaps to the JSON object */
 			json_t *extmaps = NULL;

--- a/src/record.c
+++ b/src/record.c
@@ -293,6 +293,16 @@ int janus_recorder_add_extmap(janus_recorder *recorder, int id, const char *extm
 	return 0;
 }
 
+int janus_recorder_description(janus_recorder *recorder, const char *description) {
+	if (!description)
+		return -1;
+	if (recorder->description) {
+		g_free(recorder->description);
+	}
+	recorder->description = g_strdup(description);
+	return 0;
+}
+
 int janus_recorder_opusred(janus_recorder *recorder, int red_pt) {
 	if(!recorder)
 		return -1;

--- a/src/record.c
+++ b/src/record.c
@@ -294,6 +294,8 @@ int janus_recorder_add_extmap(janus_recorder *recorder, int id, const char *extm
 }
 
 int janus_recorder_description(janus_recorder *recorder, const char *description) {
+	if(!recorder)
+		return -1;
 	if (!description)
 		return -1;
 	if(recorder->description)

--- a/src/record.c
+++ b/src/record.c
@@ -349,6 +349,8 @@ int janus_recorder_save_frame(janus_recorder *recorder, char *buffer, uint lengt
 		json_object_set_new(info, "c", json_string(recorder->codec));					/* Media codec */
 		if(recorder->fmtp)
 			json_object_set_new(info, "f", json_string(recorder->fmtp));				/* Codec-specific info */
+		if(recorder->description)
+			json_object_set_new(info, "desc", json_string(recorder->description));		/* Stream description */
 		if(recorder->extensions) {
 			/* Add the extmaps to the JSON object */
 			json_t *extmaps = NULL;

--- a/src/record.c
+++ b/src/record.c
@@ -296,9 +296,8 @@ int janus_recorder_add_extmap(janus_recorder *recorder, int id, const char *extm
 int janus_recorder_description(janus_recorder *recorder, const char *description) {
 	if (!description)
 		return -1;
-	if (recorder->description) {
+	if(recorder->description)
 		g_free(recorder->description);
-	}
 	recorder->description = g_strdup(description);
 	return 0;
 }

--- a/src/record.h
+++ b/src/record.h
@@ -49,6 +49,8 @@ typedef struct janus_recorder {
 	char *codec;
 	/*! \brief Codec-specific info (e.g., H.264 or VP9 profile) */
 	char *fmtp;
+	/*! \brief Stream description */
+	char *description;
 	/*! \brief List of RTP extensions (as a hashtable, indexed by ID) in this recording */
 	GHashTable *extensions;
 	/*! \brief When the recording file has been created and started */

--- a/src/record.h
+++ b/src/record.h
@@ -119,6 +119,11 @@ int janus_recorder_resume(janus_recorder *recorder);
  * @param[in] extmap Namespace of the RTP extension
  * @returns 0 in case of success, a negative integer otherwise */
 int janus_recorder_add_extmap(janus_recorder *recorder, int id, const char *extmap);
+/*! \brief Set the description for this recording
+ * @param[in] recorder The janus_recorder instance to add the description to
+ * @param[in] description The description
+ * @returns 0 in case of success, a negative integer otherwise */
+int janus_recorder_description(janus_recorder *recorder, const char *description);
 /*! \brief Mark this recording as using RED for audio
  * \note This will only be possible BEFORE the first frame is written, as it needs to
  * be reflected in the .mjr header: doing this after that will return an error.


### PR DESCRIPTION
Initial PoC for the idea [discussed here](https://groups.google.com/g/meetecho-janus/c/zRtRr4HZ_yY).

The stream description is stored inside the MJR JSON header.

Example:
root@d686bae6dcd2:/# janus-pp-rec --json videoroom-1234-user-7961364863991430-1649775467729201-video-1.mjr 
{"t": "v", "c": "vp8", "desc": "screenshare", "x": {"13": "urn:3gpp:video-orientation"}, "s": 1649775467729302, "u": 1649775469347109}


I'm unsure about the fact that the stream description is now saved in 2 places, the `janus_recorder` instance (newly added), and the owning `janus_videoroom_publisher_stream` (where it was located before). 

Open to feedback
