### PR TITLE
Add support of abs-capture-time extension to streaming plugin and forwarding of it's value from rtp source

### DIFF
--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -85,7 +85,7 @@
 #
 # To allow mountpoints to negotiate the abs-capture-time RTP extension,
 # you can set the 'abscapturetime_ext' property to true: this way, any
-# subscriber can receive the abs-capture-time of incoming video streams,
+# subscriber can receive the abs-capture-time of incoming RTP streams,
 # assuming the browser supports the RTP extension in the first place.
 # abscapturetime_ext = true
 #

--- a/src/ice.c
+++ b/src/ice.c
@@ -4078,24 +4078,30 @@ static void janus_ice_rtp_extension_update(janus_ice_handle *handle, janus_ice_p
 				}
 			}
 		}
+		/* Parse the abs-capture-time extension from source if needed */
+		if(handle->pc->abs_capture_time_ext_id != -1) {
+			uint64_t abs_ts = 0;
+			if(janus_rtp_header_extension_parse_abs_capture_time(packet->data, packet->length,
+					handle->pc->abs_capture_time_ext_id, &abs_ts) == 0) {
+				packet->extensions.abs_capture_ts = abs_ts;
+			}
+		}
 		/* Check if we need to add the abs-capture-time extension */
 		if(packet->extensions.abs_capture_ts > 0 && handle->pc->abs_capture_time_ext_id > 0) {
 			uint64_t abs64 = htonll(packet->extensions.abs_capture_ts);
 			if(!use_2byte) {
-				*index = (handle->pc->abs_capture_time_ext_id << 4) + 15;
+				*index = (handle->pc->abs_capture_time_ext_id << 4) + 7;
 				memcpy(index+1, &abs64, 8);
-				memset(index+9, 0, 8);
-				index += 17;
-				extlen += 17;
-				extbufsize -= 17;
+				index += 9;
+				extlen += 9;
+				extbufsize -= 9;
 			} else {
 				*index = handle->pc->abs_capture_time_ext_id;
-				*(index+1) = 16;
+				*(index+1) = 8;
 				memcpy(index+2, &abs64, 8);
-				memset(index+8, 0, 8);
-				index += 18;
-				extlen += 18;
-				extbufsize -= 18;
+				index += 10;
+				extlen += 10;
+				extbufsize -= 10;
 			}
 		}
 		/* Calculate the whole length */

--- a/src/plugins/janus_streaming.c
+++ b/src/plugins/janus_streaming.c
@@ -1348,7 +1348,7 @@ typedef struct janus_streaming_rtp_source {
 	/* Whether the playout-delay extension should be negotiated or not for new subscribers */
 	gboolean playoutdelay_ext;
 	/* Whether the abs-capture-time extension should be negotiated or not for new subscribers */
-    gboolean abscapturetime_ext;
+	gboolean abscapturetime_ext;
 } janus_streaming_rtp_source;
 
 typedef enum janus_streaming_media {
@@ -4196,7 +4196,7 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 				if(source->playoutdelay_ext)
 					janus_config_add(config, c, janus_config_item_create("playoutdelay_ext", "true"));
 				if(source->abscapturetime_ext)
-                	janus_config_add(config, c, janus_config_item_create("abscapturetime_ext", "true"));
+					janus_config_add(config, c, janus_config_item_create("abscapturetime_ext", "true"));
 				/* Iterate on all media streams */
 				janus_config_array *media = janus_config_array_create("media");
 				janus_config_add(config, c, media);
@@ -4597,7 +4597,7 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 					if(source->playoutdelay_ext)
 						janus_config_add(config, c, janus_config_item_create("playoutdelay_ext", "true"));
 					if(source->abscapturetime_ext)
-                    	janus_config_add(config, c, janus_config_item_create("abscapturetime_ext", "true"));
+						janus_config_add(config, c, janus_config_item_create("abscapturetime_ext", "true"));
 					/* Iterate on all media streams */
 					janus_config_array *media = janus_config_array_create("media");
 					janus_config_add(config, c, media);
@@ -6117,7 +6117,7 @@ static void *janus_streaming_handler(void *data) {
 				/* Also check if we have to offer the playout-delay extension */
 				session->playoutdelay_ext = source->playoutdelay_ext;
 				/* Also check if we have to offer the abs-capture-time extension */
-                session->abscapturetime_ext = source->abscapturetime_ext;
+				session->abscapturetime_ext = source->abscapturetime_ext;
 			}
 			janus_refcount_increase(&session->ref);
 done:
@@ -6165,7 +6165,7 @@ done:
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_MID, janus_rtp_extension_id(JANUS_RTP_EXTMAP_MID),
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_ABS_SEND_TIME, janus_rtp_extension_id(JANUS_RTP_EXTMAP_ABS_SEND_TIME),
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME,
-                            	(session->abscapturetime_ext ? janus_rtp_extension_id(JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME) : 0),
+								(session->abscapturetime_ext ? janus_rtp_extension_id(JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME) : 0),
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_PLAYOUT_DELAY,
 								(session->playoutdelay_ext ? janus_rtp_extension_id(JANUS_RTP_EXTMAP_PLAYOUT_DELAY) : 0),
 							JANUS_SDP_OA_DONE);
