### PR TITLE
increased sip buffer size

### DIFF
--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -1655,7 +1655,7 @@ static void janus_sip_parse_custom_contact_params(json_t *root, char *custom_par
 /* Sofia SIP logger function: when the Event Handlers mechanism is enabled,
  * we use this to intercept SIP messages sent by the stack (received
  * messages are more easily recoverable in janus_sip_sofia_callback) */
-char sofia_log[2048];
+char sofia_log[3072];
 char call_id[255];
 gboolean skip = FALSE, started = FALSE, append = FALSE;
 static void janus_sip_sofia_logger(void *stream, char const *fmt, va_list ap) {


### PR DESCRIPTION
In the last few days we have been getting a lot of spam logs from Janus on our WebRTC platform.
The log messages looks like this: **Truncation occurred, 2132 >= 2048**, and are usually caused by destination buffer being close to the size of the `sofia_log` array max size , which is set to 2048 inside `janus_sip.c` file.

The truncation occurs by invoking `janus_strlcat` function on the 1744th and 1757th line inside `janus_sip_sofia_logger` function, located in `janus_sip.c`. When the `janus_strlcat` is invoked, destination buffer, source buffer and destination size in bytes are concatenated and truncation occurs.

In this PR I made a change to the `sofia_log` array, making it 3kB, instead of the original 2kB, as I saw that the return value of the `janus_strlcat`, which causes the overflow and truncation, is never more than 2.3kB.
