### PR TITLE
janus_streaming: enrich already watching error (#3106)

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -4811,7 +4811,7 @@ static void *janus_streaming_handler(void *data) {
 				janus_mutex_unlock(&session->mutex);
 				janus_mutex_unlock(&mp->mutex);
 				janus_refcount_decrease(&mp->ref);
-				JANUS_LOG(LOG_ERR, "Already watching a stream...\n");
+				JANUS_LOG(LOG_ERR, "Already watching a stream (found %p in %s's viewers)...\n", session, id_value_str);
 				error_code = JANUS_STREAMING_ERROR_UNKNOWN_ERROR;
 				g_snprintf(error_cause, 512, "Already watching a stream");
 				goto error;


### PR DESCRIPTION
This includes the address (the session pointer) that we found in the mp->viewers list, as well as the id of the mountpoint in question.

Refs #3105

(cherry picked from commit cbbdb3c8d438a93a9b5e53c3688837b009efa4c4)