@@ -6183,7 +6183,7 @@ done:
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_MID, janus_rtp_extension_id(JANUS_RTP_EXTMAP_MID),
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_ABS_SEND_TIME, janus_rtp_extension_id(JANUS_RTP_EXTMAP_ABS_SEND_TIME),
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME,
-                            	(session->abscapturetime_ext ? janus_rtp_extension_id(JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME) : 0),
+								(session->abscapturetime_ext ? janus_rtp_extension_id(JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME) : 0),
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_PLAYOUT_DELAY,
 								(session->playoutdelay_ext ? janus_rtp_extension_id(JANUS_RTP_EXTMAP_PLAYOUT_DELAY) : 0),
 							JANUS_SDP_OA_DONE);
@@ -6446,7 +6446,7 @@ done:
 						/* Also check if we have to offer the playout-delay extension */
 						session->playoutdelay_ext = source->playoutdelay_ext;
 						/* Also check if we have to offer the abs-capture-time extension */
-                        session->abscapturetime_ext = source->abscapturetime_ext;
+						session->abscapturetime_ext = source->abscapturetime_ext;
 						/* Accept the m-line */
 						janus_sdp_generate_answer_mline(parsed_sdp, answer, m,
 							JANUS_SDP_OA_MLINE, m->type,

--- a/src/plugins/janus_streaming.c
+++ b/src/plugins/janus_streaming.c
@@ -6114,6 +6114,7 @@ done:
 					JANUS_SDP_OA_DIRECTION, JANUS_SDP_SENDONLY,
 					JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_MID, janus_rtp_extension_id(JANUS_RTP_EXTMAP_MID),
 					JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_ABS_SEND_TIME, janus_rtp_extension_id(JANUS_RTP_EXTMAP_ABS_SEND_TIME),
+					JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME, janus_rtp_extension_id(JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME),
 					JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_PLAYOUT_DELAY,
 						(session->playoutdelay_ext ? janus_rtp_extension_id(JANUS_RTP_EXTMAP_PLAYOUT_DELAY) : 0),
 					JANUS_SDP_OA_DONE);
@@ -6137,6 +6138,7 @@ done:
 							JANUS_SDP_OA_DIRECTION, JANUS_SDP_SENDONLY,
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_MID, janus_rtp_extension_id(JANUS_RTP_EXTMAP_MID),
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_ABS_SEND_TIME, janus_rtp_extension_id(JANUS_RTP_EXTMAP_ABS_SEND_TIME),
+							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME, janus_rtp_extension_id(JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME),
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_PLAYOUT_DELAY,
 								(session->playoutdelay_ext ? janus_rtp_extension_id(JANUS_RTP_EXTMAP_PLAYOUT_DELAY) : 0),
 							JANUS_SDP_OA_DONE);
@@ -6153,6 +6155,7 @@ done:
 							JANUS_SDP_OA_DIRECTION, JANUS_SDP_SENDONLY,
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_MID, janus_rtp_extension_id(JANUS_RTP_EXTMAP_MID),
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_ABS_SEND_TIME, janus_rtp_extension_id(JANUS_RTP_EXTMAP_ABS_SEND_TIME),
+							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME, janus_rtp_extension_id(JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME),
 							JANUS_SDP_OA_EXTENSION, JANUS_RTP_EXTMAP_PLAYOUT_DELAY,
 								(session->playoutdelay_ext ? janus_rtp_extension_id(JANUS_RTP_EXTMAP_PLAYOUT_DELAY) : 0),
 							JANUS_SDP_OA_DONE);
