### PR TITLE
Avoid RTX payload type collisions in 1.x (see #3078)

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -1766,7 +1766,8 @@ static void janus_ice_peerconnection_free(const janus_refcount *pc_ref) {
 	pc->remote_candidates = NULL;
 	g_free(pc->selected_pair);
 	pc->selected_pair = NULL;
-	g_list_free(pc->payload_types);
+	if(pc->payload_types != NULL)
+		g_hash_table_destroy(pc->payload_types);
 	pc->payload_types = NULL;
 	if(pc->clock_rates != NULL)
 		g_hash_table_destroy(pc->clock_rates);

--- a/src/ice.c
+++ b/src/ice.c
@@ -1766,6 +1766,17 @@ static void janus_ice_peerconnection_free(const janus_refcount *pc_ref) {
 	pc->remote_candidates = NULL;
 	g_free(pc->selected_pair);
 	pc->selected_pair = NULL;
+	g_list_free(pc->payload_types);
+	pc->payload_types = NULL;
+	if(pc->clock_rates != NULL)
+		g_hash_table_destroy(pc->clock_rates);
+	pc->clock_rates = NULL;
+	if(pc->rtx_payload_types != NULL)
+		g_hash_table_destroy(pc->rtx_payload_types);
+	pc->rtx_payload_types = NULL;
+	if(pc->rtx_payload_types_rev != NULL)
+		g_hash_table_destroy(pc->rtx_payload_types_rev);
+	pc->rtx_payload_types_rev = NULL;
 	g_free(pc);
 	pc = NULL;
 }

--- a/src/ice.h
+++ b/src/ice.h
@@ -491,6 +491,14 @@ struct janus_ice_peerconnection {
 	 * or video m-line, in order to make it easier for plugins that don't do
 	 * multistream. That said, we don't plan to keep it forever */
 	GHashTable *media_bytype;
+	/*! \brief List of payload types we can expect */
+	GList *payload_types;
+	/*! \brief Mapping of payload types to their clock rates, as advertised in the SDP */
+	GHashTable *clock_rates;
+	/*! \brief Mapping of rtx payload types to actual media-related packet types */
+	GHashTable *rtx_payload_types;
+	/*! \brief Reverse mapping of rtx payload types to actual media-related packet types */
+	GHashTable *rtx_payload_types_rev;
 	/*! \brief Helper flag to avoid flooding the console with the same error all over again */
 	gboolean noerrorlog;
 	/*! \brief Mutex to lock/unlock this stream */

--- a/src/ice.h
+++ b/src/ice.h
@@ -492,7 +492,7 @@ struct janus_ice_peerconnection {
 	 * multistream. That said, we don't plan to keep it forever */
 	GHashTable *media_bytype;
 	/*! \brief List of payload types we can expect */
-	GList *payload_types;
+	GHashTable *payload_types;
 	/*! \brief Mapping of payload types to their clock rates, as advertised in the SDP */
 	GHashTable *clock_rates;
 	/*! \brief Mapping of rtx payload types to actual media-related packet types */

--- a/src/janus.c
+++ b/src/janus.c
@@ -3964,6 +3964,20 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 	/* Iterate on all media */
 	janus_ice_peerconnection_medium *medium = NULL;
 	uint mi=0;
+	/* Let's build a list of payload types first */
+	for(mi=0; mi<g_hash_table_size(pc->media); mi++) {
+		medium = g_hash_table_lookup(pc->media, GUINT_TO_POINTER(mi));
+		if(medium && medium->type != JANUS_MEDIA_DATA) {
+			janus_sdp_mline *m = janus_sdp_mline_find_by_index(parsed_sdp, medium->mindex);
+			GList *tpt = m->ptypes;
+			while(tpt) {
+				if(!g_list_find(pc->payload_types, tpt->data))
+					pc->payload_types = g_list_prepend(pc->payload_types, tpt->data);
+				tpt = tpt->next;
+			}
+		}
+	}
+	/* Now let's iterate on media */
 	for(mi=0; mi<g_hash_table_size(pc->media); mi++) {
 		medium = g_hash_table_lookup(pc->media, GUINT_TO_POINTER(mi));
 		if(medium && medium->type == JANUS_MEDIA_VIDEO &&
@@ -3973,32 +3987,43 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 			janus_sdp_mline *m = janus_sdp_mline_find_by_index(parsed_sdp, medium->mindex);
 			if(m && m->ptypes) {
 				medium->rtx_payload_types = g_hash_table_new(NULL, NULL);
-				GList *ptypes = g_list_copy(m->ptypes), *tempP = ptypes;
-				GList *rtx_ptypes = g_hash_table_get_values(medium->rtx_payload_types);
+				if(pc->rtx_payload_types == NULL)
+					pc->rtx_payload_types = g_hash_table_new(NULL, NULL);
+				if(pc->rtx_payload_types_rev == NULL)
+					pc->rtx_payload_types_rev = g_hash_table_new(NULL, NULL);
+				GList *ptypes = pc->payload_types, *tempP = ptypes;
+				GList *rtx_ptypes = g_hash_table_get_values(pc->rtx_payload_types);
 				while(tempP) {
 					int ptype = GPOINTER_TO_INT(tempP->data);
-					int rtx_ptype = ptype+1;
-					if(rtx_ptype > 127)
-						rtx_ptype = 96;
-					while(g_list_find(m->ptypes, GINT_TO_POINTER(rtx_ptype))
-							|| g_list_find(rtx_ptypes, GINT_TO_POINTER(rtx_ptype))) {
-						rtx_ptype++;
+					/* First of all, let's check if a mapping exists already */
+					int rtx_ptype = GPOINTER_TO_INT(g_hash_table_lookup(pc->rtx_payload_types, GINT_TO_POINTER(ptype)));
+					if(rtx_ptype == 0) {
+						/* No mapping yet, find one now */
+						rtx_ptype = ptype+1;
 						if(rtx_ptype > 127)
 							rtx_ptype = 96;
-						if(rtx_ptype == ptype) {
-							/* We did a whole round? should never happen... */
-							rtx_ptype = -1;
-							break;
+						while(g_list_find(ptypes, GINT_TO_POINTER(rtx_ptype))
+								|| g_list_find(rtx_ptypes, GINT_TO_POINTER(rtx_ptype))) {
+							rtx_ptype++;
+							if(rtx_ptype > 127)
+								rtx_ptype = 96;
+							if(rtx_ptype == ptype) {
+								/* We did a whole round? should never happen... */
+								rtx_ptype = -1;
+								break;
+							}
 						}
 					}
-					if(rtx_ptype > 0)
+					if(rtx_ptype > 0) {
+						g_hash_table_insert(pc->rtx_payload_types, GINT_TO_POINTER(ptype), GINT_TO_POINTER(rtx_ptype));
+						g_hash_table_insert(pc->rtx_payload_types_rev, GINT_TO_POINTER(rtx_ptype), GINT_TO_POINTER(ptype));
 						g_hash_table_insert(medium->rtx_payload_types, GINT_TO_POINTER(ptype), GINT_TO_POINTER(rtx_ptype));
+					}
 					g_list_free(rtx_ptypes);
 					rtx_ptypes = g_hash_table_get_values(medium->rtx_payload_types);
 					medium->do_nacks = TRUE;
 					tempP = tempP->next;
 				}
-				g_list_free(ptypes);
 				g_list_free(rtx_ptypes);
 			}
 		} else if(medium && medium->type == JANUS_MEDIA_VIDEO &&

--- a/src/sdp.c
+++ b/src/sdp.c
@@ -228,10 +228,11 @@ int janus_sdp_process_remote(void *ice_handle, janus_sdp *remote_sdp, gboolean r
 				if(m->ptypes != NULL) {
 					g_list_free(medium->payload_types);
 					medium->payload_types = g_list_copy(m->ptypes);
+					if(pc->payload_types == NULL)
+						pc->payload_types = g_hash_table_new(NULL, NULL);
 					GList *temp = medium->payload_types;
 					while(temp) {
-						if(!g_list_find(pc->payload_types, temp->data))
-							pc->payload_types = g_list_prepend(pc->payload_types, GPOINTER_TO_INT(temp->data));
+						g_hash_table_insert(pc->payload_types, temp->data, temp->data);
 						temp = temp->next;
 					}
 				}


### PR DESCRIPTION
This PR aims at providing the same fix @tmatth provided in #3078 for `0.x`, that is the fact Janus might generate payload types for RTX that conflict with existing payload types: the reason for this issue was that we only had checks for avoiding conflicts within the context of a specific m-line, without taking into account payload types used in other m-lines though. This patch tries to address that by adding additional maps to the PeerConnection object in the Janus core too, that are updated every time a (re)negotiation takes place to keep track of payload type allocations and mappings with RTX one, when needed.

It seems to be working fine in the few tests I made, and specifically with the mountpoint configuration @tmatth could replicate the problem with, but of course I haven't tested this extensively. As such, please do and provide feedback, so that we can catch potential regressions before we merge this.