### PR TITLE
New regular event in handlers for core status

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -396,6 +396,12 @@ gboolean janus_ice_event_get_combine_media_stats(void) {
 	return janus_ice_event_combine_media_stats;
 }
 
+/* Number of active PeerConnection (for stats) */
+static volatile gint pc_num = 0;
+int janus_ice_get_peerconnection_num(void) {
+	return g_atomic_int_get(&pc_num);
+}
+
 /* RTP/RTCP port range */
 static uint16_t rtp_range_min = 0;
 static uint16_t rtp_range_max = 0;
@@ -1617,6 +1623,8 @@ void janus_ice_webrtc_hangup(janus_ice_handle *handle, const char *reason) {
 #endif
 		g_main_context_wakeup(handle->mainctx);
 	}
+	if(g_atomic_int_dec_and_test(&handle->has_pc))
+		g_atomic_int_dec_and_test(&pc_num);
 }
 
 static void janus_ice_webrtc_free(janus_ice_handle *handle) {
@@ -5186,4 +5194,6 @@ void janus_ice_dtls_handshake_done(janus_ice_handle *handle) {
 		janus_events_notify_handlers(JANUS_EVENT_TYPE_WEBRTC, JANUS_EVENT_SUBTYPE_WEBRTC_STATE,
 			session->session_id, handle->handle_id, handle->opaque_id, info);
 	}
+	g_atomic_int_set(&handle->has_pc, 1);
+	g_atomic_int_inc(&pc_num);
 }

--- a/src/ice.h
+++ b/src/ice.h
@@ -205,6 +205,9 @@ void janus_ice_set_event_stats_period(int period);
 /*! \brief Method to get the current event handler statistics period (see above)
  * @returns The current event handler stats period */
 int janus_ice_get_event_stats_period(void);
+/*! \brief Method to get the number of active PeerConnection (for stats)
+ * @returns The current number of active PeerConnections */
+int janus_ice_get_peerconnection_num(void);
 
 /*! \brief Method to define wether the media stats shall be dispatched in one event (true) or in dedicated single events (false - default)
  * @param[in] combine_media_stats_to_one_event true to combine media statistics in on event or false to send dedicated events */
@@ -402,6 +405,8 @@ struct janus_ice_handle {
 	janus_text2pcap *text2pcap;
 	/*! \brief Mutex to lock/unlock the ICE session */
 	janus_mutex mutex;
+	/*! \brief Atomic flag to check whether a PeerConnection was established */
+	volatile gint has_pc;
 	/*! \brief Whether a close_pc was requested recently on the PeerConnection */
 	volatile gint closepc;
 	/*! \brief Atomic flag to check if this instance has been destroyed */


### PR DESCRIPTION
This PR adds a new core event that is sent via event handlers, to provide, on a regular basis, short info on the status of the Janus server. At the moment, this includes:

* the number of active sessions
* the number of active handles (across all sessions)
* the number of active PeerConnections (across all sessions)
* the interval at which event handlers are currently configured to send media reports for each PC

While I may add more stuff in the future, this is basically it for now, as it should provide some very basic health state information that can be consumed without having to poll the Admin API or track all events that flow through.

This is an example of how the event looks like:

    {
        "emitter": "MyJanusInstance",
        "type": 256,
        "subtype": 1,
        "timestamp": 1683906438598123,
        "event": {
            "status": "update",
            "info": {
                "sessions": 0,
                "handles": 0,
                "peerconnections": 0,
                "stats-period": 1
            }
        }
    }

In this PR, I hardcoded the frequency of this event to 15 seconds. Not sure if it makes sense to make this configurable too, but in case it should be easy to do. Feedback welcome!