### PR TITLE
Check payload types before iterate them

### DIFF
--- a/src/janus.c
+++ b/src/janus.c
@@ -3975,10 +3975,12 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 		medium = g_hash_table_lookup(pc->media, GUINT_TO_POINTER(mi));
 		if(medium && medium->type != JANUS_MEDIA_DATA) {
 			janus_sdp_mline *m = janus_sdp_mline_find_by_index(parsed_sdp, medium->mindex);
-			GList *tpt = m->ptypes;
-			while(tpt) {
-				g_hash_table_insert(pc->payload_types, tpt->data, tpt->data);
-				tpt = tpt->next;
+			if(m && m->ptypes) {
+				GList *tpt = m->ptypes;
+				while(tpt) {
+					g_hash_table_insert(pc->payload_types, tpt->data, tpt->data);
+					tpt = tpt->next;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hi! Servers are getting occasionally Segmentation Fault after latest upgrade and found this might be the cause.

```c
janus.c:3974				GList *tpt = m->ptypes;
```

Backtrace:

```
(gdb) bt
#0  janus_plugin_handle_sdp (plugin_session=plugin_session@entry=0x7f2118031380, plugin=plugin@entry=0x7f21841116e0 <janus_videoroom_plugin>, 
    sdp_type=sdp_type@entry=0x7f2150251390 "answer", 
    sdp=sdp@entry=0x7f215011ec60 "v=0\r\no=- 4768054683036589029 2 IN IP4 1.1.1.1\r\ns=VideoRoom xxxxxxxxxxy\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\nc=IN IP4 127.0.0.1\r\na=recvonly\r\na=rtpmap:111 opus/48000/2\r\n"..., restart=restart@entry=0) at janus.c:3974
#1  0x000055c41321cc2d in janus_plugin_push_event (plugin_session=0x7f2118031380, plugin=0x7f21841116e0 <janus_videoroom_plugin>, 
    transaction=0x7f2108099eb0 "luWRvozMAgpB", message=0x7f21502b0b80, jsep=0x7f21501c8d80) at janus.c:3594
#2  0x00007f21840cadcc in janus_videoroom_handler (data=<optimized out>) at plugins/janus_videoroom.c:12389
#3  0x00007f21880ed0bd in ?? () from /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#4  0x00007f2187b17ea7 in start_thread (arg=<optimized out>) at pthread_create.c:477
#5  0x00007f2187a37aef in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

Attaching one of the SDP that caused it:

```
v=0
o=- 2447718136306941717 6 IN IP4 1.1.1.1
s=VideoRoom xxxxxxxxxxy
t=0 0
c=IN IP4 127.0.0.1
m=audio 9 UDP/TLS/RTP/SAVPF 111
c=IN IP4 127.0.0.1
a=recvonly
a=rtpmap:111 opus/48000/2
a=fmtp:111 useinbandfec=1
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
m=video 9 UDP/TLS/RTP/SAVPF 125
c=IN IP4 127.0.0.1
a=recvonly
a=rtpmap:125 H264/90000
a=rtcp-fb:125 ccm fir
a=rtcp-fb:125 nack
a=rtcp-fb:125 nack pli
a=rtcp-fb:125 goog-remb
a=rtcp-fb:125 transport-cc
a=fmtp:125 profile-level-id=42e01f;packetization-mode=1
a=extmap:13 urn:3gpp:video-orientation
a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:10 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
a=extmap:11 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
m=audio 9 UDP/TLS/RTP/SAVPF 111
c=IN IP4 127.0.0.1
a=recvonly
a=rtpmap:111 opus/48000/2
a=fmtp:111 useinbandfec=1
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
m=video 9 UDP/TLS/RTP/SAVPF 125
c=IN IP4 127.0.0.1
a=recvonly
a=rtpmap:125 H264/90000
a=rtcp-fb:125 ccm fir
a=rtcp-fb:125 nack
a=rtcp-fb:125 nack pli
a=rtcp-fb:125 goog-remb
a=rtcp-fb:125 transport-cc
a=fmtp:125 profile-level-id=42e01f;packetization-mode=1
a=extmap:13 urn:3gpp:video-orientation
a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:10 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
a=extmap:11 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
m=audio 9 UDP/TLS/RTP/SAVPF 111
c=IN IP4 127.0.0.1
a=recvonly
a=rtpmap:111 opus/48000/2
a=fmtp:111 useinbandfec=1
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
m=video 9 UDP/TLS/RTP/SAVPF 125
c=IN IP4 127.0.0.1
a=recvonly
a=rtpmap:125 H264/90000
a=rtcp-fb:125 ccm fir
a=rtcp-fb:125 nack
a=rtcp-fb:125 nack pli
a=rtcp-fb:125 goog-remb
a=rtcp-fb:125 transport-cc
a=fmtp:125 profile-level-id=42e01f;packetization-mode=1
a=extmap:13 urn:3gpp:video-orientation
a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:10 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
a=extmap:11 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
m=audio 9 UDP/TLS/RTP/SAVPF 111
c=IN IP4 127.0.0.1
a=recvonly
a=rtpmap:111 opus/48000/2
a=fmtp:111 useinbandfec=1
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
m=video 9 UDP/TLS/RTP/SAVPF 125
c=IN IP4 127.0.0.1
a=recvonly
a=rtpmap:125 H264/90000
a=rtcp-fb:125 ccm fir
a=rtcp-fb:125 nack
a=rtcp-fb:125 nack pli
a=rtcp-fb:125 goog-remb
a=rtcp-fb:125 transport-cc
a=fmtp:125 profile-level-id=42e01f;packetization-mode=1
a=extmap:13 urn:3gpp:video-orientation
a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:10 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
a=extmap:11 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
m=audio 9 UDP/TLS/RTP/SAVPF 111
c=IN IP4 127.0.0.1
a=recvonly
a=rtpmap:111 opus/48000/2
a=fmtp:111 useinbandfec=1
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
m=video 9 UDP/TLS/RTP/SAVPF 125
c=IN IP4 127.0.0.1
a=recvonly
a=rtpmap:125 H264/90000
a=rtcp-fb:125 ccm fir
a=rtcp-fb:125 nack
a=rtcp-fb:125 nack pli
a=rtcp-fb:125 goog-remb
a=rtcp-fb:125 transport-cc
a=fmtp:125 profile-level-id=42e01f;packetization-mode=1
a=extmap:13 urn:3gpp:video-orientation
a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:10 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
a=extmap:11 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
m=application 9 UDP/DTLS/SCTP webrtc-datachannel
c=IN IP4 127.0.0.1
```
