### PR TITLE
Update janus.d.ts: add missing RemoteTrackMetadata parameter and definition

### DIFF
--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -121,6 +121,10 @@ declare namespace JanusJS {
 		error?: (error: string) => void;
 	}
 
+	interface RemoteTrackMetadata {
+		reason: "created" | "ended" | "mute" | "unmute";
+	}
+
 	enum MessageType {
 		Recording = 'recording',
 		Starting = 'starting',
@@ -152,7 +156,7 @@ declare namespace JanusJS {
 		slowLink?: (uplink: boolean, lost: number, mid: string) => void;
 		onmessage?: (message: Message, jsep?: JSEP) => void;
 		onlocaltrack?: (track: MediaStreamTrack, on: boolean) => void;
-		onremotetrack?: (track: MediaStreamTrack, mid: string, on: boolean) => void;
+		onremotetrack?: (track: MediaStreamTrack, mid: string, on: boolean, metadata?: RemoteTrackMetadata) => void;
 		ondataopen?: Function;
 		ondata?: Function;
 		oncleanup?: Function;


### PR DESCRIPTION
PR #3150 added a new parameter "metadata" to the onremotetrack callback function of janus.js. 

This PR adds the new parameter to the Typescript definition in janus.d.ts. The parameter is defined as an optional parameter to not break existing projects.

