### PR TITLE
janus.js: remove DtlsSrtpKeyAgreement constraint

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1800,9 +1800,7 @@ function Janus(gatewayCallbacks) {
 				// For Chrome versions before 72, we force a plan-b semantic, and unified-plan otherwise
 				pc_config["sdpSemantics"] = (Janus.webRTCAdapter.browserDetails.version < 72) ? "plan-b" : "unified-plan";
 			}
-			var pc_constraints = {
-				"optional": [{"DtlsSrtpKeyAgreement": true}]
-			};
+			var pc_constraints = {};
 			if(ipv6Support) {
 				pc_constraints.optional.push({"googIPv6":true});
 			}


### PR DESCRIPTION
which is not even possible to configure otherwise in recent Chrome versions
and has been the default for the better part of a decade

(maybe remove googIPv6 too? It is going away in [M108](https://groups.google.com/g/discuss-webrtc/c/85e-f_siCws/m/4yWismzCAQAJ?)...)