### PR TITLE
Make SIP timer T1X64 configurable

### DIFF
--- a/conf/janus.plugin.sip.jcfg.sample
+++ b/conf/janus.plugin.sip.jcfg.sample
@@ -48,4 +48,8 @@ general: {
 	# one by uncommenting and setting the property below.
 	#sips_certs_dir = "/etc/sip/certs"
 
+	# Set the T1x64 timeout value (in milliseconds) used by the SIP transaction
+	# engine (default 32000 milliseconds)
+	sip_timer_t1x64 = 32000
+
 }

--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -861,6 +861,8 @@ static uint16_t rtp_range_max = 60000;
 static int dscp_audio_rtp = 0;
 static int dscp_video_rtp = 0;
 static char *sips_certs_dir = NULL;
+#define JANUS_DEFAULT_SIP_TIMER_T1X64 32000
+static int sip_timer_t1x64 = JANUS_DEFAULT_SIP_TIMER_T1X64;
 
 static gboolean query_contact_header = FALSE;
 
@@ -1888,6 +1890,16 @@ int janus_sip_init(janus_callbacks *callback, const char *config_path) {
 			keepalive_interval = 120;
 		} else {
 			JANUS_LOG(LOG_VERB, "SIP keep-alive interval set to %d seconds\n", keepalive_interval);
+		}
+
+		item = janus_config_get(config, config_general, janus_config_type_item, "sip_timer_t1x64");
+		if(item && item->value)
+			sip_timer_t1x64 = atoi(item->value);
+		if(sip_timer_t1x64 < 1) {
+			JANUS_LOG(LOG_ERR, "Invalid SIP Timer T1X64 value: %d (falling back to default)\n", sip_timer_t1x64);
+			sip_timer_t1x64 = JANUS_DEFAULT_SIP_TIMER_T1X64;
+		} else {
+			JANUS_LOG(LOG_VERB, "SIP Timer T1X64 set to %d milliseconds\n", sip_timer_t1x64);
 		}
 
 		item = janus_config_get(config, config_general, janus_config_type_item, "register_ttl");
@@ -7167,6 +7179,7 @@ gpointer janus_sip_sofia_thread(gpointer user_data) {
 				SIPTAG_SUPPORTED_STR("replaces"),	/* Advertise that we support the Replaces header */
 				SIPTAG_SUPPORTED(NULL),
 				NTATAG_CANCEL_2543(session->account.rfc2543_cancel),
+				NTATAG_SIP_T1X64(sip_timer_t1x64),
 				TAG_NULL());
 	if(query_contact_header)
 		nua_get_params(session->stack->s_nua, SIPTAG_FROM_STR(""), TAG_END());


### PR DESCRIPTION
This PR adds the possibility to specify via configuration file the SIP timer T1x64 value used by sofia-sip (used for timers B, F, H, and J (UDP)). The default value of the timer is 32 seconds. 
It can be useful to lower that value in order to reduce the failover time when using a DNS SRV record with multiple priorities in proxy/outbound proxy parameters.