### PR TITLE
SipPlugin read rfc2833 dtmf and convert to sip info event

### DIFF
--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -7408,7 +7408,7 @@ static void janus_sip_check_rfc2833(janus_sip_session *session, char *buffer, in
 		return;
 	int plen = 0;
 	char *payload_buffer = janus_rtp_payload(buffer, len, &plen);
-	if(plen < sizeof(janus_rtp_rfc2833_payload))
+	if(plen < 0 || (size_t)plen < sizeof(janus_rtp_rfc2833_payload))
 		return;
 	janus_rtp_rfc2833_payload *rfc2833_payload = (janus_rtp_rfc2833_payload *)payload_buffer;
 	uint16_t duration = ntohs(rfc2833_payload->duration);
@@ -7423,7 +7423,7 @@ static void janus_sip_check_rfc2833(janus_sip_session *session, char *buffer, in
 
 	/* Parse dtmf key */ 
 	uint16_t dtmf_key;
-	if(rfc2833_payload->event < 0 || rfc2833_payload->event > 15)
+	if(rfc2833_payload->event > 15)
 		return;
   	dtmf_key = dtmf_keys[rfc2833_payload->event];
 	char dtmf_key_str[2];

--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -875,6 +875,9 @@ static GThread *handler_thread;
 static void *janus_sip_handler(void *data);
 static void janus_sip_hangup_media_internal(janus_plugin_session *handle);
 
+#define JANUS_RTP_HEADER_LENGTH 12
+#define JANUS_RTP_RFC2833_DEFAULT_PAYLOAD_TYPE 101
+
 typedef struct janus_sip_message {
 	janus_plugin_session *handle;
 	char *transaction;
@@ -1047,6 +1050,27 @@ typedef struct janus_sip_media {
 	int audio_level_extension_id;
 } janus_sip_media;
 
+typedef struct janus_rtp_rfc2833_payload {
+#if __BYTE_ORDER == __BIG_ENDIAN
+	uint8_t event;
+	uint8_t end : 1;
+	uint8_t reserved : 1;
+	uint8_t volume : 6;
+	uint16_t duration;
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+	uint8_t event;
+	uint8_t volume : 6;
+	uint8_t reserved : 1;
+	uint8_t end : 1;
+	uint16_t duration;
+#endif
+} janus_rtp_rfc2833_payload;
+
+typedef struct janus_sip_dtmf_cache {
+	uint16_t dtmf_event_id;
+	uint32_t timestamp;
+} janus_sip_dtmf_cache;
+
 typedef struct janus_sip_session {
 	janus_plugin_session *handle;
 	ssip_t *stack;
@@ -1079,7 +1103,9 @@ typedef struct janus_sip_session {
 	GList *incoming_header_prefixes;
 	GList *active_calls;
 	janus_refcount ref;
+	janus_sip_dtmf_cache *dtmf_cache;
 } janus_sip_session;
+
 static GHashTable *sessions;
 static GHashTable *identities;
 static GHashTable *callids;
@@ -1512,7 +1538,7 @@ char *janus_sip_sdp_manipulate(janus_sip_session *session, janus_sdp *sdp, gbool
 static int janus_sip_allocate_local_ports(janus_sip_session *session, gboolean update);
 static void *janus_sip_relay_thread(void *data);
 static void janus_sip_media_cleanup(janus_sip_session *session);
-
+void janus_sip_check_rfc2833(janus_sip_session *session, char *buffer);
 
 /* URI parsing utilies */
 
@@ -7140,6 +7166,7 @@ static void *janus_sip_relay_thread(void *data) {
 						continue;
 					}
 					janus_rtp_header *header = (janus_rtp_header *)buffer;
+					janus_sip_check_rfc2833(session, buffer);
 					if(session->media.audio_ssrc_peer == 0) {
 						session->media.audio_ssrc_peer = ntohl(header->ssrc);
 						JANUS_LOG(LOG_VERB, "Got SIP peer audio SSRC: %"SCNu32"\n", session->media.audio_ssrc_peer);
@@ -7390,6 +7417,56 @@ gpointer janus_sip_sofia_thread(gpointer user_data) {
 	JANUS_LOG(LOG_VERB, "Leaving sofia loop thread...\n");
 	g_thread_unref(g_thread_self());
 	return NULL;
+}
+
+/* check peer rtp has rfc2833 and push event */
+void janus_sip_check_rfc2833(janus_sip_session *session, char *buffer) {
+	janus_rtp_header *rtp_header = (janus_rtp_header *)buffer;
+	if (rtp_header->type != JANUS_RTP_RFC2833_DEFAULT_PAYLOAD_TYPE)
+		return;
+	char *payload_buffer = buffer + JANUS_RTP_HEADER_LENGTH + rtp_header->csrccount * sizeof(uint32_t);
+	janus_rtp_rfc2833_payload *rfc2833_payload = (janus_rtp_rfc2833_payload *)payload_buffer;
+	uint16_t duration = ntohs(rfc2833_payload->duration);
+	if (rfc2833_payload->end == 0)
+		return;
+
+	/* set up cache to avoid duplication */
+	if(session->dtmf_cache != NULL && session->dtmf_cache->dtmf_event_id == rfc2833_payload->event && session->dtmf_cache->timestamp == rtp_header->timestamp)
+		return;
+	if(session->dtmf_cache != NULL){
+		g_free(session->dtmf_cache);
+		session->dtmf_cache = NULL;
+	}
+	session->dtmf_cache = g_malloc0(sizeof(janus_sip_dtmf_cache));
+	session->dtmf_cache->dtmf_event_id = rfc2833_payload->event;
+	session->dtmf_cache->timestamp = rtp_header->timestamp;
+
+	/* parse dtmf key */ 
+	uint16_t dtmf_key;
+	uint16_t dtmf_keys[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '*', '#', 'A', 'B', 'C', 'D'};
+	if (rfc2833_payload->event < 0 || rfc2833_payload->event > 15) {
+  		dtmf_key = '?';
+	} else {
+  		dtmf_key = dtmf_keys[rfc2833_payload->event];
+	}
+	char payload[128];
+	g_snprintf(payload, sizeof(payload), "Signal=%c\nDuration=%d\n", dtmf_key, duration);
+
+	/* Notify the application */
+	json_t *info = json_object();
+	json_object_set_new(info, "sip", json_string("event"));
+	json_t *result = json_object();
+	json_object_set_new(result, "event", json_string("info"));
+	json_object_set_new(result, "sender", json_string(session->callee));
+	json_object_set_new(result, "type", json_string("application/dtmf-relay"));
+	json_object_set_new(result, "content", json_string(payload));
+	if (session->callid)
+		json_object_set_new(info, "call_id", json_string(session->callid));
+	json_object_set_new(info, "result", result);
+	int ret = gateway->push_event(session->handle, &janus_sip_plugin, session->transaction, info, NULL);
+	JANUS_LOG(LOG_VERB, "  >> Pushing event to peer: %d (%s)\n", ret, janus_get_api_error(ret));
+	json_decref(info);
+	return;
 }
 
 /* Helper method to send an RTCP PLI to the SIP peer */

--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -7423,7 +7423,6 @@ static void janus_sip_check_rfc2833(janus_sip_session *session, char *buffer, in
 
 	/* Parse dtmf key */ 
 	uint16_t dtmf_key;
-	uint16_t dtmf_keys[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '*', '#', 'A', 'B', 'C', 'D'};
 	if(rfc2833_payload->event < 0 || rfc2833_payload->event > 15)
 		return;
   	dtmf_key = dtmf_keys[rfc2833_payload->event];

--- a/src/rtp.h
+++ b/src/rtp.h
@@ -72,6 +72,25 @@ typedef struct janus_rtp_header_extension {
 	uint16_t length;
 } janus_rtp_header_extension;
 
+/*! \brief RTP RFC2833 payload */
+typedef struct janus_rtp_rfc2833_payload {
+#if __BYTE_ORDER == __BIG_ENDIAN
+	uint8_t event;
+	uint8_t end:1;
+	uint8_t reserved:1;
+	uint8_t volume:6;
+	uint16_t duration;
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+	uint8_t event;
+	uint8_t volume:6;
+	uint8_t reserved:1;
+	uint8_t end:1;
+	uint16_t duration;
+#endif
+} janus_rtp_rfc2833_payload;
+
+#define JANUS_RTP_RFC2833_DEFAULT_PAYLOAD_TYPE 101
+
 /*! \brief a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level */
 #define JANUS_RTP_EXTMAP_AUDIO_LEVEL		"urn:ietf:params:rtp-hdrext:ssrc-audio-level"
 /*! \brief a=extmap:2 urn:ietf:params:rtp-hdrext:toffset */


### PR DESCRIPTION
Implement the features proposed by jkmchinese from https://janus.discourse.group/t/audiobridge-with-sip-participants/131/7

this PR get rfc2833 data from rtp stream and assemble a sip-info event push to user