### PR TITLE
Videoroom: Fix RID memory leak

### DIFF
--- a/src/plugins/janus_duktape.c
+++ b/src/plugins/janus_duktape.c
@@ -2456,7 +2456,7 @@ void janus_duktape_incoming_rtp(janus_plugin_session *handle, janus_plugin_rtp *
 	} else {
 		/* We're simulcasting, save the best video quality */
 		gboolean save = janus_rtp_simulcasting_context_process_rtp(&session->rec_simctx,
-			buf, len, session->ssrc, session->rid, session->vcodec, &session->rec_ctx);
+			buf, len, session->ssrc, session->rid, session->vcodec, &session->rec_ctx, NULL);
 		if(save) {
 			uint32_t seq_number = ntohs(rtp->seq_number);
 			uint32_t timestamp = ntohl(rtp->timestamp);
@@ -2782,7 +2782,7 @@ static void janus_duktape_relay_rtp_packet(gpointer data, gpointer user_data) {
 			return;
 		/* Process this packet: don't relay if it's not the SSRC/layer we wanted to handle */
 		gboolean relay = janus_rtp_simulcasting_context_process_rtp(&session->sim_context,
-			(char *)packet->data, packet->length, packet->ssrc, NULL, sender->vcodec, &session->vrtpctx);
+			(char *)packet->data, packet->length, packet->ssrc, NULL, sender->vcodec, &session->vrtpctx, NULL);
 		if(session->sim_context.need_pli && sender->handle) {
 			/* Send a PLI */
 			JANUS_LOG(LOG_VERB, "We need a PLI for the simulcast context\n");

--- a/src/plugins/janus_echotest.c
+++ b/src/plugins/janus_echotest.c
@@ -598,7 +598,7 @@ void janus_echotest_incoming_rtp(janus_plugin_session *handle, janus_plugin_rtp 
 			uint32_t ssrc = ntohl(header->ssrc);
 			/* Process this packet: don't relay if it's not the SSRC/layer we wanted to handle */
 			gboolean relay = janus_rtp_simulcasting_context_process_rtp(&session->sim_context,
-				buf, len, session->ssrc, session->rid, session->vcodec, &session->context);
+				buf, len, session->ssrc, session->rid, session->vcodec, &session->context, NULL);
 			if(session->sim_context.need_pli) {
 				/* Send a PLI */
 				gateway->send_pli(handle);

--- a/src/plugins/janus_lua.c
+++ b/src/plugins/janus_lua.c
@@ -2124,7 +2124,7 @@ void janus_lua_incoming_rtp(janus_plugin_session *handle, janus_plugin_rtp *rtp_
 	} else {
 		/* We're simulcasting, save the best video quality */
 		gboolean save = janus_rtp_simulcasting_context_process_rtp(&session->rec_simctx,
-			buf, len, session->ssrc, session->rid, session->vcodec, &session->rec_ctx);
+			buf, len, session->ssrc, session->rid, session->vcodec, &session->rec_ctx, NULL);
 		if(save) {
 			uint32_t seq_number = ntohs(rtp->seq_number);
 			uint32_t timestamp = ntohl(rtp->timestamp);
@@ -2422,7 +2422,7 @@ static void janus_lua_relay_rtp_packet(gpointer data, gpointer user_data) {
 			return;
 		/* Process this packet: don't relay if it's not the SSRC/layer we wanted to handle */
 		gboolean relay = janus_rtp_simulcasting_context_process_rtp(&session->sim_context,
-			(char *)packet->data, packet->length, packet->ssrc, NULL, sender->vcodec, &session->vrtpctx);
+			(char *)packet->data, packet->length, packet->ssrc, NULL, sender->vcodec, &session->vrtpctx, NULL);
 		if(session->sim_context.need_pli && sender->handle) {
 			/* Send a PLI */
 			JANUS_LOG(LOG_VERB, "We need a PLI for the simulcast context\n");

--- a/src/plugins/janus_recordplay.c
+++ b/src/plugins/janus_recordplay.c
@@ -1299,7 +1299,7 @@ void janus_recordplay_incoming_rtp(janus_plugin_session *handle, janus_plugin_rt
 		uint32_t ssrc = ntohl(header->ssrc);
 		/* Process this packet: don't save if it's not the SSRC/layer we wanted to handle */
 		gboolean save = janus_rtp_simulcasting_context_process_rtp(&session->sim_context,
-			buf, len, session->ssrc, session->rid, session->recording->vcodec, &session->context);
+			buf, len, session->ssrc, session->rid, session->recording->vcodec, &session->context, NULL);
 		if(session->sim_context.need_pli) {
 			/* Send a PLI */
 			JANUS_LOG(LOG_VERB, "We need a PLI for the simulcast context\n");

--- a/src/plugins/janus_streaming.c
+++ b/src/plugins/janus_streaming.c
@@ -9280,7 +9280,7 @@ static void janus_streaming_relay_rtp_packet(gpointer data, gpointer user_data) 
 					return;
 				/* Process this packet: don't relay if it's not the SSRC/layer we wanted to handle */
 				gboolean relay = janus_rtp_simulcasting_context_process_rtp(&s->sim_context,
-					(char *)packet->data, packet->length, packet->ssrc, NULL, packet->codec, &s->context);
+					(char *)packet->data, packet->length, packet->ssrc, NULL, packet->codec, &s->context, NULL);
 				if(!relay) {
 					/* Did a lot of time pass before we could relay a packet? */
 					gint64 now = janus_get_monotonic_time();

--- a/src/plugins/janus_videocall.c
+++ b/src/plugins/janus_videocall.c
@@ -773,7 +773,7 @@ void janus_videocall_incoming_rtp(janus_plugin_session *handle, janus_plugin_rtp
 			/* Process this packet: don't relay if it's not the SSRC/layer we wanted to handle
 			 * The caveat is that the targets in OUR simulcast context are the PEER's targets */
 			gboolean relay = janus_rtp_simulcasting_context_process_rtp(&peer->sim_context,
-				buf, len, session->ssrc, session->rid, session->vcodec, &peer->context);
+				buf, len, session->ssrc, session->rid, session->vcodec, &peer->context, NULL);
 			/* Do we need to drop this? */
 			if(!relay)
 				return;

--- a/src/plugins/plugin.h
+++ b/src/plugins/plugin.h
@@ -171,7 +171,7 @@ janus_plugin *create(void) {
  * Janus instance or it will crash.
  *
  */
-#define JANUS_PLUGIN_API_VERSION	101
+#define JANUS_PLUGIN_API_VERSION	102
 
 /*! \brief Initialization of all plugin properties to NULL
  *

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -1020,11 +1020,18 @@ void janus_rtp_simulcasting_context_reset(janus_rtp_simulcasting_context *contex
 void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, uint32_t *ssrcs, char **rids) {
 	if(simulcast == NULL)
 		return;
+
+	/* Clear existing RIDs in case this array was reused from a previous call */
+	size_t i = 0;
+	for(i=0; i<3; i++) {
+		g_free(rids[i]);
+		rids[i] = NULL;
+	}
+
 	json_t *r = json_object_get(simulcast, "rids");
 	json_t *s = json_object_get(simulcast, "ssrcs");
 	if(r && json_array_size(r) > 0) {
 		JANUS_LOG(LOG_VERB, "  -- Simulcasting is rid based\n");
-		size_t i = 0;
 		int count = json_array_size(r);
 		for(i=count; i > 0; i--) {
 			json_t *rid = json_array_get(r, i-1);
@@ -1036,7 +1043,6 @@ void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, uint32_t
 			*rid_ext_id = json_integer_value(rid_ext);
 	} else if(s && json_array_size(s) > 0) {
 		JANUS_LOG(LOG_VERB, "  -- Simulcasting is SSRC based\n");
-		size_t i = 0;
 		for(i=0; i<json_array_size(s); i++) {
 			if(i == 3)
 				break;

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -1022,11 +1022,13 @@ void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, uint32_t
 		return;
 	/* Clear existing RIDs in case this array was reused from a previous call */
 	size_t i = 0;
-	for(i=0; i<3; i++) {
-		g_free(rids[i]);
-		rids[i] = NULL;
+	if(rids) {
+		for(i=0; i<3; i++) {
+			g_free(rids[i]);
+			rids[i] = NULL;
+		}
 	}
-	if (rid_ext_id != NULL)
+	if(rid_ext_id != NULL)
 		*rid_ext_id = -1;
 	json_t *r = json_object_get(simulcast, "rids");
 	json_t *s = json_object_get(simulcast, "ssrcs");

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -1020,14 +1020,12 @@ void janus_rtp_simulcasting_context_reset(janus_rtp_simulcasting_context *contex
 void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, uint32_t *ssrcs, char **rids) {
 	if(simulcast == NULL)
 		return;
-
 	/* Clear existing RIDs in case this array was reused from a previous call */
 	size_t i = 0;
 	for(i=0; i<3; i++) {
 		g_free(rids[i]);
 		rids[i] = NULL;
 	}
-
 	json_t *r = json_object_get(simulcast, "rids");
 	json_t *s = json_object_get(simulcast, "ssrcs");
 	if(r && json_array_size(r) > 0) {

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -1026,6 +1026,8 @@ void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, uint32_t
 		g_free(rids[i]);
 		rids[i] = NULL;
 	}
+	if (rid_ext_id != NULL)
+		*rid_ext_id = -1;
 	json_t *r = json_object_get(simulcast, "rids");
 	json_t *s = json_object_get(simulcast, "ssrcs");
 	if(r && json_array_size(r) > 0) {

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -1049,7 +1049,7 @@ void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, uint32_t
 
 gboolean janus_rtp_simulcasting_context_process_rtp(janus_rtp_simulcasting_context *context,
 		char *buf, int len, uint32_t *ssrcs, char **rids,
-		janus_videocodec vcodec, janus_rtp_switching_context *sc, janus_mutex* rid_mutex) {
+		janus_videocodec vcodec, janus_rtp_switching_context *sc, janus_mutex *rid_mutex) {
 	if(!context || !buf || len < 1)
 		return FALSE;
 	janus_rtp_header *header = (janus_rtp_header *)buf;

--- a/src/rtp.h
+++ b/src/rtp.h
@@ -341,10 +341,11 @@ void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, uint32_t
  * @param[in] rids The simulcast rids to refer to, if any
  * @param[in] vcodec Video codec of the RTP payload
  * @param[in] sc RTP switching context to refer to, if any (only needed for VP8 and dropping temporal layers)
+ * @param[in] rid_mutex A mutex that must be acquired before reading the rids array, if any
  * @returns TRUE if the packet should be relayed, FALSE if it should be dropped instead */
 gboolean janus_rtp_simulcasting_context_process_rtp(janus_rtp_simulcasting_context *context,
 	char *buf, int len, uint32_t *ssrcs, char **rids,
-	janus_videocodec vcodec, janus_rtp_switching_context *sc);
+	janus_videocodec vcodec, janus_rtp_switching_context *sc, janus_mutex* rid_mutex);
 ///@}
 
 /** @name Janus AV1-SVC processing methods

--- a/src/rtp.h
+++ b/src/rtp.h
@@ -345,7 +345,7 @@ void janus_rtp_simulcasting_prepare(json_t *simulcast, int *rid_ext_id, uint32_t
  * @returns TRUE if the packet should be relayed, FALSE if it should be dropped instead */
 gboolean janus_rtp_simulcasting_context_process_rtp(janus_rtp_simulcasting_context *context,
 	char *buf, int len, uint32_t *ssrcs, char **rids,
-	janus_videocodec vcodec, janus_rtp_switching_context *sc, janus_mutex* rid_mutex);
+	janus_videocodec vcodec, janus_rtp_switching_context *sc, janus_mutex *rid_mutex);
 ///@}
 
 /** @name Janus AV1-SVC processing methods


### PR DESCRIPTION
When processing an offer from a publisher using RID-based simulcast, Videoroom calls `janus_rtp_simulcast_prepare()` for the stream associated with every m-line in the offer, even if that m-line had already appeared in a previous offer. This means the RID array is repopulated every time, but the existing values were not being freed before being overwritten. This leads to a memory leak for every successive renegotiation.

Here I just unconditionally free the previous values beforehand, assuming they need to be completely repopulated anyway. While we're at it here, should we also clear `rid_ext_id` or the SSRC array somehow? (Although they're not leaking memory, obviously)