### PR TITLE
Handling an abnormally close of the websocket in janus.js

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -613,6 +613,10 @@ function Janus(gatewayCallbacks) {
 	this.destroyOnUnload = true;
 	if(typeof gatewayCallbacks.destroyOnUnload !== 'undefined' && gatewayCallbacks.destroyOnUnload !== null)
 		this.destroyOnUnload = (gatewayCallbacks.destroyOnUnload === true);
+	// Whether we should try the other servers when the websocket closed abnormally or the HttpApiCall fails
+	let autoTryOtherServers  = true;
+	if(typeof gatewayCallbacks.autoTryOtherServers  !== 'undefined' && gatewayCallbacks.autoTryOtherServers  !== null)
+		autoTryOtherServers  = (gatewayCallbacks.autoTryOtherServers  === true);
 	// Some timeout-related values
 	let keepAlivePeriod = 25000;
 	if(typeof gatewayCallbacks.keepAlivePeriod !== 'undefined' && gatewayCallbacks.keepAlivePeriod !== null)
@@ -1032,7 +1036,7 @@ function Janus(gatewayCallbacks) {
 					connected = false;
 					// 1006 is a status code to indicate that the connection was closed abnormally,
 					// so we have to try the other servers
-					if (event.code === 1006) {
+					if (autoTryOtherServers && event.code === 1006) {
 						if (Janus.isArray(servers) && !callbacks["reconnect"]) {
 							serversIndex++;
 							if (serversIndex === servers.length) {
@@ -1082,7 +1086,7 @@ function Janus(gatewayCallbacks) {
 			},
 			error: function(textStatus, errorThrown) {
 				Janus.error(textStatus + ":", errorThrown);	// FIXME
-				if(Janus.isArray(servers) && !callbacks["reconnect"]) {
+				if(autoTryOtherServers && Janus.isArray(servers) && !callbacks["reconnect"]) {
 					serversIndex++;
 					if(serversIndex === servers.length) {
 						// We tried all the servers the user gave us, and they all failed

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -101,6 +101,7 @@ declare namespace JanusJS {
 		bundlePolicy?: RTCBundlePolicy;
 		keepAlivePeriod?: number;
 		longPollTimeout?: number;
+		autoTryOtherServers?: boolean;
 	}
 
 	interface ReconnectOptions {


### PR DESCRIPTION
Added functionality to try the next server if the websocket connection is unexpectedly terminated. Reconnection will only be done when the websocket is closed with closecode 1006. This status code is returned, for example, when the network connection, a reverse proxy or the Janus gateway itself fails. This behaviour was tested with Chrome, Edge and Firefox.