### PR TITLE
Allow Lua and Duktape plugins to relay extensions when relaying RTP packets

### DIFF
--- a/src/plugins/duktape/janus-sdp.js
+++ b/src/plugins/duktape/janus-sdp.js
@@ -397,6 +397,8 @@ JANUSSDP.generateAnswer = function(offer, options) {
 						answer.push({ type: "a", name: a.name, value: value });
 					} else if(options.disableTwcc !== true && a.value.indexOf("draft-holmer-rmcat-transport-wide-cc-extensions-01") !== -1) {
 						answer.push({ type: "a", name: a.name, value: value });
+					} else if(options.enableAudioLevel !== false && a.value.indexOf("urn:ietf:params:rtp-hdrext:ssrc-audio-level") !== -1) {
+						answer.push({ type: "a", name: a.name, value: value });
 					}
 				}
 			} else {

--- a/src/plugins/janus_duktape.c
+++ b/src/plugins/janus_duktape.c
@@ -372,6 +372,7 @@ typedef struct janus_duktape_rtp_relay_packet {
 	janus_duktape_session *sender;
 	janus_rtp_header *data;
 	gint length;
+	janus_plugin_rtp_extensions extensions;
 	gboolean is_rtp;	/* This may be a data packet and not RTP */
 	gboolean is_video;
 	uint32_t ssrc[3];
@@ -2478,6 +2479,7 @@ void janus_duktape_incoming_rtp(janus_plugin_session *handle, janus_plugin_rtp *
 	packet.data = rtp;
 	packet.length = len;
 	packet.is_video = video;
+	packet.extensions = rtp_packet->extensions;
 	packet.ssrc[0] = (sc != -1 ? session->ssrc[0] : 0);
 	packet.ssrc[1] = (sc != -1 ? session->ssrc[1] : 0);
 	packet.ssrc[2] = (sc != -1 ? session->ssrc[2] : 0);
@@ -2838,7 +2840,8 @@ static void janus_duktape_relay_rtp_packet(gpointer data, gpointer user_data) {
 		}
 		/* Send the packet */
 		if(duktape_janus_core != NULL) {
-			janus_plugin_rtp rtp = { .mindex = -1, .video = packet->is_video, .buffer = (char *)packet->data, .length = packet->length };
+			janus_plugin_rtp rtp = { .mindex = -1, .video = packet->is_video,
+				.buffer = (char *)packet->data, .length = packet->length, .extensions = packet->extensions };
 			janus_plugin_rtp_extensions_reset(&rtp.extensions);
 			duktape_janus_core->relay_rtp(session->handle, &rtp);
 		}
@@ -2854,8 +2857,8 @@ static void janus_duktape_relay_rtp_packet(gpointer data, gpointer user_data) {
 		janus_rtp_header_update(packet->data, packet->is_video ? &session->vrtpctx : &session->artpctx, packet->is_video, 0);
 		/* Send the packet */
 		if(duktape_janus_core != NULL) {
-			janus_plugin_rtp rtp = { .mindex = -1, .video = packet->is_video, .buffer = (char *)packet->data, .length = packet->length };
-			janus_plugin_rtp_extensions_reset(&rtp.extensions);
+			janus_plugin_rtp rtp = { .mindex = -1, .video = packet->is_video,
+				.buffer = (char *)packet->data, .length = packet->length, .extensions = packet->extensions };
 			duktape_janus_core->relay_rtp(session->handle, &rtp);
 		}
 		/* Restore the timestamp and sequence number to what the publisher set them to */

--- a/src/plugins/janus_lua.c
+++ b/src/plugins/janus_lua.c
@@ -372,6 +372,7 @@ typedef struct janus_lua_rtp_relay_packet {
 	janus_lua_session *sender;
 	janus_rtp_header *data;
 	gint length;
+	janus_plugin_rtp_extensions extensions;
 	gboolean is_rtp;	/* This may be a data packet and not RTP */
 	gboolean is_video;
 	uint32_t ssrc[3];
@@ -2147,6 +2148,7 @@ void janus_lua_incoming_rtp(janus_plugin_session *handle, janus_plugin_rtp *rtp_
 	packet.length = len;
 	packet.is_rtp = TRUE;
 	packet.is_video = video;
+	packet.extensions = rtp_packet->extensions;
 	packet.ssrc[0] = (sc != -1 ? session->ssrc[0] : 0);
 	packet.ssrc[1] = (sc != -1 ? session->ssrc[1] : 0);
 	packet.ssrc[2] = (sc != -1 ? session->ssrc[2] : 0);
@@ -2466,7 +2468,8 @@ static void janus_lua_relay_rtp_packet(gpointer data, gpointer user_data) {
 		}
 		/* Send the packet */
 		if(lua_janus_core != NULL) {
-			janus_plugin_rtp rtp = { .mindex = -1, .video = packet->is_video, .buffer = (char *)packet->data, .length = packet->length };
+			janus_plugin_rtp rtp = { .mindex = -1, .video = packet->is_video,
+				.buffer = (char *)packet->data, .length = packet->length, .extensions = packet->extensions };
 			janus_plugin_rtp_extensions_reset(&rtp.extensions);
 			lua_janus_core->relay_rtp(session->handle, &rtp);
 		}
@@ -2482,8 +2485,8 @@ static void janus_lua_relay_rtp_packet(gpointer data, gpointer user_data) {
 		janus_rtp_header_update(packet->data, packet->is_video ? &session->vrtpctx : &session->artpctx, packet->is_video, 0);
 		/* Send the packet */
 		if(lua_janus_core != NULL) {
-			janus_plugin_rtp rtp = { .mindex = -1, .video = packet->is_video, .buffer = (char *)packet->data, .length = packet->length };
-			janus_plugin_rtp_extensions_reset(&rtp.extensions);
+			janus_plugin_rtp rtp = { .mindex = -1, .video = packet->is_video,
+				.buffer = (char *)packet->data, .length = packet->length, .extensions = packet->extensions };
 			lua_janus_core->relay_rtp(session->handle, &rtp);
 		}
 		/* Restore the timestamp and sequence number to what the publisher set them to */

--- a/src/plugins/lua/janus-sdp.lua
+++ b/src/plugins/lua/janus-sdp.lua
@@ -444,6 +444,8 @@ function JANUSSDP.generateAnswer(offer, options)
 						answer[#answer+1] = { type = "a", name = a.name, value = value }
 					elseif options.disableTwcc ~= true and a.value:find("draft-holmer-rmcat-transport-wide-cc-extensions-01", 1, true) then
 						answer[#answer+1] = { type = "a", name = a.name, value = value }
+					elseif options.enableAudioLevel ~= false and a.value:find("urn:ietf:params:rtp-hdrext:ssrc-audio-level", 1, true) then
+						answer[#answer+1] = a
 					end
 				end
 			else


### PR DESCRIPTION
Since we merged #1884, the Lua and Duktape plugins had basically no RTP extensions support, except for those originated by the core (e.g., mid). In fact, since #1884 required the plugins to explicitly use the `.extensions` property to carry on specific extensions, and Lua/Duktape didn't use it (simply resetting the struct), this resulted in extension properties passed by media senders to be stripped by the core when relaying packets to receivers. This patch addresses this shortcoming, and ensures we now copy the struct along properly. I've tested this briefly with the `audio-level` extension in both plugins, and it looks like it's working as expected.

Planning to merge soon, so if you have feedback please do say so.