### PR TITLE
0.x: Fix media not enabled by subscribers on publisher renegotiations

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -1740,6 +1740,8 @@ typedef struct janus_videoroom_subscriber {
 	janus_rtp_simulcasting_context sim_context;
 	janus_vp8_simulcast_context vp8_context;
 	gboolean audio, video, data;		/* Whether audio, video and/or data must be sent to this subscriber */
+	gboolean audio_configured, video_configured, data_configured;		/* Whether audio, video and/or data were explicitly configured for this subscriber */
+	gboolean audio_enabled, video_enabled, data_enabled;		/* When configured, whether audio, video and/or data should be relayed for this subscriber */
 	/* As above, but can't change dynamically (says whether something was negotiated at all in SDP) */
 	gboolean audio_offered, video_offered, data_offered;
 	gboolean paused;
@@ -6853,12 +6855,15 @@ static void *janus_videoroom_handler(void *data) {
 						g_free(subscriber);
 						goto error;
 					}
+					subscriber->audio_configured = FALSE;
 					subscriber->audio = audio ? json_is_true(audio) : TRUE;	/* True by default */
 					if(!publisher->audio || !subscriber->audio_offered)
 						subscriber->audio = FALSE;	/* ... unless the publisher isn't sending any audio or we're skipping it */
+					subscriber->video_configured = FALSE;
 					subscriber->video = video ? json_is_true(video) : TRUE;	/* True by default */
 					if(!publisher->video || !subscriber->video_offered)
 						subscriber->video = FALSE;	/* ... unless the publisher isn't sending any video or we're skipping it */
+					subscriber->data_configured = FALSE;
 					subscriber->data = data ? json_is_true(data) : TRUE;	/* True by default */
 					if(!publisher->data || !subscriber->data_offered)
 						subscriber->data = FALSE;	/* ... unless the publisher isn't sending any data or we're skipping it */
@@ -7378,6 +7383,18 @@ static void *janus_videoroom_handler(void *data) {
 				json_t *min_delay = json_object_get(root, "min_delay");
 				json_t *max_delay = json_object_get(root, "max_delay");
 				/* Update the audio/video/data flags, if set */
+				if(audio) {
+					subscriber->audio_configured = TRUE;
+					subscriber->audio_enabled = json_is_true(audio);
+				}
+				if(video) {
+					subscriber->video_configured = TRUE;
+					subscriber->video_enabled = json_is_true(video);
+				}
+				if(data) {
+					subscriber->data_configured = TRUE;
+					subscriber->data_enabled = json_is_true(data);
+				}
 				janus_videoroom_publisher *publisher = subscriber->feed;
 				if(publisher) {
 					if(audio && publisher->audio && subscriber->audio_offered) {
@@ -7603,9 +7620,9 @@ static void *janus_videoroom_handler(void *data) {
 						json_decref(jsep);
 						g_free(newsdp);
 						/* Any update in the media directions? */
-						subscriber->audio = subscriber->audio && publisher->audio && subscriber->audio_offered;
-						subscriber->video = subscriber->video && publisher->video && subscriber->video_offered;
-						subscriber->data = subscriber->data && publisher->data && subscriber->data_offered;
+						subscriber->audio = (!subscriber->audio_configured || subscriber->audio_enabled) && publisher->audio && subscriber->audio_offered;
+						subscriber->video = (!subscriber->video_configured || subscriber->video_enabled) && publisher->video && subscriber->video_offered;
+						subscriber->data = (!subscriber->data_configured || subscriber->data_enabled) && publisher->data && subscriber->data_offered;
 						/* Done */
 						janus_videoroom_message_free(msg);
 						janus_refcount_decrease(&subscriber->ref);
@@ -7732,14 +7749,14 @@ static void *janus_videoroom_handler(void *data) {
 				}
 				/* Subscribe to the new one */
 				subscriber->audio = audio ? json_is_true(audio) : TRUE;	/* True by default */
-				if(!publisher->audio)
-					subscriber->audio = FALSE;	/* ... unless the publisher isn't sending any audio */
+				if(!publisher->audio || (subscriber->audio_configured && !subscriber->audio_enabled))
+					subscriber->audio = FALSE;	/* ... unless the publisher isn't sending any audio or was explicitly disabled */
 				subscriber->video = video ? json_is_true(video) : TRUE;	/* True by default */
-				if(!publisher->video)
-					subscriber->video = FALSE;	/* ... unless the publisher isn't sending any video */
+				if(!publisher->video || (subscriber->video_configured && !subscriber->video_enabled))
+					subscriber->video = FALSE;	/* ... unless the publisher isn't sending any video or was explicitly disabled */
 				subscriber->data = data ? json_is_true(data) : TRUE;	/* True by default */
-				if(!publisher->data)
-					subscriber->data = FALSE;	/* ... unless the publisher isn't sending any data */
+				if(!publisher->data || (subscriber->data_configured && !subscriber->data_enabled))
+					subscriber->data = FALSE;	/* ... unless the publisher isn't sending any data or was explicitly disabled */
 				/* Check if a simulcasting-related request is involved */
 				janus_rtp_simulcasting_context_reset(&subscriber->sim_context);
 				subscriber->sim_context.rid_ext_id = publisher->rid_extmap_id;

--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -3004,10 +3004,19 @@ json_t *janus_videoroom_query_session(janus_plugin_session *handle) {
 				}
 				json_t *media = json_object();
 				json_object_set_new(media, "audio", participant->audio ? json_true() : json_false());
+				json_object_set_new(media, "audio-configured", participant->audio_configured ? json_true() : json_false());
+				if(participant->audio_configured)
+					json_object_set_new(media, "audio-configured-enabled", participant->audio_enabled ? json_true() : json_false());
 				json_object_set_new(media, "audio-offered", participant->audio_offered ? json_true() : json_false());
 				json_object_set_new(media, "video", participant->video ? json_true() : json_false());
+				json_object_set_new(media, "video-configured", participant->video_configured ? json_true() : json_false());
+				if(participant->video_configured)
+					json_object_set_new(media, "video-configured-enabled", participant->video_enabled ? json_true() : json_false());
 				json_object_set_new(media, "video-offered", participant->video_offered ? json_true() : json_false());
 				json_object_set_new(media, "data", participant->data ? json_true() : json_false());
+				json_object_set_new(media, "data-configured", participant->data_configured ? json_true() : json_false());
+				if(participant->data_configured)
+					json_object_set_new(media, "data-configured-enabled", participant->data_enabled ? json_true() : json_false());
 				json_object_set_new(media, "data-offered", participant->data_offered ? json_true() : json_false());
 				json_object_set_new(info, "media", media);
 				if(feed && (feed->ssrc[0] != 0 || feed->rid[0] != NULL)) {


### PR DESCRIPTION
Since 493632d1aaad when a subscriber is configured the `audio`, `video` and `data` flags are honoured. If they are disabled they will stay disabled, and if they are enabled then the result will depend on whether the publisher is sending them and the subscriber has offered to receive them. The value of the flags will be either [the value given in the configure request](https://github.com/meetecho/janus-gateway/blob/402189a1446fd53f4179126a7ce5ed3ba9860c6e/plugins/janus_videoroom.c#L7385-L7408) or the value they had already if it is not explicitly given.

[When the SDP is updated for a publisher the publisher sends a configure request to update all its subscribers](https://github.com/meetecho/janus-gateway/blob/402189a1446fd53f4179126a7ce5ed3ba9860c6e/plugins/janus_videoroom.c#L8244-L8268). Before 493632d1aaad if a publisher started to publish audio, video or data the audio, video or data was automatically enabled by the subscribers. However, after that change the audio, video or data is no longer automatically enabled; [if the audio, video or data was not being sent by the publisher when the subscriber was created the corresponding flag is disabled](https://github.com/meetecho/janus-gateway/blob/402189a1446fd53f4179126a7ce5ed3ba9860c6e/plugins/janus_videoroom.c#L6857-L6865), so when the publisher starts to send it it will stay disabled in the subscriber, as it was not possible to differentiate between explicitly disabled and implicitly disabled.

~~To solve that this pull request updates the `audio`, `video` or `data` flag of subscribers when subscribers are configured due to a change in the SDP of a publisher, thus restoring the behaviour previous to 493632d1aaad for that case (which was a side effect / regression, as the main target of that commit were updates of the subscriber itself*).~~

~~Note, however, that this implies that if a subscriber was explicitly configured to disable audio, video or data when the publisher was not sending it yet that setting will not be respected once the publisher starts to send it. The subscriber will need to be explicitly configured again to disable the audio, video or data. As the flags are booleans as far as I know there is currently no way to differentiate between the flags being explicitly disabled, or being implicitly disabled due to the publisher not sending the corresponding media (which could be used to automatically enable the media once available only in this case).~~

~~Nevertheless, the flags are updated only if the audio, video or data changed, to avoid overriding the subscriber flags when the audio, video or data did not change in the publisher SDP.~~

To solve that additional variables are introduced to keep track of whether the audio, video or data were explicitly configured or not and, if they were, with which value. This is now taken into account when a subscriber is updated, so the audio, video or data will be automatically enabled if the publisher starts to send them and they were not explicitly disabled by the subscriber.
    
Besides that, for consistency the configured value is now also taken into account when switching publishers for a subscriber; if the audio, video or data was explicitly disabled it will stay disabled after the switch.

*The main target of 493632d1aaad were [these two scenarios, both for subscribers](https://github.com/meetecho/janus-gateway/pull/2963#issuecomment-1113340998):
- Send `configure` request with `XXX: false` (where _XXX_ is `audio`, `video` or `data`), then send `configure` request with `update: true` -> Before 493632d1aaad _XXX_ was enabled, after 493632d1aaad it is still disabled
- Send `configure` request with `update: true` and `XXX: false` -> Before 493632d1aaad _XXX_ was still enabled (if it was enabled before), after 493632d1aaad it is disabled
