### PR TITLE
Use shorter mids as fallbacks in 0.x

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -3791,20 +3791,20 @@ int janus_ice_setup_local(janus_ice_handle *handle, int offer, int audio, int vi
 	if(!offer) {
 		if(audio) {
 			if(handle->audio_mid == NULL)
-				handle->audio_mid = g_strdup("audio");
+				handle->audio_mid = g_strdup("a");
 			if(handle->stream_mid == NULL)
 				handle->stream_mid = handle->audio_mid;
 		}
 		if(video) {
 			if(handle->video_mid == NULL)
-				handle->video_mid = g_strdup("video");
+				handle->video_mid = g_strdup("v");
 			if(handle->stream_mid == NULL)
 				handle->stream_mid = handle->video_mid;
 		}
 #ifdef HAVE_SCTP
 		if(data) {
 			if(handle->data_mid == NULL)
-				handle->data_mid = g_strdup("data");
+				handle->data_mid = g_strdup("d");
 			if(handle->stream_mid == NULL)
 				handle->stream_mid = handle->data_mid;
 		}

--- a/janus.c
+++ b/janus.c
@@ -3732,7 +3732,7 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 						}
 					}
 					if(ice_handle->audio_mid == NULL)
-						ice_handle->audio_mid = g_strdup("audio");
+						ice_handle->audio_mid = g_strdup("a");
 				}
 				if(video) {
 					if(!janus_flags_is_set(&ice_handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_HAS_VIDEO)) {
@@ -3744,11 +3744,11 @@ json_t *janus_plugin_handle_sdp(janus_plugin_session *plugin_session, janus_plug
 						}
 					}
 					if(ice_handle->video_mid == NULL)
-						ice_handle->video_mid = g_strdup("video");
+						ice_handle->video_mid = g_strdup("v");
 				}
 				if(data) {
 					if(ice_handle->data_mid == NULL)
-						ice_handle->data_mid = g_strdup("data");
+						ice_handle->data_mid = g_strdup("d");
 				}
 			}
 		}

--- a/sdp.c
+++ b/sdp.c
@@ -1366,14 +1366,14 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 			audio++;
 			if(audio == 1 && m->port > 0) {
 				g_snprintf(buffer_part, sizeof(buffer_part),
-					" %s", handle->audio_mid ? handle->audio_mid : "audio");
+					" %s", handle->audio_mid ? handle->audio_mid : "a");
 				janus_strlcat(buffer, buffer_part, sizeof(buffer));
 			}
 		} else if(m->type == JANUS_SDP_VIDEO) {
 			video++;
 			if(video == 1 && m->port > 0) {
 				g_snprintf(buffer_part, sizeof(buffer_part),
-					" %s", handle->video_mid ? handle->video_mid : "video");
+					" %s", handle->video_mid ? handle->video_mid : "v");
 				janus_strlcat(buffer, buffer_part, sizeof(buffer));
 			}
 #ifdef HAVE_SCTP
@@ -1382,7 +1382,7 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 				data++;
 			if(data == 1 && m->port > 0) {
 				g_snprintf(buffer_part, sizeof(buffer_part),
-					" %s", handle->data_mid ? handle->data_mid : "data");
+					" %s", handle->data_mid ? handle->data_mid : "d");
 				janus_strlcat(buffer, buffer_part, sizeof(buffer));
 			}
 #endif


### PR DESCRIPTION
`0.x` historically defaulted to `audio`, `video` and `data` as mids in the SDP when not provided by the peer or the plugin. This was problematic for a couple of reasons:

1. considering they end up in RTP extensions to signal the mid packets belong to, they're needlessly long and increase the RTP overhead;
2. apparently pion is hardcoded to assume that when the mid is called "audio" or "video" you're using the legacy plan-b rather than unified plan, even when that's clearly not the case.

This patch addresses this by using much more compact defaults instead, namely `a`, `v` and `d`. This seems to be working as expected in the short test I made (RTP extensions are updated accordingly), but you may want to double check if this breaks anything for you. Planning to merge fairly quickly, so don't wait too long :wink: 