### PR TITLE
Set appropriate channel type when make DATA_CHANNEL_REQUEST message

### DIFF
--- a/src/sctp.c
+++ b/src/sctp.c
@@ -602,14 +602,14 @@ int janus_sctp_send_open_request_message(struct socket *sock, uint16_t stream, c
 	switch (pr_policy) {
 		case SCTP_PR_SCTP_NONE:
 			/* XXX: What about DATA_CHANNEL_RELIABLE_STREAM */
-			req->channel_type = DATA_CHANNEL_RELIABLE;
+			req->channel_type = unordered ? DATA_CHANNEL_RELIABLE_UNORDERED : DATA_CHANNEL_RELIABLE;
 			break;
 		case SCTP_PR_SCTP_TTL:
 			/* XXX: What about DATA_CHANNEL_UNRELIABLE */
-			req->channel_type = DATA_CHANNEL_PARTIAL_RELIABLE_TIMED;
+			req->channel_type = unordered ? DATA_CHANNEL_PARTIAL_RELIABLE_TIMED_UNORDERED : DATA_CHANNEL_PARTIAL_RELIABLE_TIMED;
 			break;
 		case SCTP_PR_SCTP_RTX:
-			req->channel_type = DATA_CHANNEL_PARTIAL_RELIABLE_REXMIT;
+			req->channel_type = unordered ? DATA_CHANNEL_PARTIAL_RELIABLE_REXMIT_UNORDERED : DATA_CHANNEL_PARTIAL_RELIABLE_REXMIT;
 			break;
 		default:
 			g_free(req);


### PR DESCRIPTION
When Janus Server open a data channel first, I found out "unordered" parameter doesn't work. (always set true)

I think in ```janus_sctp_send_open_request_message()```, ```uint8_t unordered``` parameter is never used.
So I changed the channel_type when make DATA_CHANNEL_REQUEST message, according to "unordered" parameter.

```
// sctp.h

#define DATA_CHANNEL_RELIABLE							0x00
#define DATA_CHANNEL_RELIABLE_UNORDERED					0x80
#define DATA_CHANNEL_PARTIAL_RELIABLE_REXMIT			0x01
#define DATA_CHANNEL_PARTIAL_RELIABLE_REXMIT_UNORDERED	0x81
#define DATA_CHANNEL_PARTIAL_RELIABLE_TIMED				0x02
#define DATA_CHANNEL_PARTIAL_RELIABLE_TIMED_UNORDERED	0x82
```