### PR TITLE
enable recording on session start

### DIFF
--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -6873,7 +6873,7 @@ void janus_videoroom_setup_media(janus_plugin_session *handle) {
 				GList *temp = participant->streams;
 				while(temp) {
 					janus_videoroom_publisher_stream *ps = (janus_videoroom_publisher_stream *)temp->data;
-					janus_videoroom_recorder_create(participant, ps);
+					janus_videoroom_recorder_create(ps);
 					temp = temp->next;
 				}
 				participant->recording_active = TRUE;


### PR DESCRIPTION
Currently, Janus starts recording for a participant in 3 scenarios:

- When configuring a new participant
    - In our case, recording didn’t start here because the room hasn’t started recording yet.
- When processing an SDP
    - In our case, recording didn’t start here because the room hasn’t started recording yet.
- When enable_recording is requested.
    - In our case, recording didn’t start here because the session hasn’t started yet (no WEBRTC media)

A moment later, WebRTC media is available and the session is marked as active. However, even though the room has the flag set that it should be recorded, and media is being published, no recording is being generated for the participant in question.


In this PR we simply add a check when the session starts, to also start the recording, if the room has recording enabled.

