### PR TITLE
[0.x] Parse media SSRC in RTCP reports when remote SSRCs are unknown

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -3067,23 +3067,45 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 					} else {
 						/* Check the remote SSRC, compare it to what we have: in case
 							* we're simulcasting, let's compare to the other SSRCs too */
-						guint32 rtcp_ssrc = janus_rtcp_get_sender_ssrc(buf, buflen);
-						if(rtcp_ssrc == 0) {
-							/* No SSRC, maybe an empty RR? */
-							return;
-						}
-						if(stream->video_ssrc_peer[0] && rtcp_ssrc == stream->video_ssrc_peer[0]) {
-							video = 1;
-							vindex = 0;
-						} else if(stream->video_ssrc_peer[1] && rtcp_ssrc == stream->video_ssrc_peer[1]) {
-							video = 1;
-							vindex = 1;
-						} else if(stream->video_ssrc_peer[2] && rtcp_ssrc == stream->video_ssrc_peer[2]) {
-							video = 1;
-							vindex = 2;
-						} else {
-							JANUS_LOG(LOG_VERB, "[%"SCNu64"] Dropping RTCP packet with unknown SSRC (%"SCNu32")\n", handle->handle_id, rtcp_ssrc);
-							return;
+						guint32 rtcp_ssrc;
+						/* In case sender SSRC does not match, we fallback to using media ssrc */
+						gboolean fallback = FALSE;
+						while(1) {
+							if (!fallback)
+								rtcp_ssrc = janus_rtcp_get_sender_ssrc(buf, buflen);
+							else
+								rtcp_ssrc = janus_rtcp_get_receiver_ssrc(buf, buflen);
+							if(rtcp_ssrc == 0) {
+								if (!fallback) {
+									fallback = true;
+									continue;
+								}
+								/* No SSRC, maybe an empty RR? */
+								return;
+							}
+							if((!fallback && stream->video_ssrc_peer[0] && rtcp_ssrc == stream->video_ssrc_peer[0]) || (fallback && stream->video_ssrc && rtcp_ssrc == stream->video_ssrc)) {
+								video = 1;
+								vindex = 0;
+								break;
+							} else if (fallback && stream->video_ssrc_rtx && rtcp_ssrc == stream->video_ssrc_rtx) {
+								/* rtx SSRC, we don't care */
+								return;
+							} else if(!fallback && (stream->video_ssrc_peer[1] && rtcp_ssrc == stream->video_ssrc_peer[1])) {
+								video = 1;
+								vindex = 1;
+								break;
+							} else if(!fallback && (stream->video_ssrc_peer[2] && rtcp_ssrc == stream->video_ssrc_peer[2])) {
+								video = 1;
+								vindex = 2;
+								break;
+							} else {
+								if (!fallback) {
+									fallback = TRUE;
+									continue;
+								}
+								JANUS_LOG(LOG_VERB, "[%"SCNu64"] Dropping RTCP packet with unknown SSRC (%"SCNu32")\n", handle->handle_id, rtcp_ssrc);
+								return;
+							}
 						}
 						JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Incoming RTCP, bundling: this is %s (remote SSRC: video=%"SCNu32" #%d, got %"SCNu32")\n",
 							handle->handle_id, video ? "video" : "audio", stream->video_ssrc_peer[vindex], vindex, rtcp_ssrc);
@@ -3121,24 +3143,50 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 					} else {
 						/* Check the remote SSRC, compare it to what we have: in case
 						 * we're simulcasting, let's compare to the other SSRCs too */
-						guint32 rtcp_ssrc = janus_rtcp_get_sender_ssrc(buf, buflen);
-						if(rtcp_ssrc == 0) {
-							/* No SSRC, maybe an empty RR? */
-							return;
-						}
-						if(rtcp_ssrc == stream->audio_ssrc_peer) {
-							video = 0;
-						} else if(rtcp_ssrc == stream->video_ssrc_peer[0]) {
-							video = 1;
-						} else if(stream->video_ssrc_peer[1] && rtcp_ssrc == stream->video_ssrc_peer[1]) {
-							video = 1;
-							vindex = 1;
-						} else if(stream->video_ssrc_peer[2] && rtcp_ssrc == stream->video_ssrc_peer[2]) {
-							video = 1;
-							vindex = 2;
-						} else {
-							JANUS_LOG(LOG_VERB, "[%"SCNu64"] Dropping RTCP packet with unknown SSRC (%"SCNu32")\n", handle->handle_id, rtcp_ssrc);
-							return;
+						guint32 rtcp_ssrc;
+						/* In case sender SSRC does not match, we fallback to using media ssrc */
+						gboolean fallback = FALSE;
+						while(1) {
+							if (!fallback)
+								rtcp_ssrc = janus_rtcp_get_sender_ssrc(buf, buflen);
+							else
+								rtcp_ssrc = janus_rtcp_get_receiver_ssrc(buf, buflen);
+							if(rtcp_ssrc == 0) {
+								if (!fallback) {
+									fallback = true;
+									continue;
+								}
+								/* No SSRC, maybe an empty RR? */
+								return;
+							}
+							if((!fallback && rtcp_ssrc == stream->audio_ssrc_peer) || (fallback && rtcp_ssrc == stream->audio_ssrc)) {
+								video = 0;
+								break;
+							}
+							else if (fallback && stream->video_ssrc_rtx && rtcp_ssrc == stream->video_ssrc_rtx) {
+								/* rtx SSRC, we don't care */
+								return;
+							}
+							else if((!fallback && stream->video_ssrc_peer[0] && rtcp_ssrc == stream->video_ssrc_peer[0]) || (fallback && stream->video_ssrc && rtcp_ssrc == stream->video_ssrc)) {
+								video = 1;
+								vindex = 0;
+								break;
+							} else if(!fallback && (stream->video_ssrc_peer[1] && rtcp_ssrc == stream->video_ssrc_peer[1])) {
+								video = 1;
+								vindex = 1;
+								break;
+							} else if(!fallback && (stream->video_ssrc_peer[2] && rtcp_ssrc == stream->video_ssrc_peer[2])) {
+								video = 1;
+								vindex = 2;
+								break;
+							} else {
+								if (!fallback) {
+									fallback = TRUE;
+									continue;
+								}
+								JANUS_LOG(LOG_VERB, "[%"SCNu64"] Dropping RTCP packet with unknown SSRC (%"SCNu32")\n", handle->handle_id, rtcp_ssrc);
+								return;
+							}
 						}
 						JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Incoming RTCP, bundling: this is %s (remote SSRC: video=%"SCNu32" #%d, audio=%"SCNu32", got %"SCNu32")\n",
 							handle->handle_id, video ? "video" : "audio", stream->video_ssrc_peer[vindex], vindex, stream->audio_ssrc_peer, rtcp_ssrc);

--- a/ice.c
+++ b/ice.c
@@ -3071,23 +3071,25 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 						/* In case sender SSRC does not match, we fallback to using media ssrc */
 						gboolean fallback = FALSE;
 						while(1) {
-							if (!fallback)
+							if(!fallback) {
 								rtcp_ssrc = janus_rtcp_get_sender_ssrc(buf, buflen);
-							else
+							} else {
 								rtcp_ssrc = janus_rtcp_get_receiver_ssrc(buf, buflen);
+							}
 							if(rtcp_ssrc == 0) {
-								if (!fallback) {
+								if(!fallback) {
 									fallback = true;
 									continue;
 								}
 								/* No SSRC, maybe an empty RR? */
 								return;
 							}
-							if((!fallback && stream->video_ssrc_peer[0] && rtcp_ssrc == stream->video_ssrc_peer[0]) || (fallback && stream->video_ssrc && rtcp_ssrc == stream->video_ssrc)) {
+							if((!fallback && stream->video_ssrc_peer[0] && rtcp_ssrc == stream->video_ssrc_peer[0]) ||
+									(fallback && stream->video_ssrc && rtcp_ssrc == stream->video_ssrc)) {
 								video = 1;
 								vindex = 0;
 								break;
-							} else if (fallback && stream->video_ssrc_rtx && rtcp_ssrc == stream->video_ssrc_rtx) {
+							} else if(fallback && stream->video_ssrc_rtx && rtcp_ssrc == stream->video_ssrc_rtx) {
 								/* rtx SSRC, we don't care */
 								return;
 							} else if(!fallback && (stream->video_ssrc_peer[1] && rtcp_ssrc == stream->video_ssrc_peer[1])) {
@@ -3099,7 +3101,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 								vindex = 2;
 								break;
 							} else {
-								if (!fallback) {
+								if(!fallback) {
 									fallback = TRUE;
 									continue;
 								}
@@ -3147,12 +3149,13 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 						/* In case sender SSRC does not match, we fallback to using media ssrc */
 						gboolean fallback = FALSE;
 						while(1) {
-							if (!fallback)
+							if(!fallback) {
 								rtcp_ssrc = janus_rtcp_get_sender_ssrc(buf, buflen);
-							else
+							} else {
 								rtcp_ssrc = janus_rtcp_get_receiver_ssrc(buf, buflen);
+							}
 							if(rtcp_ssrc == 0) {
-								if (!fallback) {
+								if(!fallback) {
 									fallback = true;
 									continue;
 								}
@@ -3163,11 +3166,12 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 								video = 0;
 								break;
 							}
-							else if (fallback && stream->video_ssrc_rtx && rtcp_ssrc == stream->video_ssrc_rtx) {
+							else if(fallback && stream->video_ssrc_rtx && rtcp_ssrc == stream->video_ssrc_rtx) {
 								/* rtx SSRC, we don't care */
 								return;
 							}
-							else if((!fallback && stream->video_ssrc_peer[0] && rtcp_ssrc == stream->video_ssrc_peer[0]) || (fallback && stream->video_ssrc && rtcp_ssrc == stream->video_ssrc)) {
+							else if((!fallback && stream->video_ssrc_peer[0] && rtcp_ssrc == stream->video_ssrc_peer[0]) ||
+									(fallback && stream->video_ssrc && rtcp_ssrc == stream->video_ssrc)) {
 								video = 1;
 								vindex = 0;
 								break;
@@ -3180,7 +3184,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 								vindex = 2;
 								break;
 							} else {
-								if (!fallback) {
+								if(!fallback) {
 									fallback = TRUE;
 									continue;
 								}


### PR DESCRIPTION
While making some tests between pion and Janus we found out that in some circumstances Janus could ignore incoming RTCP due to unrecognized SSRCs.

That happens when Janus receives RTCP **Receiver Reports** in connections where sources have unknown remote SSRCs (e.g. _recvonly_ connections). Pion picks a random SSRC as _sender_ SSRC and puts the _remote media_ SSRC in the _media_ header of the packet.

When Janus receives a RTCP packets from sources with unknown remote SSRCs, it parses the SSRC through `janus_rtcp_get_sender_ssrc`, that basically reads the _sender_ SSRC (in this case a random one, hence dropping the packet).

In this PR we try to add a fallback mechanism to read also from _media_ SSRC through `janus_rtcp_get_receiver_ssrc` in case the SSRC read from `janus_rtcp_get_sender_ssrc` is not recognized.



  