### PR TITLE
Update PluginDataParam type definitions to include text label and pro…

### DIFF
--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -317,6 +317,9 @@ declare namespace JanusJS {
 	}
 
 	type PluginDataParam = {
+		text?: string;
+		label?: string;
+		protocol?: string;
 		success?: (data: unknown) => void;
 		error?: (error: string) => void;
 	}


### PR DESCRIPTION
We have identified that PluginDataParam has a few missing type definitions in janus.d.ts

- text
- label as optional
- protocol as optional

NOTE: 

janus.js is either using **text** or **data** which is confusing. The html demos are only referring to **text**.
Thus, we have decided to not add **data** and add **text** as optional to avoid breaking any other app.
