### PR TITLE
Fix simulated leave message for longer string ID rooms

### DIFF
--- a/src/plugins/janus_textroom.c
+++ b/src/plugins/janus_textroom.c
@@ -3027,7 +3027,7 @@ static void janus_textroom_hangup_media_internal(janus_plugin_session *handle) {
 	}
 	janus_mutex_unlock(&session->mutex);
 	JANUS_LOG(LOG_VERB, "Leaving %d rooms\n", g_list_length(list));
-	char request[100];
+	char request[200];
 	GList *first = list;
 	while(list) {
 		char *room_id_str = (char *)list->data;


### PR DESCRIPTION
Currently, on abrupt disconnections, participants get stuck in text rooms and aren't able to re-join immediately.

This makes auto reconnect mechanisms needlessly complicated.

In this PR I added automatic leaving of all rooms when the session is being destroyed.

The bug can be reproduced in the official janus textroom demo:
- Join textroom via phone
- Join textroom via PC
- Disconnect internet on phone
- On PC you can still see this participant for 