### PR TITLE
Allow offers to include other roles besides actpass for DTLS

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -3427,7 +3427,7 @@ void janus_ice_setup_remote_candidates(janus_ice_handle *handle, guint stream_id
 	pc->process_started = TRUE;
 }
 
-int janus_ice_setup_local(janus_ice_handle *handle, gboolean offer, gboolean trickle) {
+int janus_ice_setup_local(janus_ice_handle *handle, gboolean offer, gboolean trickle, janus_dtls_role dtls_role) {
 	if(!handle || g_atomic_int_get(&handle->destroyed))
 		return -1;
 	if(janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_AGENT)) {
@@ -3610,8 +3610,7 @@ int janus_ice_setup_local(janus_ice_handle *handle, gboolean offer, gboolean tri
 	janus_refcount_increase(&handle->ref);
 	pc->stream_id = handle->stream_id;
 	pc->handle = handle;
-	/* FIXME By default, if we're being called we're DTLS clients, but this may be changed by ICE... */
-	pc->dtls_role = offer ? JANUS_DTLS_ROLE_CLIENT : JANUS_DTLS_ROLE_ACTPASS;
+	pc->dtls_role = dtls_role;
 	janus_mutex_init(&pc->mutex);
 	if(!have_turnrest_credentials) {
 		/* No TURN REST API server and credentials, any static ones? */

--- a/src/ice.h
+++ b/src/ice.h
@@ -720,8 +720,9 @@ void janus_ice_notify_media_stopped(janus_ice_handle *handle);
  * @param[in] handle The Janus ICE handle this method refers to
  * @param[in] offer Whether this is for an OFFER or an ANSWER
  * @param[in] trickle Whether ICE trickling is supported or not
+ * @param[in] dtls_role The DTLS role that should be taken for this PeerConnection
  * @returns 0 in case of success, a negative integer otherwise */
-int janus_ice_setup_local(janus_ice_handle *handle, gboolean offer, gboolean trickle);
+int janus_ice_setup_local(janus_ice_handle *handle, gboolean offer, gboolean trickle, janus_dtls_role dtls_role);
 /*! \brief Method to add local candidates to a janus_sdp SDP object representation
  * @param[in] handle The Janus ICE handle this method refers to
  * @param[in] mline The Janus SDP m-line object to add candidates to

--- a/src/janus.c
+++ b/src/janus.c
@@ -1433,8 +1433,10 @@ int janus_process_incoming_request(janus_request *request) {
 			/* Is this valid SDP? */
 			char error_str[512];
 			error_str[0] = '\0';
+			janus_dtls_role peer_dtls_role = JANUS_DTLS_ROLE_ACTPASS;
 			int audio = 0, video = 0, data = 0;
-			janus_sdp *parsed_sdp = janus_sdp_preparse(handle, jsep_sdp, error_str, sizeof(error_str), &audio, &video, &data);
+			janus_sdp *parsed_sdp = janus_sdp_preparse(handle, jsep_sdp, error_str, sizeof(error_str),
+				(offer && !renegotiation ? &peer_dtls_role : NULL), &audio, &video, &data);
 			if(parsed_sdp == NULL) {
 				/* Invalid SDP */
 				ret = janus_process_error_string(request, session_id, transaction_text, JANUS_ERROR_JSEP_INVALID_SDP, error_str);
@@ -1454,8 +1456,12 @@ int janus_process_incoming_request(janus_request *request) {
 			if(!renegotiation) {
 				/* New session */
 				if(offer) {
+					/* Check which DTLS role we should take */
+					janus_dtls_role dtls_role = JANUS_DTLS_ROLE_CLIENT;
+					if(peer_dtls_role == JANUS_DTLS_ROLE_CLIENT)
+						dtls_role = JANUS_DTLS_ROLE_SERVER;
 					/* Setup ICE locally (we received an offer) */
-					if(janus_ice_setup_local(handle, offer, do_trickle) < 0) {
+					if(janus_ice_setup_local(handle, offer, do_trickle, dtls_role) < 0) {
 						JANUS_LOG(LOG_ERR, "Error setting ICE locally\n");
 						janus_sdp_destroy(parsed_sdp);
 						g_free(jsep_type);
@@ -3660,7 +3666,7 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 	char error_str[512];
 	error_str[0] = '\0';
 	int audio = 0, video = 0, data = 0;
-	janus_sdp *parsed_sdp = janus_sdp_preparse(ice_handle, sdp, error_str, sizeof(error_str), &audio, &video, &data);
+	janus_sdp *parsed_sdp = janus_sdp_preparse(ice_handle, sdp, error_str, sizeof(error_str), NULL, &audio, &video, &data);
 	if(parsed_sdp == NULL) {
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] Couldn't parse SDP... %s\n", ice_handle->handle_id, error_str);
 		return NULL;
@@ -3690,7 +3696,7 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 			janus_flags_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX);
 			/* Process SDP in order to setup ICE locally (this is going to result in an answer from the browser) */
 			janus_mutex_lock(&ice_handle->mutex);
-			if(janus_ice_setup_local(ice_handle, FALSE, TRUE) < 0) {
+			if(janus_ice_setup_local(ice_handle, FALSE, TRUE, JANUS_DTLS_ROLE_ACTPASS) < 0) {
 				JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error setting ICE locally\n", ice_handle->handle_id);
 				janus_sdp_destroy(parsed_sdp);
 				janus_mutex_unlock(&ice_handle->mutex);

--- a/src/sdp.c
+++ b/src/sdp.c
@@ -31,7 +31,7 @@
 
 /* Pre-parse SDP: is this SDP valid? how many audio/video lines? any features to take into account? */
 janus_sdp *janus_sdp_preparse(void *ice_handle, const char *jsep_sdp, char *error_str, size_t errlen,
-		int *audio, int *video, int *data) {
+		janus_dtls_role *dtls_role, int *audio, int *video, int *data) {
 	if(!ice_handle || !jsep_sdp) {
 		JANUS_LOG(LOG_ERR, "  Can't preparse, invalid arguments\n");
 		return NULL;
@@ -42,6 +42,34 @@ janus_sdp *janus_sdp_preparse(void *ice_handle, const char *jsep_sdp, char *erro
 		JANUS_LOG(LOG_ERR, "  Error parsing SDP? %s\n", error_str ? error_str : "(unknown reason)");
 		/* Invalid SDP */
 		return NULL;
+	}
+	gboolean dtls_role_found = FALSE;
+	if(dtls_role) {
+		/* We're interested in checking which role was advertised, traverse global attributes too */
+		GList *tempA = parsed_sdp->attributes;
+		while(tempA) {
+			janus_sdp_attribute *a = (janus_sdp_attribute *)tempA->data;
+			if(a->name && !strcasecmp(a->name, "setup")) {
+				if(a->value == NULL) {
+					JANUS_LOG(LOG_ERR, "[%"SCNu64"] Invalid setup attribute (no value)\n", handle->handle_id);
+					janus_sdp_destroy(parsed_sdp);
+					return NULL;
+				}
+				if(!strcasecmp(a->value, "actpass")) {
+					JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer advertised 'actpass' DTLS role, we'll be a DTLS client\n", handle->handle_id);
+					*dtls_role = JANUS_DTLS_ROLE_ACTPASS;
+				} else if(!strcasecmp(a->value, "passive")) {
+					JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer advertised 'passive' DTLS role, we'll be a DTLS client\n", handle->handle_id);
+					*dtls_role = JANUS_DTLS_ROLE_SERVER;
+				} else if(!strcasecmp(a->value, "active")) {
+					JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer advertised 'active' DTLS role, we'll be a DTLS server\n", handle->handle_id);
+					*dtls_role = JANUS_DTLS_ROLE_CLIENT;
+				}
+				dtls_role_found = TRUE;
+				break;
+			}
+			tempA = tempA->next;
+		}
 	}
 	/* Look for m-lines */
 	GList *temp = parsed_sdp->m_lines;
@@ -79,6 +107,23 @@ janus_sdp *janus_sdp_preparse(void *ice_handle, const char *jsep_sdp, char *erro
 							return NULL;
 						}
 					}
+				} else if(dtls_role && !dtls_role_found && !strcasecmp(a->name, "setup")) {
+					if(a->value == NULL) {
+						JANUS_LOG(LOG_ERR, "[%"SCNu64"] Invalid setup attribute (no value)\n", handle->handle_id);
+						janus_sdp_destroy(parsed_sdp);
+						return NULL;
+					}
+					if(!strcasecmp(a->value, "actpass")) {
+						JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer advertised 'actpass' DTLS role, we'll be a DTLS client\n", handle->handle_id);
+						*dtls_role = JANUS_DTLS_ROLE_ACTPASS;
+					} else if(!strcasecmp(a->value, "passive")) {
+						JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer advertised 'passive' DTLS role, we'll be a DTLS client\n", handle->handle_id);
+						*dtls_role = JANUS_DTLS_ROLE_SERVER;
+					} else if(!strcasecmp(a->value, "active")) {
+						JANUS_LOG(LOG_VERB, "[%"SCNu64"] Peer advertised 'active' DTLS role, we'll be a DTLS server\n", handle->handle_id);
+						*dtls_role = JANUS_DTLS_ROLE_CLIENT;
+					}
+					dtls_role_found = TRUE;
 				}
 			}
 			tempA = tempA->next;

--- a/src/sdp.h
+++ b/src/sdp.h
@@ -28,6 +28,7 @@
 #include <inttypes.h>
 
 #include "sdp-utils.h"
+#include "dtls.h"
 
 
 /** @name Janus SDP helper methods
@@ -39,11 +40,13 @@
  * @param[in] jsep_sdp The SDP that the browser peer originated
  * @param[in,out] error_str Buffer to receive a reason for an error, if any
  * @param[in] errlen The length of the error buffer
+ * @param[out] dtls_role The advertised DTLS role
  * @param[out] audio The number of audio m-lines
  * @param[out] video The number of video m-lines
  * @param[out] data The number of SCTP m-lines
  * @returns The Janus SDP object in case of success, NULL in case the SDP is invalid */
-janus_sdp *janus_sdp_preparse(void *handle, const char *jsep_sdp, char *error_str, size_t errlen, int *audio, int *video, int *data);
+janus_sdp *janus_sdp_preparse(void *handle, const char *jsep_sdp, char *error_str, size_t errlen,
+	janus_dtls_role *dtls_role, int *audio, int *video, int *data);
 
 /*! \brief Method to process a remote parsed session description
  * \details This method will process a session description coming from a peer, and set up the ICE candidates accordingly


### PR DESCRIPTION
[RFC5763](https://datatracker.ietf.org/doc/html/rfc5763) says offers should always use `actpass` as a `setup` value for negotiating DTLS, which is what we did in Janus so far: for incoming offers, we always blindly assumed `actpass` would be sent, and so we'd reply with `active` to act as DTLS clients ourselves. This means that if a client sends a `a=setup:active` attribute in their offer, we reply with `a=setup:active` as well, and DTLS won't start. This isn't an issue normally, as basically all endpoints (including browsers) always send `actpass` in their offers.

That said, the WHIP specifcation seems to be going into a direction where a custom role may be specified for WHIP clients instead: I don't like the idea, but there's nothing I can do about it, so this patch tries to address this by checking what's being offered, and set our role accordingly. I have tested this by modifying an SDP offer originated by a browser to force an active role, which resulted in Janus taking the passive role (rather than active as before), and that worked as expected.

While this PR is for multistream, I'll make the same changes to `0.x` as soon as I merge it (which will happen soon).