### PR TITLE
janus.d.ts: fix typo and update PluginCreateAnswerParam to use tracks

### DIFF
--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -167,7 +167,7 @@ declare namespace JanusJS {
 	}
 
 	interface OfferParams {
-		tracks?: TrackOptions[];
+		tracks?: TrackOption[];
 		trickle?: boolean;
 		iceRestart?: boolean;
 		success?: (jsep: JSEP) => void;
@@ -253,7 +253,10 @@ declare namespace JanusJS {
 
 	type PluginCreateAnswerParam = {
 		jsep: JSEP;
-		media: { audioSend: any, videoSend: any };
+		tracks?: TrackOption[];
+
+		/** @deprecated use tracks instead */
+		media?: { audioSend: any, videoSend: any };
 		success?: (data: JSEP) => void;
 		error?: (error: string) => void;
 	}


### PR DESCRIPTION
Hello!

This is a very simple PR affecting only the janus.d.ts file.

1/ We found a typo where **TrackOptions** should be **TrackOption**
2/ We also have updated the PluginCreateAnswerParam type to have the newer **tracks** parameter and marked the **media** as deprecated. (same as OfferParam)

Best regards, Aymeric