### PR TITLE
Workaround for Linux CGroup V2 causing dropped packets with a memory limit set

### DIFF
--- a/record.c
+++ b/record.c
@@ -21,6 +21,7 @@
 #include <sys/stat.h>
 #include <errno.h>
 #include <libgen.h>
+#include <fcntl.h>
 
 #include <glib.h>
 #include <jansson.h>
@@ -464,6 +465,19 @@ int janus_recorder_save_frame(janus_recorder *recorder, char *buffer, uint lengt
 		header->seq_number = htons(seq);
 		header->timestamp = htonl(timestamp);
 	}
+
+	/* Mark the file as POSIX_FADV_DONTNEED, since we won't be reading from it at all. This
+	 * prevents polution of the page cache, but also fixes a nasty bug where CGroupsV2
+	 * considers the page cache to be used kernel memory, and won't allocate new UDP
+	 * buffer space if it's full, leading to dropped packets. Can't just do this once
+	 * at the start unfortunately, so we do it every ~100 packets.
+	 */
+	recorder->unflushed_count++;
+	if (recorder->unflushed_count == 100) {
+		posix_fadvise(fileno(recorder->file), 0, 0, POSIX_FADV_DONTNEED);
+		recorder->unflushed_count = 0;
+	}
+
 	/* Done */
 	janus_mutex_unlock_nodebug(&recorder->mutex);
 	return 0;

--- a/record.h
+++ b/record.h
@@ -73,6 +73,8 @@ typedef struct janus_recorder {
 	volatile gint destroyed;
 	/*! \brief Reference counter for this instance */
 	janus_refcount ref;
+	/*! \brief Used to flush the page cache every n packets */
+	int unflushed_count;
 } janus_recorder;
 
 /*! \brief Initialize the recorder code


### PR DESCRIPTION
I'd like to preface this by saying this is not a bug in Janus - but rather subtle / broken behaviour from CGroup V2 on Linux. With a memory limit set, the page cache is considered as 'in use' when allocating network buffers. This PR is a workaround that's worked so far for us, but it's likely not the best solution and might not be suitable for inclusion. This is more to get a discussion going, or even just point anyone who's had the same problem in the right direction!

We deploy Janus in Docker containers with a 512MB memory limit, and started noticing that whenever we have a large-ish number of participants in a room (>6) and recording turned on, within 30 minutes, incoming video packets would start getting lost by Janus. This would manifest as glitchy video (NACKs would be sent and they'd recover, but the cycle was continuous) and slowlink events.

Digging further, these losses would show up as drops in `/proc/net/udp` and with [dropwatch](https://github.com/nhorman/dropwatch). My first thought was that there was something to do with UDP receive buffer sizes going on here, but experimentation with manually tweaking `SO_RCVBUF` in libnice didn't yield any results.

It seemed related to recording; turning it on / off started and stopped the issue, and the issue disappeared with simply the `fwrite` calls in `record.c` commented out. I tried a few combinations, such as a different FS, and tmpfs. Interestingly, running on tmpfs did not replicate the problem, but running an ext4 FS image backed by tmpfs did.

Eventually, I traced it down to `__sk_mem_raise_allocated` failing in the kernel because it couldn't charge the CGroup for usage. CGroup V2 changed the behaviour, and now keeps track of the page cache on a per CGroup basis, rather than globally in CGroup V1 (why we hadn't hit this before!). Combined with Linux not freeing the page cache when trying to grow a buffer, led to video packets being dropped. I figured audio was unaffected since they're smaller and it didn't need to reallocate.

This was easy to confirm; once the server had gotten into the dropping state, running `sync; echo 3 > /proc/sys/vm/drop_caches` fixed it completely up until the page cache filled up again.

If you'd like to recreate this, it should be easy enough:
* Use CGroups V2
* Run a Janus Docker Container with a low memory limit set (eg, 64MB) to make reproduction quicker 
* Enable recording, and make sure you're recording to a real disk
* Connect a few browsers to a videoroom on it.