### PR TITLE
Update janus.js to allow a flexible usage of insertable streams and e2ee

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -1889,6 +1889,12 @@ function Janus(gatewayCallbacks) {
 				}
 			}
 		}
+
+		if (callbacks.externalEncryption) {
+			insertableStreams = true;
+			config.externalEncryption = true;
+		}
+
 		if(RTCRtpSender && (RTCRtpSender.prototype.createEncodedStreams ||
 				(RTCRtpSender.prototype.createEncodedAudioStreams &&
 				RTCRtpSender.prototype.createEncodedVideoStreams)) && insertableStreams) {
@@ -2186,7 +2192,7 @@ function Janus(gatewayCallbacks) {
 			return null;
 		}
 		// If transforms are present, notify Janus that the media is end-to-end encrypted
-		if(config.insertableStreams)
+		if(config.insertableStreams || config.externalEncryption)
 			offer.e2ee = true;
 		return offer;
 	}
@@ -2223,7 +2229,7 @@ function Janus(gatewayCallbacks) {
 			return null;
 		}
 		// If transforms are present, notify Janus that the media is end-to-end encrypted
-		if(config.insertableStreams)
+		if(config.insertableStreams || config.externalEncryption)
 			answer.e2ee = true;
 		return answer;
 	}
@@ -3171,6 +3177,7 @@ function Janus(gatewayCallbacks) {
 			config.dataChannel = {};
 			config.dtmfSender = null;
 			config.insertableStreams = false;
+			config.externalEncryption = false;
 		}
 		pluginHandle.oncleanup();
 	}

--- a/html/janus.js
+++ b/html/janus.js
@@ -1889,12 +1889,10 @@ function Janus(gatewayCallbacks) {
 				}
 			}
 		}
-
-		if (callbacks.externalEncryption) {
+		if(callbacks.externalEncryption) {
 			insertableStreams = true;
 			config.externalEncryption = true;
 		}
-
 		if(RTCRtpSender && (RTCRtpSender.prototype.createEncodedStreams ||
 				(RTCRtpSender.prototype.createEncodedAudioStreams &&
 				RTCRtpSender.prototype.createEncodedVideoStreams)) && insertableStreams) {

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -174,6 +174,7 @@ declare namespace JanusJS {
 		tracks?: TrackOption[];
 		trickle?: boolean;
 		iceRestart?: boolean;
+		externalEncryption?: boolean;
 		success?: (jsep: JSEP) => void;
 		error?: (error: Error) => void;
 		customizeSdp?: (jsep: JSEP) => void;
@@ -250,14 +251,16 @@ declare namespace JanusJS {
 			timer: number;
 		};
 
-		sdpSent: boolean,
-		insertableStreams?: any,
-		candidates: RTCIceCandidateInit[],
+		sdpSent: boolean;
+		insertableStreams?: boolean;
+		externalEncryption?: boolean;
+		candidates: RTCIceCandidateInit[];
 	}
 
 	type PluginCreateAnswerParam = {
 		jsep: JSEP;
 		tracks?: TrackOption[];
+		externalEncryption?: boolean;
 
 		/** @deprecated use tracks instead */
 		media?: { audioSend: any, videoSend: any };


### PR DESCRIPTION
This PR will allow a more flexible usage of insertable streams and e2ee.

When using **externalEncryption** in offer or answer janus.js will activate "encodedInsertableStreams" and will use **e2ee: true** parameter, even if encodedInsertableStreams is not supported and even if "transforms" callbacks are not provided.

The change also allows developers to handle the encryption of the streams (either with createEncodedStreams or RTCRtpScriptTransform) outside of janus.js.
