### PR TITLE
Add newline for SIP headers that are overflown in length

### DIFF
--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -1619,9 +1619,10 @@ static void janus_sip_parse_custom_headers(json_t *root, char *custom_headers, s
 					continue;
 				}
 				char h[255];
-				g_snprintf(h, 255, "%s: %s\r\n", key, json_string_value(value));
+				g_snprintf(h, 255, "%s: %s", key, json_string_value(value));
 				JANUS_LOG(LOG_VERB, "Adding custom header, %s\n", h);
 				janus_strlcat(custom_headers, h, size);
+				janus_strlcat(custom_headers, "\r\n", size);
 				iter = json_object_iter_next(headers, iter);
 			}
 		}

--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -1622,7 +1622,7 @@ static void janus_sip_parse_custom_headers(json_t *root, char *custom_headers, s
 				char h[255];
 				g_snprintf(h, 255, "%s: %s", key, json_string_value(value));
 				JANUS_LOG(LOG_VERB, "Adding custom header, %s\n", h);
-				janus_strlcat(custom_headers, h, size);
+				janus_strlcat(custom_headers, h, size - 2);
 				janus_strlcat(custom_headers, "\r\n", size);
 				iter = json_object_iter_next(headers, iter);
 			}


### PR DESCRIPTION
Before this PR, if some header (key+value) is overflown (longer than 256 chars), it would result in it being truncated, but no newline was added, so it would result in next header actually being written on same line as overflown one, hence it was not interpreted as separate header on SIP level.

This PR makes sure that newline is added always, even if header (key+value) is longer than 256 chars.