### PR TITLE
Fix rtcp out quality stats

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -4216,7 +4216,8 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 				.video = (medium->type == JANUS_MEDIA_VIDEO), .buffer = rtcpbuf, .length = srlen+sdeslen };
 			janus_ice_relay_rtcp_internal(handle, medium, &rtcp, FALSE);
 			/* Check if we detected too many losses, and send a slowlink event in case */
-			guint lost = janus_rtcp_context_get_lost_all(rtcp_ctx, TRUE);
+			gint lost = janus_rtcp_context_get_lost_all(rtcp_ctx, TRUE);
+			lost = lost > 0 ? lost : 0;
 			janus_slow_link_update(medium, handle, TRUE, lost);
 		}
 		if(medium->recv) {
@@ -4242,7 +4243,8 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 					janus_ice_relay_rtcp_internal(handle, medium, &rtcp, FALSE);
 					if(vindex == 0) {
 						/* Check if we detected too many losses, and send a slowlink event in case */
-						guint lost = janus_rtcp_context_get_lost_all(medium->rtcp_ctx[vindex], FALSE);
+						gint lost = janus_rtcp_context_get_lost_all(medium->rtcp_ctx[vindex], FALSE);
+						lost = lost > 0 ? lost : 0;
 						janus_slow_link_update(medium, handle, FALSE, lost);
 					}
 				}

--- a/src/rtcp.h
+++ b/src/rtcp.h
@@ -262,7 +262,7 @@ typedef struct rtcp_context
 	uint32_t received_prior;
 	uint32_t expected;
 	uint32_t expected_prior;
-	uint32_t lost, lost_remote;
+	int32_t lost, lost_remote;
 
 	uint32_t retransmitted;
 	uint32_t retransmitted_prior;
@@ -304,7 +304,7 @@ uint32_t janus_rtcp_context_get_rtt(janus_rtcp_context *ctx);
  * @param[in] ctx The RTCP context to query
  * @param[in] remote Whether we're quering the remote (provided by peer) or local (computed by Janus) info
  * @returns The total number of lost packets */
-uint32_t janus_rtcp_context_get_lost_all(janus_rtcp_context *ctx, gboolean remote);
+int32_t janus_rtcp_context_get_lost_all(janus_rtcp_context *ctx, gboolean remote);
 /*! \brief Method to retrieve the jitter from an existing RTCP context
  * @param[in] ctx The RTCP context to query
  * @param[in] remote Whether we're quering the remote (provided by peer) or local (computed by Janus) info


### PR DESCRIPTION
We got notified about some spurious values of out link quality metrics.

This PR aims at fixing that unwanted behavior, specifically by:
- parsing the reported total lost as a signed integer since it could be a negative value
```
cumulative number of packets lost: 24 bits
      The total number of RTP data packets from source SSRC_n that have
      been lost since the beginning of reception.  This number is
      defined to be the number of packets expected less the number of
      packets actually received, where the number of packets received
      includes any which are late or duplicates.  Thus, packets that
      arrive late are not counted as lost, and the loss may be negative
      if there are duplicates.
```
- improving the float math when evaluating the metrics
- as a side effect, dealing internally with inbound losses by using signed integer, but still skipping negative cumulative losses in the RTCP reports sent to RTCP peers
```
	uint32_t expected_interval = ctx->expected - ctx->expected_prior;
	uint32_t received_interval = ctx->received - ctx->received_prior;
	int32_t lost_interval = 0;
	if (expected_interval > received_interval) {
		lost_interval = expected_interval - received_interval;
	}
	ctx->lost += lost_interval;
```