### PR TITLE
Skip medium checks when relaying RTP/data, and lock when doing RTCP

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -406,6 +406,22 @@ static uint16_t rtp_range_max = 0;
 #define JANUS_ICE_PACKET_TEXT	2
 #define JANUS_ICE_PACKET_BINARY	3
 #define JANUS_ICE_PACKET_SCTP	4
+/* Helper to convert packet types to core types */
+static janus_media_type janus_media_type_from_packet(int type) {
+	switch(type) {
+		case JANUS_ICE_PACKET_AUDIO:
+			return JANUS_MEDIA_AUDIO;
+		case JANUS_ICE_PACKET_VIDEO:
+			return JANUS_MEDIA_VIDEO;
+		case JANUS_ICE_PACKET_TEXT:
+		case JANUS_ICE_PACKET_BINARY:
+		case JANUS_ICE_PACKET_SCTP:
+			return JANUS_MEDIA_DATA;
+		default:
+			break;
+	}
+	return JANUS_MEDIA_UNKNOWN;
+}
 /* Janus enqueued (S)RTP/(S)RTCP packet to send */
 typedef struct janus_ice_queued_packet {
 	gint mindex;
@@ -706,7 +722,8 @@ static int janus_seq_in_range(guint16 seqn, guint16 start, guint16 len) {
 
 
 /* Internal method for relaying RTCP messages, optionally filtering them in case they come from plugins */
-void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, janus_plugin_rtcp *packet, gboolean filter_rtcp);
+void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, janus_ice_peerconnection_medium *medium,
+	janus_plugin_rtcp *packet, gboolean filter_rtcp);
 
 
 /* Map of active plugin sessions */
@@ -2916,7 +2933,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 						janus_rtcp_fix_ssrc(NULL, nackbuf, res, 1,
 							medium->ssrc, medium->ssrc_peer[vindex]);
 						janus_plugin_rtcp rtcp = { .mindex = medium->mindex, .video = video, .buffer = nackbuf, .length = res };
-						janus_ice_relay_rtcp_internal(handle, &rtcp, FALSE);
+						janus_ice_relay_rtcp_internal(handle, medium, &rtcp, FALSE);
 					}
 					/* Update stats */
 					medium->nack_sent_recent_cnt += nacks_count;
