### PR TITLE
Support for dummy publishers in VideoRoom

### DIFF
--- a/conf/janus.plugin.videoroom.jcfg.sample
+++ b/conf/janus.plugin.videoroom.jcfg.sample
@@ -44,6 +44,14 @@
 #               for admin to manage listening only participants. default=false)
 # require_e2ee = true|false (whether all participants are required to publish and subscribe
 #             using end-to-end media encryption, e.g., via Insertable Streams; default=false)
+# dummy_publisher = true|false (whether a dummy publisher should be created in this room,
+#                 with one separate m-line for each codec supported in the room; this is
+#                 useful when there's a need to create subscriptions with placeholders
+#                 for some or all m-lines, even when they aren't used yet; default=false)
+# dummy_streams = in case dummy_publisher is set to true, array of codecs to offer,
+#				optionally with a fmtp attribute to match (codec/fmtp properties).
+#				If not provided, all codecs enabled in the room are offered, with no fmtp.
+#				Notice that the fmtp is parsed, and only a few codecs are supported.
 #}
 
 general: {

--- a/html/mvideoroomtest.js
+++ b/html/mvideoroomtest.js
@@ -184,6 +184,8 @@ $(document).ready(function() {
 												Janus.debug("Got a list of available publishers/feeds:", list);
 												var sources = null;
 												for(var f in list) {
+													if(list[f]["dummy"])
+														continue;
 													var id = list[f]["id"];
 													var display = list[f]["display"];
 													var streams = list[f]["streams"];
@@ -230,6 +232,8 @@ $(document).ready(function() {
 												Janus.debug("Got a list of available publishers/feeds:", list);
 												var sources = null;
 												for(var f in list) {
+													if(list[f]["dummy"])
+														continue;
 													var id = list[f]["id"];
 													var display = list[f]["display"];
 													var streams = list[f]["streams"];

--- a/html/screensharingtest.js
+++ b/html/screensharingtest.js
@@ -211,6 +211,8 @@ $(document).ready(function() {
 													var list = msg["publishers"];
 													Janus.debug("Got a list of available publishers/feeds:", list);
 													for(var f in list) {
+														if(list[f]["dummy"])
+															continue;
 														var id = list[f]["id"];
 														var display = list[f]["display"];
 														Janus.debug("  >> [" + id + "] " + display);
@@ -224,6 +226,8 @@ $(document).ready(function() {
 												var list = msg["publishers"];
 												Janus.debug("Got a list of available publishers/feeds:", list);
 												for(var f in list) {
+													if(list[f]["dummy"])
+														continue;
 													var id = list[f]["id"];
 													var display = list[f]["display"];
 													Janus.debug("  >> [" + id + "] " + display);

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -183,6 +183,8 @@ $(document).ready(function() {
 												var list = msg["publishers"];
 												Janus.debug("Got a list of available publishers/feeds:", list);
 												for(var f in list) {
+													if(list[f]["dummy"])
+														continue;
 													var id = list[f]["id"];
 													var streams = list[f]["streams"];
 													for(var i in streams) {
@@ -215,6 +217,8 @@ $(document).ready(function() {
 												var list = msg["publishers"];
 												Janus.debug("Got a list of available publishers/feeds:", list);
 												for(var f in list) {
+													if(list[f]["dummy"])
+														continue;
 													var id = list[f]["id"];
 													var display = list[f]["display"];
 													var streams = list[f]["streams"];

--- a/html/vp9svctest.js
+++ b/html/vp9svctest.js
@@ -171,6 +171,8 @@ $(document).ready(function() {
 												var list = msg["publishers"];
 												Janus.debug("Got a list of available publishers/feeds:", list);
 												for(var f in list) {
+													if(list[f]["dummy"])
+														continue;
 													var id = list[f]["id"];
 													var display = list[f]["display"];
 													var streams = list[f]["streams"];
@@ -204,6 +206,8 @@ $(document).ready(function() {
 												var list = msg["publishers"];
 												Janus.debug("Got a list of available publishers/feeds:", list);
 												for(var f in list) {
+													if(list[f]["dummy"])
+														continue;
 													var id = list[f]["id"];
 													var display = list[f]["display"];
 													var streams = list[f]["streams"];

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -10302,7 +10302,7 @@ static void *janus_videoroom_handler(void *data) {
 					g_hash_table_iter_init(&iter, videoroom->participants);
 					while (!g_atomic_int_get(&videoroom->destroyed) && g_hash_table_iter_next(&iter, NULL, &value)) {
 						janus_videoroom_publisher *p = value;
-						if(p != participant && g_atomic_int_get(&p->session->started))
+						if(p != participant && g_atomic_int_get(&p->session->started) && !p->dummy)
 							count++;
 					}
 					if(count == videoroom->max_publishers) {


### PR DESCRIPTION
In a VideoRoom, you can only subscribe to someone if they're actually in the room: as a consequence, if the room is empty, you can't create a subscription handle/PeerConnection, because there's not an ID to subscribe to. This patch tries to address that, and open some interesting opportunities.

Specifically, it adds the concept of "dummy publisher". When you create a new room, you can ask for a dummy publisher to be created: this publisher will have an ID like all other (real) participants, but will only exist for the purpose of allowing you to subscribe to something, without ever sending you any data. It also acts as an empty placeholder that you can switch to/from. Of course, this dummy publisher is clearly marked so that you can skip it if needed, or know how to use it. When creating a dummy publisher, by default a stream is added for each of the supported codecs in the room. You can limit the codecs to support in the dummy publisher, as well as specifying some fmtp attributes to advertise, when creating the room.

The syntax is relatively straightforward, as all you need to enable the feature (which is disabled by default) is add a

    dummy_publisher: true

property when creating the room (statically or dynamically). As anticipated, this will create a publisher with a different stream for each supported codec, which means that if the room is created like this:

    audiocodec: "opus",
    videocodec: "vp8,vp9",
    dummy_publisher: true

meaning Opus is the only supported codec for audio, but the room accepts both VP8 and VP9, then this dummy publisher will be created with three publisher streams, as if they were publishing an Opus audio stream, a VP8 video stream, and a VP9 video stream, thus allowing other participants in the room to subscribe to whatever they want. You can enforce a finer grain control on the streams to make available passing a `dummy_stream` array too when creating the room, where each object needs to reference an existing codec, e.g.:

    dummy_publisher: true,
    dummy_streams = [ { codec: "opus" }, { codec: "vp8" }, { codec: "vp9" } ]

If for instance you only want to have the dummy publisher to have Opus and VP8, but not VP9, you'd use something like this:

    dummy_publisher: true,
    dummy_streams = [ { codec: "opus" }, { codec: "vp8" } ]

If you want the dummy publisher to offer something specific in the SDP, you can add an `fmtp` property in the codec object, e.g.:

    dummy_publisher: true,
    dummy_streams = [ { codec:  "opus", fmtp: "stereo=1" }, { codec: "vp8" } ]

to advertise the Opus stream as stereo in its fmtp attribute.

As anticipated, dummy publishers are listed just as any other valid publisher in the room, which means you can use and reference them exactly as you already do: you can subscribe/unsubscribe to them, switch to them, etc. You can recognize a dummy publisher by the `dummy: true` property in the publishers list, which will make it easy to identify them quickly (this PR changes the demos too so that they're skipped by default).

From the few tests I've made this seems to be working as expected, but of course feedback in case it's not working as expected or it's breaking something that worked before is more than welcome.