### PR TITLE
Add support of abs-capture-time extension to streaming plugin and forwarding of it's value from rtp source

### DIFF
--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -83,6 +83,13 @@
 # assuming the browser supports the RTP extension in the first place.
 # playoutdelay_ext = true
 #
+# To allow mountpoints to negotiate the abs-capture-time RTP extension,
+# you can set the 'abscapturetime_src_ext_id' property to value in range 1..14 inclusive: this way, any
+# subscriber can receive the abs-capture-time of incoming RTP streams,
+# assuming the browser supports the RTP extension in the first place.
+# Incoming RTP stream should provide abs-capture-time exactly in the same header id.
+# abscapturetime_src_ext_id = 1
+#
 # The following options are only valid for the 'rtsp' type:
 # url = RTSP stream URL (only for restreaming RTSP)
 # rtsp_user = RTSP authorization username (only if type=rtsp)

--- a/src/ice.c
+++ b/src/ice.c
@@ -4103,20 +4103,18 @@ static void janus_ice_rtp_extension_update(janus_ice_handle *handle, janus_ice_p
 		if(packet->extensions.abs_capture_ts > 0 && handle->pc->abs_capture_time_ext_id > 0) {
 			uint64_t abs64 = htonll(packet->extensions.abs_capture_ts);
 			if(!use_2byte) {
-				*index = (handle->pc->abs_capture_time_ext_id << 4) + 15;
+				*index = (handle->pc->abs_capture_time_ext_id << 4) + 7;
 				memcpy(index+1, &abs64, 8);
-				memset(index+9, 0, 8);
-				index += 17;
-				extlen += 17;
-				extbufsize -= 17;
+				index += 9;
+				extlen += 9;
+				extbufsize -= 9;
 			} else {
 				*index = handle->pc->abs_capture_time_ext_id;
-				*(index+1) = 16;
+				*(index+1) = 8;
 				memcpy(index+2, &abs64, 8);
-				memset(index+8, 0, 8);
-				index += 18;
-				extlen += 18;
-				extbufsize -= 18;
+				index += 10;
+				extlen += 10;
+				extbufsize -= 10;
 			}
 		}
 		/* Calculate the whole length */

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -504,6 +504,8 @@ int janus_rtp_extension_id(const char *type) {
 		return 14;
 	else if(!strcasecmp(type, JANUS_RTP_EXTMAP_ABS_SEND_TIME))
 		return 2;
+	else if(!strcasecmp(type, JANUS_RTP_EXTMAP_ABS_CAPTURE_TIME))
+		return 7;
 	else if(!strcasecmp(type, JANUS_RTP_EXTMAP_VIDEO_ORIENTATION))
 		return 13;
 	else if(!strcasecmp(type, JANUS_RTP_EXTMAP_TRANSPORT_WIDE_CC))


### PR DESCRIPTION
1. Added support of abs-capture-time extension in streaming plugin
2. Added parsing of abs-capture-time extension from RTP source for forwarding it further to webrtc
3. Removed memset(index+9, 0, 8); as it doesn't make sense to fill rest of bytes with zeroes if we parse only 8 bytes of extension.