### PR TITLE
audiobridge: memory leak fixed

### DIFF
--- a/src/plugins/janus_audiobridge.c
+++ b/src/plugins/janus_audiobridge.c
@@ -8617,6 +8617,8 @@ static void *janus_audiobridge_participant_thread(void *data) {
 					janus_audiobridge_relay_rtp_packet(participant->session, outpkt);
 				}
 			}
+		}
+		if(mixedpkt) {
 			g_free(mixedpkt->data);
 			g_free(mixedpkt);
 		}


### PR DESCRIPTION
in participant sender thread.

The problem is [it has more conditions](https://github.com/meetecho/janus-gateway/blob/1870a5a5e32ab5fde07793ea58069cc29ea9b78d/src/plugins/janus_audiobridge.c#L8565) than just check `mixedpkt` for `NULL`...