### PR TITLE
0.x: Honor "audio", "data", "video" flag changes in subscriber updates.

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -7454,9 +7454,9 @@ static void *janus_videoroom_handler(void *data) {
 						json_decref(jsep);
 						g_free(newsdp);
 						/* Any update in the media directions? */
-						subscriber->audio = publisher->audio && subscriber->audio_offered;
-						subscriber->video = publisher->video && subscriber->video_offered;
-						subscriber->data = publisher->data && subscriber->data_offered;
+						subscriber->audio = subscriber->audio && publisher->audio && subscriber->audio_offered;
+						subscriber->video = subscriber->video && publisher->video && subscriber->video_offered;
+						subscriber->data = subscriber->data && publisher->data && subscriber->data_offered;
 						/* Done */
 						janus_videoroom_message_free(msg);
 						janus_refcount_decrease(&subscriber->ref);


### PR DESCRIPTION
If a `configure` request is sent for a subscriber with `update: true` and `video: false`, the flags are evaluated in https://github.com/fancycode/janus-gateway/blob/79f0b172be0fc1d9e45e6fa77935b336444ffda4/plugins/janus_videoroom.c#L7234-L7257 but then later might get overridden again.