### PR TITLE
Extend sessions_mutex scope to avoid rogue inserts in mp viewers list (see #3246)

### DIFF
--- a/src/plugins/janus_streaming.c
+++ b/src/plugins/janus_streaming.c
@@ -5733,11 +5733,11 @@ static void *janus_streaming_handler(void *data) {
 			janus_streaming_message_free(msg);
 			continue;
 		}
-		janus_mutex_unlock(&sessions_mutex);
 		/* Handle request */
 		error_code = 0;
 		root = NULL;
 		if(msg->message == NULL) {
+			janus_mutex_unlock(&sessions_mutex);
 			JANUS_LOG(LOG_ERR, "No message??\n");
 			error_code = JANUS_STREAMING_ERROR_NO_MESSAGE;
 			g_snprintf(error_cause, 512, "%s", "No message??");
@@ -5748,8 +5748,10 @@ static void *janus_streaming_handler(void *data) {
 		JANUS_VALIDATE_JSON_OBJECT(root, request_parameters,
 			error_code, error_cause, TRUE,
 			JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
-		if(error_code != 0)
+		if(error_code != 0) {
+			janus_mutex_unlock(&sessions_mutex);
 			goto error;
+		}
 		json_t *request = json_object_get(root, "request");
 		const char *request_text = json_string_value(request);
 		json_t *result = NULL;
@@ -5763,8 +5765,10 @@ static void *janus_streaming_handler(void *data) {
 			JANUS_VALIDATE_JSON_OBJECT(root, watch_parameters,
 				error_code, error_cause, TRUE,
 				JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
-			if(error_code != 0)
+			if(error_code != 0) {
+				janus_mutex_unlock(&sessions_mutex);
 				goto error;
+			}
 			if(!string_ids) {
 				JANUS_VALIDATE_JSON_OBJECT(root, id_parameters,
 					error_code, error_cause, TRUE,
@@ -5774,8 +5778,10 @@ static void *janus_streaming_handler(void *data) {
 					error_code, error_cause, TRUE,
 					JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 			}
-			if(error_code != 0)
+			if(error_code != 0) {
+				janus_mutex_unlock(&sessions_mutex);
 				goto error;
+			}
 			json_t *id = json_object_get(root, "id");
 			guint64 id_value = 0;
 			char id_num[30], *id_value_str = NULL;
@@ -5794,6 +5800,7 @@ static void *janus_streaming_handler(void *data) {
 				for(i=0; i<json_array_size(mids); i++) {
 					json_t *s = json_array_get(mids, i);
 					if(!json_is_string(s)) {
+						janus_mutex_unlock(&sessions_mutex);
 						error_code = JANUS_STREAMING_ERROR_INVALID_ELEMENT;
 						g_snprintf(error_cause, 512, "The media array must only contain strings (mid values)");
 						goto error;
@@ -5814,6 +5821,7 @@ static void *janus_streaming_handler(void *data) {
 				string_ids ? (gpointer)id_value_str : (gpointer)&id_value);
 			if(mp == NULL) {
 				janus_mutex_unlock(&mountpoints_mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				JANUS_LOG(LOG_VERB, "No such mountpoint/stream %s\n", id_value_str);
 				error_code = JANUS_STREAMING_ERROR_NO_SUCH_MOUNTPOINT;
 				g_snprintf(error_cause, 512, "No such mountpoint/stream %s", id_value_str);
@@ -5826,6 +5834,7 @@ static void *janus_streaming_handler(void *data) {
 			if(error_code != 0) {
 				janus_refcount_decrease(&mp->ref);
 				janus_mutex_unlock(&mountpoints_mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				goto error;
 			}
 			janus_mutex_lock(&mp->mutex);
@@ -5839,6 +5848,7 @@ static void *janus_streaming_handler(void *data) {
 					/* Already triggered a renegotiation, and still waiting for an answer */
 					janus_mutex_unlock(&session->mutex);
 					janus_mutex_unlock(&mp->mutex);
+					janus_mutex_unlock(&sessions_mutex);
 					JANUS_LOG(LOG_ERR, "Already renegotiating mountpoint %s\n", session->mountpoint->id_str);
 					error_code = JANUS_STREAMING_ERROR_INVALID_STATE;
 					g_snprintf(error_cause, 512, "Already renegotiating mountpoint %s", session->mountpoint->id_str);
@@ -5858,6 +5868,7 @@ static void *janus_streaming_handler(void *data) {
 					g_snprintf(error_cause, 512, "Already watching mountpoint %s", session->mountpoint->id_str);
 					janus_mutex_unlock(&session->mutex);
 					janus_mutex_unlock(&mp->mutex);
+					janus_mutex_unlock(&sessions_mutex);
 					janus_refcount_decrease(&mp->ref);
 					goto error;
 				} else {
@@ -5870,6 +5881,7 @@ static void *janus_streaming_handler(void *data) {
 						janus_refcount_decrease(&mp->ref);
 						janus_mutex_unlock(&session->mutex);
 						janus_mutex_unlock(&mp->mutex);
+						janus_mutex_unlock(&sessions_mutex);
 						goto error;
 					}
 					if(!g_atomic_int_compare_and_exchange(&session->renegotiating, 0, 1)) {
@@ -5880,6 +5892,7 @@ static void *janus_streaming_handler(void *data) {
 						janus_refcount_decrease(&mp->ref);
 						janus_mutex_unlock(&session->mutex);
 						janus_mutex_unlock(&mp->mutex);
+						janus_mutex_unlock(&sessions_mutex);
 						goto error;
 					}
 					/* Simple renegotiation, remove the extra uneeded reference */
@@ -5894,6 +5907,7 @@ static void *janus_streaming_handler(void *data) {
 			if(g_list_find(mp->viewers, session) != NULL) {
 				janus_mutex_unlock(&session->mutex);
 				janus_mutex_unlock(&mp->mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				janus_refcount_decrease(&mp->ref);
 				JANUS_LOG(LOG_ERR, "Already watching a stream (found %p in %s's viewers)...\n", session, id_value_str);
 				error_code = JANUS_STREAMING_ERROR_UNKNOWN_ERROR;
@@ -5926,6 +5940,7 @@ static void *janus_streaming_handler(void *data) {
 				session->mountpoint = NULL;
 				janus_mutex_unlock(&session->mutex);
 				janus_mutex_unlock(&mp->mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				janus_refcount_decrease(&mp->ref);
 				JANUS_LOG(LOG_ERR, "Can't offer an SDP with no audio, video or data for this mountpoint\n");
 				error_code = JANUS_STREAMING_ERROR_INVALID_REQUEST;
@@ -5959,6 +5974,7 @@ static void *janus_streaming_handler(void *data) {
 					janus_mutex_unlock(&session->mutex);
 					janus_refcount_decrease(&session->ref);	/* This is for the failed thread */
 					janus_mutex_unlock(&mp->mutex);
+					janus_mutex_unlock(&sessions_mutex);
 					janus_refcount_decrease(&mp->ref);		/* This is for the failed thread */
 					janus_refcount_decrease(&mp->ref);
 					JANUS_LOG(LOG_ERR, "Got error %d (%s) trying to launch the on-demand thread...\n",
@@ -6018,7 +6034,8 @@ static void *janus_streaming_handler(void *data) {
 							session->mountpoint = NULL;
 							janus_mutex_unlock(&session->mutex);
 							janus_mutex_unlock(&mp->mutex);
-							janus_refcount_decrease(&mp->ref);
+							janus_mutex_unlock(&sessions_mutex);
+						janus_refcount_decrease(&mp->ref);
 							goto error;
 						}
 						/* In case this mountpoint is simulcasting, let's aim high by default */
@@ -6057,6 +6074,7 @@ static void *janus_streaming_handler(void *data) {
 							session->mountpoint = NULL;
 							janus_mutex_unlock(&session->mutex);
 							janus_mutex_unlock(&mp->mutex);
+							janus_mutex_unlock(&sessions_mutex);
 							janus_refcount_decrease(&mp->ref);
 							goto error;
 						}
@@ -6202,10 +6220,12 @@ done:
 			}
 			janus_mutex_unlock(&session->mutex);
 			janus_mutex_unlock(&mp->mutex);
+			janus_mutex_unlock(&sessions_mutex);
 		} else if(!strcasecmp(request_text, "watch") && jsep_sdp != NULL) {
 			/* New subscriber provided an offer, plugin will answer */
 			if(sdp_type == NULL || strcasecmp(sdp_type, "offer")) {
 				/* This isn't an offer, respond with an error */
+				janus_mutex_unlock(&sessions_mutex);
 				JANUS_LOG(LOG_ERR, "User provided SDP for a watch request must be an offer\n");
 				error_code = JANUS_STREAMING_ERROR_INVALID_SDP;
 				g_snprintf(error_cause, 512, "User provided SDP for a watch request must be an offer");
@@ -6214,6 +6234,7 @@ done:
 			char error_str[512];
 			janus_sdp *parsed_sdp = janus_sdp_parse(jsep_sdp, error_str, sizeof(error_str));
 			if(parsed_sdp == NULL) {
+				janus_mutex_unlock(&sessions_mutex);
 				JANUS_LOG(LOG_ERR, "Error parsing SDP: %s\n", error_str);
 				error_code = JANUS_STREAMING_ERROR_INVALID_SDP;
 				g_snprintf(error_cause, 512, "Error parsing SDP: %s", error_str);
@@ -6226,6 +6247,7 @@ done:
 				error_code, error_cause, TRUE,
 				JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 			if(error_code != 0) {
+				janus_mutex_unlock(&sessions_mutex);
 				janus_sdp_destroy(parsed_sdp);
 				goto error;
 			}
@@ -6239,6 +6261,7 @@ done:
 					JANUS_STREAMING_ERROR_MISSING_ELEMENT, JANUS_STREAMING_ERROR_INVALID_ELEMENT);
 			}
 			if(error_code != 0) {
+				janus_mutex_unlock(&sessions_mutex);
 				janus_sdp_destroy(parsed_sdp);
 				goto error;
 			}
@@ -6258,6 +6281,7 @@ done:
 				string_ids ? (gpointer)id_value_str : (gpointer)&id_value);
 			if(mp == NULL) {
 				janus_mutex_unlock(&mountpoints_mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				janus_sdp_destroy(parsed_sdp);
 				JANUS_LOG(LOG_VERB, "No such mountpoint/stream %s\n", id_value_str);
 				error_code = JANUS_STREAMING_ERROR_NO_SUCH_MOUNTPOINT;
@@ -6271,6 +6295,7 @@ done:
 			if(error_code != 0) {
 				janus_refcount_decrease(&mp->ref);
 				janus_mutex_unlock(&mountpoints_mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				janus_sdp_destroy(parsed_sdp);
 				goto error;
 			}
@@ -6284,6 +6309,7 @@ done:
 				g_snprintf(error_cause, 512, "Already watching mountpoint %s", session->mountpoint->id_str);
 				janus_mutex_unlock(&session->mutex);
 				janus_mutex_unlock(&mp->mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				janus_refcount_decrease(&mp->ref);
 				janus_sdp_destroy(parsed_sdp);
 				goto error;
@@ -6291,6 +6317,7 @@ done:
 			if(g_list_find(mp->viewers, session) != NULL) {
 				janus_mutex_unlock(&session->mutex);
 				janus_mutex_unlock(&mp->mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				janus_refcount_decrease(&mp->ref);
 				JANUS_LOG(LOG_ERR, "Already watching a stream (found %p in %s's viewers)...\n", session, id_value_str);
 				error_code = JANUS_STREAMING_ERROR_UNKNOWN_ERROR;
@@ -6495,7 +6522,9 @@ done:
 			janus_refcount_increase(&session->ref);
 			janus_mutex_unlock(&session->mutex);
 			janus_mutex_unlock(&mp->mutex);
+			janus_mutex_unlock(&sessions_mutex);
 		} else if(!strcasecmp(request_text, "start")) {
+			janus_mutex_unlock(&sessions_mutex);
 			if(session->mountpoint == NULL) {
 				JANUS_LOG(LOG_VERB, "Can't start: no mountpoint set\n");
 				error_code = JANUS_STREAMING_ERROR_NO_SUCH_MOUNTPOINT;
@@ -6529,6 +6558,7 @@ done:
 				gateway->notify_event(&janus_streaming_plugin, session->handle, info);
 			}
 		} else if(!strcasecmp(request_text, "pause")) {
+			janus_mutex_unlock(&sessions_mutex);
 			if(session->mountpoint == NULL) {
 				JANUS_LOG(LOG_VERB, "Can't pause: no mountpoint set\n");
 				error_code = JANUS_STREAMING_ERROR_NO_SUCH_MOUNTPOINT;
@@ -6549,6 +6579,7 @@ done:
 				gateway->notify_event(&janus_streaming_plugin, session->handle, info);
 			}
 		} else if(!strcasecmp(request_text, "configure")) {
+			janus_mutex_unlock(&sessions_mutex);
 			janus_streaming_mountpoint *mp = session->mountpoint;
 			if(mp == NULL) {
 				JANUS_LOG(LOG_VERB, "Can't configure: not on a mountpoint\n");
@@ -6563,7 +6594,7 @@ done:
 			json_t *audio = json_object_get(root, "audio");
 			json_t *video = json_object_get(root, "video");
 			json_t *data = json_object_get(root, "data");
-			
+
 			/* We use an array of streams to state the changes we want to make,
 			 * were for each stream we specify the 'mid' to impact (e.g., send) */
 			json_t *streams = json_object_get(root, "streams");
@@ -6604,7 +6635,7 @@ done:
 				json_array_append_new(streams, stream);
 				json_object_set_new(root, "streams", streams);
 			}
-				
+
 			size_t i = 0;
 			size_t streams_size = json_array_size(streams);
 			for(i=0; i<streams_size; i++) {
@@ -6651,7 +6682,7 @@ done:
 			if(error_code != 0) {
 				goto error;
 			}
-			
+
 			if(mp->streaming_source == janus_streaming_source_rtp) {
 				/* Enforce the requested changes */
 				for(i=0; i<json_array_size(streams); i++) {
@@ -6811,6 +6842,7 @@ done:
 			janus_streaming_mountpoint *oldmp = session->mountpoint;
 			if(oldmp == NULL) {
 				janus_mutex_unlock(&session->mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				JANUS_LOG(LOG_VERB, "Can't switch: not on a mountpoint\n");
 				error_code = JANUS_STREAMING_ERROR_NO_SUCH_MOUNTPOINT;
 				g_snprintf(error_cause, 512, "Can't switch: not on a mountpoint");
@@ -6819,6 +6851,7 @@ done:
 			if(oldmp->streaming_type != janus_streaming_type_live ||
 					oldmp->streaming_source != janus_streaming_source_rtp) {
 				janus_mutex_unlock(&session->mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				JANUS_LOG(LOG_VERB, "Can't switch: not on a live RTP mountpoint\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_SWITCH;
 				g_snprintf(error_cause, 512, "Can't switch: not on a live RTP mountpoint");
@@ -6836,6 +6869,7 @@ done:
 			}
 			if(error_code != 0) {
 				janus_mutex_unlock(&session->mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				janus_refcount_decrease(&oldmp->ref);
 				goto error;
 			}
@@ -6855,6 +6889,7 @@ done:
 			if(mp == NULL || g_atomic_int_get(&mp->destroyed)) {
 				janus_mutex_unlock(&mountpoints_mutex);
 				janus_mutex_unlock(&session->mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				JANUS_LOG(LOG_VERB, "No such mountpoint/stream %s\n", id_value_str);
 				error_code = JANUS_STREAMING_ERROR_NO_SUCH_MOUNTPOINT;
 				g_snprintf(error_cause, 512, "No such mountpoint/stream %s", id_value_str);
@@ -6867,6 +6902,7 @@ done:
 				janus_refcount_decrease(&mp->ref);
 				janus_mutex_unlock(&mountpoints_mutex);
 				janus_mutex_unlock(&session->mutex);
+				janus_mutex_unlock(&sessions_mutex);
 				JANUS_LOG(LOG_VERB, "Can't switch: target is not a live RTP mountpoint\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_SWITCH;
 				g_snprintf(error_cause, 512, "Can't switch: target is not a live RTP mountpoint");
@@ -6937,6 +6973,7 @@ done:
 			g_atomic_int_set(&session->paused, 0);
 			janus_mutex_unlock(&session->mutex);
 			janus_mutex_unlock(&mp->mutex);
+			janus_mutex_unlock(&sessions_mutex);
 			/* Done with the request, remove the references we took for that */
 			janus_refcount_decrease(&oldmp->ref);
 			janus_refcount_decrease(&mp->ref);
@@ -6951,6 +6988,7 @@ done:
 				gateway->notify_event(&janus_streaming_plugin, session->handle, info);
 			}
 		} else if(!strcasecmp(request_text, "stop")) {
+			janus_mutex_unlock(&sessions_mutex);
 			if(g_atomic_int_get(&session->stopping) || !g_atomic_int_get(&session->started)) {
 				/* Been there, done that: ignore */
 				janus_streaming_message_free(msg);
@@ -6971,6 +7009,7 @@ done:
 			/* Tell the core to tear down the PeerConnection, hangup_media will do the rest */
 			gateway->close_pc(session->handle);
 		} else {
+			janus_mutex_unlock(&sessions_mutex);
 			JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
 			error_code = JANUS_STREAMING_ERROR_INVALID_REQUEST;
 			g_snprintf(error_cause, 512, "Unknown request '%s'", request_text);


### PR DESCRIPTION
Port to `1.x` of #3246, see discussion there for context.