### PR TITLE
avoid parsing whitespace as invalid JSON

### DIFF
--- a/src/transports/janus_websockets.c
+++ b/src/transports/janus_websockets.c
@@ -1347,6 +1347,9 @@ static int janus_websockets_common_callback(
 					incoming_curr += error.position;
 					JANUS_LOG(LOG_HUGE, "[%s-%p] Parsed JSON message - consumed %zu/%zu bytes\n",
 						log_prefix, wsi, (size_t)(incoming_curr - ws_client->incoming), incoming_length);
+					/* Trailing whitespace after the last message results in invalid JSON error */
+					while (incoming_curr < incoming_end && isspace(*incoming_curr))
+						incoming_curr++;
 					if(incoming_curr == incoming_end) {
 						/* Process messages in order */
 						json_t **msg = message_buffer;


### PR DESCRIPTION
A single WebSocket message may contain multiple requests. The code parses one request, then continues looking for more requests in the same WebSocket message. This works fine as long as the **last** request has no trailing whitespace. However, if there is any trailing whitespace after the last request an attempt to parse it as JSON results in an error.

This PR simply skips any trailing whitespace after each request