### PR TITLE
Don't call .stop() in onremotetrack when track is notified as removed by janus.js (fixes #3055)

### DIFF
--- a/html/audiobridgetest.js
+++ b/html/audiobridgetest.js
@@ -304,16 +304,6 @@ $(document).ready(function() {
 										return;
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										if(remoteStream) {
-											try {
-												var tracks = remoteStream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										remoteStream = null;
 										$('#roomaudio').remove();
 										return;

--- a/html/canvas.js
+++ b/html/canvas.js
@@ -173,17 +173,6 @@ $(document).ready(function() {
 									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										var stream = remoteTracks[mid];
-										if(stream) {
-											try {
-												var tracks = stream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										$('#peervideo' + mid).remove();
 										if(track.kind === "video") {
 											remoteVideos--;

--- a/html/devicetest.js
+++ b/html/devicetest.js
@@ -376,17 +376,6 @@ $(document).ready(function() {
 									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										var stream = remoteTracks[mid];
-										if(stream) {
-											try {
-												var tracks = stream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										$('#peervideo' + mid).remove();
 										if(track.kind === "video") {
 											remoteVideos--;

--- a/html/e2etest.js
+++ b/html/e2etest.js
@@ -229,17 +229,6 @@ $(document).ready(function() {
 									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										var stream = remoteTracks[mid];
-										if(stream) {
-											try {
-												var tracks = stream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										$('#peervideo' + mid).remove();
 										if(track.kind === "video") {
 											remoteVideos--;

--- a/html/echotest.js
+++ b/html/echotest.js
@@ -285,17 +285,6 @@ $(document).ready(function() {
 									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										var stream = remoteTracks[mid];
-										if(stream) {
-											try {
-												var tracks = stream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										$('#peervideo' + mid).remove();
 										if(track.kind === "video") {
 											remoteVideos--;

--- a/html/multiopus.js
+++ b/html/multiopus.js
@@ -208,17 +208,6 @@ $(document).ready(function() {
 									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										var stream = remoteTracks[mid];
-										if(stream) {
-											try {
-												var tracks = stream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										$('#peervideo' + mid).remove();
 										if(track.kind === "video") {
 											remoteVideos--;

--- a/html/mvideoroomtest.js
+++ b/html/mvideoroomtest.js
@@ -739,18 +739,6 @@ function subscribeTo(sources) {
 				Janus.debug(" >> mid " + mid + " is in slot " + slot);
 				if(!on) {
 					// Track removed, get rid of the stream and the rendering
-					var stream = remoteTracks[mid];
-					if(stream) {
-						try {
-							var tracks = stream.getTracks();
-							for(var i in tracks) {
-								var mst = tracks[i];
-								// Temporarily disabled as per https://github.com/meetecho/janus-gateway/issues/3055
-								//~ if(mst)
-									//~ mst.stop();
-							}
-						} catch(e) {}
-					}
 					$('#remotevideo' + slot + '-' + mid).remove();
 					if(track.kind === "video" && feed) {
 						feed.remoteVideos--;

--- a/html/nosiptest.js
+++ b/html/nosiptest.js
@@ -248,17 +248,6 @@ $(document).ready(function() {
 									Janus.debug("[caller] Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										var stream = remoteTracks[mid];
-										if(stream) {
-											try {
-												var tracks = stream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										$('#peervideo' + mid).remove();
 										if(track.kind === "video") {
 											remoteVideos--;

--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -282,17 +282,6 @@ $(document).ready(function() {
 									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										var stream = remoteTracks[mid];
-										if(stream) {
-											try {
-												var tracks = stream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										$('#thevideo' + mid).remove();
 										if(track.kind === "video") {
 											remoteVideos--;

--- a/html/screensharingtest.js
+++ b/html/screensharingtest.js
@@ -511,17 +511,6 @@ function newRemoteFeed(id, display) {
 				Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 				if(!on) {
 					// Track removed, get rid of the stream and the rendering
-					var stream = remoteTracks[mid];
-					if(stream) {
-						try {
-							var tracks = stream.getTracks();
-							for(var i in tracks) {
-								var mst = tracks[i];
-								if(mst)
-									mst.stop();
-							}
-						} catch(e) {}
-					}
 					$('#screenvideo' + mid).remove();
 					if(track.kind === "video") {
 						remoteVideos--;

--- a/html/siptest.js
+++ b/html/siptest.js
@@ -525,17 +525,6 @@ $(document).ready(function() {
 									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										var stream = remoteTracks[mid];
-										if(stream) {
-											try {
-												var tracks = stream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										$('#peervideom' + mid).remove();
 										if(track.kind === "video") {
 											remoteVideos--;
@@ -1498,17 +1487,6 @@ function addHelper(helperCreated) {
 				Janus.debug("[Helper #" + helperId + "] Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 				if(!on) {
 					// Track removed, get rid of the stream and the rendering
-					var stream = helpers[helperId].remoteTracks[mid];
-					if(stream) {
-						try {
-							var tracks = stream.getTracks();
-							for(var i in tracks) {
-								var mst = tracks[i];
-								if(mst)
-									mst.stop();
-							}
-						} catch(e) {}
-					}
 					$('#peervideo' + helperId + 'm' + mid).remove();
 					if(track.kind === "video") {
 						remoteVideos--;

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -159,17 +159,6 @@ $(document).ready(function() {
 										mstreamId = "mstream0";
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										var stream = remoteTracks[mid];
-										if(stream) {
-											try {
-												var tracks = stream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										$('#remotevideo' + mid).remove();
 										if(track.kind === "video") {
 											remoteVideos--;

--- a/html/videocalltest.js
+++ b/html/videocalltest.js
@@ -362,17 +362,6 @@ $(document).ready(function() {
 									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										var stream = remoteTracks[mid];
-										if(stream) {
-											try {
-												var tracks = stream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										$('#peervideo' + mid).remove();
 										if(track.kind === "video") {
 											remoteVideos--;

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -650,17 +650,6 @@ function newRemoteFeed(id, display, streams) {
 				Janus.debug("Remote feed #" + remoteFeed.rfindex + ", remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 				if(!on) {
 					// Track removed, get rid of the stream and the rendering
-					var stream = remoteFeed.remoteTracks[mid];
-					if(stream) {
-						try {
-							var tracks = stream.getTracks();
-							for(var i in tracks) {
-								var mst = tracks[i];
-								if(mst !== null && mst !== undefined)
-									mst.stop();
-							}
-						} catch(e) {}
-					}
 					$('#remotevideo'+remoteFeed.rfindex + '-' + mid).remove();
 					if(track.kind === "video") {
 						remoteFeed.remoteVideos--;

--- a/html/virtualbg.js
+++ b/html/virtualbg.js
@@ -236,17 +236,6 @@ $(document).ready(function() {
 									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										var stream = remoteTracks[mid];
-										if(stream) {
-											try {
-												var tracks = stream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										$('#peervideo' + mid).remove();
 										if(track.kind === "video") {
 											remoteVideos--;

--- a/html/vp9svctest.js
+++ b/html/vp9svctest.js
@@ -608,17 +608,6 @@ function newRemoteFeed(id, display, streams) {
 				Janus.debug("Remote feed #" + remoteFeed.rfindex + ", remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
 				if(!on) {
 					// Track removed, get rid of the stream and the rendering
-					var stream = remoteFeed.remoteTracks[mid];
-					if(stream) {
-						try {
-							var tracks = stream.getTracks();
-							for(var i in tracks) {
-								var mst = tracks[i];
-								if(mst !== null && mst !== undefined)
-									mst.stop();
-							}
-						} catch(e) {}
-					}
 					$('#remotevideo'+remoteFeed.rfindex + '-' + mid).remove();
 					if(track.kind === "video") {
 						remoteFeed.remoteVideos--;

--- a/html/webaudio.js
+++ b/html/webaudio.js
@@ -149,17 +149,6 @@ $(document).ready(function() {
 									// Now that we're aware of the remote stream, we process it to visualize it
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
-										var stream = remoteTracks[mid];
-										if(stream) {
-											try {
-												var tracks = stream.getTracks();
-												for(var i in tracks) {
-													var mst = tracks[i];
-													if(mst)
-														mst.stop();
-												}
-											} catch(e) {}
-										}
 										$('#peeraudio' + mid).remove();
 										delete remoteTracks[mid];
 										return;


### PR DESCRIPTION
This is a fix for the issue reported in #3055, where the symptom was the multistream VideoRoom demo breaking when someone left a room and then joined again (or someone else joined): for existing subscribers, m-lines would be reused, and media would be broken. This was caused by us closing the remote stream in the `onremotetrack` callback for a removed track: since the new track (new user) actually remains the same after the renegotiation, this ends up breaking the rendering.

Initially we thought it might be caused by us re-using track IDs in SDPs from Janus, but even after making sure we generate fresh ones when needed, the problem remained the same, and we could see the `ontrack` callback of the PeerConnection would still report the previous track ID as being added: not sure why, but maybe because as far as SDP is concerned the fact we changed the ID of the track didn't change anything, since the m-line still "lives", and so the browser assumed the previous one was still in use and ignored the new one.

As such, we decided to go for a different fix, and just removed all calls to `.stop()` for the remote track when one is removed. We gave this some thought and realized this could have caused issues also when a track was only temporarily paused, e.g., freezed because of losses: in fact, the `onremotetrack(false)` event is fired in response to an `onmuted` event on the track, not `onended`, which is by definition not conclusive. Besides, the `.stop()` calls we had were probably a leftover when we still cloned tracks before using them in demos, which is something we stopped doing in #3009.

Not sure if this can cause leaks in demos, now, but it definitely fixes the problem. Feedback would be welcome before we merge, of course. Also pinging @fippo who may point out gross mistakes we're doing :hand_over_mouth: 