### PR TITLE
Add support for ICE consent freshness (requires libnice >= 0.1.19)

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -270,8 +270,11 @@ media: {
 # it should work in ICE-Lite mode (by default it doesn't). If libnice is
 # at least 0.1.15, you can choose which ICE nomination mode to use: valid
 # values are "regular" and "aggressive" (the default depends on the libnice
-# version itself; if we can set it, we set aggressive nomination). You can
-# also configure whether to use connectivity checks as keep-alives, which
+# version itself; if we can set it, we set aggressive nomination). If
+# libnice is at least 0.1.19, you can enable consent freshness checks for
+# PeerConnections as well: this will issue regular checks to check whether
+# or not the WebRTC peer isn't available anymore. Enabling consent freshness
+# will automatically also enable using connectivity checks as keep-alives, which
 # might help detecting when a peer is no longer available (notice that
 # current libnice master is breaking connections after 50 seconds when
 # keepalive-conncheck is being used, so if you want to use it, better
@@ -286,6 +289,7 @@ nat: {
 	nice_debug = false
 	#full_trickle = true
 	#ice_nomination = "regular"
+	#ice_consent_freshness = true
 	#ice_keepalive_conncheck = true
 	#ice_lite = true
 	#ice_tcp = true

--- a/configure.ac
+++ b/configure.ac
@@ -424,6 +424,12 @@ AC_CHECK_LIB([nice],
              [AC_MSG_NOTICE([libnice version does not have nice_agent_new_full])]
              )
 
+AC_CHECK_LIB([nice],
+             [nice_agent_consent_lost],
+             [AC_DEFINE(HAVE_CONSENT_FRESHNESS)],
+             [AC_MSG_NOTICE([libnice version does not have nice_agent_consent_lost])]
+             )
+
 AC_CHECK_LIB([dl],
              [dlopen],
              [JANUS_MANUAL_LIBS="${JANUS_MANUAL_LIBS} -ldl"],

--- a/src/ice.h
+++ b/src/ice.h
@@ -151,6 +151,15 @@ void janus_ice_set_nomination_mode(const char *nomination);
  * @returns "regular" or "aggressive" */
 const char *janus_ice_get_nomination_mode(void);
 #endif
+/*! \brief Method to enable/disable consent freshness in PeerConnections.
+ * \note This is only available on libnice >= 0.1.19, and automatically enables
+ * keepalive connectivity checks too. Documentation for the setting:
+ * https://libnice.freedesktop.org/libnice/NiceAgent.html#NiceAgent--consent-freshness
+ * @param[in] enabled Whether the functionality should be enabled or disabled */
+void janus_ice_set_consent_freshness_enabled(gboolean enabled);
+/*! \brief Method to check whether consent fresnhess will be enabled in ICE
+ * @returns true if enabled, false (default) otherwise */
+gboolean janus_ice_is_consent_freshness_enabled(void);
 /*! \brief Method to enable/disable connectivity checks as keepalives for PeerConnections.
  * \note The main rationale behind this setting is provided in the libnice documentation:
  * https://libnice.freedesktop.org/libnice/NiceAgent.html#NiceAgent--keepalive-conncheck

--- a/src/janus.c
+++ b/src/janus.c
@@ -366,6 +366,7 @@ static json_t *janus_info(const char *transaction) {
 #ifdef HAVE_ICE_NOMINATION
 	json_object_set_new(info, "ice-nomination", json_string(janus_ice_get_nomination_mode()));
 #endif
+	json_object_set_new(info, "ice-consent-freshness", janus_ice_is_consent_freshness_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "ice-keepalive-conncheck", janus_ice_is_keepalive_conncheck_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "full-trickle", janus_ice_is_full_trickle_enabled() ? json_true() : json_false());
 	json_object_set_new(info, "mdns-enabled", janus_ice_is_mdns_enabled() ? json_true() : json_false());
@@ -5201,6 +5202,9 @@ gint main(int argc, char *argv[]) {
 		janus_ice_set_nomination_mode(item->value);
 #endif
 	}
+	item = janus_config_get(config, config_nat, janus_config_type_item, "ice_consent_freshness");
+	if(item && item->value)
+		janus_ice_set_consent_freshness_enabled(janus_is_true(item->value));
 	item = janus_config_get(config, config_nat, janus_config_type_item, "ice_keepalive_conncheck");
 	if(item && item->value)
 		janus_ice_set_keepalive_conncheck_enabled(janus_is_true(item->value));


### PR DESCRIPTION
As the subject says, this adds support for ICE consent freshness, which was recently (since 0.1.19) added to libnice. While we already had configurable support for using connectivity checks as keep-alives (`ice_keepalive_conncheck: true` in `janus.jcfg`), we didn't have support for consent freshness yet. The documentation for the libnice feature can be found [here](https://libnice.freedesktop.org/libnice/NiceAgent.html#NiceAgent--consent-freshness).

This PR adds configurable support for consent freshness too, now, via a new configuration property called `ice_consent_freshness`. Notice that, as explained in the documentation, enabling consent freshness automatically enables `keepalive-conncheck` too.

As part of this patch, we added a new `ice-failed` event that the Janus API can originate. If, as a consequence of enabling these features, Janus detects the PC going to a `failed` state after it was previously connected/ready (meaning the PC may be gone), an `ice-failed` event will be sent to the user to whom the handle belongs. The rationale for that is that we wait for a few seconds before closing the PC for good, which should give the user some time to possibly try and recover, e.g., via an ICE restart (in case the `failed` detection wasn't a truly fatal one).

While we plan to merge soon, we encourage you to test this a bit and provide feedback, most importantly to ensure enabling this feature doesn't introduce potential issues (e.g., too aggressively closing things that really shouldn't be closed, maybe because of occasional packet loss affecting connectivity checks rather than a PC that has truly gone away).

As usual, I'll backport this to `0.x` too once this is deemed ready to be merged.