@@ -6338,6 +6341,7 @@ done:
 								JANUS_SDP_OA_DIRECTION, JANUS_SDP_SENDONLY,
 								JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_MID,
 								JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_ABS_SEND_TIME,
+								JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME,
 								JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_PLAYOUT_DELAY,
 								JANUS_SDP_OA_DONE);
 							/* Done */
@@ -6422,6 +6426,7 @@ done:
 							JANUS_SDP_OA_DIRECTION, JANUS_SDP_SENDONLY,
 							JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_MID,
 							JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_ABS_SEND_TIME,
+							JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME,
 							JANUS_SDP_OA_ACCEPT_EXTMAP, JANUS_RTP_EXTMAP_PLAYOUT_DELAY,
 							JANUS_SDP_OA_DONE);
 						/* Done */
@@ -6563,7 +6568,7 @@ done:
 			json_t *audio = json_object_get(root, "audio");
 			json_t *video = json_object_get(root, "video");
 			json_t *data = json_object_get(root, "data");
-			
+
 			/* We use an array of streams to state the changes we want to make,
 			 * were for each stream we specify the 'mid' to impact (e.g., send) */
 			json_t *streams = json_object_get(root, "streams");
@@ -6604,7 +6609,7 @@ done:
 				json_array_append_new(streams, stream);
 				json_object_set_new(root, "streams", streams);
 			}
-				
+
 			size_t i = 0;
 			size_t streams_size = json_array_size(streams);
 			for(i=0; i<streams_size; i++) {
@@ -6651,7 +6656,7 @@ done:
 			if(error_code != 0) {
 				goto error;
 			}
-			
+
 			if(mp->streaming_source == janus_streaming_source_rtp) {
 				/* Enforce the requested changes */
 				for(i=0; i<json_array_size(streams); i++) {

--- a/src/plugins/janus_streaming.c
+++ b/src/plugins/janus_streaming.c
@@ -3011,9 +3011,9 @@ json_t *janus_streaming_query_session(janus_plugin_session *handle) {
 					json_object_set_new(pd, "max-delay", json_integer(s->max_delay));
 					json_object_set_new(info, "playout-delay", pd);
 				}
-				if(session->abscapturetime_ext) {
+				if(session->abscapturetime_ext)
 					json_object_set_new(info, "abs-capture-time", json_true());
-				}
+
 				json_array_append_new(media, info);
 				temp = temp->next;
 			}

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -365,6 +365,10 @@ int janus_rtp_header_extension_set_abs_send_time(char *buf, int len, int id, uin
 	return 0;
 }
 
+/*
+	It parses only the shortened version of abs-capture-time without estimated-capture-clock-offset
+	Check http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time for details.
+*/
 int janus_rtp_header_extension_parse_abs_capture_time(char *buf, int len, int id, uint64_t *abs_ts) {
 	char *ext = NULL;
 	uint8_t idlen = 0;
@@ -504,6 +508,8 @@ int janus_rtp_extension_id(const char *type) {
 		return 14;
 	else if(!strcasecmp(type, JANUS_RTP_EXTMAP_ABS_SEND_TIME))
 		return 2;
+	else if(!strcasecmp(type, JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME))
+		return 7;
 	else if(!strcasecmp(type, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION))
 		return 13;
 	else if(!strcasecmp(type, JANUS_RTP_EXTMAP_TRANSPORT_WIDE_CC))

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -365,10 +365,6 @@ int janus_rtp_header_extension_set_abs_send_time(char *buf, int len, int id, uin
 	return 0;
 }
 
-/*
-	It parses only the shortened version of abs-capture-time without estimated-capture-clock-offset
-	Check http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time for details.
-*/
 int janus_rtp_header_extension_parse_abs_capture_time(char *buf, int len, int id, uint64_t *abs_ts) {
 	char *ext = NULL;
 	uint8_t idlen = 0;


### PR DESCRIPTION
1. Added support of abs-capture-time extension in streaming plugin
2. Added parsing of abs-capture-time extension from RTP source for forwarding it further to webrtc
3. Removed `memset(index+9, 0, 8);` as it doesn't make sense to fill rest of bytes with zeroes if we parse only 8 bytes of extension.