### PR TITLE
Do not create a publisher stream entry for rejected SDP offer m-line.

### DIFF
--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -3164,7 +3164,7 @@ static json_t *janus_videoroom_subscriber_offer(janus_videoroom_subscriber *subs
 		if(stream->type != JANUS_VIDEOROOM_MEDIA_DATA) {
 			if((stream->type == JANUS_VIDEOROOM_MEDIA_AUDIO && stream->acodec == JANUS_AUDIOCODEC_NONE) ||
 			   (stream->type == JANUS_VIDEOROOM_MEDIA_VIDEO && stream->vcodec == JANUS_VIDEOCODEC_NONE)) {
-				// Publisher stream codec unsupported or rejected. Do not add to the offer.
+				/* Publisher stream codec unsupported or rejected. Do not add to the offer. */
 				temp = temp->next;
 				continue;
 			}

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -3162,6 +3162,12 @@ static json_t *janus_videoroom_subscriber_offer(janus_videoroom_subscriber *subs
 			}
 		}
 		if(stream->type != JANUS_VIDEOROOM_MEDIA_DATA) {
+			if((stream->type == JANUS_VIDEOROOM_MEDIA_AUDIO && stream->acodec == JANUS_AUDIOCODEC_NONE) ||
+			   (stream->type == JANUS_VIDEOROOM_MEDIA_VIDEO && stream->vcodec == JANUS_VIDEOCODEC_NONE)) {
+				// Publisher stream codec unsupported or rejected. Do not add to the offer.
+				temp = temp->next;
+				continue;
+			}
 			pt = stream->pt;
 			codec = (stream->type == JANUS_VIDEOROOM_MEDIA_AUDIO ?
 				janus_audiocodec_name(stream->acodec) : janus_videocodec_name(stream->vcodec));


### PR DESCRIPTION
Entering a stream into the publisher instance will cause an m-line in any subsequent subscription request for that publisher to attempt to create an m-line for a codec named 'none', which will cause the operation to fail.