### PR TITLE
When label is larger than 64, label is truncated and new context will…

### DIFF
--- a/src/sctp.h
+++ b/src/sctp.h
@@ -81,7 +81,7 @@ typedef struct janus_sctp_channel {
 	/*! \brief SCTP channel ID */
 	uint32_t id;
 	/*! \brief SCTP channel label */
-	char label[64];
+	char label[128];
 	/*! \brief SCTP protocol */
 	char protocol[64];
 	/*! \brief Value of the PR-SCTP policy (http://tools.ietf.org/html/rfc6458) */


### PR DESCRIPTION
We are facing an issue with the videoroom plugin and datachannels regarding the char label[64] in struct janus_sctp_channel.

Our videoroom IDs are usually 32 characters long and few other IDs have even more characters. In the videoroom plugin, the labels are built by Janus with the combination of 2 IDs, an underscore and a NULL character which ends up being a size of 66.

When label are larger than 64, the sctp.c source code is truncating the label value up to 64, but later, whenever the code searches for a label, the strcmp will always fail. Thus, the janus_sctp_channel context is never found.

We propose to extend the label size from 64 to 128.

This is an easy fix and a safe one and allows for string IDs in videoroom of a larger size.

The issue would still exists for label with higher size but 128 seems a better trade-off as videoroom IDs and publisher IDs of sizes between 32 and 64 may be common.

