### PR TITLE
Convert strlen calls to strnlen

### DIFF
--- a/src/events/janus_wsevh.c
+++ b/src/events/janus_wsevh.c
@@ -376,7 +376,7 @@ int janus_wsevh_init(const char *config_path) {
 		goto error;
 	}
 	path[0] = '/';
-	if(strlen(p) > 1)
+	if(strnlen(p, 1 + 1) > 1)
 		g_strlcpy(path + 1, p, sizeof(path)-2);
 	/* Before connecting, let's check if the server expects a subprotocol */
 	item = janus_config_get(config, config_general, janus_config_type_item, "subprotocol");

--- a/src/plugins/janus_streaming.c
+++ b/src/plugins/janus_streaming.c
@@ -7663,7 +7663,7 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 					index++;
 					continue;
 				}
-				if(strlen(line) < 3) {
+				if(strnlen(line, 3) < 3) {
 					JANUS_LOG(LOG_ERR, "Invalid RTSP line (%zu bytes): %s\n", strlen(line), line);
 					success = FALSE;
 					break;
@@ -7843,7 +7843,7 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 					index++;
 					continue;
 				}
-				if(strlen(line) < 3) {
+				if(strnlen(line, 3) < 3) {
 					JANUS_LOG(LOG_ERR, "Invalid RTSP line (%zu bytes): %s\n", strlen(line), line);
 					success = FALSE;
 					break;

--- a/src/postprocessing/janus-pp-rec.c
+++ b/src/postprocessing/janus-pp-rec.c
@@ -198,7 +198,7 @@ static char *janus_pp_extensions_string(const char **allowed, char *supported, s
 	janus_strlcat(supported, "[", suplen);
 	const char **ext = allowed;
 	while(*ext != NULL) {
-		if(strlen(supported) > 1)
+		if(strnlen(supported, 1 + 1) > 1)
 			janus_strlcat(supported, ", ", suplen);
 		janus_strlcat(supported, *ext, suplen);
 		ext++;

--- a/src/sdp-utils.c
+++ b/src/sdp-utils.c
@@ -327,7 +327,7 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen) {
 				index++;
 				continue;
 			}
-			if(strlen(line) < 3) {
+			if(strnlen(line, 3) < 3) {
 				if(error)
 					g_snprintf(error, errlen, "Invalid line (%zu bytes): %s", strlen(line), line);
 				success = FALSE;
@@ -465,7 +465,7 @@ janus_sdp *janus_sdp_parse(const char *sdp, char *error, size_t errlen) {
 						/* Start with media type, port and protocol */
 						char type[32];
 						char proto[64];
-						if(strlen(line) > 200) {
+						if(strnlen(line, 200 + 1) > 200) {
 							janus_sdp_mline_destroy(m);
 							if(error)
 								g_snprintf(error, errlen, "Invalid m= line (too long): %zu", strlen(line));

--- a/src/sdp.c
+++ b/src/sdp.c
@@ -100,7 +100,7 @@ janus_sdp *janus_sdp_preparse(void *ice_handle, const char *jsep_sdp, char *erro
 						return NULL;
 					}
 					if((m->type == JANUS_SDP_AUDIO || m->type == JANUS_SDP_VIDEO) && m->port > 0) {
-						if(strlen(a->value) > 16) {
+						if(strnlen(a->value, 16 + 1) > 16) {
 							JANUS_LOG(LOG_ERR, "[%"SCNu64"] mid on m-line #%d too large: (%zu > 16)\n",
 								handle->handle_id, m->index, strlen(a->value));
 							janus_sdp_destroy(parsed_sdp);
@@ -298,7 +298,7 @@ int janus_sdp_process_remote(void *ice_handle, janus_sdp *remote_sdp, gboolean r
 			if(a->name && a->value) {
 				if(!strcasecmp(a->name, "mid")) {
 					/* Found mid attribute */
-					if(strlen(a->value) > 16) {
+					if(strnlen(a->value, 16 + 1) > 16) {
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"] mid on m-line #%d too large: (%zu > 16)\n",
 							handle->handle_id, m->index, strlen(a->value));
 						return -2;
@@ -759,7 +759,7 @@ int janus_sdp_process_local(void *ice_handle, janus_sdp *remote_sdp, gboolean up
 			if(a->name && a->value) {
 				if(!strcasecmp(a->name, "mid")) {
 					/* Found mid attribute */
-					if(strlen(a->value) > 16) {
+					if(strnlen(a->value, 16 + 1) > 16) {
 						JANUS_LOG(LOG_ERR, "[%"SCNu64"] mid on m-line #%d too large: (%zu > 16)\n",
 							handle->handle_id, m->index, strlen(a->value));
 						return -2;

--- a/src/transports/janus_http.c
+++ b/src/transports/janus_http.c
@@ -685,7 +685,7 @@ int janus_http_init(janus_transport_callbacks *callback, const char *config_path
 				return -1;
 			}
 			ws_path = g_strdup(item->value);
-			if(strlen(ws_path) > 1 && ws_path[strlen(ws_path)-1] == '/') {
+			if(strnlen(ws_path, 1 + 1) > 1 && ws_path[strlen(ws_path)-1] == '/') {
 				/* Remove the trailing slash, it makes things harder when we parse requests later */
 				ws_path[strlen(ws_path)-1] = '\0';
 			}
@@ -700,7 +700,7 @@ int janus_http_init(janus_transport_callbacks *callback, const char *config_path
 				return -1;
 			}
 			admin_ws_path = g_strdup(item->value);
-			if(strlen(admin_ws_path) > 1 && admin_ws_path[strlen(admin_ws_path)-1] == '/') {
+			if(strnlen(admin_ws_path, 1 + 1) > 1 && admin_ws_path[strlen(admin_ws_path)-1] == '/') {
 				/* Remove the trailing slash, it makes things harder when we parse requests later */
 				admin_ws_path[strlen(admin_ws_path)-1] = '\0';
 			}
@@ -1423,7 +1423,7 @@ static MHD_Result janus_http_handler(void *cls, struct MHD_Connection *connectio
 	}
 	/* Get path components */
 	if(strcasecmp(url, ws_path)) {
-		if(strlen(ws_path) > 1) {
+		if(strnlen(ws_path, 1 + 1) > 1) {
 			basepath = g_strsplit(url, ws_path, -1);
 		} else {
 			/* The base path is the web server too itself, we process the url itself */
@@ -1821,7 +1821,7 @@ static MHD_Result janus_http_admin_handler(void *cls, struct MHD_Connection *con
 	}
 	/* Get path components */
 	if(strcasecmp(url, admin_ws_path)) {
-		if(strlen(admin_ws_path) > 1) {
+		if(strnlen(admin_ws_path, 1 + 1) > 1) {
 			basepath = g_strsplit(url, admin_ws_path, -1);
 		} else {
 			/* The base path is the web server too itself, we process the url itself */

--- a/src/transports/janus_pfunix.c
+++ b/src/transports/janus_pfunix.c
@@ -180,7 +180,7 @@ static int janus_pfunix_create_socket(char *pfname, gboolean use_dgram) {
 	if(pfname == NULL)
 		return -1;
 	int fd = -1;
-	if(strlen(pfname) > UNIX_PATH_MAX) {
+	if(strnlen(pfname, UNIX_PATH_MAX + 1) > UNIX_PATH_MAX) {
 		JANUS_LOG(LOG_WARN, "The provided path name (%s) is longer than %lu characters, it will be truncated\n", pfname, UNIX_PATH_MAX);
 		pfname[UNIX_PATH_MAX] = '\0';
 	}


### PR DESCRIPTION
- For `strlen(x) > c` comparisons, use `strnlen(x, c + 1) > c` (so O(1) instead of O(n))
- For `strlen(x) < c` comparisons, use `strnlen(x, c) < c`, so (so O(1) instead of O(n))

I didn't change `strlen(x) > 0` comparisons (or any other comparison to 0) since compilers already optimize away the `strlen` call by transforming those to e.g., `x[0] != '\0'`, see https://godbolt.org/z/KGW359ca1

N.B. Some of these calls are still followed by `strlen` calls, but this is always in the error and/or logging case (not the most likely path).

Inspired by https://code.videolan.org/videolan/vlc/-/merge_requests/2477/diffs