@@ -4089,7 +4106,7 @@ static gboolean janus_ice_outgoing_transport_wide_cc_feedback(gpointer user_data
 			/* Enqueue it, we'll send it later */
 			if(len > 0) {
 				janus_plugin_rtcp rtcp = { .mindex = medium->mindex, .video = TRUE, .buffer = rtcpbuf, .length = len };
-				janus_ice_relay_rtcp_internal(handle, &rtcp, FALSE);
+				janus_ice_relay_rtcp_internal(handle, medium, &rtcp, FALSE);
 			}
 			if(packets_to_process != packets) {
 				g_queue_free(packets_to_process);
@@ -4147,7 +4164,7 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 			/* Enqueue it, we'll send it later */
 			janus_plugin_rtcp rtcp = { .mindex = medium->mindex,
 				.video = (medium->type == JANUS_MEDIA_VIDEO), .buffer = rtcpbuf, .length = srlen+sdeslen };
-			janus_ice_relay_rtcp_internal(handle, &rtcp, FALSE);
+			janus_ice_relay_rtcp_internal(handle, medium, &rtcp, FALSE);
 			/* Check if we detected too many losses, and send a slowlink event in case */
 			guint lost = janus_rtcp_context_get_lost_all(rtcp_ctx, TRUE);
 			janus_slow_link_update(medium, handle, TRUE, lost);
@@ -4172,7 +4189,7 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 					/* Enqueue it, we'll send it later */
 					janus_plugin_rtcp rtcp = { .mindex = medium->mindex,
 						.video = (medium->type == JANUS_MEDIA_VIDEO), .buffer = rtcpbuf, .length = 32 };
-					janus_ice_relay_rtcp_internal(handle, &rtcp, FALSE);
+					janus_ice_relay_rtcp_internal(handle, medium, &rtcp, FALSE);
 					if(vindex == 0) {
 						/* Check if we detected too many losses, and send a slowlink event in case */
 						guint lost = janus_rtcp_context_get_lost_all(medium->rtcp_ctx[vindex], FALSE);
@@ -4490,7 +4507,12 @@ static gboolean janus_ice_outgoing_traffic_handle(janus_ice_handle *handle, janu
 		return G_SOURCE_CONTINUE;
 	}
 	/* Find the right medium instance */
-	medium = g_hash_table_lookup(pc->media, GINT_TO_POINTER(pkt->mindex));
+	if(pkt->mindex != -1) {
+		medium = g_hash_table_lookup(pc->media, GINT_TO_POINTER(pkt->mindex));
+	} else {
+		janus_media_type mtype = janus_media_type_from_packet(pkt->type);
+		medium = g_hash_table_lookup(pc->media_bytype, GINT_TO_POINTER(mtype));
+	}
 	if(medium == NULL) {
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] No medium #%d associated to this packet??\n", handle->handle_id, pkt->mindex);
 		janus_ice_free_queued_packet(pkt);
@@ -4833,16 +4855,9 @@ void janus_ice_relay_rtp(janus_ice_handle *handle, janus_plugin_rtp *packet) {
 	if(!handle || !handle->pc || handle->queued_packets == NULL || packet == NULL || packet->buffer == NULL ||
 			!janus_is_rtp(packet->buffer, packet->length))
 		return;
-	/* Find the right medium instance */
-	janus_ice_peerconnection_medium *medium = (packet->mindex != -1 ?
-			g_hash_table_lookup(handle->pc->media, GINT_TO_POINTER(packet->mindex)) :
-			g_hash_table_lookup(handle->pc->media_bytype,
-				GINT_TO_POINTER(packet->video ? JANUS_MEDIA_VIDEO : JANUS_MEDIA_AUDIO)));
-	if(!medium)
-		return;
 	/* Queue this packet as it is (we'll prune/update/set extensions later) */
 	janus_ice_queued_packet *pkt = g_malloc(sizeof(janus_ice_queued_packet));
-	pkt->mindex = medium->mindex;
+	pkt->mindex = packet->mindex;
 	pkt->data = g_malloc(packet->length + SRTP_MAX_TAG_LEN);
 	memcpy(pkt->data, packet->buffer, packet->length);
 	pkt->length = packet->length;
@@ -4857,16 +4872,10 @@ void janus_ice_relay_rtp(janus_ice_handle *handle, janus_plugin_rtp *packet) {
 	janus_ice_queue_packet(handle, pkt);
 }
 
-void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, janus_plugin_rtcp *packet, gboolean filter_rtcp) {
-	if(!handle || !handle->pc || handle->queued_packets == NULL || packet == NULL || packet->buffer == NULL ||
+void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, janus_ice_peerconnection_medium *medium,
+		janus_plugin_rtcp *packet, gboolean filter_rtcp) {
+	if(!handle || !handle->pc || handle->queued_packets == NULL || medium == NULL || packet == NULL || packet->buffer == NULL ||
 			!janus_is_rtcp(packet->buffer, packet->length))
-		return;
-	/* Find the right medium instance */
-	janus_ice_peerconnection_medium *medium = (packet->mindex != -1 ?
-			g_hash_table_lookup(handle->pc->media, GINT_TO_POINTER(packet->mindex)) :
-			g_hash_table_lookup(handle->pc->media_bytype,
-				GINT_TO_POINTER(packet->video ? JANUS_MEDIA_VIDEO : JANUS_MEDIA_AUDIO)));
-	if(!medium)
 		return;
 	/* We use this internal method to check whether we need to filter RTCP (e.g., to make
 	 * sure we don't just forward any SR/RR from peers/plugins, but use our own) or it has
@@ -4910,16 +4919,21 @@ void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, janus_plugin_rtcp *
 }
 
 void janus_ice_relay_rtcp(janus_ice_handle *handle, janus_plugin_rtcp *packet) {
-	janus_ice_relay_rtcp_internal(handle, packet, TRUE);
+	/* Find the right medium instance */
+	janus_mutex_lock(&handle->mutex);
+	janus_ice_peerconnection_medium *medium = (packet->mindex != -1 ?
+			g_hash_table_lookup(handle->pc->media, GINT_TO_POINTER(packet->mindex)) :
+			g_hash_table_lookup(handle->pc->media_bytype,
+				GINT_TO_POINTER(packet->video ? JANUS_MEDIA_VIDEO : JANUS_MEDIA_AUDIO)));
+	if(!medium) {
+		janus_mutex_unlock(&handle->mutex);
+		return;
+	}
+	janus_refcount_increase(&medium->ref);
+	janus_mutex_unlock(&handle->mutex);
+	janus_ice_relay_rtcp_internal(handle, medium, packet, TRUE);
 	/* If this is a PLI and we're simulcasting, send a PLI on other layers as well */
 	if(packet->video && janus_rtcp_has_pli(packet->buffer, packet->length)) {
-		/* Find the right medium instance */
-		janus_ice_peerconnection_medium *medium = (packet->mindex != -1 ?
-				g_hash_table_lookup(handle->pc->media, GINT_TO_POINTER(packet->mindex)) :
-				g_hash_table_lookup(handle->pc->media_bytype,
-					GINT_TO_POINTER(packet->video ? JANUS_MEDIA_VIDEO : JANUS_MEDIA_AUDIO)));
-		if(!medium)
-			return;
 		if(medium->ssrc_peer[1]) {
 			char plibuf[12];
 			memset(plibuf, 0, 12);
@@ -4927,7 +4941,7 @@ void janus_ice_relay_rtcp(janus_ice_handle *handle, janus_plugin_rtcp *packet) {
 			janus_rtcp_fix_ssrc(NULL, plibuf, sizeof(plibuf), 1,
 				medium->ssrc, medium->ssrc_peer[1]);
 			janus_plugin_rtcp rtcp = { .mindex = medium->mindex, .video = TRUE, .buffer = plibuf, .length = sizeof(plibuf) };
-			janus_ice_relay_rtcp_internal(handle, &rtcp, FALSE);
+			janus_ice_relay_rtcp_internal(handle, medium, &rtcp, FALSE);
 		}
 		if(medium->ssrc_peer[2]) {
 			char plibuf[12];
@@ -4936,9 +4950,10 @@ void janus_ice_relay_rtcp(janus_ice_handle *handle, janus_plugin_rtcp *packet) {
 			janus_rtcp_fix_ssrc(NULL, plibuf, sizeof(plibuf), 1,
 				medium->ssrc, medium->ssrc_peer[2]);
 			janus_plugin_rtcp rtcp = { .mindex = medium->mindex, .video = TRUE, .buffer = plibuf, .length = sizeof(plibuf) };
-			janus_ice_relay_rtcp_internal(handle, &rtcp, FALSE);
+			janus_ice_relay_rtcp_internal(handle, medium, &rtcp, FALSE);
 		}
 	}
+	janus_refcount_decrease(&medium->ref);
 }
 
 void janus_ice_send_pli(janus_ice_handle *handle) {
@@ -4976,14 +4991,9 @@ void janus_ice_send_remb(janus_ice_handle *handle, uint32_t bitrate) {
 void janus_ice_relay_data(janus_ice_handle *handle, janus_plugin_data *packet) {
 	if(!handle || !handle->pc || handle->queued_packets == NULL || packet == NULL || packet->buffer == NULL || packet->length < 1)
 		return;
-	/* Find the right medium instance */
-	janus_ice_peerconnection_medium *medium = g_hash_table_lookup(handle->pc->media_bytype,
-		GINT_TO_POINTER(JANUS_MEDIA_DATA));
-	if(!medium)	/* Queue this packet */
-		return;
 	janus_ice_queued_packet *pkt = g_malloc(sizeof(janus_ice_queued_packet));
 	pkt->data = g_malloc(packet->length);
-	pkt->mindex = medium->mindex;
+	pkt->mindex = -1;
 	memcpy(pkt->data, packet->buffer, packet->length);
 	pkt->length = packet->length;
 	pkt->type = packet->binary ? JANUS_ICE_PACKET_BINARY : JANUS_ICE_PACKET_TEXT;


### PR DESCRIPTION
We were notified about some rare crashes when relaying packets, and it turned out the problem was in an unsafe access to the structures we use to index media streams in a PeerConnection, which under some race conditions could cause a lookup on a pointer now dead. Looking at the code, we noticed the same medium lookup pattern when relaying RTP, RTCP or data.

In most of the core code, it's normal for those hashtable to be accessed without a mutex, since the vast majority of those accesses happen within the context of the handle loop, and the handle loop itself is the only one that can actually free a PeerConnection object. This wasn't true for `janus_ice_relay_rtp`, `janus_ice_relay_rtcp` and `janus_ice_relay_data`, though, where the context is whatever thread is running when the plugin invokes those methods: since they were also accessing those hashtables without a mutex, a race condition could occur.

This patch tries to address this broken behaviour, in a couple of different ways:

1. for RTP and data, we skip the medium lookup entirely: in fact, we had the check only to see if it was a valid target, and then only use the medium to see which `mindex` to assign to the packet to enqueue. A fix for this was easy, since all we had to do was just enqueue with whatever `mindex` was provided by the plugin, and let the event loop then obtain the right medium instance: the core was already performing this lookup, so we just had to extend it for `mindex` values of `-1` (which translate to "give me the first medium instance of the specified type). This way, the race condition can't occur anymore.
2. for RTCP,  we couldn't just move the code `janus_ice_relay_rtcp` performs to the loop itself, since that method can actually result in multiple packets to enqueue rather than just one (e.g., a PLI on a simulcast publisher), while the loop would process an already enqueued packet. As such, for RTCP we do still perform the lookup on the medium, but now use the handle mutex to protect it, and increase a reference to the medium until we're done with it: since the handle mutex is the one that's used to update the abovementioned hashtables, this way we should be able to ensure no race condition can occur. As part of these changes, I also extended `janus_ice_relay_rtcp_internal` to include the medium instance: in fact, as it was we were needlessly performing the medium lookup twice any time `janus_ice_relay_rtcp_internal` was invoked, which was silly since every time we call it we already have access to a medium to work with.

I tested this briefly and this seems to be working fine for normal usage, but of course we'll need to ensure this actually fixes the crashes that originated this effort in the first place. Please do test this and provide feedback, so that we can merge this soon.