### PR TITLE
Fixed strcasestr()

### DIFF
--- a/src/sdp.c
+++ b/src/sdp.c
@@ -161,10 +161,10 @@ int janus_sdp_process_remote(void *ice_handle, janus_sdp *remote_sdp, gboolean r
 		if(a && a->name && a->value) {
 			if(!strcasecmp(a->name, "fingerprint")) {
 				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Fingerprint (global) : %s\n", handle->handle_id, a->value);
-				if(strcasestr(a->value, "sha-256 ") == a->value) {
+				if(!strncasecmp(a->value, "sha-256 ", strlen("sha-256 "))) {
 					rhashing = g_strdup("sha-256");
 					rfingerprint = g_strdup(a->value + strlen("sha-256 "));
-				} else if(strcasestr(a->value, "sha-1 ") == a->value) {
+				} else if(!strncasecmp(a->value, "sha-1 ", strlen("sha-1 "))) {
 					JANUS_LOG(LOG_WARN, "[%"SCNu64"]  Hashing algorithm not the one we expected (sha-1 instead of sha-256), but that's ok\n", handle->handle_id);
 					rhashing = g_strdup("sha-1");
 					rfingerprint = g_strdup(a->value + strlen("sha-1 "));
@@ -342,12 +342,12 @@ int janus_sdp_process_remote(void *ice_handle, janus_sdp *remote_sdp, gboolean r
 					}
 				} else if(!strcasecmp(a->name, "fingerprint")) {
 					JANUS_LOG(LOG_VERB, "[%"SCNu64"] Fingerprint (local) : %s\n", handle->handle_id, a->value);
-					if(strcasestr(a->value, "sha-256 ") == a->value) {
+					if(!strncasecmp(a->value, "sha-256 ", strlen("sha-256 "))) {
 						g_free(rhashing);	/* FIXME We're overwriting the global one, if any */
 						rhashing = g_strdup("sha-256");
 						g_free(rfingerprint);	/* FIXME We're overwriting the global one, if any */
 						rfingerprint = g_strdup(a->value + strlen("sha-256 "));
-					} else if(strcasestr(a->value, "sha-1 ") == a->value) {
+					} else if(!strncasecmp(a->value, "sha-1 ", strlen("sha-1 "))) {
 						JANUS_LOG(LOG_WARN, "[%"SCNu64"]  Hashing algorithm not the one we expected (sha-1 instead of sha-256), but that's ok\n", handle->handle_id);
 						g_free(rhashing);	/* FIXME We're overwriting the global one, if any */
 						rhashing = g_strdup("sha-1");
@@ -357,6 +357,7 @@ int janus_sdp_process_remote(void *ice_handle, janus_sdp *remote_sdp, gboolean r
 						/* FIXME We should handle this somehow anyway... OpenSSL supports them all */
 						JANUS_LOG(LOG_WARN, "[%"SCNu64"]  Hashing algorithm not the one we expected (sha-256), *NOT* cool\n", handle->handle_id);
 					}
+
 				} else if(!strcasecmp(a->name, "setup")) {
 					JANUS_LOG(LOG_VERB, "[%"SCNu64"] DTLS setup (local):  %s\n", handle->handle_id, a->value);
 					if(!update) {


### PR DESCRIPTION
* Source : sdp.c
* Problem : strncasecmp() function -> This function may fail to find matches on some platforms
* Reference : https://www.gnu.org/software/gnulib/manual/html_node/strcasestr.html
* It has caused problems in our system and it would be good to solve them in a safe way.
* My System info
```
$> gcc --version
gcc (Ubuntu 11.2.0-19ubuntu1) 11.2.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE

$> getconf -a | grep libc
GNU_LIBC_VERSION                   glibc 2.35
```
* Test code
```
// test code
#include <stdio.h>
#include <string.h>

int main() {
	char *data = "sha-256 F1:CD:64:51:BE:0C:5E:3E:81:60:9B:64:AA:4E:27:91:B9:B6:E4:59:29:AB:EB:A2:83:71:1C:9A:86:56:DC:BD";

	if(strcasestr(data, "sha-256 ") == data) {
		printf("Ok!\n");
	} else {
		printf("Failed!\n");
	}

	return 0;
}

$> ./a.out
Failed!
```