### PR TITLE
Cleanup some g_free usage

### DIFF
--- a/src/events/janus_mqttevh.c
+++ b/src/events/janus_mqttevh.c
@@ -637,15 +637,9 @@ static void janus_mqttevh_client_destroy_context(janus_mqttevh_context **ptr) {
 
 	if(ctx) {
 		MQTTAsync_destroy(&ctx->client);
-		if(ctx->publish.topic != NULL) {
-			g_free(ctx->publish.topic);
-		}
-		if(ctx->connect.username != NULL) {
-			g_free(ctx->connect.username);
-		}
-		if(ctx->connect.password != NULL) {
-			g_free(ctx->connect.password);
-		}
+		g_free(ctx->publish.topic);
+		g_free(ctx->connect.username);
+		g_free(ctx->connect.password);
 		g_free(ctx);
 		*ptr = NULL;
 	}

--- a/src/events/janus_rabbitmqevh.c
+++ b/src/events/janus_rabbitmqevh.c
@@ -112,14 +112,14 @@ static amqp_bytes_t rmq_exchange;
 static janus_mutex mutex;
 
 static char *rmqhost = NULL;
-static const char *vhost = NULL, *username = NULL, *password = NULL;
-static const char *ssl_cacert_file = NULL;
-static const char *ssl_cert_file = NULL;
-static const char *ssl_key_file = NULL;
+static char *vhost = NULL, *username = NULL, *password = NULL;
+static char *ssl_cacert_file = NULL;
+static char *ssl_cert_file = NULL;
+static char *ssl_key_file = NULL;
 static gboolean ssl_enable = FALSE;
 static gboolean ssl_verify_peer = FALSE;
 static gboolean ssl_verify_hostname = FALSE;
-static const char *route_key = NULL, *exchange = NULL, *exchange_type = NULL ;
+static char *route_key = NULL, *exchange = NULL, *exchange_type = NULL ;
 static uint16_t heartbeat = 0;
 static uint16_t rmqport = AMQP_PROTOCOL_PORT;
 static gboolean declare_outgoing_queue = TRUE;
@@ -331,10 +331,8 @@ int janus_rabbitmqevh_init(const char *config_path) {
 error:
 	/* If we got here, something went wrong */
 	success = FALSE;
-	if(route_key)
-		g_free((char *)route_key);
-	if(exchange)
-		g_free((char *)exchange);
+	g_free(route_key);
+	g_free(exchange);
 	/* Fall through */
 done:
 	if(config)
@@ -453,22 +451,14 @@ void janus_rabbitmqevh_destroy(void) {
 	if(rmq_conn) {
 		amqp_destroy_connection(rmq_conn);
 	}
-	if(rmq_exchange.bytes)
-		g_free((char *)rmq_exchange.bytes);
-	if(rmqhost)
-		g_free((char *)rmqhost);
-	if(vhost)
-		g_free((char *)vhost);
-	if(username)
-		g_free((char *)username);
-	if(password)
-		g_free((char *)password);
-	if(ssl_cacert_file)
-		g_free((char *)ssl_cacert_file);
-	if(ssl_cert_file)
-		g_free((char *)ssl_cert_file);
-	if(ssl_key_file)
-		g_free((char *)ssl_key_file);
+	g_free(rmq_exchange.bytes);
+	g_free(rmqhost);
+	g_free(vhost);
+	g_free(username);
+	g_free(password);
+	g_free(ssl_cacert_file);
+	g_free(ssl_cert_file);
+	g_free(ssl_key_file);
 
 	janus_mutex_destroy(&mutex);
 	g_atomic_int_set(&initialized, 0);

--- a/src/sdp.c
+++ b/src/sdp.c
@@ -395,18 +395,10 @@ int janus_sdp_process_remote(void *ice_handle, janus_sdp *remote_sdp, gboolean r
 				/* Missing mandatory information, failure... */
 				JANUS_LOG(LOG_ERR, "[%"SCNu64"] SDP missing mandatory information\n", handle->handle_id);
 				JANUS_LOG(LOG_ERR, "[%"SCNu64"] %p, %p, %p, %p\n", handle->handle_id, ruser, rpass, rfingerprint, rhashing);
-				if(ruser)
-					g_free(ruser);
-				ruser = NULL;
-				if(rpass)
-					g_free(rpass);
-				rpass = NULL;
-				if(rhashing)
-					g_free(rhashing);
-				rhashing = NULL;
-				if(rfingerprint)
-					g_free(rfingerprint);
-				rfingerprint = NULL;
+				g_free(ruser);
+				g_free(rpass);
+				g_free(rhashing);
+				g_free(rfingerprint);
 				return -2;
 			}
 			/* If we received the ICE credentials for the first time, enforce them */


### PR DESCRIPTION
Namely:
- simplify `if (x) g_free(x)` to just `g_free(x)` (this was the main motivation for this PR).
- use `char *` instead of `const char *` for values that will be freed to avoid having to cast away constness
- remove some instances of `if (x) { g_free(x); x = NULL }` where `x` goes out of scope.