### PR TITLE
Added plugin text to attach success respond

### DIFF
--- a/src/janus.c
+++ b/src/janus.c
@@ -1272,6 +1272,7 @@ int janus_process_incoming_request(janus_request *request) {
 		json_t *reply = janus_create_message("success", session_id, transaction_text);
 		json_t *data = json_object();
 		json_object_set_new(data, "id", json_integer(handle_id));
+		json_object_set_new(data, "plugin", json_string(plugin_text));
 		json_object_set_new(reply, "data", data);
 		/* Send the success reply */
 		ret = janus_process_success(request, reply);


### PR DESCRIPTION
Hello.

Long time ago I watched Lorenzo Miniero's presentation talking about he wanted to leave his footprint in Linux Open Source community. I liked a lot. Recently I just wanted to use Janus gateway. Then I noticed there is something missed. When I try to attach multiple plugins same time, responses were kinda ambiguous.
```
{"data": {"id": 1031698377864485}, "janus": "success", "session_id": 3203095836386583, "transaction": "aD1WAa4BgPTi"}
{"data": {"id": 7385971511868724}, "janus": "success", "session_id": 3203095836386583, "transaction": "aD1WAa4BgPTi"}
```

only different thing is `data.id`. But I don't know which plugin it is. So I added a property called `plugin` to `data` object. Which is looks like this.
```
{"data": {"id": 5163072378294882, "plugin": "janus.plugin.videocall"}, "janus": "success", "session_id": 4508896580813890, "transaction": "iZ77uvbSIiCT"}
{"data": {"id": 6691722777787441, "plugin": "janus.plugin.echotest"}, "janus": "success", "session_id": 4508896580813890, "transaction": "iZ77uvbSIiCT"}
```
Now I can determine success reponse messages for which plugins. Which helps a lot for writing my own custom clients.

Please accept. Thank you.