### PR TITLE
Add reason of track being added/removed in onremotetrack in janus.js

### DIFF
--- a/html/audiobridgetest.js
+++ b/html/audiobridgetest.js
@@ -298,8 +298,12 @@ $(document).ready(function() {
 									$('#room').removeClass('hide').show();
 									$('#participant').removeClass('hide').html(myusername).show();
 								},
-								onremotetrack: function(track, mid, on) {
-									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+								onremotetrack: function(track, mid, on, metadata) {
+									Janus.debug(
+										"Remote track (mid=" + mid + ") " +
+										(on ? "added" : "removed") +
+										(metadata ? " (" + metadata.reason + ") ": "") + ":", track
+									);
 									if(remoteStream || track.kind !== "audio")
 										return;
 									if(!on) {

--- a/html/audiobridgetest.js
+++ b/html/audiobridgetest.js
@@ -302,7 +302,7 @@ $(document).ready(function() {
 									Janus.debug(
 										"Remote track (mid=" + mid + ") " +
 										(on ? "added" : "removed") +
-										(metadata ? " (" + metadata.reason + ") ": "") + ":", track
+										(metadata ? " (" + metadata.reason + ") " : "") + ":", track
 									);
 									if(remoteStream || track.kind !== "audio")
 										return;

--- a/html/canvas.js
+++ b/html/canvas.js
@@ -169,8 +169,12 @@ $(document).ready(function() {
 										});
 									}
 								},
-								onremotetrack: function(track, mid, on) {
-									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+								onremotetrack: function(track, mid, on, metadata) {
+									Janus.debug(
+										"Remote track (mid=" + mid + ") " +
+										(on ? "added" : "removed") +
+										(metadata? " (" + metadata.reason + ") ": "") + ":", track
+									);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
 										$('#peervideo' + mid).remove();

--- a/html/canvas.js
+++ b/html/canvas.js
@@ -173,7 +173,7 @@ $(document).ready(function() {
 									Janus.debug(
 										"Remote track (mid=" + mid + ") " +
 										(on ? "added" : "removed") +
-										(metadata? " (" + metadata.reason + ") ": "") + ":", track
+										(metadata? " (" + metadata.reason + ") " : "") + ":", track
 									);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering

--- a/html/echotest.js
+++ b/html/echotest.js
@@ -281,8 +281,12 @@ $(document).ready(function() {
 										});
 									}
 								},
-								onremotetrack: function(track, mid, on) {
-									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+								onremotetrack: function(track, mid, on, metadata) {
+									Janus.debug(
+										"Remote track (mid=" + mid + ") " +
+										(on ? "added" : "removed") +
+										(metadata ? " (" + metadata.reason + ") ": "") + ":", track
+									);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
 										$('#peervideo' + mid).remove();

--- a/html/janus.js
+++ b/html/janus.js
@@ -1913,7 +1913,7 @@ function Janus(gatewayCallbacks) {
 			// Notify about the new track event
 			let mid = event.transceiver ? event.transceiver.mid : event.track.id;
 			try {
-				pluginHandle.onremotetrack(event.track, mid, true);
+				pluginHandle.onremotetrack(event.track, mid, true, { reason: 'created' });
 			} catch(e) {
 				Janus.error("Error calling onremotetrack", e);
 			}
@@ -1930,7 +1930,7 @@ function Janus(gatewayCallbacks) {
 					t => t.receiver.track === ev.target) : null;
 				let mid = transceiver ? transceiver.mid : ev.target.id;
 				try {
-					pluginHandle.onremotetrack(ev.target, mid, false);
+					pluginHandle.onremotetrack(ev.target, mid, false, { reason: 'ended' });
 				} catch(e) {
 					Janus.error("Error calling onremotetrack on removal", e);
 				}
@@ -1946,7 +1946,7 @@ function Janus(gatewayCallbacks) {
 							t => t.receiver.track === ev.target) : null;
 						let mid = transceiver ? transceiver.mid : ev.target.id;
 						try {
-							pluginHandle.onremotetrack(ev.target, mid, false);
+							pluginHandle.onremotetrack(ev.target, mid, false, { reason: 'mute' } );
 						} catch(e) {
 							Janus.error("Error calling onremotetrack on mute", e);
 						}
@@ -1968,7 +1968,7 @@ function Janus(gatewayCallbacks) {
 						let transceiver = transceivers ? transceivers.find(
 							t => t.receiver.track === ev.target) : null;
 						let mid = transceiver ? transceiver.mid : ev.target.id;
-						pluginHandle.onremotetrack(ev.target, mid, true);
+						pluginHandle.onremotetrack(ev.target, mid, true, { reason: 'unmute' });
 					} catch(e) {
 						Janus.error("Error calling onremotetrack on unmute", e);
 					}

--- a/html/multiopus.js
+++ b/html/multiopus.js
@@ -204,8 +204,12 @@ $(document).ready(function() {
 										});
 									}
 								},
-								onremotetrack: function(track, mid, on) {
-									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+								onremotetrack: function(track, mid, on, metadata) {
+									Janus.debug(
+										"Remote track (mid=" + mid + ") " +
+										(on ? "added" : "removed") +
+										(metadata? " (" + metadata.reason + ") ": "") + ":", track
+									);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
 										$('#peervideo' + mid).remove();

--- a/html/mvideoroomtest.js
+++ b/html/mvideoroomtest.js
@@ -744,8 +744,12 @@ function subscribeTo(sources) {
 			onlocaltrack: function(track, on) {
 				// The subscriber stream is recvonly, we don't expect anything here
 			},
-			onremotetrack: function(track, mid, on) {
-				Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+			onremotetrack: function(track, mid, on, metadata) {
+				Janus.debug(
+					"Remote track (mid=" + mid + ") " +
+					(on ? "added" : "removed") +
+					(metadata ? " (" + metadata.reason + ") ": "") + ":", track
+				);
 				// Which publisher are we getting on this mid?
 				let sub = subStreams[mid];
 				let feed = feedStreams[sub.feed_id];

--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -276,10 +276,14 @@ $(document).ready(function() {
 										});
 									}
 								},
-								onremotetrack: function(track, mid, on) {
+								onremotetrack: function(track, mid, on, metadata) {
 									if(playing === false)
 										return;
-									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+									Janus.debug(
+										"Remote track (mid=" + mid + ") " +
+										(on ? "added" : "removed") +
+										(metadata? " (" + metadata.reason + ") ": "") + ":", track
+									);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
 										$('#thevideo' + mid).remove();

--- a/html/screensharingtest.js
+++ b/html/screensharingtest.js
@@ -511,8 +511,23 @@ function newRemoteFeed(id, display) {
 			onlocaltrack: function(track, on) {
 				// The subscriber stream is recvonly, we don't expect anything here
 			},
-			onremotetrack: function(track, mid, on) {
-				Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+			onremotetrack: function(track, mid, on, metadata) {
+				Janus.debug(
+					"Remote track (mid=" + mid + ") " +
+					(on ? "added" : "removed") +
+					(metadata? " (" + metadata.reason + ") ": "") + ":", track
+				);
+				// Screen sharing tracks are sometimes muted/unmuted by browser
+				// when data is not flowing fast enough, this can make streams blink,
+				// we can ignore these
+				if(
+					track.kind === "video"
+					&& metadata
+					&& (metadata.reason === "mute" || metadata.reason === "unmute")
+				) {
+					Janus.log("Ignoring mute/unmute on screen-sharing track.")
+					return
+				}
 				if(!on) {
 					// Track removed, get rid of the stream and the rendering
 					$('#screenvideo' + mid).remove();

--- a/html/screensharingtest.js
+++ b/html/screensharingtest.js
@@ -515,16 +515,12 @@ function newRemoteFeed(id, display) {
 				Janus.debug(
 					"Remote track (mid=" + mid + ") " +
 					(on ? "added" : "removed") +
-					(metadata? " (" + metadata.reason + ") ": "") + ":", track
+					(metadata? " (" + metadata.reason + ") " : "") + ":", track
 				);
 				// Screen sharing tracks are sometimes muted/unmuted by browser
-				// when data is not flowing fast enough, this can make streams blink,
-				// we can ignore these
-				if(
-					track.kind === "video"
-					&& metadata
-					&& (metadata.reason === "mute" || metadata.reason === "unmute")
-				) {
+				// when data is not flowing fast enough; this can make streams blink.
+				// We can ignore these.
+				if(track.kind === "video" && metadata && (metadata.reason === "mute" || metadata.reason === "unmute")) {
 					Janus.log("Ignoring mute/unmute on screen-sharing track.")
 					return
 				}

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -152,8 +152,12 @@ $(document).ready(function() {
 											});
 									}
 								},
-								onremotetrack: function(track, mid, on) {
-									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+								onremotetrack: function(track, mid, on, metadata) {
+									Janus.debug(
+										"Remote track (mid=" + mid + ") " +
+										(on ? "added" : "removed") +
+										(metadata ? " (" + metadata.reason + ") ": "") + ":", track
+									);
 									var mstreamId = "mstream"+mid;
 									if(streamsList[selectedStream] && streamsList[selectedStream].legacy)
 										mstreamId = "mstream0";

--- a/html/videocalltest.js
+++ b/html/videocalltest.js
@@ -358,8 +358,12 @@ $(document).ready(function() {
 										});
 									}
 								},
-								onremotetrack: function(track, mid, on) {
-									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+								onremotetrack: function(track, mid, on, metadata) {
+									Janus.debug(
+										"Remote track (mid=" + mid + ") " +
+										(on ? "added" : "removed") +
+										(metadata ? " (" + metadata.reason + ") ": "") + ":", track
+									);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
 										$('#peervideo' + mid).remove();

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -647,8 +647,13 @@ function newRemoteFeed(id, display, streams) {
 			onlocaltrack: function(track, on) {
 				// The subscriber stream is recvonly, we don't expect anything here
 			},
-			onremotetrack: function(track, mid, on) {
-				Janus.debug("Remote feed #" + remoteFeed.rfindex + ", remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+			onremotetrack: function(track, mid, on, metadata) {
+				Janus.debug(
+					"Remote feed #" + remoteFeed.rfindex +
+					", remote track (mid=" + mid + ") " +
+					(on ? "added" : "removed") +
+					(metadata? " (" + metadata.reason + ") ": "") + ":", track
+				);
 				if(!on) {
 					// Track removed, get rid of the stream and the rendering
 					$('#remotevideo'+remoteFeed.rfindex + '-' + mid).remove();

--- a/html/virtualbg.js
+++ b/html/virtualbg.js
@@ -232,8 +232,12 @@ $(document).ready(function() {
 										});
 									}
 								},
-								onremotetrack: function(track, mid, on) {
-									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+								onremotetrack: function(track, mid, on, metadata) {
+									Janus.debug(
+										"Remote track (mid=" + mid + ") " +
+										(on ? "added" : "removed") +
+										(metadata? " (" + metadata.reason + ") ": "") + ":", track
+									);
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering
 										$('#peervideo' + mid).remove();

--- a/html/vp9svctest.js
+++ b/html/vp9svctest.js
@@ -434,7 +434,7 @@ function publishOwnFeed(useAudio) {
 	let tracks = [];
 	if(useAudio)
 		tracks.push({ type: 'audio', capture: true, recv: false });
-	tracks.push({ type: 'video', capture: true, recv: false, simulcast: doSimulcast });
+	tracks.push({ type: 'video', capture: true, recv: false, simulcast: false});
 	//~ tracks.push({ type: 'data' });
 
 	sfutest.createOffer(
@@ -604,8 +604,13 @@ function newRemoteFeed(id, display, streams) {
 			onlocaltrack: function(track, on) {
 				// The subscriber stream is recvonly, we don't expect anything here
 			},
-			onremotetrack: function(track, mid, on) {
-				Janus.debug("Remote feed #" + remoteFeed.rfindex + ", remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+			onremotetrack: function(track, mid, on, metadata) {
+				Janus.debug(
+					"Remote feed #" + remoteFeed.rfindex +
+					", remote track (mid=" + mid + ") " +
+					(on ? "added" : "removed") +
+					(metadata? " (" + metadata.reason + ") ": "") + ":", track
+				);
 				if(!on) {
 					// Track removed, get rid of the stream and the rendering
 					$('#remotevideo'+remoteFeed.rfindex + '-' + mid).remove();

--- a/html/webaudio.js
+++ b/html/webaudio.js
@@ -144,8 +144,12 @@ $(document).ready(function() {
 									Janus.debug("Local track " + (on ? "added" : "removed") + ":", track);
 									// We don't do anything here, since we captured the stream ourselves
 								},
-								onremotetrack: function(track, mid, on) {
-									Janus.debug("Remote track (mid=" + mid + ") " + (on ? "added" : "removed") + ":", track);
+								onremotetrack: function(track, mid, on, metadata) {
+									Janus.debug(
+										"Remote track (mid=" + mid + ") " +
+										(on ? "added" : "removed") +
+										(metadata? " (" + metadata.reason + ") ": "") + ":", track
+									);
 									// Now that we're aware of the remote stream, we process it to visualize it
 									if(!on) {
 										// Track removed, get rid of the stream and the rendering

--- a/src/mainpage.dox
+++ b/src/mainpage.dox
@@ -399,8 +399,11 @@ janus.attach(
         onlocaltrack: function(track, added) {
             // A local track to display has just been added (getUserMedia worked!) or removed
         },
-        onremotetrack: function(track, mid, added) {
+        onremotetrack: function(track, mid, added, metadata) {
             // A remote track (working PeerConnection!) with a specific mid has just been added or removed
+            // You can query metadata to get some more information on why track was added or removed
+            // metadata fields:
+            //   - reason: 'created' | 'ended' | 'mute' | 'unmute'
         },
         oncleanup: function() {
             // PeerConnection with the plugin closed, clean the UI
@@ -589,9 +592,12 @@ janus.attach(
             // Invoked after createOffer
             // This is info on a local track: when added, we can choose to render
         },
-        onremotetrack: function(track, mid, added) {
+        onremotetrack: function(track, mid, added, metadata) {
             // Invoked after handleRemoteJsep has got us a PeerConnection
             // This is info on a remote track: when added, we can choose to render
+            // You can query metadata to get some more information on why track was added or removed
+            // metadata fields:
+            //   - reason: 'created' | 'ended' | 'mute' | 'unmute'
         },
         [..]
   \endverbatim
@@ -639,9 +645,13 @@ janus.attach(
         onlocaltrack: function(track, added) {
             // This will NOT be invoked, we chose recvonly
         },
-        onremotetrack: function(track, mid, added) {
+        onremotetrack: function(track, mid, added, metadata) {
             // Invoked after send has got us a PeerConnection
             // This is info on a remote track: when added, we can choose to render
+            // This is info on a remote track: when added, we can choose to render
+            // You can query metadata to get some more information on why track was added or removed
+            // metadata fields:
+            //   - reason: 'created' | 'ended' | 'mute' | 'unmute'
         },
         [..]
   \endverbatim


### PR DESCRIPTION
Added a metadata object to janus.js `onremotetrack` callbacks with reason why track is being added/removed. Thanks to that users can decide if they want to handle the call or ignore it.

It can be used to fix blinking screen-sharing sessions as discussed here: https://groups.google.com/g/meetecho-janus/c/bZaQA4MqJcs
(user is being notified about track removal, when it's only a `mute` call)

After the change `onremotetrack` call will lok like this:
```
 onremotetrack: function(track, mid, added, metadata) {
            // A remote track (working PeerConnection!) with a specific mid has just been added or removed
            // You can query metadata to get some more information on why track was added or removed
            // metadata fields:
            //   - reason: 'created' | 'ended' | 'mute' | 'unmute'
        },
```

Change should be backwards compatible, as it's only adding a new parameter to callbacks that will be ignored by current client code.

I have tested demo pages with the change and it looks like everything is fine.
Also updated documentation.