### PR TITLE
Optionally support X-Forwarded-For in both HTTP and WebSocket transports (fixes #3158)

### DIFF
--- a/conf/janus.transport.http.jcfg.sample
+++ b/conf/janus.transport.http.jcfg.sample
@@ -20,6 +20,8 @@ general: {
 	#secure_interface = "eth0"		# Whether we should bind this server to a specific interface only
 	#secure_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address (v4 or v6) only
 	#acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+	#acl_forwarded = true			# Whether we should check the X-Forwarded-For header too for the ACL
+									# (default=false, since without a proxy in the middle this could be abused)
 	#mhd_connection_limit = 1020		# Open connections limit in libmicrohttpd (default=1020)
 	#mhd_debug = false					# Ask libmicrohttpd to write warning and error messages to stderr (default=false)
 }
@@ -46,6 +48,8 @@ admin: {
 	#admin_secure_interface = "eth0"	# Whether we should bind this server to a specific interface only
 	#admin_secure_ip = "192.168.0.1"	# Whether we should bind this server to a specific IP address (v4 or v6) only
 	#admin_acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+	#admin_acl_forwarded = true			# Whether we should check the X-Forwarded-For header too for the admin ACL
+										# (default=false, since without a proxy in the middle this could be abused)
 }
 
 # The HTTP servers created in Janus support CORS out of the box, but by

--- a/conf/janus.transport.websockets.jcfg.sample
+++ b/conf/janus.transport.websockets.jcfg.sample
@@ -21,6 +21,8 @@ general: {
 									# to debug, supported values: err, warn, notice, info, debug, parser,
 									# header, ext, client, latency, user, count (plus 'none' and 'all')
 	#ws_acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+	#ws_acl_forwarded = true		# Whether we should check the X-Forwarded-For header too for the ACL
+									# (default=false, since without a proxy in the middle this could be abused)
 }
 
 # If you want to expose the Admin API via WebSockets as well, you need to
@@ -39,6 +41,8 @@ admin: {
 	#admin_wss_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address only
 	#admin_wss_unix = "/run/awss.sock"	# Use WebSocket server over UNIX socket instead of TCP
 	#admin_ws_acl = "127.,192.168.0."	# Only allow requests coming from this comma separated list of addresses
+	#admin_ws_acl_forwarded = true		# Whether we should check the X-Forwarded-For header too for the ACL
+										# (default=false, since without a proxy in the middle this could be abused)
 }
 
 # The HTTP servers created in Janus support CORS out of the box, but by

--- a/src/transports/janus_websockets.c
+++ b/src/transports/janus_websockets.c
@@ -332,6 +332,7 @@ static gboolean enforce_cors = FALSE;
 
 /* WebSockets ACL list for both Janus and Admin API */
 static GList *janus_websockets_access_list = NULL, *janus_websockets_admin_access_list = NULL;
+static gboolean janus_websockets_check_xff = FALSE, janus_websockets_admin_check_xff = FALSE;
 static janus_mutex access_list_mutex;
 static void janus_websockets_allow_address(const char *ip, gboolean admin) {
 	if(ip == NULL)
@@ -649,6 +650,10 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 			}
 			g_strfreev(list);
 			list = NULL;
+			/* Check if we should use the value of X-Forwarded-For for checks too */
+			item = janus_config_get(config, config_general, janus_config_type_item, "ws_acl_forwarded");
+			if(item && item->value)
+				janus_websockets_check_xff = janus_is_true(item->value);
 		}
 		item = janus_config_get(config, config_admin, janus_config_type_item, "admin_ws_acl");
 		if(item && item->value) {
@@ -667,6 +672,10 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 			}
 			g_strfreev(list);
 			list = NULL;
+			/* Check if we should use the value of X-Forwarded-For for checks too */
+			item = janus_config_get(config, config_general, janus_config_type_item, "admin_ws_acl_forwarded");
+			if(item && item->value)
+				janus_websockets_admin_check_xff = janus_is_true(item->value);
 		}
 
 		/* Any custom value for the Access-Control-Allow-Origin header? */
@@ -1182,6 +1191,18 @@ static int janus_websockets_common_callback(
 				/* Close the connection */
 				lws_callback_on_writable(wsi);
 				return -1;
+			}
+			/* Check if an X-Forwarded-For header was provided */
+			char xff[1024] = {0};
+			if(lws_hdr_copy(wsi, xff, 1023, WSI_TOKEN_X_FORWARDED_FOR) > 0) {
+				/* If the ACL is enabled, are we supposed to use this header too for checks? */
+				if(((!admin && janus_websockets_check_xff) || (admin && janus_websockets_admin_check_xff)) && !janus_websockets_is_allowed(xff, admin)) {
+					JANUS_LOG(LOG_ERR, "[%s-%p] IP %s is unauthorized to connect to the WebSockets %s API interface\n",
+						log_prefix, wsi, xff, admin ? "Admin" : "Janus");
+					/* Close the connection */
+					lws_callback_on_writable(wsi);
+					return -1;
+				}
 			}
 			JANUS_LOG(LOG_VERB, "[%s-%p] WebSocket connection accepted\n", log_prefix, wsi);
 			if(ws_client == NULL) {


### PR DESCRIPTION
See #3158 for rationale. This patch allows both HTTP and WebSocket transports to optionally inspect the `X-Forwarded-For` header in requests to check whether or not a request is allowed by the transport's ACL rules. The support is optional and disabled by default to avoid abuses, since spoofing the header is trivial: as such, it should only be configured if a proxy is indeed in front of Janus, it's the only one able to talk to Janus, and there's reasons to filter clients contacting the proxy.

I haven't checked if the APIs I used require specific versions of MHD or libwebsockets. I'll wait for our Github Actions to see if the ones we use normally do support them. Feedback welcome, as usual.