### PR TITLE
enable recording on session start

### DIFF
--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -6866,6 +6866,19 @@ void janus_videoroom_setup_media(janus_plugin_session *handle) {
 			/* Notify all other participants that there's a new boy in town */
 			janus_videoroom_notify_about_publisher(participant, FALSE);
 			janus_refcount_decrease(&participant->ref);
+
+			/* Check if we need to start recording */
+			janus_mutex_lock(&participant->rec_mutex);
+			if(participant->room->record) {
+				GList *temp = participant->streams;
+				while(temp) {
+					janus_videoroom_publisher_stream *ps = (janus_videoroom_publisher_stream *)temp->data;
+					janus_videoroom_recorder_create(participant, ps);
+					temp = temp->next;
+				}
+				participant->recording_active = TRUE;
+			}
+			janus_mutex_unlock(&participant->rec_mutex);
 		} else if(session->participant_type == janus_videoroom_p_type_subscriber) {
 			janus_videoroom_subscriber *s = janus_videoroom_session_get_subscriber(session);
 			if(s && s->streams) {

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -6867,7 +6867,7 @@ void janus_videoroom_setup_media(janus_plugin_session *handle) {
 			janus_videoroom_notify_about_publisher(participant, FALSE);
 			/* Check if we need to start recording */
 			janus_mutex_lock(&participant->rec_mutex);
-			if(participant->room && participant->room->record) {
+			if((participant->room && participant->room->record) || participant->recording_active) {
 				GList *temp = participant->streams;
 				while(temp) {
 					janus_videoroom_publisher_stream *ps = (janus_videoroom_publisher_stream *)temp->data;

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -6865,11 +6865,9 @@ void janus_videoroom_setup_media(janus_plugin_session *handle) {
 			janus_videoroom_publisher *participant = janus_videoroom_session_get_publisher(session);
 			/* Notify all other participants that there's a new boy in town */
 			janus_videoroom_notify_about_publisher(participant, FALSE);
-			janus_refcount_decrease(&participant->ref);
-
 			/* Check if we need to start recording */
 			janus_mutex_lock(&participant->rec_mutex);
-			if(participant->room->record) {
+			if(participant->room && participant->room->record) {
 				GList *temp = participant->streams;
 				while(temp) {
 					janus_videoroom_publisher_stream *ps = (janus_videoroom_publisher_stream *)temp->data;
@@ -6879,6 +6877,7 @@ void janus_videoroom_setup_media(janus_plugin_session *handle) {
 				participant->recording_active = TRUE;
 			}
 			janus_mutex_unlock(&participant->rec_mutex);
+			janus_refcount_decrease(&participant->ref);
 		} else if(session->participant_type == janus_videoroom_p_type_subscriber) {
 			janus_videoroom_subscriber *s = janus_videoroom_session_get_subscriber(session);
 			if(s && s->streams) {

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -6873,7 +6873,7 @@ void janus_videoroom_setup_media(janus_plugin_session *handle) {
 				GList *temp = participant->streams;
 				while(temp) {
 					janus_videoroom_publisher_stream *ps = (janus_videoroom_publisher_stream *)temp->data;
-					janus_videoroom_recorder_create(participant, ps);
+					janus_videoroom_recorder_create(ps);
 					temp = temp->next;
 				}
 				participant->recording_active = TRUE;


### PR DESCRIPTION
(Continuation of #3012)

Currently, Janus starts recording for a participant in 3 scenarios:

- When configuring a new participant
    - In our case, recording didn’t start here because the room hasn’t started recording yet.
- When processing an SDP
    - In our case, recording didn’t start here because the room hasn’t started recording yet.
- When enable_recording is requested.
    - In our case, recording didn’t start here because the session hasn’t started yet (no WEBRTC media)

A moment later, WebRTC media is available and the session is marked as active. However, even though the room has the flag set that it should be recorded, and media is being published, no recording is being generated for the participant in question.


In this PR we simply add a check when the session starts, to also start the recording, if the room has recording enabled.

