### PR TITLE
janus_streaming: remove always false branch

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -4807,7 +4807,7 @@ static void *janus_streaming_handler(void *data) {
 			}
 			/* New viewer: we send an offer ourselves */
 			JANUS_LOG(LOG_VERB, "Request to watch mountpoint/stream %s\n", id_value_str);
-			if(session->mountpoint != NULL || g_list_find(mp->viewers, session) != NULL) {
+			if(g_list_find(mp->viewers, session) != NULL) {
 				janus_mutex_unlock(&session->mutex);
 				janus_mutex_unlock(&mp->mutex);
 				janus_refcount_decrease(&mp->ref);


### PR DESCRIPTION
No functional change, this is just for clarity.

Since every branch of the previous `if (session->mountpoint != NULL)` conditional terminates in either `goto error` or `goto done`, there is no case where `session->mountpoint` will be non-null when arriving at this check.

(cherry picked from commit de77c51eed223efda588e38376a75b72ae8d65fd)

This is a backport of #3096