### PR TITLE
Handle publishing of multiple streams from same publisher

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1208,7 +1208,6 @@ function Janus(gatewayCallbacks) {
 						detached : false,
 						webrtcStuff : {
 							started : false,
-							myStream : null,
 							myStreams : [],
 							streamExternal : false,
 							remoteStreams : [],

--- a/html/janus.js
+++ b/html/janus.js
@@ -1736,20 +1736,20 @@ function Janus(gatewayCallbacks) {
 		var addTracks = false;
 
 		if(!config.myStreams.length || !media.update || (config.streamExternal && !media.replaceAudio && !media.replaceVideo)) {
-            if(stream) {
-			    config.myStreams.push(stream);
-            }
+			if(stream) {
+				config.myStreams.push(stream);
+			}
 			addTracks = true;
 
 		} else {
 			// We only need to update the existing stream
 
-            var myStream = config.myStreams[0];
-            if(media.streamId) {
-                myStream = config.myStreams.find(function(str) {
-                    return str.id === media.streamId;
-                });
-            }
+			var myStream = config.myStreams[0];
+			if(media.streamId) {
+				myStream = config.myStreams.find(function(str) {
+					return str.id === media.streamId;
+				});
+			}
 
 			if(((!media.update && isAudioSendEnabled(media)) || (media.update && (media.addAudio || media.replaceAudio))) &&
 					stream.getAudioTracks() && stream.getAudioTracks().length) {
@@ -1893,29 +1893,29 @@ function Janus(gatewayCallbacks) {
 
 				var incomingStream = event.streams[0];
 
-                var remoteStreamIndex;
-                var remoteStream = config.remoteStreams.find(function(str, index) {
-                    if(str.id === incomingStream.id) {
-                        remoteStreamIndex = index;
-                        return true;
-                    }
-                    return false;
-                });
+				var remoteStreamIndex;
+				var remoteStream = config.remoteStreams.find(function(str, index) {
+					if(str.id === incomingStream.id) {
+						remoteStreamIndex = index;
+						return true;
+					}
+					return false;
+				});
 
-                if(remoteStream) {
-                    config.remoteStreams[remoteStreamIndex] = incomingStream
-                } else {
-                    config.remoteStreams.push(incomingStream)
-                    remoteStreamIndex = config.remoteStreams.length-1;
-                    remoteStream = config.remoteStreams[remoteStreamIndex];
-                }
+				if(remoteStream) {
+					config.remoteStreams[remoteStreamIndex] = incomingStream
+				} else {
+					config.remoteStreams.push(incomingStream)
+					remoteStreamIndex = config.remoteStreams.length-1;
+					remoteStream = config.remoteStreams[remoteStreamIndex];
+				}
 
-                if(!event.track)
+				if(!event.track)
 					return;
 
 				// Notify about the new track event
 				var mid = event.transceiver ? event.transceiver.mid : event.track.id;
-                try {
+				try {
 					pluginHandle.onremotetrack(event.track, mid, true);
 				} catch(e) {
 					Janus.error(e);
@@ -1972,7 +1972,7 @@ function Janus(gatewayCallbacks) {
 					if(remoteStream && trackMutedTimeoutId == null) {
 						trackMutedTimeoutId = setTimeout(function() {
 							Janus.log("Removing remote track");
-                            if (remoteStream) {
+							if (remoteStream) {
 								config.remoteStreams[remoteStreamIndex].removeTrack(ev.target);
 								// Notify the application the track is gone
 								var mid = ev.target.id;
@@ -2088,9 +2088,9 @@ function Janus(gatewayCallbacks) {
 			};
 		}
 		// If there's a new local stream, let's notify the application
-        var myStream = config.myStreams.find(function(str) {
-            return str.id === stream.id;
-        });
+		var myStream = config.myStreams.find(function(str) {
+			return str.id === stream.id;
+		});
 
 		if(myStream) {
 			var tracks = myStream.getTracks();
@@ -2165,25 +2165,25 @@ function Janus(gatewayCallbacks) {
 		}
 		var config = pluginHandle.webrtcStuff;
 		config.trickle = isTrickleEnabled(callbacks.trickle);
-        // Which stream we are going to work on?
-        var myStream = null;
-        var myStreamIndex = null;
+		// Which stream we are going to work on?
+		var myStream = null;
+		var myStreamIndex = null;
 
-        if(config.myStreams.length) {
+		if(config.myStreams.length) {
 
-            if(media.streamId) {
-                myStream = config.myStreams.find(function(str, index) {
-                    if(str.id === media.streamId) {
-                        myStreamIndex = index;
-                        return true;
-                    }
-                    return false;
-                });
-            } else if(config.myStreams[0]) {
-                myStream = config.myStreams[0];
-                myStreamIndex = 0;
-            }
-        }
+			if(media.streamId) {
+				myStream = config.myStreams.find(function(str, index) {
+					if(str.id === media.streamId) {
+						myStreamIndex = index;
+						return true;
+					}
+					return false;
+				});
+			} else if(config.myStreams[0]) {
+				myStream = config.myStreams[0];
+				myStreamIndex = 0;
+			}
+		}
 
 		// Are we updating a session?
 		if(!config.pc) {
@@ -2199,15 +2199,15 @@ function Janus(gatewayCallbacks) {
 			if(callbacks.stream) {
 				// External stream: is this the same as the one we were using before?
 
-                var existingStream = config.myStreams.find(function(str) {
-                    if(str.id === callbacks.stream.id) {
-                        myStreamIndex = index;
-                        return true;
-                    }
-                    return false;
-                });
+				var existingStream = config.myStreams.find(function(str) {
+					if(str.id === callbacks.stream.id) {
+						myStreamIndex = index;
+						return true;
+					}
+					return false;
+				});
 
-                myStream = existingStream
+				myStream = existingStream
 
 				if(callbacks.stream !== myStream) {
 					Janus.log("Renegotiation involves a new external stream");
@@ -2408,19 +2408,19 @@ function Janus(gatewayCallbacks) {
 			Janus.debug(stream);
 			// If this is an update, let's check if we need to release the previous stream
 
-            myStream = config.myStreams.find(function(str, index) {
-                if(str.id === stream.id) {
-                    myStreamIndex = index;
-                    return true;
-                }
-                return false;
-            });
+			myStream = config.myStreams.find(function(str, index) {
+				if(str.id === stream.id) {
+					myStreamIndex = index;
+					return true;
+				}
+				return false;
+			});
 
 			if(media.update && myStream && myStream !== callbacks.stream && !config.streamExternal && !media.replaceAudio && !media.replaceVideo) {
 				// We're replacing a stream we captured ourselves with an external one
 				Janus.stopAllTracks(myStream);
 
-                config.myStreams.splice(myStreamIndex, 1);
+				config.myStreams.splice(myStreamIndex, 1);
 				myStream = null;
 				myStreamIndex = null;
 			}

--- a/html/janus.js
+++ b/html/janus.js
@@ -2169,6 +2169,8 @@ function Janus(gatewayCallbacks) {
         var myStream = null;
         var myStreamIndex = null;
 
+        if(config.myStreams.length) {
+
             if(media.streamId) {
                 myStream = config.myStreams.find(function(str, index) {
                     if(str.id === media.streamId) {

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -168,14 +168,14 @@ declare namespace JanusJS {
 			sdp: string;
 			type: string;
 		};
-		myStream: MediaStream;
+		myStreams: Array<MediaStream>;
 		pc: RTCPeerConnection;
 		receiverTransforms: {
 			audio: TransformStream;
 			video: TransformStream;
 		};
 		remoteSdp: string;
-		remoteStream: MediaStream;
+		remoteStreams: Array<MediaStream>;
 		senderTransforms: {
 			audio: TransformStream;
 			video: TransformStream;

--- a/src/mainpage.dox
+++ b/src/mainpage.dox
@@ -658,6 +658,7 @@ janus.attach(
  * local audio track), and capture a new audio source;
  * - \c replaceVideo: if set, stop capturing the current video (remove the
  * local video track), and capture a new video source.
+ * - \c streamId: if set, above action / actions will be performed on the published external stream with this ID.
  *
  * Notice that these properties are only processed when you're trying a
  * renegotiation, and will be ignored when creating a new PeerConnection.


### PR DESCRIPTION
It used to save the single published stream in config.myStream, and config.remoteStream for remote stream.

Now both has been changed to config.myStreams and config.remoteStreams respectively to hold an array of MediaStream.

In case of media.update offer, file will look for media.streamId to fetch the correct stream from config.myStreams array to update. Usually this stream ID will belong to an external stream which was already published earlier. 

In media.update request, if media.streamId is not provide then file will automatically take the first MediaStream inside config.myStreams array to update.

Useful Hint for Frontend Developers:
In order to provide the stream ID for the update offer, an object map of stream ID can be stored while publishing the external stream earlier. 
