### PR TITLE
janus_streaming: unlock before decref of mounpoint

### DIFF
--- a/src/plugins/janus_streaming.c
+++ b/src/plugins/janus_streaming.c
@@ -5782,12 +5782,12 @@ static void *janus_streaming_handler(void *data) {
 			if(session->mountpoint != NULL) {
 				if(session->mountpoint != mp) {
 					/* Already watching something else */
-					janus_refcount_decrease(&mp->ref);
 					JANUS_LOG(LOG_ERR, "Already watching mountpoint %s\n", session->mountpoint->id_str);
 					error_code = JANUS_STREAMING_ERROR_INVALID_STATE;
 					g_snprintf(error_cause, 512, "Already watching mountpoint %s", session->mountpoint->id_str);
 					janus_mutex_unlock(&session->mutex);
 					janus_mutex_unlock(&mp->mutex);
+					janus_refcount_decrease(&mp->ref);
 					goto error;
 				} else {
 					/* Make sure it's not an API error */


### PR DESCRIPTION
The mutex should not be held while decrementing the reference count. In the unlikely event that the refcount were 0, janus_streaming_mountpoint_free would deadlock trying to acquire this same mutex.

This is again unlikely since the reference count is incremented right before and so presumably is never 0 here.