### PR TITLE
Add option to manually insert SPS/PPS RTP packets for H.264 mountpoints

### DIFF
--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -44,7 +44,7 @@
 # videoskew = true|false (whether the plugin should perform skew
 #		analisys and compensation on incoming video RTP stream, EXPERIMENTAL)
 # videosvc = true|false (whether the video will have SVC support; works only for VP9-SVC, default=false)
-# h264sps = if using H.264 as a video codec, value of the sprops-parameter-sets
+# h264sps = if using H.264 as a video codec, value of the sprop-parameter-sets
 #		that would normally be sent via SDP, but that we'll use to instead
 #		manually ingest SPS and PPS packets via RTP for streams that miss it
 # collision = in case of collision (more than one SSRC hitting the same port), the plugin

--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -44,6 +44,9 @@
 # videoskew = true|false (whether the plugin should perform skew
 #		analisys and compensation on incoming video RTP stream, EXPERIMENTAL)
 # videosvc = true|false (whether the video will have SVC support; works only for VP9-SVC, default=false)
+# h264sps = if using H.264 as a video codec, value of the sprops-parameter-sets
+#		that would normally be sent via SDP, but that we'll use to instead
+#		manually ingest SPS and PPS packets via RTP for streams that miss it
 # collision = in case of collision (more than one SSRC hitting the same port), the plugin
 #		will discard incoming RTP packets with a new SSRC unless this many milliseconds
 #		passed, which would then change the current SSRC (0=disabled)

--- a/utils.c
+++ b/utils.c
@@ -843,17 +843,17 @@ gboolean janus_vp9_is_keyframe(const char *buffer, int len) {
 	return FALSE;
 }
 
