### PR TITLE
Fixed not muting if there is more than one audio stream

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2874,7 +2874,7 @@ function Janus(gatewayCallbacks) {
 				}
 				transceiver.sender.track.enabled = mute ? false : true;
 			} else {
-				for(const videostream of config.myStream.getVideoTracks()){
+				for(const videostream of config.myStream.getVideoTracks()) {
 					videostream.enabled = !mute
 				}
 			}
@@ -2897,7 +2897,7 @@ function Janus(gatewayCallbacks) {
 				}
 				transceiver.sender.track.enabled = mute ? false : true;
 			} else {
-				for(const audiostream of config.myStream.getAudioTracks()){
+				for(const audiostream of config.myStream.getAudioTracks()) {
 					audiostream.enabled = !mute
 				}
 			}

--- a/html/janus.js
+++ b/html/janus.js
@@ -2874,7 +2874,9 @@ function Janus(gatewayCallbacks) {
 				}
 				transceiver.sender.track.enabled = mute ? false : true;
 			} else {
-				config.myStream.getVideoTracks()[0].enabled = mute ? false : true;
+				for(const videostream of config.myStream.getVideoTracks()){
+					videostream.enabled = !mute
+				}
 			}
 		} else {
 			// Mute/unmute audio track
@@ -2895,7 +2897,9 @@ function Janus(gatewayCallbacks) {
 				}
 				transceiver.sender.track.enabled = mute ? false : true;
 			} else {
-				config.myStream.getAudioTracks()[0].enabled = mute ? false : true;
+				for(const audiostream of config.myStream.getAudioTracks()){
+					audiostream.enabled = !mute
+				}
 			}
 		}
 		return true;


### PR DESCRIPTION
Whenever there is more than one audio track due to changing audio devices during a call, such as switching to a bluetooth device, muting would no longer work because it always assumed that the first track is the only one.

Switch to cycle through all tracks and set the mute status on all.

Version 0.x also affected