### PR TITLE
Send data stats when using event handlers

### DIFF
--- a/src/dtls-bio.c
+++ b/src/dtls-bio.c
@@ -158,6 +158,12 @@ static int janus_dtls_bio_agent_write(BIO *bio, const char *in, int inl) {
 	if(bytes > 0) {
 		pc->dtls_out_stats.info[0].packets++;
 		pc->dtls_out_stats.info[0].bytes += bytes;
+		/* If there's a datachannel medium, update the stats there too */
+		janus_ice_peerconnection_medium *medium = g_hash_table_lookup(pc->media_bytype, GINT_TO_POINTER(JANUS_MEDIA_DATA));
+		if(medium) {
+			medium->in_stats.info[0].packets++;
+			medium->in_stats.info[0].bytes += bytes;
+		}
 	}
 	return bytes;
 }

--- a/src/ice.h
+++ b/src/ice.h
@@ -272,6 +272,10 @@ typedef enum janus_media_type {
 	JANUS_MEDIA_VIDEO,
 	JANUS_MEDIA_DATA
 } janus_media_type;
+/*! \brief Helper method to get the string associated to a janus_media_mtype value
+ * @param[in] type The type to stringify
+ * @returns The type as a string, if valid, or NULL otherwise */
+const char *janus_media_type_str(janus_media_type type);
 
 /*! \brief Janus media statistics
  * \note To improve with more stuff */


### PR DESCRIPTION
I was made aware that, when using event handlers, we send stats for all medium instances except the one used for data channels, so only audio and video. Considering we do expose info on received/sent DTLS data (in terms of packets and bytes) in the Admin API, I thought I'd use that to send stats for the datachannel medium instance too, when available. Of course, considering there's no RTCP involved, the event is much more barebones:

    {
        "emitter": "MyJanusInstance",
        "type": 32,
        "subtype": 3,
        "timestamp": 1671040193161999,
        "session_id": 2405066358686740,
        "handle_id": 8068184951870531,
        "opaque_id": "echotest-qyUKcffvvvHR",
        "event": {
            "mid": "2",
            "mindex": 2,
            "media": "data",
            "packets-received": 9,
            "packets-sent": 7,
            "bytes-received": 1847,
            "bytes-sent": 1688
        }
    }

That said, it should still be useful for monitoring purposes. It's worth pointing out that, if you have an event handler recipient, and you're doing validation on received payloads, you should now be prepared to receive events with type `32` that have less info, since we're not using it for audio and video alone.

Planning to merge soon: when that happens, I'll update `0.x` with the same fix too.