### PR TITLE
add display variable on videoroomtest.js in html

### DIFF
--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -148,6 +148,7 @@ $(document).ready(function() {
 														continue;
 													var id = list[f]["id"];
 													var streams = list[f]["streams"];
+													var display = list[f]["display"];
 													for(var i in streams) {
 														var stream = streams[i];
 														stream["id"] = id;


### PR DESCRIPTION
It didn't display existing user's name on new user's webpage when the new user join the room.
And, I found display variable didn't define here.