-gboolean janus_h264_is_keyframe(const char *buffer, int len) {
+static gboolean janus_h264_contains_nal(const char *buffer, int len, int val) {
 	if(!buffer || len < 6)
 		return FALSE;
 	/* Parse H264 header now */
 	uint8_t fragment = *buffer & 0x1F;
 	uint8_t nal = *(buffer+1) & 0x1F;
-	if(fragment == 7 || ((fragment == 28 || fragment == 29) && nal == 7)) {
-		JANUS_LOG(LOG_HUGE, "Got an H264 key frame\n");
+	if(fragment == val || ((fragment == 28 || fragment == 29) && nal == val && (*(buffer+1) & 0x80))) {
+		JANUS_LOG(LOG_HUGE, "Got an H264 NAL %d\n", val);
 		return TRUE;
 	} else if(fragment == 24) {
-		/* May we find an SPS in this STAP-A? */
+		/* May we find it in this STAP-A? */
 		buffer++;
 		len--;
 		uint16_t psize = 0;
@@ -864,16 +864,28 @@ gboolean janus_h264_is_keyframe(const char *buffer, int len) {
 			buffer += 2;
 			len -= 2;
 			int nal = *buffer & 0x1F;
-			if(nal == 7) {
-				JANUS_LOG(LOG_HUGE, "Got an SPS/PPS\n");
+			if(nal == val) {
+				JANUS_LOG(LOG_HUGE, "Got an H264 NAL %d\n", val);
 				return TRUE;
 			}
 			buffer += psize;
 			len -= psize;
 		}
 	}
-	/* If we got here it's not a key frame */
+	/* If we got here we didn't find it */
 	return FALSE;
+}
+
+gboolean janus_h264_is_keyframe(const char *buffer, int len) {
+	return janus_h264_contains_nal(buffer, len, 7);
+}
+
+gboolean janus_h264_is_i_frame(const char *buffer, int len) {
+	return janus_h264_contains_nal(buffer, len, 5);
+}
+
+gboolean janus_h264_is_b_frame(const char *buffer, int len) {
+	return janus_h264_contains_nal(buffer, len, 1);
 }
 
 gboolean janus_av1_is_keyframe(const char *buffer, int len) {

--- a/utils.h
+++ b/utils.h
@@ -325,10 +325,26 @@ gboolean janus_vp8_is_keyframe(const char *buffer, int len);
 gboolean janus_vp9_is_keyframe(const char *buffer, int len);
 
 /*! \brief Helper method to check if an H.264 frame is a keyframe or not
+ * @note This checks the presence of an SPS NAL (7), nor an I-Frame (5),
+ * since SPS/PPS are what's needed for a browser to actually be able to
+ * decode a stream. If for some reason you want to check for I-Frames
+ * instead, use the janus_h264_is_i_frame() function
  * @param[in] buffer The RTP payload to process
  * @param[in] len The length of the RTP payload
  * @returns TRUE if it's a keyframe, FALSE otherwise */
 gboolean janus_h264_is_keyframe(const char *buffer, int len);
+
+/*! \brief Helper method to check if an H.264 frame contains an I-Frame or not
+ * @param[in] buffer The RTP payload to process
+ * @param[in] len The length of the RTP payload
+ * @returns TRUE if it's an I-Frame, FALSE otherwise */
+gboolean janus_h264_is_i_frame(const char *buffer, int len);
+
+/*! \brief Helper method to check if an H.264 frame contains a B-Frame or not
+ * @param[in] buffer The RTP payload to process
+ * @param[in] len The length of the RTP payload
+ * @returns TRUE if it's a B-Frame, FALSE otherwise */
+gboolean janus_h264_is_b_frame(const char *buffer, int len);
 
 /*! \brief Helper method to check if an AV1 frame is a keyframe or not
  * @param[in] buffer The RTP payload to process


### PR DESCRIPTION
When using H.264 in the Streaming plugin, there's all sort of headaches. A common one is getting browsers to like the negotiated stream, which we can do overriding the `fmtp` attribute in the SDP. Another one, though, are RTP streams where information on the streams are not part of the bitstream, but in the SDP instead, specifically in the `sprop-parameter-sets` field of the `fmtp`: for those so far we didn't have any solution, since browsers ignore the `sprop-parameter-sets` if we send it along. As such, I decided to try and come up with a fix for that too, which is what this experimental PR is about.

In "regular" H.264 streams where everything works, keyframes are usually preceded by RTP packets with SPS/PPS payloads in them: that's where info on the stream is (e.g., the video resolution). A missing SPS/PPS means the decoder doesn't know how to properly decode the video. When you look at the `sprop-parameter-sets`, that's basically a base64-encoded version of the same information, which is why stacks sometimes decide not to send it in-band (as RTP packets) but in the SDP instead (e.g., because it will never change). As such, what this patch does is basically decode a `sprop-parameter-sets` and turn it into an RTP packet we can manually inject in the RTP stream subscribers get: more precisely, we monitor incoming packets, and anytime we find an IDR-Slide start (wich marks the start of a keyframe), we send the SPS/PPS packet first, by shifting sequence numbers accordingly. This way, even if the source never sent any SPS/PPS via RTP, WebRTC subscribers to get them, which makes video playable.

The way I implemented it is quite basic, and is basically a new configuration property, called `h264sps`, that you can specify when creating a mountpoint. When that property is set, the Streaming plugin will parse its value, and create an RTP packet template it can use for ingestion purposes. The value of that property must be whatever `sprop-parameter-sets` is associated with the stream you'll relay via a mountpoint. For instance, for a video I have on my laptop, when I use ffmpeg to send it without transcoding to Janus:

    ffmpeg -re -i meetecho-spot.mp4 -vcodec copy -an -f rtp rtp://127.0.0.1:8004?pkt_size=1200

it will print this SDP on stdout:

```
SDP:
v=0
o=- 0 0 IN IP4 127.0.0.1
s=No Name
c=IN IP4 127.0.0.1
t=0 0
a=tool:libavformat LIBAVFORMAT_VERSION
m=video 8004 RTP/AVP 96
b=AS:294
a=rtpmap:96 H264/90000
a=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z0LAHtkB4I/rAWoMDAyAAAADAIAAABkHixck,aMuMsg==; profile-level-id=42C01E
```

where the important part obviously is:

    sprop-parameter-sets=Z0LAHtkB4I/rAWoMDAyAAAADAIAAABkHixck,aMuMsg==

This means I can add this property when creating an H.264 mountpoint:

    h264sps = "Z0LAHtkB4I/rAWoMDAyAAAADAIAAABkHixck,aMuMsg=="

and the Streaming plugin will then start sending SPS/PPS RTP packets on my behalf while handling the incoming stream and relaying it to subscribers:

```
[h264-sample] New video stream! (ssrc=3112861902, index 0)
[WARN] [h264-sample] Sending SPS/PPS (seq=1, ts=0)
[WARN] [h264-sample] Sending SPS/PPS (seq=40, ts=136800)
[WARN] [h264-sample] Sending SPS/PPS (seq=78, ts=270000)
[WARN] [h264-sample] Sending SPS/PPS (seq=201, ts=540000)
[WARN] [h264-sample] Sending SPS/PPS (seq=364, ts=810000)
[WARN] [h264-sample] Sending SPS/PPS (seq=527, ts=1080000)
[WARN] [h264-sample] Sending SPS/PPS (seq=654, ts=1350000)
...
```

That's basically it. In the few tests I made so far, this seemed to work, which is promising.

That said, I decided to keep it a draft for a few different reasons. First of all, the integration is not complete: this is a feature that makes the most sense when used with RTSP servers, for instance (which are the most likely to only contain the SPS/PPS info in the SDP), but I haven't added the `sprop-parameter-sets` processing there yet; the next step is probably that one (even though I don't have access to any RTSP camera that only sends SPS/PPS in the SDP; if you do and can give me access to it, that would help). Besides, while this can get video working where it didn't before, this may still not be enough, e.g., when the stream is actually encoded using B-frames too (you'll get very frequent freezes instead of nothing at all). Finally, I want to make sure this is tested properly by people using the Streaming plugin and H.264 often, in order to make sure there's no regressions: at the moment, in fact, when you configure an `h264sps` property, SPS/PPS will always be injected, and if your RTP stream already contains them, no idea what happens (it probably breaks, I guess).

To conclude, I've started working on this on `0.x` simply because it was easier for me to mess with video streams there, but of course the plan is to port it to `master` right away as soon as (or I should say if) this is merged.

Feedback welcome!