### PR TITLE
Update TypeScript signature of createOffer

### DIFF
--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -174,7 +174,7 @@ declare namespace JanusJS {
 		error?: (error: Error) => void;
 		customizeSdp?: (jsep: JSEP) => void;
 
-		// @deprecated use tracks instead
+		/** @deprecated use tracks instead */
 		media?: {
 			audioSend?: boolean;
 			audioRecv?: boolean;

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -195,9 +195,6 @@ declare namespace JanusJS {
 			failIfNoVideo?: boolean;
 			screenshareFrameRate?: number;
 		};
-		// @deprecated use tracks instead
-		stream?: MediaStream;
-
 	}
 
 	interface PluginMessage {

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -173,6 +173,31 @@ declare namespace JanusJS {
 		success?: (jsep: JSEP) => void;
 		error?: (error: Error) => void;
 		customizeSdp?: (jsep: JSEP) => void;
+
+		// @deprecated use tracks instead
+		media?: {
+			audioSend?: boolean;
+			audioRecv?: boolean;
+			videoSend?: boolean;
+			videoRecv?: boolean;
+			audio?: boolean | { deviceId: string };
+			video?:
+				| boolean
+				| { deviceId: string }
+				| 'lowres'
+				| 'lowres-16:9'
+				| 'stdres'
+				| 'stdres-16:9'
+				| 'hires'
+				| 'hires-16:9';
+			data?: boolean;
+			failIfNoAudio?: boolean;
+			failIfNoVideo?: boolean;
+			screenshareFrameRate?: number;
+		};
+		// @deprecated use tracks instead
+		stream?: MediaStream;
+
 	}
 
 	interface PluginMessage {

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -167,30 +167,12 @@ declare namespace JanusJS {
 	}
 
 	interface OfferParams {
-		media?: {
-			audioSend?: boolean;
-			audioRecv?: boolean;
-			videoSend?: boolean;
-			videoRecv?: boolean;
-			audio?: boolean | { deviceId: string };
-			video?:
-				| boolean
-				| { deviceId: string }
-				| 'lowres'
-				| 'lowres-16:9'
-				| 'stdres'
-				| 'stdres-16:9'
-				| 'hires'
-				| 'hires-16:9';
-			data?: boolean;
-			failIfNoAudio?: boolean;
-			failIfNoVideo?: boolean;
-			screenshareFrameRate?: number;
-		};
+		tracks?: TrackOptions[];
 		trickle?: boolean;
-		stream?: MediaStream;
-		success: Function;
-		error: (error: any) => void;
+		iceRestart?: boolean;
+		success?: (jsep: JSEP) => void;
+		error?: (error: Error) => void;
+		customizeSdp?: (jsep: JSEP) => void;
 	}
 
 	interface PluginMessage {
@@ -267,27 +249,27 @@ declare namespace JanusJS {
 	}
 
 	type TrackOption = {
-		add: boolean;
-		replace: boolean;
-		remove: boolean;
+		add?: boolean;
+		replace?: boolean;
+		remove?: boolean;
 		type: 'video' | 'screen' | 'audio' | 'data';
-		mid: string;
+		mid?: string;
 		capture: boolean | MediaStreamTrack;
-		recv: boolean;
-		group: 'default' | string;
-		gumGroup: TrackOption['group'];
-		simulcast: boolean;
-		svc: string;
-		simulcastMaxBitrates: {
-			low: number,
-			medium: number,
-			high: number,
+		recv?: boolean;
+		group?: 'default' | string;
+		gumGroup?: TrackOption['group'];
+		simulcast?: boolean;
+		svc?: string;
+		simulcastMaxBitrates?: {
+			low: number;
+			medium: number;
+			high: number;
 		};
-		sendEncodings: RTCRtpEncodingParameters;
-		framerate: number;
-		bitrate: number;
-		dontStop: boolean;
-		transforms: {
+		sendEncodings?: RTCRtpEncodingParameters;
+		framerate?: number;
+		bitrate?: number;
+		dontStop?: boolean;
+		transforms?: {
 			sender: ReadableWritablePair;
 			receiver: ReadableWritablePair;
 		};


### PR DESCRIPTION
This PR introduces an update to the TypeScript signature of the `createOffer` API method  to include correct type annotations, aligning with the documentation provided on [Janus API Documentation](https://janus.conf.meetecho.com/docs/JS.html) for initial offer creation and ICE restart.

I suggest considering the use of [TSDoc](https://tsdoc.org/) to document the API and generate part of the JavaScript API documentation. Integrating it with Doxygen could improve codebase maintainability, readability, and automate the process of keeping the API documentation up-to-date.
