### PR TITLE
Allow plugins to specify msid in SDPs

### DIFF
--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -155,7 +155,8 @@ rtp-sample: {
 # each identifying a single stream to add, that will then translate to
 # a dedicated m-line in the SDP. For each stream, you specify the type,
 # a unique ID (mid), and can provide a short description (label) so that
-# the client side can know what's what when rendering the streams. Notice
+# the client side can know what's what when rendering the streams;
+# optionally, a msid to add to the SDP m-line can be provided as well. Notice
 # how the port/pt/codec/fmtp/etc. stuff is called just like that, without
 # any audio/video/data prefix: in fact, each media stream can be configured
 # the same way, and it's the type that allows us to differentiate them.

--- a/html/mvideoroomtest.js
+++ b/html/mvideoroomtest.js
@@ -25,6 +25,7 @@ var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringV
 var acodec = (getQueryStringValue("acodec") !== "" ? getQueryStringValue("acodec") : null);
 var vcodec = (getQueryStringValue("vcodec") !== "" ? getQueryStringValue("vcodec") : null);
 var subscriber_mode = (getQueryStringValue("subscriber-mode") === "yes" || getQueryStringValue("subscriber-mode") === "true");
+var use_msid = (getQueryStringValue("msid") === "yes" || getQueryStringValue("msid") === "true");
 
 $(document).ready(function() {
 	// Initialize the library (all console debuggers enabled)
@@ -627,6 +628,7 @@ function subscribeTo(sources) {
 					room: myroom,
 					ptype: "subscriber",
 					streams: subscription,
+					use_msid: use_msid,
 					private_id: mypvtid
 				};
 				remoteFeed.send({ message: subscribe });

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -25,6 +25,7 @@ var acodec = (getQueryStringValue("acodec") !== "" ? getQueryStringValue("acodec
 var vcodec = (getQueryStringValue("vcodec") !== "" ? getQueryStringValue("vcodec") : null);
 var doDtx = (getQueryStringValue("dtx") === "yes" || getQueryStringValue("dtx") === "true");
 var subscriber_mode = (getQueryStringValue("subscriber-mode") === "yes" || getQueryStringValue("subscriber-mode") === "true");
+var use_msid = (getQueryStringValue("msid") === "yes" || getQueryStringValue("msid") === "true");
 
 $(document).ready(function() {
 	// Initialize the library (all console debuggers enabled)
@@ -546,6 +547,7 @@ function newRemoteFeed(id, display, streams) {
 					room: myroom,
 					ptype: "subscriber",
 					streams: subscription,
+					use_msid: use_msid,
 					private_id: mypvtid
 				};
 				remoteFeed.send({ message: subscribe });

--- a/src/ice.c
+++ b/src/ice.c
@@ -1812,6 +1812,10 @@ static void janus_ice_peerconnection_medium_dereference(janus_ice_peerconnection
 static void janus_ice_peerconnection_medium_free(const janus_refcount *medium_ref) {
 	janus_ice_peerconnection_medium *medium = janus_refcount_containerof(medium_ref, janus_ice_peerconnection_medium, ref);
 	g_free(medium->mid);
+	g_free(medium->msid);
+	g_free(medium->mstid);
+	g_free(medium->remote_msid);
+	g_free(medium->remote_mstid);
 	g_free(medium->rid[0]);
 	medium->rid[0] = NULL;
 	g_free(medium->rid[1]);

--- a/src/ice.h
+++ b/src/ice.h
@@ -512,6 +512,8 @@ struct janus_ice_peerconnection_medium {
 	int mindex;
 	/*! \brief Media ID */
 	char *mid;
+	/*! \brief Media Stream ID info */
+	char *msid, *mstid, *remote_msid, *remote_mstid;
 	/*! \brief SSRC of the server for this medium */
 	guint32 ssrc;
 	/*! \brief Retransmission SSRC of the server for this medium */

--- a/src/janus.c
+++ b/src/janus.c
@@ -3207,6 +3207,20 @@ json_t *janus_admin_peerconnection_medium_summary(janus_ice_peerconnection_mediu
 		json_object_set_new(m, "type", json_string("data"));
 	json_object_set_new(m, "mindex", json_integer(medium->mindex));
 	json_object_set_new(m, "mid", json_string(medium->mid));
+	if(medium->msid || medium->remote_msid) {
+		json_t *mm = json_object();
+		if(medium->msid) {
+			json_object_set_new(mm, "local-stream", json_string(medium->msid));
+			if(medium->mstid)
+				json_object_set_new(mm, "local-track", json_string(medium->mstid));
+		}
+		if(medium->remote_msid) {
+			json_object_set_new(mm, "remote-stream", json_string(medium->remote_msid));
+			if(medium->remote_mstid)
+				json_object_set_new(mm, "remote-track", json_string(medium->remote_mstid));
+		}
+		json_object_set_new(m, "msid", mm);
+	}
 	if(medium->type != JANUS_MEDIA_DATA) {
 		json_object_set_new(m, "do_nacks", medium->do_nacks ? json_true() : json_false());
 		json_object_set_new(m, "nack-queue-ms", json_integer(medium->nack_queue_ms));
@@ -3796,7 +3810,34 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 			GList *tempA = m->attributes;
 			while(tempA) {
 				janus_sdp_attribute *a = (janus_sdp_attribute *)tempA->data;
-				if(a->name && a->value && !strcasecmp(a->name, "extmap")) {
+				if(a->name && a->value && !strcasecmp(a->name, "msid")) {
+					/* Found msid attribute */
+					char msid[65], mstid[65];
+					msid[0] = '\0';
+					mstid[0] = '\0';
+					if(sscanf(a->value, "%64s %64s", msid, mstid) != 2) {
+						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Invalid msid on m-line #%d\n",
+							ice_handle->handle_id, m->index);
+						janus_sdp_destroy(parsed_sdp);
+						return NULL;
+					}
+					if(medium->msid == NULL || strcasecmp(medium->msid, msid)) {
+						char *old_msid = medium->msid;
+						medium->msid = g_strdup(msid);
+						g_free(old_msid);
+					}
+					if(medium->mstid == NULL || strcasecmp(medium->mstid, mstid)) {
+						char *old_mstid = medium->mstid;
+						medium->mstid = g_strdup(mstid);
+						g_free(old_mstid);
+					}
+					/* Remove this msid attribute, the core will add it again later */
+					GList *msid_attr = tempA;
+					tempA = tempA->next;
+					m->attributes = g_list_remove_link(m->attributes, msid_attr);
+					g_list_free_full(msid_attr, (GDestroyNotify)janus_sdp_attribute_destroy);
+					continue;
+				} else if(a->name && a->value && !strcasecmp(a->name, "extmap")) {
 					if(strstr(a->value, JANUS_RTP_EXTMAP_MID))
 						have_mid = TRUE;
 					else if(strstr(a->value, JANUS_RTP_EXTMAP_RID))

--- a/src/sdp-utils.h
+++ b/src/sdp-utils.h
@@ -261,8 +261,10 @@ JANUS_SDP_OA_MLINE = 1,
 JANUS_SDP_OA_ENABLED,
 /*! \brief When generating an offer or answer automatically, use this direction for media (depends on value that follows, sendrecv by default) */
 JANUS_SDP_OA_DIRECTION,
-/*! \brief When generating an offer automatically, use this mid media (depends on value that follows, needs to be a string) */
+/*! \brief When generating an offer automatically, use this mid (depends on value that follows, needs to be a string) */
 JANUS_SDP_OA_MID,
+/*! \brief When generating an offer or answer automatically, use this msid (depends on the two strings that follow, stream and track ID respectively) */
+JANUS_SDP_OA_MSID,
 /*! \brief When generating an offer or answer automatically, use this codec (depends on value that follows, opus/vp8 by default) */
 JANUS_SDP_OA_CODEC,
 /*! \brief When generating an offer (this is ignored for answers), negotiate this extension: needs two arguments, extmap value and extension ID (can be used multiple times) */


### PR DESCRIPTION
When we were working on multistream support in #2211, one of the main questions was whether we were planning to add [msid](https://datatracker.ietf.org/doc/rfc8830/) support as well. If you're not familiar with msid, it stands for "MediaStream ID", and provides a way to specify, in the SDP, mappings between m-lines and streams how they're captured: m-lines with the same MediaStream ID will be grouped together, meaning they'll also be tied with respect to, e.g., RTCP feedback and synchronization.

In Janus we've always negotiated msid, but using "janus" as the same ID for all tracks: while this was not a problem in `0.x` (where you could only have a single audio/video track per PeerConnection anyway), it could be in master/multistream, since in that case we can end up with dozens of tracks coming from different sources in the same PeerConnection, and having them all part of the same stream in the recipient can be problematic. You can find some additional context in the following comments and the discussion that followed:

https://github.com/meetecho/janus-gateway/pull/2211#issuecomment-673130839
https://github.com/meetecho/janus-gateway/pull/2211#issuecomment-682052423
https://github.com/meetecho/janus-gateway/pull/2211#issuecomment-964213569
https://github.com/meetecho/janus-gateway/pull/2211#issuecomment-964427964

This patch tries to address those comments and solve the potential problems they highlighted; since @mirkobrankovic and @roisasson seemed the most interested in this, I explicitly mentioned them so that they're aware of this effort, and can provide some feedback in case.

Specifically, this patch now allows plugins to specify which msid they'd like to show up in the SDPs they generate. This is important because, since msid provides correlation on tracks in a WebRTC session, plugins are the only ones that can provide it: the Janus core only acts as an intermediary for the WebRTC part itself, but is not aware of what the media streams are for, or from. When msid values are provided, the Janus core will use those in the SDP instead of the ones it generated so far; it will still do that in case no msid is provided by the plugin, meaning this is backwards compatible. Of course, since plugins may also want to be aware of the msid values on the way in, the patch now ensures we don't strip them from the SDP before passing it to plugins: as a consequence, msid may now be also used automatically by plugins that simply route SDPs without using the SDP utils, e.g., the VideoCall.

The only plugin that at the moment explicitly sets msid if required is the VideoRoom, which is the one most likely to benefit from this effort once completed, due to its SFU nature that might involve many tracks at the same time. By default, the VideoRoom plugin will do nothing with msid, to ensure it doesn't impact existing deployments: if you do want to test msid, you'll need to add a `use_msid: true` when sending a "join" for a new subscriber, which will result in the VideoRoom plugin generating an `msid` SDP attribute for all m-lines in the subscriber offers. Specifically, it will use the publisher ID as the Stream part, and the subscription m-line mid as the track part, meaning you'll see something like:

    a=msid:5480440801491836 0

This should allow applications to differentiate m-lines by publisher. The fact we use the mid value from the subscription for the track is both for the sake of simplicity, and to ensure the same uniqueness mid guarantees within the context of a PeerConnection: notice that's not the mid of the publisher (otherwise you can end up with duplicates in the SDP if you're subscribed to the same stream more than once), but the one from the subscription. This means that in the SDP you should expect something like this:

    a=mid:0
    a=msid:5480440801491836 0
    [..]
    a=mid:1
    a=msid:5480440801491836 1
    [..]
    a=mid:2
    a=msid:7382950455515988 2
    [..]
    a=mid:3
    a=msid:7382950455515988 3

This example shows two different publishers, both sending two different things (e.g., audio and video).

If you want to test this, I made the `use_msid` property easily tweakable via the `msid` query string argument in the `mvideoroomtest.html` demo, which means that you just need to open

    mvideoroomtest.html?msid=true

using the demo in this PR and it should be using this new feature.

Notice that I'm publishing this PR as a draft as this is still experimental, and I haven't spent much time testing it yet. Besides, it's probably still incomplete, since while I've made msid configurable, the `cname` in all m-lines is still the same as before, and referencing the same stream ID we use by default (`janus`). Not sure if this could cause desync problems (I did notice at least one), but if you see one stream more desynced than others it should at least already confirm that msid is doing its job (since it means that all streams are treated the same way, as we currently do).

Please do test and provide feedback. Depending on the interest and the info I'll receive, I'll work on improving this, so that if it does provide considerable benefits we can merge it hopefully soon enough.