### PR TITLE
Update demos and docs to Bootstrap 5.x

### DIFF
--- a/docs/doxy-boot.js
+++ b/docs/doxy-boot.js
@@ -1,8 +1,8 @@
 $(document).ready(function() {
 
-	$("div.headertitle").addClass("page-header");
+	$("div.headertitle").addClass("pb-2 mt-4 mb-2 border-bottom");
 	$("div.title").addClass("h1");
-	
+
 	$('li > a[href="index.html"] > span').before("<i class='fa fa-cog'></i> ");
 	// $('li > a[href="index.html"] > span').text("CoActionOS");
 	$('li > a[href="modules.html"] > span').before("<i class='fa fa-square'></i> ");
@@ -15,51 +15,54 @@ $(document).ready(function() {
 	$('li > a[href="functions_vars.html"] > span').before("<i class='fa fa-list'></i> ");
 	$('li > a[href="functions_enum.html"] > span').before("<i class='fa fa-list'></i> ");
 	$('li > a[href="functions_eval.html"] > span').before("<i class='fa fa-list'></i> ");
-	$('img[src="ftv2ns.png"]').replaceWith('<span class="label label-danger">N</span> ');
-	$('img[src="ftv2cl.png"]').replaceWith('<span class="label label-danger">C</span> ');
-	
-	$("ul.tablist").addClass("nav nav-pills nav-justified");
+	$('img[src="ftv2ns.png"]').replaceWith('<span class="badge badge-danger">N</span> ');
+	$('img[src="ftv2cl.png"]').replaceWith('<span class="badge badge-danger">C</span> ');
+
+	$("ul.tablist").addClass("nav nav-pills nav-fill");
 	$("ul.tablist").css("margin-top", "0.5em");
 	$("ul.tablist").css("margin-bottom", "0.5em");
-	$("li.current").addClass("active");
+	$("ul.tablist > li").addClass("nav-item");
+	$("ul.tablist > li > a").addClass("nav-link");
+	$("li.current").children().addClass("active");
 	$("iframe").attr("scrolling", "yes");
-	
+
 	$("#nav-path > ul").addClass("breadcrumb");
-	
+
 	$("table.params").addClass("table");
 	$("div.ingroups").wrapInner("<small></small>");
+	$("div.ingroups > small > a").addClass("text-muted");
 	$("div.levels").css("margin", "0.5em");
-	$("div.levels > span").addClass("btn btn-default btn-xs");
+	$("div.levels > span").addClass("btn btn-secondary btn-sm");
 	$("div.levels > span").css("margin-right", "0.25em");
-	
+
 	$("table.directory").addClass("table table-striped");
-	$("div.summary > a").addClass("btn btn-default btn-xs");
+	$("div.summary > a").addClass("btn btn-secondary btn-sm");
 	$("table.fieldtable").addClass("table");
-	$(".fragment").addClass("well");
-	$(".memitem").addClass("panel panel-default");
-	$(".memproto").addClass("panel-heading");
-	$(".memdoc").addClass("panel-body");
-	$("span.mlabel").addClass("label label-info");
-	
+	$(".fragment").addClass("card card-body bg-gray");
+	$(".memitem").addClass("card");
+	$(".memproto").addClass("card-header");
+	$(".memdoc").addClass("card-body");
+	$("span.mlabel").addClass("badge badge-info");
+
 	$("table.memberdecls").addClass("table");
 	$("[class^=memitem]").addClass("active");
-	
-	$("div.ah").addClass("btn btn-default");
+
+	$("div.ah").addClass("btn btn-secondary");
 	$("span.mlabels").addClass("pull-right");
 	$("table.mlabels").css("width", "100%")
 	$("td.mlabels-right").addClass("pull-right");
 
-	$("div.ttc").addClass("panel panel-info");
-	$("div.ttname").addClass("panel-heading");
-	$("div.ttdef,div.ttdoc,div.ttdeci").addClass("panel-body");
-	
-	$('div.tabs').addClass('container well');
-	$('div.tabs2').addClass('container well');
-	$('div.tabs3').addClass('container well');
+	$("div.ttc").addClass("card card-info");
+	$("div.ttname").addClass("card-header");
+	$("div.ttdef,div.ttdoc,div.ttdeci").addClass("card-body");
+
+	$('div.tabs').addClass('container card card-body bg-gray mb-3');
+	$('div.tabs2').addClass('container card card-body bg-gray mb-3');
+	$('div.tabs3').addClass('container card card-body bg-gray mb-3');
 	$('div.header').addClass('container');
 	$('div.contents').addClass('container');
 	$('div.groupHeader').addClass('alert-link').parent().parent().addClass('alert alert-info');
-	
+
 	$('#MSearchBox').remove();//.parent().appendTo('#topmenu');
 
 	$('code').each(function() { $(this).html($(this).html().replace("–", "--")); } );

--- a/docs/doxy-boot.js
+++ b/docs/doxy-boot.js
@@ -15,8 +15,8 @@ $(document).ready(function() {
 	$('li > a[href="functions_vars.html"] > span').before("<i class='fa fa-list'></i> ");
 	$('li > a[href="functions_enum.html"] > span').before("<i class='fa fa-list'></i> ");
 	$('li > a[href="functions_eval.html"] > span').before("<i class='fa fa-list'></i> ");
-	$('img[src="ftv2ns.png"]').replaceWith('<span class="badge badge-danger">N</span> ');
-	$('img[src="ftv2cl.png"]').replaceWith('<span class="badge badge-danger">C</span> ');
+	$('img[src="ftv2ns.png"]').replaceWith('<span class="badge bg-danger">N</span> ');
+	$('img[src="ftv2cl.png"]').replaceWith('<span class="badge bg-danger">C</span> ');
 
 	$("ul.tablist").addClass("nav nav-pills nav-fill");
 	$("ul.tablist").css("margin-top", "0.5em");
@@ -42,7 +42,7 @@ $(document).ready(function() {
 	$(".memitem").addClass("card");
 	$(".memproto").addClass("card-header");
 	$(".memdoc").addClass("card-body");
-	$("span.mlabel").addClass("badge badge-info");
+	$("span.mlabel").addClass("badge bg-info");
 
 	$("table.memberdecls").addClass("table");
 	$("[class^=memitem]").addClass("active");

--- a/docs/doxy-boot.js
+++ b/docs/doxy-boot.js
@@ -3,18 +3,18 @@ $(document).ready(function() {
 	$("div.headertitle").addClass("pb-2 mt-4 mb-2 border-bottom");
 	$("div.title").addClass("h1");
 
-	$('li > a[href="index.html"] > span').before("<i class='fa fa-cog'></i> ");
+	$('li > a[href="index.html"] > span').before("<i class='fa-solid fa-gear'></i> ");
 	// $('li > a[href="index.html"] > span').text("CoActionOS");
-	$('li > a[href="modules.html"] > span').before("<i class='fa fa-square'></i> ");
-	$('li > a[href="namespaces.html"] > span').before("<i class='fa fa-bars'></i> ");
-	$('li > a[href="annotated.html"] > span').before("<i class='fa fa-list-ul'></i> ");
-	$('li > a[href="classes.html"] > span').before("<i class='fa fa-book'></i> ");
-	$('li > a[href="inherits.html"] > span').before("<i class='fa fa-sitemap'></i> ");
-	$('li > a[href="functions.html"] > span').before("<i class='fa fa-list'></i> ");
-	$('li > a[href="functions_func.html"] > span').before("<i class='fa fa-list'></i> ");
-	$('li > a[href="functions_vars.html"] > span').before("<i class='fa fa-list'></i> ");
-	$('li > a[href="functions_enum.html"] > span').before("<i class='fa fa-list'></i> ");
-	$('li > a[href="functions_eval.html"] > span').before("<i class='fa fa-list'></i> ");
+	$('li > a[href="modules.html"] > span').before("<i class='fa-solid fa-square'></i> ");
+	$('li > a[href="namespaces.html"] > span').before("<i class='fa-solid fa-bars'></i> ");
+	$('li > a[href="annotated.html"] > span').before("<i class='fa-solid fa-list-ul'></i> ");
+	$('li > a[href="classes.html"] > span').before("<i class='fa-solid fa-book'></i> ");
+	$('li > a[href="inherits.html"] > span').before("<i class='fa-solid fa-sitemap'></i> ");
+	$('li > a[href="functions.html"] > span').before("<i class='fa-solid fa-list'></i> ");
+	$('li > a[href="functions_func.html"] > span').before("<i class='fa-solid fa-list'></i> ");
+	$('li > a[href="functions_vars.html"] > span').before("<i class='fa-solid fa-list'></i> ");
+	$('li > a[href="functions_enum.html"] > span').before("<i class='fa-solid fa-list'></i> ");
+	$('li > a[href="functions_eval.html"] > span').before("<i class='fa-solid fa-list'></i> ");
 	$('img[src="ftv2ns.png"]').replaceWith('<span class="badge bg-danger">N</span> ');
 	$('img[src="ftv2cl.png"]').replaceWith('<span class="badge bg-danger">C</span> ');
 

--- a/docs/header.html
+++ b/docs/header.html
@@ -8,14 +8,15 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>$title</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="$relpath^dynsections.js"></script>
 $treeview
 $search
 $mathjax
 $extrastylesheet
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" rel="stylesheet">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" rel="stylesheet">
 <link href="css/demo.css" rel="stylesheet">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="doxy-boot.js"></script>
 </head>
 <body>
@@ -39,7 +40,7 @@ $extrastylesheet
 			<li class="nav-item"><a class="nav-link" href="https://janus-legacy.conf.meetecho.com/">Janus (0.x)</a></li>
 			<li class="nav-item"><a class="nav-link januscon" target="_blank" href="https://januscon.it">JanusCon!</a></li>
 		</ul>
-		<ul class="navbar-nav ml-auto">
+		<ul class="navbar-nav ms-auto">
 			<li class="nav-item">
 				<a class="nav-link meetecho-logo" target="_blank" href="https://www.meetecho.com">
 					<img src="meetecho-logo.png"/>

--- a/docs/header.html
+++ b/docs/header.html
@@ -13,41 +13,39 @@ $treeview
 $search
 $mathjax
 $extrastylesheet
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" rel="stylesheet">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" rel="stylesheet">
 <link href="css/demo.css" rel="stylesheet">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="doxy-boot.js"></script>
 </head>
 <body>
 <div id="top"><!-- do not remove this div, it is closed by doxygen! -->
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
 <div class="container">
-	<div class="navbar-header">
-		<a class="navbar-brand" href=".">$projectname</a>
-		<button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-			<span class="icon-bar"></span>
-			<span class="icon-bar"></span>
-			<span class="icon-bar"></span>
-		</button>
-	</div>
-	<div class="navbar-collapse collapse">
-		<ul class="nav navbar-nav">
-			<li><a href="https://janus.conf.meetecho.com/">Home</a></li>
-			<li><a href="https://janus.conf.meetecho.com/demos.html">Demos</a></li>
-			<li class="active"><a href="index.html">Documentation</a></li>
-			<li><a href="https://janus.conf.meetecho.com/citeus.html">Papers</a></li>
-			<li><a href="https://janus.conf.meetecho.com/support.html">Need help?</a></li>
-			<li><a href="https://janus-legacy.conf.meetecho.com/">Janus (0.x)</a></li>
-			<li><a class="januscon" target="_blank" href="https://januscon.it">JanusCon!</a></li>
+	<a class="navbar-brand" href="https://janus.conf.meetecho.com/">$projectname</a>
+	<button type="button" class="navbar-toggler" data-toggle="collapse" data-target=".navbar-collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false">
+		<span class="navbar-toggler-icon"></span>
+	</button>
+	<div class="navbar-collapse collapse" id="navbarResponsive">
+		<ul class="navbar-nav">
+			<li class="nav-item"><a class="nav-link" href="https://janus.conf.meetecho.com/">Home</a></li>
+			<li class="nav-item"><a class="nav-link" href="https://janus.conf.meetecho.com/">Demos</a></li>
+			<li class="nav-item"><a class="nav-link active" href="index.html">Documentation</a></li>
+			<li class="nav-item"><a class="nav-link" href="https://janus.conf.meetecho.com/citeus.html">Papers</a></li>
+			<li class="nav-item"><a class="nav-link" href="https://janus.conf.meetecho.com/support.html">Need help?</a></li>
+			<li class="nav-item"><a class="nav-link" href="https://janus-legacy.conf.meetecho.com/">Janus (0.x)</a></li>
+			<li class="nav-item"><a class="nav-link januscon" target="_blank" href="https://januscon.it">JanusCon!</a></li>
 		</ul>
-		<div class="navbar-header navbar-right">
-			<ul class="nav navbar-nav">
-				<li><a target="_blank" href="https://www.meetecho.com" class="navbar-link meetecho-logo"><img src="meetecho-logo.png"/></a></li>
-			</ul>
-		</div>
+		<ul class="navbar-nav ml-auto">
+			<li class="nav-item">
+				<a class="nav-link meetecho-logo" target="_blank" href="https://www.meetecho.com">
+					<img src="meetecho-logo.png"/>
+				</a>
+			</li>
+		</ul>
 	</div>
 </div>
-</nav>
+</div>

--- a/docs/header.html
+++ b/docs/header.html
@@ -7,7 +7,7 @@
 <meta name="generator" content="Doxygen $doxygenversion"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>$title</title>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="$relpath^dynsections.js"></script>
 $treeview

--- a/html/admin.html
+++ b/html/admin.html
@@ -6,49 +6,49 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Admin/Monitor</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="admin.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='admin.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='admin.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Janus WebRTC Server: Admin/Monitor</h1>
 			</div>
 
-			<div>
+			<div class="mt-4">
 				<ul id="admintabs" class="nav nav-tabs" role="tablist">
-					<li role="presentation" class="active"><a href="#home" aria-controls="home" role="tab" data-toggle="tab">Home</a></li>
-					<li role="presentation" class="disabled"><a href="#serverinfo" aria-controls="serverinfo" role="tab" data-toggle="tab">Server Info</a></li>
-					<li role="presentation" class="disabled"><a href="#settings" aria-controls="settings" role="tab" data-toggle="tab">Settings</a></li>
-					<li role="presentation" class="disabled"><a href="#plugins" aria-controls="plugins" role="tab" data-toggle="tab">Plugins</a></li>
-					<li role="presentation" class="disabled"><a href="#transports" aria-controls="transports" role="tab" data-toggle="tab">Transports</a></li>
-					<li role="presentation" class="disabled"><a href="#handlesinfo" aria-controls="handlesinfo" role="tab" data-toggle="tab">Handles</a></li>
-					<li role="presentation" class="disabled"><a href="#tokens" aria-controls="tokens" role="tab" data-toggle="tab">Stored Tokens</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link active" href="#home" aria-controls="home" role="tab" data-toggle="tab">Home</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#serverinfo" aria-controls="serverinfo" role="tab" data-toggle="tab">Server Info</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#settings" aria-controls="settings" role="tab" data-toggle="tab">Settings</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#plugins" aria-controls="plugins" role="tab" data-toggle="tab">Plugins</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#transports" aria-controls="transports" role="tab" data-toggle="tab">Transports</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#handlesinfo" aria-controls="handlesinfo" role="tab" data-toggle="tab">Handles</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#tokens" aria-controls="tokens" role="tab" data-toggle="tab">Stored Tokens</a></li>
 				</ul>
 
 				<div class="tab-content" style="padding: 20px;">
-					<div role="tabpanel" class="tab-pane fade in active" id="home">
+					<div role="tabpanel" class="tab-pane fade in active show" id="home">
 						<p>This is just an example of how you can build an UI on top of the
 						existing <code>Admin/Monitor</code> interface. This page will only
 						work as it is if you enabled the API (which is disabled by default)
@@ -83,41 +83,46 @@
 						you enabled the stored-token authentication mechanism in Janus, of course.</p>
 					</div>
 					<div role="tabpanel" class="tab-pane fade" id="serverinfo">
-						<h4>Server Info</h4>
+						<h5>Server Info</h5>
 						<div>
-							<table class="table table-striped" id="server-details">
+							<table class="table table-striped mb-5" id="server-details">
 							</table>
 						</div>
-						<h4>Dependencies</h4>
+						<h5>Dependencies</h5>
 						<div>
-							<table class="table table-striped" id="server-deps">
+							<table class="table table-striped mb-5" id="server-deps">
 							</table>
 						</div>
-						<h4>Plugins</h4>
+						<h5>Plugins</h5>
 						<div>
-							<table class="table table-striped" id="server-plugins">
+							<table class="table table-striped mb-5" id="server-plugins">
 							</table>
 						</div>
-						<h4>Transports</h4>
+						<h5>Transports</h5>
 						<div>
-							<table class="table table-striped" id="server-transports">
+							<table class="table table-striped mb-5" id="server-transports">
 							</table>
 						</div>
-						<h4>Event handlers</h4>
+						<h5>Event handlers</h5>
 						<div>
-							<table class="table table-striped" id="server-handlers">
+							<table class="table table-striped mb-5" id="server-handlers">
+							</table>
+						</div>
+						<h5>Loggers</h5>
+						<div>
+							<table class="table table-striped mb-5" id="server-loggers">
 							</table>
 						</div>
 					</div>
 					<div role="tabpanel" class="tab-pane fade" id="settings">
-						<h4>Settings <i id="update-settings" class="fa fa-refresh" title="Refresh settings" style="cursor: pointer;"></i></h4>
+						<h5>Settings <i id="update-settings" class="fa fa-refresh" title="Refresh settings" style="cursor: pointer;"></i></h5>
 						<div>
 							<table class="table table-striped" id="server-settings">
 							</table>
 						</div>
 					</div>
 					<div role="tabpanel" class="tab-pane fade" id="plugins">
-						<h4>Plugins</h4>
+						<h5>Plugins</h5>
 						<div class="row">
 							<div class="col-md-3">
 								<table class="table" id="plugins-list">
@@ -131,13 +136,13 @@
 								</div>
 								<div class="row">
 									<h5>Response</h5>
-									<pre id="plugin-response"></pre>
+									<pre class="card card-body bg-gray w-100" id="plugin-response"></pre>
 								</div>
 							</div>
 						</div>
 					</div>
 					<div role="tabpanel" class="tab-pane fade" id="transports">
-						<h4>Transports</h4>
+						<h5>Transports</h5>
 						<div class="row">
 							<div class="col-md-3">
 								<table class="table" id="transports-list">
@@ -151,42 +156,44 @@
 								</div>
 								<div class="row">
 									<h5>Response</h5>
-									<pre id="transport-response"></pre>
+									<pre class="card card-body bg-gray w-100" id="transport-response"></pre>
 								</div>
 							</div>
 						</div>
 					</div>
 					<div role="tabpanel" class="tab-pane fade" id="handlesinfo">
-						<div id="sessions" class="col-md-2">
-							<h4>Sessions (<span id="sessions-num">0</span>) <i id="update-sessions" class="fa fa-refresh" title="Refresh list of sessions" style="cursor: pointer;"></i></h4>
-							<div id="sessions-list" class="list-group">
+						<div class="row">
+							<div id="sessions" class="col-md-2">
+								<h5>Sessions (<span id="sessions-num">0</span>) <i id="update-sessions" class="fa fa-refresh" title="Refresh list of sessions" style="cursor: pointer;"></i></h5>
+								<div id="sessions-list" class="list-group">
+								</div>
 							</div>
-						</div>
-						<div id="handles" class="col-md-2">
-							<h4>Handles (<span id="handles-num"></span>) <i id="update-handles" class="fa fa-refresh" title="Refresh list of handles" style="cursor: pointer;"></i></h4>
-							<div id="handles-list" class="list-group">
+							<div id="handles" class="col-md-2">
+								<h5>Handles (<span id="handles-num"></span>) <i id="update-handles" class="fa fa-refresh" title="Refresh list of handles" style="cursor: pointer;"></i></h5>
+								<div id="handles-list" class="list-group">
+								</div>
 							</div>
-						</div>
-						<div id="info" class="col-md-8">
-							<h4>Handle Info <i id="update-handle" class="fa fa-refresh" title="Refresh handle info" style="cursor: pointer;"></i></h4>
-							<div id="options" class="hide">
-								<label class="checkbox-inline" title="Autorefresh this info every 5s">
-									<input id="autorefresh" type="checkbox" value="" title="Autorefresh this info every 5s">Autorefresh
-								</label>
-								<label class="checkbox-inline" title="Show information as HTML">
-									<input id="prettify" type="checkbox" value="" title="Show information as HTML">Prettify
-								</label>
-								<label class="checkbox-inline" title="Start of stop capturing traffic to .pcap">
-									<input id="capture" type="checkbox" value="" title="Start of stop capturing traffic to .pcap">
-									<span id="capturetext">Start capture</span>
-								</label>
-							</div>
-							<div id="handle-info">
+							<div id="info" class="col-md-8">
+								<h5>Handle Info <i id="update-handle" class="fa fa-refresh" title="Refresh handle info" style="cursor: pointer;"></i></h5>
+								<div id="options" class="hide">
+									<label class="checkbox-inline" title="Autorefresh this info every 5s">
+										<input id="autorefresh" type="checkbox" value="" title="Autorefresh this info every 5s">Autorefresh
+									</label>
+									<label class="checkbox-inline" title="Show information as HTML">
+										<input id="prettify" type="checkbox" value="" title="Show information as HTML">Prettify
+									</label>
+									<label class="checkbox-inline" title="Start of stop capturing traffic to .pcap">
+										<input id="capture" type="checkbox" value="" title="Start of stop capturing traffic to .pcap">
+										<span id="capturetext">Start capture</span>
+									</label>
+								</div>
+								<div id="handle-info">
+								</div>
 							</div>
 						</div>
 					</div>
 					<div role="tabpanel" class="tab-pane fade" id="tokens">
-						<h4>Stored Tokens <i id="update-tokens" class="fa fa-refresh" title="Refresh tokens" style="cursor: pointer;"></i></h4>
+						<h5>Stored Tokens <i id="update-tokens" class="fa fa-refresh" title="Refresh tokens" style="cursor: pointer;"></i></h5>
 						<div>
 							<table class="table table-striped" id="auth-tokens">
 							</table>

--- a/html/admin.html
+++ b/html/admin.html
@@ -21,7 +21,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 </head>
 <body>
 
@@ -116,7 +116,7 @@
 						</div>
 					</div>
 					<div role="tabpanel" class="tab-pane fade" id="settings">
-						<h5>Settings <i id="update-settings" class="fa fa-refresh" title="Refresh settings" style="cursor: pointer;"></i></h5>
+						<h5>Settings <i id="update-settings" class="fa-solid fa-rotate" title="Refresh settings" style="cursor: pointer;"></i></h5>
 						<div>
 							<table class="table table-striped" id="server-settings">
 							</table>
@@ -165,17 +165,17 @@
 					<div role="tabpanel" class="tab-pane fade" id="handlesinfo">
 						<div class="row">
 							<div id="sessions" class="col-md-2">
-								<h5>Sessions (<span id="sessions-num">0</span>) <i id="update-sessions" class="fa fa-refresh" title="Refresh list of sessions" style="cursor: pointer;"></i></h5>
+								<h5>Sessions (<span id="sessions-num">0</span>) <i id="update-sessions" class="fa-solid fa-rotate" title="Refresh list of sessions" style="cursor: pointer;"></i></h5>
 								<div id="sessions-list" class="list-group">
 								</div>
 							</div>
 							<div id="handles" class="col-md-2">
-								<h5>Handles (<span id="handles-num"></span>) <i id="update-handles" class="fa fa-refresh" title="Refresh list of handles" style="cursor: pointer;"></i></h5>
+								<h5>Handles (<span id="handles-num"></span>) <i id="update-handles" class="fa-solid fa-rotate" title="Refresh list of handles" style="cursor: pointer;"></i></h5>
 								<div id="handles-list" class="list-group">
 								</div>
 							</div>
 							<div id="info" class="col-md-8">
-								<h5>Handle Info <i id="update-handle" class="fa fa-refresh" title="Refresh handle info" style="cursor: pointer;"></i></h5>
+								<h5>Handle Info <i id="update-handle" class="fa-solid fa-rotate" title="Refresh handle info" style="cursor: pointer;"></i></h5>
 								<div id="options" class="hide">
 									<label class="checkbox-inline" title="Autorefresh this info every 5s">
 										<input id="autorefresh" type="checkbox" value="" title="Autorefresh this info every 5s">Autorefresh
@@ -194,7 +194,7 @@
 						</div>
 					</div>
 					<div role="tabpanel" class="tab-pane fade" id="tokens">
-						<h5>Stored Tokens <i id="update-tokens" class="fa fa-refresh" title="Refresh tokens" style="cursor: pointer;"></i></h5>
+						<h5>Stored Tokens <i id="update-tokens" class="fa-solid fa-rotate" title="Refresh tokens" style="cursor: pointer;"></i></h5>
 						<div>
 							<table class="table table-striped" id="auth-tokens">
 							</table>

--- a/html/admin.html
+++ b/html/admin.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Admin/Monitor</title>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>

--- a/html/admin.html
+++ b/html/admin.html
@@ -6,8 +6,9 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Admin/Monitor</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="admin.js"></script>
 <script>
 	$(function() {
@@ -18,7 +19,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 </head>
@@ -38,13 +39,13 @@
 
 			<div class="mt-4">
 				<ul id="admintabs" class="nav nav-tabs" role="tablist">
-					<li role="presentation" class="nav-item"><a class="nav-link active" href="#home" aria-controls="home" role="tab" data-toggle="tab">Home</a></li>
-					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#serverinfo" aria-controls="serverinfo" role="tab" data-toggle="tab">Server Info</a></li>
-					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#settings" aria-controls="settings" role="tab" data-toggle="tab">Settings</a></li>
-					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#plugins" aria-controls="plugins" role="tab" data-toggle="tab">Plugins</a></li>
-					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#transports" aria-controls="transports" role="tab" data-toggle="tab">Transports</a></li>
-					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#handlesinfo" aria-controls="handlesinfo" role="tab" data-toggle="tab">Handles</a></li>
-					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#tokens" aria-controls="tokens" role="tab" data-toggle="tab">Stored Tokens</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link active" href="#home" aria-controls="home" role="tab" data-bs-toggle="tab">Home</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#serverinfo" aria-controls="serverinfo" role="tab" data-bs-toggle="tab">Server Info</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#settings" aria-controls="settings" role="tab" data-bs-toggle="tab">Settings</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#plugins" aria-controls="plugins" role="tab" data-bs-toggle="tab">Plugins</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#transports" aria-controls="transports" role="tab" data-bs-toggle="tab">Transports</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#handlesinfo" aria-controls="handlesinfo" role="tab" data-bs-toggle="tab">Handles</a></li>
+					<li role="presentation" class="nav-item"><a class="nav-link disabled" href="#tokens" aria-controls="tokens" role="tab" data-bs-toggle="tab">Stored Tokens</a></li>
 				</ul>
 
 				<div class="tab-content" style="padding: 20px;">
@@ -125,8 +126,8 @@
 						<h5>Plugins</h5>
 						<div class="row">
 							<div class="col-md-3">
-								<table class="table" id="plugins-list">
-								</table>
+								<ul class="list-group" id="plugins-list">
+								</ul>
 							</div>
 							<div id="plugin-message" class="col-md-9 hide">
 								<div class="row">
@@ -145,8 +146,8 @@
 						<h5>Transports</h5>
 						<div class="row">
 							<div class="col-md-3">
-								<table class="table" id="transports-list">
-								</table>
+								<ul class="list-group" id="transports-list">
+								</ul>
 							</div>
 							<div id="transport-message" class="col-md-9 hide">
 								<div class="row">

--- a/html/admin.js
+++ b/html/admin.js
@@ -50,15 +50,11 @@ function promptAccessDetails() {
 	let secretPlaceholder = "Insert the Admin API secret";
 	bootbox.alert({
 		message: "<div class='input-group mt-3 mb-1'>" +
-			"	<div class='input-group-prepend'>" +
-			"		<span class='input-group-text'><i class='fa fa-cloud-upload fa-fw'></i></span>" +
-			"	</div>" +
+			"	<span class='input-group-text'><i class='fa fa-cloud-upload fa-fw'></i></span>" +
 			"	<input class='form-control' type='text' value='" + server + "' placeholder='" + serverPlaceholder + "' autocomplete='off' id='server'></input>" +
 			"</div>" +
 			"<div class='input-group mt-3 mb-1'>" +
-			"	<div class='input-group-prepend'>" +
-			"		<span class='input-group-text'><i class='fa fa-key fa-fw'></i></span>" +
-			"	</div>" +
+			"	<span class='input-group-text'><i class='fa fa-key fa-fw'></i></span>" +
 			"	<input class='form-control' type='password'  value='" + secret + "'placeholder='" + secretPlaceholder + "' autocomplete='off' id='secret'></input>" +
 			"</div>",
 		closeButton: false,
@@ -1412,17 +1408,17 @@ function updateTokens() {
 			}
 			$('#auth-tokens').append(
 				'<tr>' +
-				'	<td><input type="text" id="token" placeholder="Token to add" onkeypress="return checkEnter(this, event);" style="width: 100%;"></td>' +
+				'	<td><input type="text" class="form-control" id="token" placeholder="Token to add" onkeypress="return checkEnter(this, event);" style="width: 100%;"></td>' +
 				'	<td><div id="permissions"></div></td>' +
 				'	<td><button id="addtoken" type="button" class="btn btn-xs btn-success">Add token</button></td>' +
 				'</tr>');
-			let pluginsCheckboxes = "";
+			let pluginsCheckboxes = '';
 			for(let i in plugins) {
 				let plugin = plugins[i];
 				pluginsCheckboxes +=
-					'<div class="checkbox">' +
-					'	<label>' +
-					'		<input checked type="checkbox" value="' + plugin + '">' + plugin + '</input>' +
+					'<div class="form-check">' +
+					'	<input checked class="form-check-input" type="checkbox" value="' + plugin + '">' +
+					'	<label class="form-check-label" for="' + plugin + '">' + plugin + '</label>' +
 					'</div>';
 			}
 			$('#permissions').html(pluginsCheckboxes);

--- a/html/admin.js
+++ b/html/admin.js
@@ -10,7 +10,7 @@ if(window.location.protocol === 'http:')
 else
 	server = "https://" + window.location.hostname + ":7889/admin";
 // If you don't want the page to prompt you for a password, insert it here
-var secret = "";
+var secret = "janusoverlord";
 
 var session = null;		// Selected session
 var handle = null;		// Selected handle
@@ -49,12 +49,16 @@ function promptAccessDetails() {
 	let serverPlaceholder = "Insert the address of the Admin API backend";
 	let secretPlaceholder = "Insert the Admin API secret";
 	bootbox.alert({
-		message: "<div class='input-group margin-bottom-sm'>" +
-			"	<span class='input-group-addon'><i class='fa fa-cloud-upload fa-fw'></i></span>" +
+		message: "<div class='input-group mt-3 mb-1'>" +
+			"	<div class='input-group-prepend'>" +
+			"		<span class='input-group-text'><i class='fa fa-cloud-upload fa-fw'></i></span>" +
+			"	</div>" +
 			"	<input class='form-control' type='text' value='" + server + "' placeholder='" + serverPlaceholder + "' autocomplete='off' id='server'></input>" +
 			"</div>" +
-			"<div class='input-group margin-bottom-sm'>" +
-			"	<span class='input-group-addon'><i class='fa fa-key fa-fw'></i></span>" +
+			"<div class='input-group mt-3 mb-1'>" +
+			"	<div class='input-group-prepend'>" +
+			"		<span class='input-group-text'><i class='fa fa-key fa-fw'></i></span>" +
+			"	</div>" +
 			"	<input class='form-control' type='password'  value='" + secret + "'placeholder='" + secretPlaceholder + "' autocomplete='off' id='secret'></input>" +
 			"</div>",
 		closeButton: false,
@@ -103,14 +107,16 @@ function updateServerInfo() {
 			}
 			console.log("Got server info:");
 			console.log(json);
-			var pluginsJson = json.plugins;
+			let pluginsJson = json.plugins;
 			let transportsJson = json.transports;
 			let eventsJson = json.events;
+			let loggersJson = json.loggers;
 			delete json.janus;
 			delete json.transaction;
 			delete json.plugins;
 			delete json.transports;
 			delete json.events;
+			delete json.loggers;
 			$('#server-details').empty();
 			for(let k in json) {
 				if(k === "dependencies") {
@@ -158,7 +164,9 @@ function updateServerInfo() {
 					'</tr>');
 				pluginsIndex.push(p);
 				$('#plugins-list').append(
-					'<a id="plugin-'+(pluginsIndex.length-1)+'" href="#" class="list-group-item">'+p+'</a>'
+					'<a id="plugin-' + (pluginsIndex.length-1) + '" href="#" class="list-group-item list-group-item-action">' +
+						'<small>' + p + '</small>' +
+					'</a>'
 				);
 				$('#plugin-'+(pluginsIndex.length-1)).click(function(event) {
 					event.preventDefault();
@@ -190,7 +198,9 @@ function updateServerInfo() {
 					'</tr>');
 				transportsIndex.push(t);
 				$('#transports-list').append(
-					'<a id="transport-'+(transportsIndex.length-1)+'" href="#" class="list-group-item">'+t+'</a>'
+					'<a id="transport-' + (transportsIndex.length-1) + '" href="#" class="list-group-item list-group-item-action">' +
+						'<small>' + t + '</small>' +
+					'</a>'
 				);
 				$('#transport-'+(transportsIndex.length-1)).click(function(event) {
 					event.preventDefault();
@@ -220,13 +230,31 @@ function updateServerInfo() {
 					'	<td>' + v.version_string + '</td>' +
 					'</tr>');
 			}
+			$('#server-loggers').html(
+				'<tr>' +
+				'	<th>Name</th>' +
+				'	<th>Author</th>' +
+				'	<th>Description</th>' +
+				'	<th>Version</th>' +
+				'</tr>'
+			);
+			for(let e in loggersJson) {
+				let v = loggersJson[e];
+				$('#server-loggers').append(
+					'<tr>' +
+					'	<td>' + v.name + '</td>' +
+					'	<td>' + v.author + '</td>' +
+					'	<td>' + v.description + '</td>' +
+					'	<td>' + v.version_string + '</td>' +
+					'</tr>');
+			}
 			// Unlock tabs
-			$('#admintabs li').removeClass('disabled');
+			$('#admintabs li a').removeClass('disabled');
 			// Refresh settings now
 			updateSettings();
 			// Refresh sessions and handles now
-			$('#handles').hide();
-			$('#info').hide();
+			$('#handles').addClass('hide');
+			$('#info').addClass('hide');
 			$('#update-sessions').click(updateSessions);
 			$('#update-handles').click(updateHandles);
 			$('#update-handle').click(updateHandleInfo);
@@ -256,7 +284,7 @@ function updateServerInfo() {
 			});
 			// Only check tokens if the mechanism is enabled
 			if(!json["auth_token"]) {
-				$('a[href=#tokens]').parent().addClass('disabled');
+				$('a[href=#tokens]').addClass('disabled');
 				$('a[href=#tokens]').attr('href', '#').unbind('click').click(function (e) { e.preventDefault(); return false; });
 			} else {
 				updateTokens();
@@ -880,10 +908,10 @@ function updateSessions() {
 				handle = null;
 				currentHandle = null;
 				$('#handles-list').empty();
-				$('#handles').hide();
+				$('#handles').addClass('hide');
 				$('#handle-info').empty();
-				$('#options').hide();
-				$('#info').hide();
+				$('#options').addClass('hide');
+				$('#info').addClass('hide');
 				return;
 			}
 			console.log("Got sessions:");
@@ -894,7 +922,9 @@ function updateSessions() {
 			for(let i=0; i<sessions.length; i++) {
 				let s = sessions[i];
 				$('#sessions-list').append(
-					'<a id="session-'+s+'" href="#" class="list-group-item">'+s+'</a>'
+					'<a id="session-' + s + '" href="#" class="list-group-item list-group-item-action">' +
+						'<small>' + s + '</small>' +
+					'</a>'
 				);
 				$('#session-'+s).click(function() {
 					let sh = $(this).text();
@@ -905,10 +935,10 @@ function updateSessions() {
 					handle = null;
 					currentHandle = null;
 					$('#handles-list').empty();
-					$('#handles').show();
+					$('#handles').removeClass('hide');
 					$('#handle-info').empty();
-					$('#options').hide();
-					$('#info').hide();
+					$('#options').addClass('hide');
+					$('#info').addClass('hide');
 					updateHandles();
 				});
 			}
@@ -921,10 +951,10 @@ function updateSessions() {
 					handle = null;
 					currentHandle = null;
 					$('#handles-list').empty();
-					$('#handles').hide();
+					$('#handles').addClass('hide');
 					$('#handle-info').empty();
-					$('#options').hide();
-					$('#info').hide();
+					$('#options').addClass('hide');
+					$('#info').addClass('hide');
 				}
 			}
 			setTimeout(function() {
@@ -944,10 +974,10 @@ function updateSessions() {
 			handle = null;
 			currentHandle = null;
 			$('#handles-list').empty();
-			$('#handles').hide();
+			$('#handles').addClass('hide');
 			$('#handle-info').empty();
-			$('#options').hide();
-			$('#info').hide();
+			$('#options').addClass('hide');
+			$('#info').addClass('hide');
 			if(!prompting && !alerted) {
 				alerted = true;
 				bootbox.alert("Couldn't contact the backend: is Janus down, or is the Admin/Monitor interface disabled?", function() {
@@ -1002,7 +1032,9 @@ function updateHandles() {
 			for(let i=0; i<handles.length; i++) {
 				let h = handles[i];
 				$('#handles-list').append(
-					'<a id="handle-'+h+'" href="#" class="list-group-item">'+h+'</a>'
+					'<a id="handle-' + h + '" href="#" class="list-group-item list-group-item-action">' +
+						'<small>' + h + '</small>' +
+					'</a>'
 				);
 				$('#handle-'+h).click(function() {
 					let hi = $(this).text();
@@ -1013,8 +1045,8 @@ function updateHandles() {
 					$('#handles-list a').removeClass('active');
 					$('#handle-'+hi).addClass('active');
 					$('#handle-info').empty();
-					$('#options').hide();
-					$('#info').show();
+					$('#options').addClass('hide');
+					$('#info').removeClass('hide');
 					updateHandleInfo();
 				});
 			}
@@ -1026,8 +1058,8 @@ function updateHandles() {
 					handle = null;
 					currentHandle = null;
 					$('#handle-info').empty();
-					$('#options').hide();
-					$('#info').hide();
+					$('#options').addClass('hide');
+					$('#info').addClass('hide');
 				}
 			}
 			setTimeout(function() {
@@ -1115,7 +1147,7 @@ function updateHandleInfo(refresh) {
 				$('#update-handle').removeClass('fa-spin').click(updateHandleInfo);
 			}, 1000);
 			// Show checkboxes
-			$('#options').removeClass('hide').show();
+			$('#options').removeClass('hide');
 			// If the related box is checked, autorefresh this handle info every tot seconds
 			if($('#autorefresh')[0].checked) {
 				setTimeout(function() {
@@ -1150,13 +1182,13 @@ function updateHandleInfo(refresh) {
 
 function rawHandleInfo() {
 	// Just use <pre> and show the handle info as it is
-	$('#handle-info').html('<pre>' + JSON.stringify(handleInfo, null, 4) + '</pre>');
+	$('#handle-info').html('<pre class="card card-body bg-gray">' + JSON.stringify(handleInfo, null, 4) + '</pre>');
 }
 
 function prettyHandleInfo() {
 	// Prettify the handle info, processing it and turning it into tables
 	$('#handle-info').html('<table class="table table-striped" id="handle-info-table"></table>');
-	$('#options').hide();
+	$('#options').addClass('hide');
 	for(let k in handleInfo) {
 		let v = handleInfo[k];
 		if(k === "plugin_specific") {
@@ -1318,7 +1350,7 @@ function prettyHandleInfo() {
 				'</tr>');
 		}
 	}
-	$('#options').show();
+	$('#options').removeClass('hide');
 }
 
 // Tokens
@@ -1528,7 +1560,7 @@ function captureTrafficPrompt() {
 			},
 			{
 				label: "Close",
-				className: "btn btn-default pull-left",
+				className: "btn btn-secondary pull-left",
 				callback: function() {
 					$('#capture').removeAttr('checked');
 					$('#capturetext').html('Start capture');

--- a/html/admin.js
+++ b/html/admin.js
@@ -50,11 +50,11 @@ function promptAccessDetails() {
 	let secretPlaceholder = "Insert the Admin API secret";
 	bootbox.alert({
 		message: "<div class='input-group mt-3 mb-1'>" +
-			"	<span class='input-group-text'><i class='fa fa-cloud-upload fa-fw'></i></span>" +
+			"	<span class='input-group-text'><i class='fa-solid fa-cloud-arrow-up'></i></span>" +
 			"	<input class='form-control' type='text' value='" + server + "' placeholder='" + serverPlaceholder + "' autocomplete='off' id='server'></input>" +
 			"</div>" +
 			"<div class='input-group mt-3 mb-1'>" +
-			"	<span class='input-group-text'><i class='fa fa-key fa-fw'></i></span>" +
+			"	<span class='input-group-text'><i class='fa-solid fa-key'></i></span>" +
 			"	<input class='form-control' type='password'  value='" + secret + "'placeholder='" + secretPlaceholder + "' autocomplete='off' id='secret'></input>" +
 			"</div>",
 		closeButton: false,
@@ -617,7 +617,7 @@ function resetPluginRequest() {
 		'	<th></th>' +
 		'</tr>' +
 		'<tr>' +
-		'	<td><i id="addattr" class="fa fa-plus-circle" style="cursor: pointer;"></i></td>' +
+		'	<td><i id="addattr" class="fa-solid fa-plus-circle" style="cursor: pointer;"></i></td>' +
 		'	<td></td>' +
 		'	<td></td>' +
 		'	<td><button id="sendmsg" type="button" class="btn btn-xs btn-success pull-right">Send message</button></td>' +
@@ -683,7 +683,7 @@ function addPluginMessageAttribute() {
 		'			<option>boolean</option>' +
 		'		</select>' +
 		'	</td>' +
-		'	<td><i id="rmattr' + num + '" class="fa fa-window-close" style="cursor: pointer;"></i></td>' +
+		'	<td><i id="rmattr' + num + '" class="fa-solid fa-rectangle-xmark" style="cursor: pointer;"></i></td>' +
 		'</tr>'
 	);
 	$('#rmattr' + num).click(function() {
@@ -748,7 +748,7 @@ function resetTransportRequest() {
 		'	<th></th>' +
 		'</tr>' +
 		'<tr>' +
-		'	<td><i id="traddattr" class="fa fa-plus-circle" style="cursor: pointer;"></i></td>' +
+		'	<td><i id="traddattr" class="fa-solid fa-plus-circle" style="cursor: pointer;"></i></td>' +
 		'	<td></td>' +
 		'	<td></td>' +
 		'	<td><button id="trsendmsg" type="button" class="btn btn-xs btn-success pull-right">Send message</button></td>' +
@@ -814,7 +814,7 @@ function addTransportMessageAttribute() {
 		'			<option>boolean</option>' +
 		'		</select>' +
 		'	</td>' +
-		'	<td><i id="rmtrattr' + num + '" class="fa fa-window-close" style="cursor: pointer;"></i></td>' +
+		'	<td><i id="rmtrattr' + num + '" class="fa-solid fa-rectangle-xmark" style="cursor: pointer;"></i></td>' +
 		'</tr>'
 	);
 	$('#rmtrattr' + num).click(function() {

--- a/html/audiobridgetest.html
+++ b/html/audiobridgetest.html
@@ -7,9 +7,10 @@
 <title>Janus WebRTC Server (multistream): Audio Bridge Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/10.6.2/bootstrap-slider.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -24,7 +25,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/10.6.2/css/bootstrap-slider.css" type="text/css"/>
@@ -65,12 +66,10 @@
 			</div>
 			<div class="container mt-4 hide" id="audiojoin">
 				<div class="row">
-					<span class="badge badge-info" id="you"></span>
+					<span class="badge bg-info" id="you"></span>
 					<div class="col-md-12" id="controls">
 						<div class="input-group mt-3 mb-1 hide" id="registernow">
-							<div class="input-group-prepend">
-								<span class="input-group-text">@</span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
 							<input class="form-control" type="text" placeholder="Choose a display name" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
 							<span class="input-group-btn">
 								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>
@@ -84,7 +83,7 @@
 					<div class="col-md-6">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Participants <span class="badge badge-info hide" id="participant"></span>
+								<span class="card-title">Participants <span class="badge bg-info hide" id="participant"></span>
 								<div class="btn-group btn-group-sm top-right">
 									<button class="btn btn-danger hide" autocomplete="off" id="toggleaudio">Mute</button>
 									<button class="btn btn-primary hide" autocomplete="off" id="position">Position</button>

--- a/html/audiobridgetest.html
+++ b/html/audiobridgetest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Audio Bridge Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/audiobridgetest.html
+++ b/html/audiobridgetest.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/10.6.2/bootstrap-slider.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>

--- a/html/audiobridgetest.html
+++ b/html/audiobridgetest.html
@@ -40,7 +40,7 @@
 	<div class="row">
 		<div class="col-md-12">
 			<div class="pb-2 mt-4 mb-2 border-bottom">
-				<h1>Plugin Demo: Audio Room (mixed)
+				<h1>Plugin Demo: Audio Bridge (mixed)
 					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>

--- a/html/audiobridgetest.html
+++ b/html/audiobridgetest.html
@@ -27,7 +27,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/10.6.2/css/bootstrap-slider.css" type="text/css"/>
 </head>
 <body>
@@ -69,7 +69,7 @@
 					<span class="badge bg-info" id="you"></span>
 					<div class="col-md-12" id="controls">
 						<div class="input-group mt-3 mb-1 hide" id="registernow">
-							<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-user"></i></span>
 							<input class="form-control" type="text" placeholder="Choose a display name" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
 							<span class="input-group-btn">
 								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>

--- a/html/audiobridgetest.html
+++ b/html/audiobridgetest.html
@@ -8,7 +8,7 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/10.6.2/bootstrap-slider.min.js"></script>
@@ -17,34 +17,34 @@
 <script type="text/javascript" src="audiobridgetest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='audiobridgetest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='audiobridgetest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/10.6.2/css/bootstrap-slider.css" type="text/css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Audio Room (mixed)
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -63,12 +63,14 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="audiojoin">
+			<div class="container mt-4 hide" id="audiojoin">
 				<div class="row">
-					<span class="label label-info" id="you"></span>
+					<span class="badge badge-info" id="you"></span>
 					<div class="col-md-12" id="controls">
-						<div class="input-group margin-bottom-md hide" id="registernow">
-							<span class="input-group-addon">@</span>
+						<div class="input-group mt-3 mb-1 hide" id="registernow">
+							<div class="input-group-prepend">
+								<span class="input-group-text">@</span>
+							</div>
 							<input class="form-control" type="text" placeholder="Choose a display name" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
 							<span class="input-group-btn">
 								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>
@@ -77,27 +79,29 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="room">
+			<div class="container mt-4 hide" id="room">
 				<div class="row">
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Participants <span class="label label-info hide" id="participant"></span>
-								<button class="btn-xs btn-danger hide pull-right" autocomplete="off" id="toggleaudio">Mute</button>
-								<button class="btn-xs btn-primary hide pull-right" autocomplete="off" id="position">Position</button></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Participants <span class="badge badge-info hide" id="participant"></span>
+								<div class="btn-group btn-group-sm top-right">
+									<button class="btn btn-danger hide" autocomplete="off" id="toggleaudio">Mute</button>
+									<button class="btn btn-primary hide" autocomplete="off" id="position">Position</button>
+								</div>
 							</div>
-							<div class="panel-body">
+							<div class="card-body">
 								<ul id="list" class="list-group">
 								</ul>
 							</div>
 						</div>
 					</div>
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Mixed Audio</h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Mixed Audio</span>
 							</div>
-							<div class="panel-body" id="mixedaudio"></div>
+							<div class="card-body" id="mixedaudio"></div>
 						</div>
 					</div>
 				</div>

--- a/html/audiobridgetest.js
+++ b/html/audiobridgetest.js
@@ -157,8 +157,8 @@ $(document).ready(function() {
 														$('#list').append('<li id="rp' + id +'" class="list-group-item">' +
 															slider +
 															display +
-															' <i class="absetup fa fa-chain-broken"></i>' +
-															' <i class="abmuted fa fa-microphone-slash"></i></li>');
+															' <i class="absetup fa-solid fa-link-slash"></i>' +
+															' <i class="abmuted fa-solid fa-microphone-slash"></i></li>');
 														if(spatial !== null && spatial !== undefined) {
 															$('#sp' + id).slider({ min: 0, max: 100, step: 1, value: 50, handle: 'triangle', enabled: false });
 															$('#position').removeClass('hide');
@@ -201,8 +201,8 @@ $(document).ready(function() {
 														$('#list').append('<li id="rp' + id +'" class="list-group-item">' +
 															slider +
 															display +
-															' <i class="absetup fa fa-chain-broken"></i>' +
-															' <i class="abmuted fa fa-microphone-slash"></i></li>');
+															' <i class="absetup fa-solid fa-link-slash"></i>' +
+															' <i class="abmuted fa-solid fa-microphone-slash"></i></li>');
 														if(spatial !== null && spatial !== undefined) {
 															$('#sp' + id).slider({ min: 0, max: 100, step: 1, value: 50, handle: 'triangle', enabled: false });
 															$('#position').removeClass('hide');
@@ -246,8 +246,8 @@ $(document).ready(function() {
 														$('#list').append('<li id="rp' + id +'" class="list-group-item">' +
 															slider +
 															display +
-															' <i class="absetup fa fa-chain-broken"></i>' +
-															' <i class="abmuted fa fa-microphone-slash"></i></li>');
+															' <i class="absetup fa-solid fa-link-slash"></i>' +
+															' <i class="abmuted fa-solid fa-microphone-slash"></i></li>');
 														if(spatial !== null && spatial !== undefined) {
 															$('#sp' + id).slider({ min: 0, max: 100, step: 1, value: 50, handle: 'triangle', enabled: false });
 															$('#position').removeClass('hide');

--- a/html/audiobridgetest.js
+++ b/html/audiobridgetest.js
@@ -85,7 +85,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -392,7 +392,7 @@ function registerUsername() {
 		let username = $('#username').val();
 		if(username === "") {
 			$('#you')
-				.removeClass().addClass('badge badge-warning')
+				.removeClass().addClass('badge bg-warning')
 				.html("Insert your display name (e.g., pippo)");
 			$('#username').removeAttr('disabled');
 			$('#register').removeAttr('disabled').click(registerUsername);
@@ -400,7 +400,7 @@ function registerUsername() {
 		}
 		if(/[^a-zA-Z0-9]/.test(username)) {
 			$('#you')
-				.removeClass().addClass('badge badge-warning')
+				.removeClass().addClass('badge bg-warning')
 				.html('Input is not alphanumeric');
 			$('#username').removeAttr('disabled').val("");
 			$('#register').removeAttr('disabled').click(registerUsername);

--- a/html/audiobridgetest.js
+++ b/html/audiobridgetest.js
@@ -124,6 +124,13 @@ $(document).ready(function() {
 																if(stereo && jsep.sdp.indexOf("stereo=1") == -1) {
 																	// Make sure that our offer contains stereo too
 																	jsep.sdp = jsep.sdp.replace("useinbandfec=1", "useinbandfec=1;stereo=1");
+																	// Create a spinner waiting for the remote video
+																	$('#mixedaudio').html(
+																		'<div class="text-center">' +
+																		'	<div id="spinner" class="spinner-border" role="status">' +
+																		'		<span class="visually-hidden">Loading...</span>' +
+																		'	</div>' +
+																		'</div>');
 																}
 															},
 															success: function(jsep) {
@@ -314,12 +321,16 @@ $(document).ready(function() {
 										$('#roomaudio').remove();
 										return;
 									}
+									$('#spinner').remove();
 									remoteStream = new MediaStream([track]);
 									$('#room').removeClass('hide');
 									if($('#roomaudio').length === 0) {
-										$('#mixedaudio').append('<audio class="rounded centered" id="roomaudio" width="100%" height="100%" autoplay/>');
+										$('#mixedaudio').append('<audio class="rounded centered w-100" id="roomaudio" controls autoplay/>');
+										$('#roomaudio').get(0).volume = 0;
 									}
 									Janus.attachMediaStream($('#roomaudio').get(0), remoteStream);
+									$('#roomaudio').get(0).play();
+									$('#roomaudio').get(0).volume = 1;
 									// Mute button
 									audioenabled = true;
 									$('#toggleaudio').click(

--- a/html/audiobridgetest.js
+++ b/html/audiobridgetest.js
@@ -58,8 +58,8 @@ $(document).ready(function() {
 									mixertest = pluginHandle;
 									Janus.log("Plugin attached! (" + mixertest.getPlugin() + ", id=" + mixertest.getId() + ")");
 									// Prepare the username registration
-									$('#audiojoin').removeClass('hide').show();
-									$('#registernow').removeClass('hide').show();
+									$('#audiojoin').removeClass('hide');
+									$('#registernow').removeClass('hide');
 									$('#register').click(registerUsername);
 									$('#username').focus();
 									$('#start').removeAttr('disabled').html("Stop")
@@ -78,6 +78,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -160,18 +161,18 @@ $(document).ready(function() {
 															' <i class="abmuted fa fa-microphone-slash"></i></li>');
 														if(spatial !== null && spatial !== undefined) {
 															$('#sp' + id).slider({ min: 0, max: 100, step: 1, value: 50, handle: 'triangle', enabled: false });
-															$('#position').removeClass('hide').show();
+															$('#position').removeClass('hide');
 														}
-														$('#rp' + id + ' > i').hide();
+														$('#rp' + id + ' > i').addClass('hide');
 													}
 													if(muted === true || muted === "true")
-														$('#rp' + id + ' > i.abmuted').removeClass('hide').show();
+														$('#rp' + id + ' > i.abmuted').removeClass('hide');
 													else
-														$('#rp' + id + ' > i.abmuted').hide();
+														$('#rp' + id + ' > i.abmuted').addClass('hide');
 													if(setup === true || setup === "true")
-														$('#rp' + id + ' > i.absetup').hide();
+														$('#rp' + id + ' > i.absetup').addClass('hide');
 													else
-														$('#rp' + id + ' > i.absetup').removeClass('hide').show();
+														$('#rp' + id + ' > i.absetup').removeClass('hide');
 													if(spatial !== null && spatial !== undefined)
 														$('#sp' + id).slider('setValue', spatial);
 												}
@@ -204,18 +205,18 @@ $(document).ready(function() {
 															' <i class="abmuted fa fa-microphone-slash"></i></li>');
 														if(spatial !== null && spatial !== undefined) {
 															$('#sp' + id).slider({ min: 0, max: 100, step: 1, value: 50, handle: 'triangle', enabled: false });
-															$('#position').removeClass('hide').show();
+															$('#position').removeClass('hide');
 														}
-														$('#rp' + id + ' > i').hide();
+														$('#rp' + id + ' > i').addClass('hide');
 													}
 													if(muted === true || muted === "true")
-														$('#rp' + id + ' > i.abmuted').removeClass('hide').show();
+														$('#rp' + id + ' > i.abmuted').removeClass('hide');
 													else
-														$('#rp' + id + ' > i.abmuted').hide();
+														$('#rp' + id + ' > i.abmuted').addClass('hide');
 													if(setup === true || setup === "true")
-														$('#rp' + id + ' > i.absetup').hide();
+														$('#rp' + id + ' > i.absetup').addClass('hide');
 													else
-														$('#rp' + id + ' > i.absetup').removeClass('hide').show();
+														$('#rp' + id + ' > i.absetup').removeClass('hide');
 													if(spatial !== null && spatial !== undefined)
 														$('#sp' + id).slider('setValue', spatial);
 												}
@@ -249,18 +250,18 @@ $(document).ready(function() {
 															' <i class="abmuted fa fa-microphone-slash"></i></li>');
 														if(spatial !== null && spatial !== undefined) {
 															$('#sp' + id).slider({ min: 0, max: 100, step: 1, value: 50, handle: 'triangle', enabled: false });
-															$('#position').removeClass('hide').show();
+															$('#position').removeClass('hide');
 														}
-														$('#rp' + id + ' > i').hide();
+														$('#rp' + id + ' > i').addClass('hide');
 													}
 													if(muted === true || muted === "true")
-														$('#rp' + id + ' > i.abmuted').removeClass('hide').show();
+														$('#rp' + id + ' > i.abmuted').removeClass('hide');
 													else
-														$('#rp' + id + ' > i.abmuted').hide();
+														$('#rp' + id + ' > i.abmuted').addClass('hide');
 													if(setup === true || setup === "true")
-														$('#rp' + id + ' > i.absetup').hide();
+														$('#rp' + id + ' > i.absetup').addClass('hide');
 													else
-														$('#rp' + id + ' > i.absetup').removeClass('hide').show();
+														$('#rp' + id + ' > i.absetup').removeClass('hide');
 													if(spatial !== null && spatial !== undefined)
 														$('#sp' + id).slider('setValue', spatial);
 												}
@@ -295,9 +296,9 @@ $(document).ready(function() {
 								onlocaltrack: function(track, on) {
 									Janus.debug("Local track " + (on ? "added" : "removed") + ":", track);
 									// We're not going to attach the local audio stream
-									$('#audiojoin').hide();
-									$('#room').removeClass('hide').show();
-									$('#participant').removeClass('hide').html(myusername).show();
+									$('#audiojoin').addClass('hide');
+									$('#room').removeClass('hide');
+									$('#participant').removeClass('hide').html(myusername).removeClass('hide');
 								},
 								onremotetrack: function(track, mid, on, metadata) {
 									Janus.debug(
@@ -314,7 +315,7 @@ $(document).ready(function() {
 										return;
 									}
 									remoteStream = new MediaStream([track]);
-									$('#room').removeClass('hide').show();
+									$('#room').removeClass('hide');
 									if($('#roomaudio').length === 0) {
 										$('#mixedaudio').append('<audio class="rounded centered" id="roomaudio" width="100%" height="100%" autoplay/>');
 									}
@@ -329,7 +330,7 @@ $(document).ready(function() {
 											else
 												$('#toggleaudio').html("Unmute").removeClass("btn-danger").addClass("btn-success");
 											mixertest.send({ message: { request: "configure", muted: !audioenabled }});
-										}).removeClass('hide').show();
+										}).removeClass('hide');
 									// Spatial position, if enabled
 									$('#position').click(
 										function() {
@@ -346,10 +347,10 @@ $(document).ready(function() {
 								oncleanup: function() {
 									webrtcUp = false;
 									Janus.log(" ::: Got a cleanup notification :::");
-									$('#participant').empty().hide();
+									$('#participant').empty().addClass('hide');
 									$('#list').empty();
 									$('#mixedaudio').empty();
-									$('#room').hide();
+									$('#room').addClass('hide');
 									remoteStream = null;
 								}
 							});
@@ -391,7 +392,7 @@ function registerUsername() {
 		let username = $('#username').val();
 		if(username === "") {
 			$('#you')
-				.removeClass().addClass('label label-warning')
+				.removeClass().addClass('badge badge-warning')
 				.html("Insert your display name (e.g., pippo)");
 			$('#username').removeAttr('disabled');
 			$('#register').removeAttr('disabled').click(registerUsername);
@@ -399,7 +400,7 @@ function registerUsername() {
 		}
 		if(/[^a-zA-Z0-9]/.test(username)) {
 			$('#you')
-				.removeClass().addClass('label label-warning')
+				.removeClass().addClass('badge badge-warning')
 				.html('Input is not alphanumeric');
 			$('#username').removeAttr('disabled').val("");
 			$('#register').removeAttr('disabled').click(registerUsername);

--- a/html/canvas.html
+++ b/html/canvas.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>

--- a/html/canvas.html
+++ b/html/canvas.html
@@ -7,8 +7,9 @@
 <title>Janus WebRTC Server (multistream): Canvas Capture</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
@@ -17,37 +18,37 @@
 <script type="text/javascript" src="canvas.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='canvas.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='canvas.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Canvas Capture
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
-						<h3>Demo details</h3>
+						<h3 class="mt-3">Demo details</h3>
 						<p>This is a variant of the Echo Test demo meant to showcase how
 						you can use an HTML5 <code>canvas</code> element as a WebRTC media
 						source: everything is exactly the same in term of available controls,
@@ -75,76 +76,86 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="videos">
+			<div class="container mt-4 hide" id="videos">
 				<div class="row">
 					<div class="col-md-6">
 						<div class="row">
-							<div class="panel panel-default">
-								<div class="panel-heading">
-									<h3 class="panel-title">Local Stream
-										<div class="btn-group btn-group-xs pull-right hide">
+							<div class="card">
+								<div class="card-header">
+									<span class="card-title">Local Stream
+										<div class="btn-group btn-group-sm top-right hide">
 											<button class="btn btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
 											<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
-											<div class="btn-group btn-group-xs">
+											<div class="btn-group btn-group-sm">
 												<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
 													Bandwidth<span class="caret"></span>
 												</button>
 												<ul id="bitrate" class="dropdown-menu" role="menu">
-													<li><a href="#" id="0">No limit</a></li>
-													<li><a href="#" id="128">Cap to 128kbit</a></li>
-													<li><a href="#" id="256">Cap to 256kbit</a></li>
-													<li><a href="#" id="512">Cap to 512kbit</a></li>
-													<li><a href="#" id="1024">Cap to 1mbit</a></li>
-													<li><a href="#" id="1500">Cap to 1.5mbit</a></li>
-													<li><a href="#" id="2000">Cap to 2mbit</a></li>
+													<a class="dropdown-item" href="#" id="0">No limit</a>
+													<a class="dropdown-item" href="#" id="128">Cap to 128kbit</a>
+													<a class="dropdown-item" href="#" id="256">Cap to 256kbit</a>
+													<a class="dropdown-item" href="#" id="512">Cap to 512kbit</a>
+													<a class="dropdown-item" href="#" id="1024">Cap to 1mbit</a>
+													<a class="dropdown-item" href="#" id="1500">Cap to 1.5mbit</a>
+													<a class="dropdown-item" href="#" id="2000">Cap to 2mbit</a>
 												</ul>
 											</div>
 										</div>
 									</h3>
 								</div>
-								<div class="panel-body" id="videoleft">
+								<div class="card-body" id="videoleft">
 									<video class="rounded centered hide" id="myvideo" width="100%" height="100%" muted="muted"></video>
 									<video class="rounded centered hide" id="canvasvideo" width="640" height="480" muted="muted"></video>
 									<canvas id="canvas" class="hide" width="640" height="480" style="display: block; margin: auto; padding: 0"></canvas>
 								</div>
 							</div>
 						</div>
-						<div class="row">
-							<div class="panel panel-default">
-								<div class="panel-heading">
-									<h3 class="panel-title">Tweaks</h3>
+						<div class="row mt-3 mb-3">
+							<div class="card" style="width: 100%;">
+								<div class="card-header">
+									<span class="card-title">Tweaks</span>
 								</div>
-								<div class="panel-body" id="tweaks">
-									<div class="input-group margin-bottom-sm">
-										<span class="input-group-addon"><i class="fa fa-font fa-fw"></i></span>
-										<input class="form-control" type="text" autocomplete="off" id="font" onkeypress="return checkEnter(event);"></input>
+								<div class="card-body" id="tweaks">
+									<div class="input-group mb-2">
+										<div class="input-group-prepend">
+											<span class="input-group-text"><i class="fa fa-font fa-fw"></i></span>
+										</div>
+										<input type="text" class="form-control" autocomplete="off" id="font" onkeypress="return checkEnter(event);"></input>
 									</div>
-									<div class="input-group margin-bottom-sm">
-										<span class="input-group-addon"><i class="fa fa-eraser fa-fw"></i></span>
-										<input class="form-control" type="text" autocomplete="off" id="color" onkeypress="return checkEnter(event);"></input>
+									<div class="input-group mt-2 mb-2">
+										<div class="input-group-prepend">
+											<span class="input-group-text"><i class="fa fa-eraser fa-fw"></i></span>
+										</div>
+										<input type="text" class="form-control" autocomplete="off" id="color" onkeypress="return checkEnter(event);"></input>
 									</div>
-									<div class="input-group margin-bottom-sm">
-										<span class="input-group-addon"><i class="fa fa-text-width fa-fw"></i></span>
-										<input class="form-control" type="text" autocomplete="off" id="posX" onkeypress="return checkEnter(event);"></input>
+									<div class="input-group mt-2 mb-2">
+										<div class="input-group-prepend">
+											<span class="input-group-text"><i class="fa fa-text-width fa-fw"></i></span>
+										</div>
+										<input type="text" class="form-control" autocomplete="off" id="posX" onkeypress="return checkEnter(event);"></input>
 									</div>
-									<div class="input-group margin-bottom-sm">
-										<span class="input-group-addon"><i class="fa fa-text-height fa-fw"></i></span>
-										<input class="form-control" type="text" autocomplete="off" id="posY" onkeypress="return checkEnter(event);"></input>
+									<div class="input-group mt-2 mb-2">
+										<div class="input-group-prepend">
+											<span class="input-group-text"><i class="fa fa-text-height fa-fw"></i></span>
+										</div>
+										<input type="text" class="form-control" autocomplete="off" id="posY" onkeypress="return checkEnter(event);"></input>
 									</div>
-									<div class="input-group margin-bottom-sm">
-										<span class="input-group-addon"><i class="fa fa-edit fa-fw"></i></span>
-										<input class="form-control" type="text" autocomplete="off" id="text" onkeypress="return checkEnter(event);"></input>
+									<div class="input-group mt-2">
+										<div class="input-group-prepend">
+											<span class="input-group-text"><i class="fa fa-edit fa-fw"></i></span>
+										</div>
+										<input type="text" class="form-control" autocomplete="off" id="text" onkeypress="return checkEnter(event);"></input>
 									</div>
 								</div>
 							</div>
 						</div>
 					</div>
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Stream <span class="label label-primary hide" id="curres"></span> <span class="label label-info hide" id="curbitrate"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Stream <span class="badge badge-primary hide" id="curres"></span> <span class="badge badge-info hide" id="curbitrate"></span></span>
 							</div>
-							<div class="panel-body" id="videoright"></div>
+							<div class="card-body" id="videoright"></div>
 						</div>
 					</div>
 				</div>

--- a/html/canvas.html
+++ b/html/canvas.html
@@ -7,10 +7,10 @@
 <title>Janus WebRTC Server (multistream): Canvas Capture</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -25,7 +25,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
@@ -87,8 +87,8 @@
 											<button class="btn btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
 											<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
 											<div class="btn-group btn-group-sm">
-												<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-													Bandwidth<span class="caret"></span>
+												<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">
+													Bandwidth
 												</button>
 												<ul id="bitrate" class="dropdown-menu" role="menu">
 													<a class="dropdown-item" href="#" id="0">No limit</a>
@@ -117,33 +117,23 @@
 								</div>
 								<div class="card-body" id="tweaks">
 									<div class="input-group mb-2">
-										<div class="input-group-prepend">
-											<span class="input-group-text"><i class="fa fa-font fa-fw"></i></span>
-										</div>
+										<span class="input-group-text"><i class="fa fa-font fa-fw"></i></span>
 										<input type="text" class="form-control" autocomplete="off" id="font" onkeypress="return checkEnter(event);"></input>
 									</div>
 									<div class="input-group mt-2 mb-2">
-										<div class="input-group-prepend">
-											<span class="input-group-text"><i class="fa fa-eraser fa-fw"></i></span>
-										</div>
+										<span class="input-group-text"><i class="fa fa-eraser fa-fw"></i></span>
 										<input type="text" class="form-control" autocomplete="off" id="color" onkeypress="return checkEnter(event);"></input>
 									</div>
 									<div class="input-group mt-2 mb-2">
-										<div class="input-group-prepend">
-											<span class="input-group-text"><i class="fa fa-text-width fa-fw"></i></span>
-										</div>
+										<span class="input-group-text"><i class="fa fa-text-width fa-fw"></i></span>
 										<input type="text" class="form-control" autocomplete="off" id="posX" onkeypress="return checkEnter(event);"></input>
 									</div>
 									<div class="input-group mt-2 mb-2">
-										<div class="input-group-prepend">
-											<span class="input-group-text"><i class="fa fa-text-height fa-fw"></i></span>
-										</div>
+										<span class="input-group-text"><i class="fa fa-text-height fa-fw"></i></span>
 										<input type="text" class="form-control" autocomplete="off" id="posY" onkeypress="return checkEnter(event);"></input>
 									</div>
 									<div class="input-group mt-2">
-										<div class="input-group-prepend">
-											<span class="input-group-text"><i class="fa fa-edit fa-fw"></i></span>
-										</div>
+										<span class="input-group-text"><i class="fa fa-edit fa-fw"></i></span>
 										<input type="text" class="form-control" autocomplete="off" id="text" onkeypress="return checkEnter(event);"></input>
 									</div>
 								</div>
@@ -153,7 +143,7 @@
 					<div class="col-md-6">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Stream <span class="badge badge-primary hide" id="curres"></span> <span class="badge badge-info hide" id="curbitrate"></span></span>
+								<span class="card-title">Remote Stream <span class="badge bg-primary hide" id="curres"></span> <span class="badge bg-info hide" id="curbitrate"></span></span>
 							</div>
 							<div class="card-body" id="videoright"></div>
 						</div>

--- a/html/canvas.html
+++ b/html/canvas.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Canvas Capture</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/canvas.html
+++ b/html/canvas.html
@@ -27,7 +27,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
@@ -117,23 +117,23 @@
 								</div>
 								<div class="card-body" id="tweaks">
 									<div class="input-group mb-2">
-										<span class="input-group-text"><i class="fa fa-font fa-fw"></i></span>
+										<span class="input-group-text"><i class="fa-solid fa-font"></i></span>
 										<input type="text" class="form-control" autocomplete="off" id="font" onkeypress="return checkEnter(event);"></input>
 									</div>
 									<div class="input-group mt-2 mb-2">
-										<span class="input-group-text"><i class="fa fa-eraser fa-fw"></i></span>
+										<span class="input-group-text"><i class="fa-solid fa-eraser"></i></span>
 										<input type="text" class="form-control" autocomplete="off" id="color" onkeypress="return checkEnter(event);"></input>
 									</div>
 									<div class="input-group mt-2 mb-2">
-										<span class="input-group-text"><i class="fa fa-text-width fa-fw"></i></span>
+										<span class="input-group-text"><i class="fa-solid fa-text-width"></i></span>
 										<input type="text" class="form-control" autocomplete="off" id="posX" onkeypress="return checkEnter(event);"></input>
 									</div>
 									<div class="input-group mt-2 mb-2">
-										<span class="input-group-text"><i class="fa fa-text-height fa-fw"></i></span>
+										<span class="input-group-text"><i class="fa-solid fa-text-height"></i></span>
 										<input type="text" class="form-control" autocomplete="off" id="posY" onkeypress="return checkEnter(event);"></input>
 									</div>
 									<div class="input-group mt-2">
-										<span class="input-group-text"><i class="fa fa-edit fa-fw"></i></span>
+										<span class="input-group-text"><i class="fa-solid fa-pen-to-square"></i></span>
 										<input type="text" class="form-control" autocomplete="off" id="text" onkeypress="return checkEnter(event);"></input>
 									</div>
 								</div>

--- a/html/canvas.js
+++ b/html/canvas.js
@@ -11,7 +11,6 @@ var opaqueId = "canvas-"+Janus.randomString(12);
 
 var remoteTracks = {}, remoteVideos = 0;
 var bitrateTimer = null;
-var spinner = null;
 
 var audioenabled = false;
 var videoenabled = false;
@@ -129,9 +128,6 @@ $(document).ready(function() {
 										if(result === "done") {
 											// The plugin closed the echo test
 											bootbox.alert("The Echo Test is over");
-											if(spinner)
-												spinner.stop();
-											spinner = null;
 											$('video').remove();
 											$('#waitingvideo').remove();
 											$('#peervideo').remove();
@@ -292,9 +288,6 @@ $(document).ready(function() {
 								},
 								oncleanup: function() {
 									Janus.log(" ::: Got a cleanup notification :::");
-									if(spinner)
-										spinner.stop();
-									spinner = null;
 									if(bitrateTimer)
 										clearInterval(bitrateTimer);
 									bitrateTimer = null;

--- a/html/canvas.js
+++ b/html/canvas.js
@@ -197,6 +197,7 @@ $(document).ready(function() {
 										return;
 									}
 									// If we're here, a new track was added
+									$('#spinner').remove();
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;
@@ -417,6 +418,13 @@ function createCanvas() {
 						success: function(jsep) {
 							Janus.debug("Got SDP!", jsep);
 							echotest.send({ message: body, jsep: jsep });
+							// Create a spinner waiting for the remote video
+							$('#videoright').html(
+								'<div class="text-center">' +
+								'	<div id="spinner" class="spinner-border" role="status">' +
+								'		<span class="visually-hidden">Loading...</span>' +
+								'	</div>' +
+								'</div>');
 						},
 						error: function(error) {
 							Janus.error("WebRTC error:", error);

--- a/html/canvas.js
+++ b/html/canvas.js
@@ -191,7 +191,7 @@ $(document).ready(function() {
 												if($('#videoright .no-video-container').length === 0) {
 													$('#videoright').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No remote video available</span>' +
 														'</div>');
 												}
@@ -219,7 +219,7 @@ $(document).ready(function() {
 											if($('#videoright .no-video-container').length === 0) {
 												$('#videoright').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}

--- a/html/canvas.js
+++ b/html/canvas.js
@@ -90,6 +90,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -137,8 +138,8 @@ $(document).ready(function() {
 											$('#toggleaudio').attr('disabled', true);
 											$('#togglevideo').attr('disabled', true);
 											$('#bitrate').attr('disabled', true);
-											$('#curbitrate').hide();
-											$('#curres').hide();
+											$('#curbitrate').addClass('hide');
+											$('#curres').addClass('hide');
 											return;
 										}
 										// Any loss?
@@ -203,7 +204,7 @@ $(document).ready(function() {
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 									}
 									if(track.kind === "audio") {
 										// New audio track: create a stream out of it, and use a hidden <audio> element
@@ -235,7 +236,7 @@ $(document).ready(function() {
 										Janus.attachMediaStream($('#peervideo' + mid).get(0), stream);
 										// FIXME we'll need this for additional videos too
 										if(!bitrateTimer) {
-											$('#curbitrate').removeClass('hide').show();
+											$('#curbitrate').removeClass('hide');
 											bitrateTimer = setInterval(function() {
 												if(!$("#peervideo" + mid).get(0))
 													return;
@@ -247,7 +248,7 @@ $(document).ready(function() {
 												let width = $("#peervideo" + mid).get(0).videoWidth;
 												let height = $("#peervideo" + mid).get(0).videoHeight;
 												if(width > 0 && height > 0)
-													$('#curres').removeClass('hide').text(width+'x'+height).show();
+													$('#curres').removeClass('hide').text(width+'x'+height).removeClass('hide');
 											}, 1000);
 										}
 									}
@@ -274,8 +275,9 @@ $(document).ready(function() {
 												$('#togglevideo').html("Enable video").removeClass("btn-danger").addClass("btn-success");
 											echotest.send({ message: { video: videoenabled }});
 										});
-									$('#toggleaudio').parent().removeClass('hide').show();
+									$('#toggleaudio').parent().removeClass('hide');
 									$('#bitrate a').click(function() {
+										$('.dropdown-toggle').dropdown('hide');
 										let id = $(this).attr("id");
 										let bitrate = parseInt(id)*1000;
 										if(bitrate === 0) {
@@ -303,8 +305,8 @@ $(document).ready(function() {
 									$('#toggleaudio').attr('disabled', true);
 									$('#togglevideo').attr('disabled', true);
 									$('#bitrate').attr('disabled', true);
-									$('#curbitrate').hide();
-									$('#curres').hide();
+									$('#curbitrate').addClass('hide');
+									$('#curres').addClass('hide');
 									simulcastStarted = false;
 									$('#simulcast').remove();
 									remoteTracks = {};
@@ -457,27 +459,21 @@ function getQueryStringValue(name) {
 // Helpers to create Simulcast-related UI, if enabled
 function addSimulcastButtons(temporal) {
 	$('#curres').parent().append(
-		'<div id="simulcast" class="btn-group-vertical btn-group-vertical-xs pull-right">' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
-		'			<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality" style="width: 33%">SL 2</button>' +
-		'			<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality" style="width: 33%">SL 1</button>' +
-		'			<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality" style="width: 34%">SL 0</button>' +
-		'		</div>' +
+		'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
+		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs hide" style="width: 100%">' +
-		'			<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2" style="width: 34%">TL 2</button>' +
-		'			<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1" style="width: 33%">TL 1</button>' +
-		'			<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0" style="width: 33%">TL 0</button>' +
-		'		</div>' +
+		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {
 		// Chromium-based browsers only have two temporal layers
 		$('#tl-2').remove();
-		$('#tl-1').css('width', '50%');
-		$('#tl-0').css('width', '50%');
 	}
 	// Enable the simulcast selection buttons
 	$('#sl-0').removeClass('btn-primary btn-success').addClass('btn-primary')

--- a/html/canvas.js
+++ b/html/canvas.js
@@ -97,7 +97,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -285,7 +285,7 @@ $(document).ready(function() {
 										} else {
 											Janus.log("Capping bandwidth to " + bitrate + " via REMB");
 										}
-										$('#bitrateset').html($(this).html() + '<span class="caret"></span>').parent().removeClass('open');
+										$('#bitrateset').text($(this).text()).parent().removeClass('open');
 										echotest.send({ message: { bitrate: bitrate }});
 										return false;
 									});
@@ -461,14 +461,14 @@ function addSimulcastButtons(temporal) {
 	$('#curres').parent().append(
 		'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
 		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
-		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
-		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
-		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
 		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
-		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
-		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
-		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {

--- a/html/citeus.html
+++ b/html/citeus.html
@@ -6,29 +6,29 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Cite us!</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top a[href='citeus.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top a[href='citeus.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Cite us!</h1>
 			</div>
 			<div>
@@ -43,7 +43,7 @@
 			</div>
 			<hr id="janus"/>
 			<h4><a href="http://dl.acm.org/citation.cfm?id=2670389">IPTComm 2014: "Janus: a general purpose WebRTC gateway"</a></h4>
-			<pre>
+			<pre class="card card-body bg-gray mb-5">
 @inproceedings{IPTComm2014-Janus,
 	author = {Amirante, A. and Castaldi, T. and Miniero, L. and Romano, S. P.},
 	title = {Janus: A General Purpose WebRTC Gateway},
@@ -65,7 +65,7 @@
 			</pre>
 			<hr id="awes"/>
 			<h4><a href="https://dl.acm.org/citation.cfm?doid=2749215.2749223">AWeS 2015: "Performance analysis of the Janus WebRTC gateway"</a></h4>
-			<pre>
+			<pre class="card card-body bg-gray mb-5">
 @inproceedings{AWeS2015-Janus,
 	author = {Amirante, Alessandro and Castaldi, Tobia and Miniero, Lorenzo and Romano, Simon Pietro},
 	title = {Performance Analysis of the Janus WebRTC Gateway},
@@ -87,7 +87,7 @@
 			</pre>
 			<hr id="jattack"/>
 			<h4><a href="https://ieeexplore.ieee.org/document/7780247/">IPTComm 2016: "Jattack: a WebRTC load testing tool"</a></h4>
-			<pre>
+			<pre class="card card-body bg-gray mb-5">
 @inproceedings{IPTComm2016-Jattack,
 	author = {Amirante, A. and Castaldi, T. and Miniero, L. and Romano, S. P.},
 	title = {Jattack: a WebRTC load testing tool},
@@ -104,7 +104,7 @@
 			</pre>
 			<hr id="ietf"/>
 			<h4><a href="https://ieeexplore.ieee.org/document/7992930/">IEEE Communications Standards Magazine: "Empowering Remote Participation in IETF Meetings through WebRTC"</a></h4>
-			<pre>
+			<pre class="card card-body bg-gray mb-5">
 @article{DBLP:journals/csm/AmiranteCMS17,
 	author = {Amirante, A. and Castaldi, T. and Miniero, L. and Saviano, P.},
 	title = {Empowering Remote Participation in {IETF} Meetings through WebRTC},
@@ -122,7 +122,7 @@
 			</pre>
 			<hr id="iceland"/>
 			<h4><a href="https://ieeexplore.ieee.org/document/8567641/">IPTComm 2018: "Measuring Janus temperature in ICE-land"</a></h4>
-			<pre>
+			<pre class="card card-body bg-gray mb-5">
 @inproceedings{IPTComm2018-libnice,
 	author = {Amirante, A. and Castaldi, T. and Miniero, L. and Romano, S. P. and Toppi, A.},
 	year = {2018},
@@ -131,10 +131,9 @@
 	title = {Measuring Janus temperature in ICE-land},
 	doi = {10.1109/IPTCOMM.2018.8567641}
 }			</pre>
-			</pre>
 			<hr id="docker"/>
 			<h4><a href="https://ieeexplore.ieee.org/abstract/document/8894526">IEEE Internet Computing: "Container NATs and Session-Oriented Standards: Friends or Foe?"</a></h4>
-			<pre>
+			<pre class="card card-body bg-gray mb-5">
 @ARTICLE{8894526,
   author={A. {Amirante} and S. P. {Romano}},
   journal={IEEE Internet Computing},
@@ -144,6 +143,7 @@
   number={6},
   pages={28-37}
 }
+			</pre>
 		</div>
 	</div>
 

--- a/html/citeus.html
+++ b/html/citeus.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Cite us!</title>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script>

--- a/html/citeus.html
+++ b/html/citeus.html
@@ -6,7 +6,8 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Cite us!</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script>
 	$(function() {
 		$(".fixed-top").load("navbar.html", function() {
@@ -15,7 +16,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 </head>
 <body>

--- a/html/css/demo.css
+++ b/html/css/demo.css
@@ -1,3 +1,15 @@
+body {
+	padding-top: 80px;
+}
+
+.hide {
+	display: none !important;
+}
+
+.z-2 {
+	z-index: 2000;
+}
+
 .rounded {
 	border-radius: 5px;
 }
@@ -11,11 +23,35 @@
 	position: relative;
 }
 
+.top-left {
+	position: absolute;
+	top: 0px;
+	left: 0px;
+}
+
+.top-right {
+	position: absolute;
+	top: 0px;
+	right: 0px;
+}
+
+.bottom-left {
+	position: absolute;
+	bottom: 0px;
+	left: 0px;
+}
+
+.bottom-right {
+	position: absolute;
+	bottom: 0px;
+	right: 0px;
+}
+
 .navbar-brand {
 	margin-left: 0px !important;
 }
 
-.navbar-default {
+.navbar {
 	-webkit-box-shadow: 0px 3px 5px rgba(100, 100, 100, 0.49);
 	-moz-box-shadow:    0px 3px 5px rgba(100, 100, 100, 0.49);
 	box-shadow:         0px 3px 5px rgba(100, 100, 100, 0.49);
@@ -23,6 +59,13 @@
 
 .navbar-header {
 	padding-left: 40px;
+}
+
+.btn-group-xs > .btn, .btn-xs {
+	padding: 1px 5px;
+	font-size: 12px;
+	line-height: 1.5;
+	border-radius: 3px;
 }
 
 .margin-sm {
@@ -104,6 +147,11 @@ pre {
 	white-space: -pre-wrap;
 	white-space: -o-pre-wrap;
 	word-wrap: break-word;
+	background-color: #f5f5f5;
+}
+
+.bg-gray {
+	background-color: #f5f5f5;
 }
 
 .januscon {

--- a/html/css/demo.css
+++ b/html/css/demo.css
@@ -72,25 +72,6 @@ a {
 	border-radius: 3px;
 }
 
-.margin-sm {
-	margin: 5px !important;
-}
-.margin-md {
-	margin: 10px !important;
-}
-.margin-xl {
-	margin: 20px !important;
-}
-.margin-bottom-sm {
-	margin-bottom: 5px !important;
-}
-.margin-bottom-md {
-	margin-bottom: 10px !important;
-}
-.margin-bottom-xl {
-	margin-bottom: 20px !important;
-}
-
 .divider {
 	width: 100%;
 	text-align: center;
@@ -126,6 +107,7 @@ div.no-video-container {
 	width: 100%;
 	height: 240px;
 	text-align: center;
+	padding-top: 5rem !important;
 }
 
 .no-video-text {

--- a/html/css/demo.css
+++ b/html/css/demo.css
@@ -111,7 +111,7 @@ a {
 .fa-4 {
 	font-size: 7em !important;
 }
-.fa-5 {
+.fa-xl {
 	font-size: 12em !important;
 }
 .fa-6 {

--- a/html/css/demo.css
+++ b/html/css/demo.css
@@ -2,6 +2,10 @@ body {
 	padding-top: 80px;
 }
 
+a {
+	text-decoration: none;
+}
+
 .hide {
 	display: none !important;
 }

--- a/html/demos.html
+++ b/html/demos.html
@@ -6,7 +6,8 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Demo Tests</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script>
 	$(function() {
 		$(".fixed-top").load("navbar.html", function() {
@@ -16,7 +17,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 </head>
 <body>

--- a/html/demos.html
+++ b/html/demos.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Demo Tests</title>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script>

--- a/html/demos.html
+++ b/html/demos.html
@@ -6,35 +6,35 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Demo Tests</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='demos.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='demos.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Janus WebRTC Server: Demo Tests</h1>
 			</div>
-			<table class="table table-striped">
+			<table class="table table-striped mt-5">
 				<tr>
-					<td colspan=2><h3>Plugin demos</h3></td>
+					<td class="table-info" colspan=2><h3>Plugin demos</h3></td>
 				</tr>
 				<tr>
 					<td><a href="echotest.html">Echo Test</a></td>
@@ -77,18 +77,18 @@
 					<td>A webinar-like screen sharing session, based on the Video Room plugin.</td>
 				</tr>
 			</table>
-			<table class="table table-striped">
+			<table class="table table-striped mt-5">
 				<tr>
-					<td colspan=2><h3>Other legacy demos</h3></td>
+					<td class="table-info" colspan=2><h3>Other legacy demos</h3></td>
 				</tr>
 				<tr>
 					<td><a href="nosiptest.html">NoSIP (SDP/RTP)</a></td>
 					<td>A legacy interop demo (e.g., with a SIP peer) where signalling is up to the application.</td>
 				</tr>
 			</table>
-			<table class="table table-striped">
+			<table class="table table-striped mt-5">
 				<tr>
-					<td colspan=2><h3>Advanced demos</h3></td>
+					<td class="table-info" colspan=2><h3>Advanced demos</h3></td>
 				</tr>
 				<tr>
 					<td><a href="devicetest.html">Device Selection</a></td>

--- a/html/devicetest.html
+++ b/html/devicetest.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>

--- a/html/devicetest.html
+++ b/html/devicetest.html
@@ -27,7 +27,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
@@ -120,7 +120,7 @@
 							<div class="card-body" id="videoleft"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-up"></i></span>
 							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled>
 						</div>
 					</div>
@@ -142,7 +142,7 @@
 							<div class="card-body" id="videoright"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-down"></i></span>
 							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>

--- a/html/devicetest.html
+++ b/html/devicetest.html
@@ -7,8 +7,9 @@
 <title>Janus WebRTC Server (multistream): Device Selection Test</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
@@ -17,37 +18,37 @@
 <script type="text/javascript" src="devicetest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='devicetest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='devicetest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Device Selection
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
-						<h3>Demo details</h3>
+						<h3 class="mt-3">Demo details</h3>
 						<p>This is a variant of the Echo Test demo: everything is exactly
 						the same in term of available controls, features, and the like, with
 						the substantial difference that you can select which of the available
@@ -68,8 +69,8 @@
 					</div>
 				</div>
 			</div>
-			<div class="container">
-				<div class="row hide" id="devices">
+			<div class="container mt-4">
+				<div class="row mb-4 hide" id="devices">
 					<form class="form-inline">
 						<div class="form-group" style="margin-right: 20px;">
 							<label for="audio-device">Audio device (input):</label>
@@ -87,44 +88,46 @@
 				</div>
  				<div class="row hide" id="videos">
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Local Stream
-									<div class="btn-group btn-group-xs pull-right hide">
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Local Stream
+									<div class="btn-group btn-group-sm top-right hide">
 										<button class="btn btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
 										<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
-										<div class="btn-group btn-group-xs">
+										<div class="btn-group btn-group-sm">
 											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
 												Bandwidth<span class="caret"></span>
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
-												<li><a href="#" id="0">No limit</a></li>
-												<li><a href="#" id="128">Cap to 128kbit</a></li>
-												<li><a href="#" id="256">Cap to 256kbit</a></li>
-												<li><a href="#" id="512">Cap to 512kbit</a></li>
-												<li><a href="#" id="1024">Cap to 1mbit</a></li>
-												<li><a href="#" id="1500">Cap to 1.5mbit</a></li>
-												<li><a href="#" id="2000">Cap to 2mbit</a></li>
+												<a class="dropdown-item" href="#" id="0">No limit</a>
+												<a class="dropdown-item" href="#" id="128">Cap to 128kbit</a>
+												<a class="dropdown-item" href="#" id="256">Cap to 256kbit</a>
+												<a class="dropdown-item" href="#" id="512">Cap to 512kbit</a>
+												<a class="dropdown-item" href="#" id="1024">Cap to 1mbit</a>
+												<a class="dropdown-item" href="#" id="1500">Cap to 1.5mbit</a>
+												<a class="dropdown-item" href="#" id="2000">Cap to 2mbit</a>
 											</ul>
 										</div>
 									</div>
-								</h3>
+								</span>
 							</div>
-							<div class="panel-body" id="videoleft"></div>
+							<div class="card-body" id="videoleft"></div>
 						</div>
-						<div class="input-group margin-bottom-sm">
-							<span class="input-group-addon"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							<input class="form-control" type="text" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled />
+						<div class="input-group mt-3 mb-3">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							</div>
+							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled>
 						</div>
 					</div>
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Stream
-									<span class="label label-primary hide" id="curres"></span>
-									<span class="label label-info hide" id="curbitrate"></span>
-									<div class="btn-group btn-group-xs pull-right hide" id="output-devices">
-										<div class="btn-group btn-group-xs">
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Stream
+									<span class="badge badge-primary hide" id="curres"></span>
+									<span class="badge badge-info hide" id="curbitrate"></span>
+									<div class="btn-group btn-group-sm bottom-right hide" id="output-devices">
+										<div class="btn-group btn-group-sm">
 											<button id="outputdeviceset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
 												Output device<span class="caret"></span>
 											</button>
@@ -132,13 +135,15 @@
 											</ul>
 										</div>
 									</div>
-								</h3>
+								</span>
 							</div>
-							<div class="panel-body" id="videoright"></div>
+							<div class="card-body" id="videoright"></div>
 						</div>
-						<div class="input-group margin-bottom-sm">
-							<span class="input-group-addon"><i class="fa fa-cloud-download fa-fw"></i></span>
-							<input class="form-control" type="text" id="datarecv" disabled />
+						<div class="input-group mt-3 mb-3">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							</div>
+							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>
 				</div>

--- a/html/devicetest.html
+++ b/html/devicetest.html
@@ -7,10 +7,10 @@
 <title>Janus WebRTC Server (multistream): Device Selection Test</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -25,7 +25,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
@@ -71,21 +71,27 @@
 			</div>
 			<div class="container mt-4">
 				<div class="row mb-4 hide" id="devices">
-					<form class="form-inline">
-						<div class="form-group" style="margin-right: 20px;">
-							<label for="audio-device">Audio device (input):</label>
-							<select id="audio-device" class="form-control"></select>
+					<div class="row">
+						<div class="col-md-4">
+							<div class="form-group">
+								<label for="audio-device">Audio device (input):</label>
+								<select id="audio-device" class="form-control"></select>
+							</div>
 						</div>
-						<div class="form-group" style="margin-right: 20px;">
-							<label for="video-device">Video device (input):</label>
-							<select id="video-device" class="form-control"></select>
+						<div class="col-md-4">
+							<div class="form-group">
+								<label for="video-device">Video device (input):</label>
+								<select id="video-device" class="form-control"></select>
+							</div>
 						</div>
-						<div class="form-group">
-							<div id="change-devices" class="form-control btn btn-primary">Change devices</div>
+						<div class="col-md-4 mt-auto">
+							<div class="form-group">
+								<div id="change-devices" class="form-control btn btn-primary">Change devices</div>
+							</div>
 						</div>
-					</form>
-					<hr>
+					</div>
 				</div>
+				<hr/>
  				<div class="row hide" id="videos">
 					<div class="col-md-6">
 						<div class="card">
@@ -95,8 +101,8 @@
 										<button class="btn btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
 										<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
 										<div class="btn-group btn-group-sm">
-											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-												Bandwidth<span class="caret"></span>
+											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">
+												Bandwidth</span>
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
 												<a class="dropdown-item" href="#" id="0">No limit</a>
@@ -114,9 +120,7 @@
 							<div class="card-body" id="videoleft"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled>
 						</div>
 					</div>
@@ -124,25 +128,21 @@
 						<div class="card">
 							<div class="card-header">
 								<span class="card-title">Remote Stream
-									<span class="badge badge-primary hide" id="curres"></span>
-									<span class="badge badge-info hide" id="curbitrate"></span>
+									<span class="badge bg-primary hide" id="curres"></span>
+									<span class="badge bg-info hide" id="curbitrate"></span>
 									<div class="btn-group btn-group-sm bottom-right hide" id="output-devices">
-										<div class="btn-group btn-group-sm">
-											<button id="outputdeviceset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-												Output device<span class="caret"></span>
-											</button>
-											<ul id="audiooutput" class="dropdown-menu" role="menu">
-											</ul>
-										</div>
+										<button id="outputdeviceset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">
+											Output device
+										</button>
+										<ul id="audiooutput" class="dropdown-menu" role="menu">
+										</ul>
 									</div>
 								</span>
 							</div>
 							<div class="card-body" id="videoright"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>

--- a/html/devicetest.html
+++ b/html/devicetest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Device Selection Test</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/devicetest.js
+++ b/html/devicetest.js
@@ -329,7 +329,7 @@ $(document).ready(function() {
 												if($('#videoleft .no-video-container').length === 0) {
 													$('#videoleft').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No webcam available</span>' +
 														'</div>');
 												}
@@ -354,7 +354,7 @@ $(document).ready(function() {
 											if($('#videoleft .no-video-container').length === 0) {
 												$('#videoleft').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}
@@ -396,7 +396,7 @@ $(document).ready(function() {
 												if($('#videoright .no-video-container').length === 0) {
 													$('#videoright').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No remote video available</span>' +
 														'</div>');
 												}
@@ -424,7 +424,7 @@ $(document).ready(function() {
 											if($('#videoright .no-video-container').length === 0) {
 												$('#videoright').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}

--- a/html/devicetest.js
+++ b/html/devicetest.js
@@ -12,7 +12,6 @@ var opaqueId = "devicetest-"+Janus.randomString(12);
 var localTracks = {}, localVideos = 0,
 	remoteTracks = {}, remoteVideos = 0;
 var bitrateTimer = null;
-var spinner = null;
 
 var audioDeviceId = null;
 var videoDeviceId = null;
@@ -265,9 +264,6 @@ $(document).ready(function() {
 										if(result === "done") {
 											// The plugin closed the echo test
 											bootbox.alert("The Echo Test is over");
-											if(spinner)
-												spinner.stop();
-											spinner = null;
 											$('video').remove();
 											$('#waitingvideo').remove();
 											audioenabled = true;
@@ -507,9 +503,6 @@ $(document).ready(function() {
 								},
 								oncleanup: function() {
 									Janus.log(" ::: Got a cleanup notification :::");
-									if(spinner)
-										spinner.stop();
-									spinner = null;
 									$('video').remove();
 									$('#waitingvideo').remove();
 									$('.no-video-container').remove();

--- a/html/devicetest.js
+++ b/html/devicetest.js
@@ -69,7 +69,7 @@ function initDevices(devices) {
 					$('#peervideo1').get(0).setSinkId(deviceId)
 						.then(function() {
 							Janus.log('Audio output device attached:', deviceId);
-							$('#outputdeviceset').html(label + '<span class="caret"></span>').parent().removeClass('open');
+							$('#outputdeviceset').text(label).parent().removeClass('open');
 						}).catch(function(error) {
 							Janus.error(error);
 							bootbox.alert(error);
@@ -233,7 +233,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -275,7 +275,7 @@ $(document).ready(function() {
 											videoenabled = true;
 											$('#togglevideo').attr('disabled', true).html("Disable video").removeClass("btn-success").addClass("btn-danger");
 											$('#bitrate').attr('disabled', true);
-											$('#bitrateset').html('Bandwidth<span class="caret"></span>');
+											$('#bitrateset').text('Bandwidth');
 											$('#curbitrate').addClass('hide');
 											if(bitrateTimer)
 												clearInterval(bitrateTimer);
@@ -283,7 +283,7 @@ $(document).ready(function() {
 											$('#curres').addClass('hide');
 											$('#datasend').val('').attr('disabled', true);
 											$('#datarecv').val('');
-											$('#outputdeviceset').html('Output device<span class="caret"></span>');
+											$('#outputdeviceset').text('Output device');
 											return;
 										}
 										// Any loss?
@@ -490,7 +490,7 @@ $(document).ready(function() {
 										} else {
 											Janus.log("Capping bandwidth to " + bitrate + " via REMB");
 										}
-										$('#bitrateset').html($(this).html() + '<span class="caret"></span>').parent().removeClass('open');
+										$('#bitrateset').text($(this).text()).parent().removeClass('open');
 										echotest.send({ message: { bitrate: bitrate }});
 										return false;
 									});
@@ -520,7 +520,7 @@ $(document).ready(function() {
 									videoenabled = true;
 									$('#togglevideo').attr('disabled', true).html("Disable video").removeClass("btn-success").addClass("btn-danger");
 									$('#bitrate').attr('disabled', true);
-									$('#bitrateset').html('Bandwidth<span class="caret"></span>');
+									$('#bitrateset').html('Bandwidth');
 									$('#curbitrate').addClass('hide');
 									if(bitrateTimer)
 										clearInterval(bitrateTimer);
@@ -528,7 +528,7 @@ $(document).ready(function() {
 									$('#curres').addClass('hide');
 									$('#datasend').val('').attr('disabled', true);
 									$('#datarecv').val('');
-									$('#outputdeviceset').html('Output device<span class="caret"></span>');
+									$('#outputdeviceset').html('Output device');
 									simulcastStarted = false;
 									$('#simulcast').remove();
 									localTracks = {};
@@ -588,14 +588,14 @@ function getQueryStringValue(name) {
 function addSimulcastButtons(temporal) {
 	$(	'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
 		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
-		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
-		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
-		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
 		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
-		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
-		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
-		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>').insertBefore('#output-devices');
 	if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {

--- a/html/devicetest.js
+++ b/html/devicetest.js
@@ -165,6 +165,13 @@ function restartCapture() {
 			success: function(jsep) {
 				Janus.debug("Got SDP!", jsep);
 				echotest.send({ message: body, jsep: jsep });
+				// Create a spinner waiting for the remote video
+				$('#videoright').html(
+					'<div class="text-center">' +
+					'	<div id="spinner" class="spinner-border" role="status">' +
+					'		<span class="visually-hidden">Loading...</span>' +
+					'	</div>' +
+					'</div>');
 			},
 			error: function(error) {
 				Janus.error("WebRTC error:", error);
@@ -402,6 +409,7 @@ $(document).ready(function() {
 										return;
 									}
 									// If we're here, a new track was added
+									$('#spinner').remove();
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;

--- a/html/docs/index.html
+++ b/html/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server: Documentation</title>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="jquery.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script>

--- a/html/docs/index.html
+++ b/html/docs/index.html
@@ -5,8 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server: Documentation</title>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.7.2/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script>
 	$(function() {
 		$(".fixed-top").load("navbar.html", function() {
@@ -15,7 +16,7 @@
 		$(".footer").load("../footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="../css/demo.css" type="text/css"/>
 </head>
 <body>
@@ -33,7 +34,7 @@
 			</div>
 			<h3>Janus WebRTC Server: Documentation</h3>
 			<p>You can build a documentation for the server adding:</p>
-			<div class="alert alert-info">--enable-docs</div>
+			<pre class="card card-body bg-gray">--enable-docs</pre>
 			<p>to the configure options. You'll need <a href="http://www.doxygen.org">Doxygen</a> and <a href="http://www.graphviz.org/">Graphviz</a> installed.</p>
 		</div>
 	</div>

--- a/html/docs/index.html
+++ b/html/docs/index.html
@@ -6,29 +6,29 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server: Documentation</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.7.2/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("../navbar.html", function() {
-			$(".navbar-static-top a[href='docs']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top a[href='docs']").parent().addClass("active");
 		});
 		$(".footer").load("../footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="../css/demo.css" type="text/css"/>
 </head>
 <body>
-	
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Documentation</h1>
 			</div>
 			<h3>Janus WebRTC Server: Documentation</h3>

--- a/html/e2etest.html
+++ b/html/e2etest.html
@@ -7,8 +7,9 @@
 <title>Janus WebRTC Server (multistream): End-to-end Encryption Test</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
@@ -17,34 +18,34 @@
 <script type="text/javascript" src="e2etest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='e2etest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='e2etest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: End-to-end Encryption
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -70,49 +71,53 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="videos">
+			<div class="container mt-4 hide" id="videos">
 				<div class="row">
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Local Stream
-									<div class="btn-group btn-group-xs pull-right hide">
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Local Stream
+									<div class="btn-group btn-group-sm top-right hide">
 										<button class="btn btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
 										<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
-										<div class="btn-group btn-group-xs">
+										<div class="btn-group btn-group-sm">
 											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
 												Bandwidth<span class="caret"></span>
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
-												<li><a href="#" id="0">No limit</a></li>
-												<li><a href="#" id="128">Cap to 128kbit</a></li>
-												<li><a href="#" id="256">Cap to 256kbit</a></li>
-												<li><a href="#" id="512">Cap to 512kbit</a></li>
-												<li><a href="#" id="1024">Cap to 1mbit</a></li>
-												<li><a href="#" id="1500">Cap to 1.5mbit</a></li>
-												<li><a href="#" id="2000">Cap to 2mbit</a></li>
+												<a class="dropdown-item" href="#" id="0">No limit</a>
+												<a class="dropdown-item" href="#" id="128">Cap to 128kbit</a>
+												<a class="dropdown-item" href="#" id="256">Cap to 256kbit</a>
+												<a class="dropdown-item" href="#" id="512">Cap to 512kbit</a>
+												<a class="dropdown-item" href="#" id="1024">Cap to 1mbit</a>
+												<a class="dropdown-item" href="#" id="1500">Cap to 1.5mbit</a>
+												<a class="dropdown-item" href="#" id="2000">Cap to 2mbit</a>
 											</ul>
 										</div>
 									</div>
-								</h3>
+								</span>
 							</div>
-							<div class="panel-body" id="videoleft"></div>
+							<div class="card-body" id="videoleft"></div>
 						</div>
-						<div class="input-group margin-bottom-sm">
-							<span class="input-group-addon"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							<input class="form-control" type="text" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled></input>
+						<div class="input-group mt-3 mb-3">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							</div>
+							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled>
 						</div>
 					</div>
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Stream <span class="label label-primary hide" id="curres"></span> <span class="label label-info hide" id="curbitrate"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Stream <span class="badge badge-primary hide" id="curres"></span> <span class="badge badge-info hide" id="curbitrate"></span></span>
 							</div>
-							<div class="panel-body" id="videoright"></div>
+							<div class="card-body" id="videoright"></div>
 						</div>
-						<div class="input-group margin-bottom-sm">
-							<span class="input-group-addon"><i class="fa fa-cloud-download fa-fw"></i></span>
-							<input class="form-control" type="text" id="datarecv" disabled></input>
+						<div class="input-group mt-3 mb-3">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							</div>
+							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>
 				</div>

--- a/html/e2etest.html
+++ b/html/e2etest.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>

--- a/html/e2etest.html
+++ b/html/e2etest.html
@@ -7,10 +7,10 @@
 <title>Janus WebRTC Server (multistream): End-to-end Encryption Test</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -25,7 +25,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
@@ -66,7 +66,7 @@
 						<p>Notice that at the time of writing, only video can be end-to-end encrypted,
 						and not audio. More importantly, at the moment this will only work if you're
 						using a recent of Chrome version that has been started either with the following flag:</p>
-						<p><div class="alert alert-info"><code>--enable-experimental-web-platform-features --force-fieldtrials=WebRTC-GenericDescriptorAdvertised/Enabled/</code></div></p>
+						<pre class="card card-body bg-gray">--enable-experimental-web-platform-features --force-fieldtrials=WebRTC-GenericDescriptorAdvertised/Enabled/</pre>
 						<p>Press the <code>Start</code> button above to launch the demo.</p>
 					</div>
 				</div>
@@ -81,8 +81,8 @@
 										<button class="btn btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
 										<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
 										<div class="btn-group btn-group-sm">
-											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-												Bandwidth<span class="caret"></span>
+											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">
+												Bandwidth
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
 												<a class="dropdown-item" href="#" id="0">No limit</a>
@@ -100,23 +100,19 @@
 							<div class="card-body" id="videoleft"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled>
 						</div>
 					</div>
 					<div class="col-md-6">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Stream <span class="badge badge-primary hide" id="curres"></span> <span class="badge badge-info hide" id="curbitrate"></span></span>
+								<span class="card-title">Remote Stream <span class="badge bg-primary hide" id="curres"></span> <span class="badge bg-info hide" id="curbitrate"></span></span>
 							</div>
 							<div class="card-body" id="videoright"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>

--- a/html/e2etest.html
+++ b/html/e2etest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): End-to-end Encryption Test</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/e2etest.html
+++ b/html/e2etest.html
@@ -27,7 +27,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
@@ -100,7 +100,7 @@
 							<div class="card-body" id="videoleft"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-up"></i></span>
 							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled>
 						</div>
 					</div>
@@ -112,7 +112,7 @@
 							<div class="card-body" id="videoright"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-down"></i></span>
 							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>

--- a/html/e2etest.js
+++ b/html/e2etest.js
@@ -87,7 +87,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -334,7 +334,7 @@ $(document).ready(function() {
 										} else {
 											Janus.log("Capping bandwidth to " + bitrate + " via REMB");
 										}
-										$('#bitrateset').html($(this).html() + '<span class="caret"></span>').parent().removeClass('open');
+										$('#bitrateset').text($(this).text()).parent().removeClass('open');
 										echotest.send({ message: { bitrate: bitrate }});
 										return false;
 									});
@@ -427,14 +427,14 @@ function addSimulcastButtons(temporal) {
 	$('#curres').parent().append(
 		'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
 		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
-		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
-		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
-		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
 		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
-		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
-		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
-		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {

--- a/html/e2etest.js
+++ b/html/e2etest.js
@@ -12,7 +12,6 @@ var opaqueId = "echotest-"+Janus.randomString(12);
 var localTracks = {}, localVideos = 0,
 	remoteTracks = {}, remoteVideos = 0;
 var bitrateTimer = null;
-var spinner = null;
 
 var audioenabled = false;
 var videoenabled = false;
@@ -119,9 +118,6 @@ $(document).ready(function() {
 										if(result === "done") {
 											// The plugin closed the echo test
 											bootbox.alert("The Echo Test is over");
-											if(spinner)
-												spinner.stop();
-											spinner = null;
 											$('video').remove();
 											$('#waitingvideo').remove();
 											$('#toggleaudio').attr('disabled', true);
@@ -351,9 +347,6 @@ $(document).ready(function() {
 								},
 								oncleanup: function() {
 									Janus.log(" ::: Got a cleanup notification :::");
-									if(spinner)
-										spinner.stop();
-									spinner = null;
 									if(bitrateTimer)
 										clearInterval(bitrateTimer);
 									bitrateTimer = null;

--- a/html/e2etest.js
+++ b/html/e2etest.js
@@ -176,7 +176,7 @@ $(document).ready(function() {
 												if($('#videoleft .no-video-container').length === 0) {
 													$('#videoleft').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No webcam available</span>' +
 														'</div>');
 												}
@@ -201,7 +201,7 @@ $(document).ready(function() {
 											if($('#videoleft .no-video-container').length === 0) {
 												$('#videoleft').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}
@@ -240,7 +240,7 @@ $(document).ready(function() {
 												if($('#videoright .no-video-container').length === 0) {
 													$('#videoright').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No remote video available</span>' +
 														'</div>');
 												}
@@ -268,7 +268,7 @@ $(document).ready(function() {
 											if($('#videoright .no-video-container').length === 0) {
 												$('#videoright').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}

--- a/html/e2etest.js
+++ b/html/e2etest.js
@@ -246,6 +246,7 @@ $(document).ready(function() {
 										return;
 									}
 									// If we're here, a new track was added
+									$('#spinner').remove();
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;
@@ -586,6 +587,13 @@ function promptCryptoKey() {
 					if(vcodec)
 						body["videocodec"] = vcodec;
 					echotest.send({ message: body, jsep: jsep });
+					// Create a spinner waiting for the remote video
+					$('#videoright').html(
+						'<div class="text-center">' +
+						'	<div id="spinner" class="spinner-border" role="status">' +
+						'		<span class="visually-hidden">Loading...</span>' +
+						'	</div>' +
+						'</div>');
 				},
 				error: function(error) {
 					Janus.error("WebRTC error:", error);

--- a/html/e2etest.js
+++ b/html/e2etest.js
@@ -80,6 +80,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -126,8 +127,8 @@ $(document).ready(function() {
 											$('#toggleaudio').attr('disabled', true);
 											$('#togglevideo').attr('disabled', true);
 											$('#bitrate').attr('disabled', true);
-											$('#curbitrate').hide();
-											$('#curres').hide();
+											$('#curbitrate').addClass('hide');
+											$('#curres').addClass('hide');
 											return;
 										}
 										// Any loss?
@@ -191,7 +192,7 @@ $(document).ready(function() {
 										return;
 									}
 									if($('#videoleft video').length === 0) {
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 									}
 									if(track.kind === "audio") {
 										// We ignore local audio tracks, they'd generate echo anyway
@@ -252,7 +253,7 @@ $(document).ready(function() {
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 									}
 									if(track.kind === "audio") {
 										// New audio track: create a stream out of it, and use a hidden <audio> element
@@ -284,7 +285,7 @@ $(document).ready(function() {
 										Janus.attachMediaStream($('#peervideo' + mid).get(0), stream);
 										// FIXME we'll need this for additional videos too
 										if(!bitrateTimer) {
-											$('#curbitrate').removeClass('hide').show();
+											$('#curbitrate').removeClass('hide');
 											bitrateTimer = setInterval(function() {
 												if(!$("#peervideo" + mid).get(0))
 													return;
@@ -296,7 +297,7 @@ $(document).ready(function() {
 												let width = $("#peervideo" + mid).get(0).videoWidth;
 												let height = $("#peervideo" + mid).get(0).videoHeight;
 												if(width > 0 && height > 0)
-													$('#curres').removeClass('hide').text(width+'x'+height).show();
+													$('#curres').removeClass('hide').text(width+'x'+height).removeClass('hide');
 											}, 1000);
 										}
 									}
@@ -323,8 +324,9 @@ $(document).ready(function() {
 												$('#togglevideo').html("Enable video").removeClass("btn-danger").addClass("btn-success");
 											echotest.send({ message: { video: videoenabled }});
 										});
-									$('#toggleaudio').parent().removeClass('hide').show();
+									$('#toggleaudio').parent().removeClass('hide');
 									$('#bitrate a').click(function() {
+										$('.dropdown-toggle').dropdown('hide');
 										let id = $(this).attr("id");
 										let bitrate = parseInt(id)*1000;
 										if(bitrate === 0) {
@@ -340,7 +342,7 @@ $(document).ready(function() {
 								// eslint-disable-next-line no-unused-vars
 								ondataopen: function(label, protocol) {
 									Janus.log("The DataChannel is available!");
-									$('#videos').removeClass('hide').show();
+									$('#videos').removeClass('hide');
 									$('#datasend').removeAttr('disabled');
 								},
 								ondata: function(data) {
@@ -362,8 +364,8 @@ $(document).ready(function() {
 									$('#toggleaudio').attr('disabled', true);
 									$('#togglevideo').attr('disabled', true);
 									$('#bitrate').attr('disabled', true);
-									$('#curbitrate').hide();
-									$('#curres').hide();
+									$('#curbitrate').addClass('hide');
+									$('#curres').addClass('hide');
 									$('#datasend').attr('disabled', true);
 									simulcastStarted = false;
 									$('#simulcast').remove();
@@ -423,27 +425,21 @@ function getQueryStringValue(name) {
 // Helpers to create Simulcast-related UI, if enabled
 function addSimulcastButtons(temporal) {
 	$('#curres').parent().append(
-		'<div id="simulcast" class="btn-group-vertical btn-group-vertical-xs pull-right">' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
-		'			<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality" style="width: 33%">SL 2</button>' +
-		'			<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality" style="width: 33%">SL 1</button>' +
-		'			<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality" style="width: 34%">SL 0</button>' +
-		'		</div>' +
+		'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
+		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs hide" style="width: 100%">' +
-		'			<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2" style="width: 34%">TL 2</button>' +
-		'			<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1" style="width: 33%">TL 1</button>' +
-		'			<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0" style="width: 33%">TL 0</button>' +
-		'		</div>' +
+		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {
 		// Chromium-based browsers only have two temporal layers
 		$('#tl-2').remove();
-		$('#tl-1').css('width', '50%');
-		$('#tl-0').css('width', '50%');
 	}
 	// Enable the simulcast selection buttons
 	$('#sl-0').removeClass('btn-primary btn-success').addClass('btn-primary')

--- a/html/echotest.html
+++ b/html/echotest.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>

--- a/html/echotest.html
+++ b/html/echotest.html
@@ -7,8 +7,9 @@
 <title>Janus WebRTC Server (multistream): Echo Test</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
@@ -17,34 +18,34 @@
 <script type="text/javascript" src="echotest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='echotest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='echotest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Echo Test
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -91,49 +92,53 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="videos">
+			<div class="container mt-4 hide" id="videos">
 				<div class="row">
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Local Stream
-									<div class="btn-group btn-group-xs pull-right hide">
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Local Stream
+									<div class="btn-group btn-group-sm top-right hide">
 										<button class="btn btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
 										<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
-										<div class="btn-group btn-group-xs">
+										<div class="btn-group btn-group-sm">
 											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
 												Bandwidth<span class="caret"></span>
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
-												<li><a href="#" id="0">No limit</a></li>
-												<li><a href="#" id="128">Cap to 128kbit</a></li>
-												<li><a href="#" id="256">Cap to 256kbit</a></li>
-												<li><a href="#" id="512">Cap to 512kbit</a></li>
-												<li><a href="#" id="1024">Cap to 1mbit</a></li>
-												<li><a href="#" id="1500">Cap to 1.5mbit</a></li>
-												<li><a href="#" id="2000">Cap to 2mbit</a></li>
+												<a class="dropdown-item" href="#" id="0">No limit</a>
+												<a class="dropdown-item" href="#" id="128">Cap to 128kbit</a>
+												<a class="dropdown-item" href="#" id="256">Cap to 256kbit</a>
+												<a class="dropdown-item" href="#" id="512">Cap to 512kbit</a>
+												<a class="dropdown-item" href="#" id="1024">Cap to 1mbit</a>
+												<a class="dropdown-item" href="#" id="1500">Cap to 1.5mbit</a>
+												<a class="dropdown-item" href="#" id="2000">Cap to 2mbit</a>
 											</ul>
 										</div>
 									</div>
-								</h3>
+								</span>
 							</div>
-							<div class="panel-body" id="videoleft"></div>
+							<div class="card-body" id="videoleft"></div>
 						</div>
-						<div class="input-group margin-bottom-sm">
-							<span class="input-group-addon"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							<input class="form-control" type="text" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled />
+						<div class="input-group mt-3 mb-3">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							</div>
+							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled>
 						</div>
 					</div>
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Stream <span class="label label-primary hide" id="curres"></span> <span class="label label-info hide" id="curbitrate"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Stream <span class="badge badge-primary hide" id="curres"></span> <span class="badge badge-info hide" id="curbitrate"></span></span>
 							</div>
-							<div class="panel-body" id="videoright"></div>
+							<div class="card-body" id="videoright"></div>
 						</div>
-						<div class="input-group margin-bottom-sm">
-							<span class="input-group-addon"><i class="fa fa-cloud-download fa-fw"></i></span>
-							<input class="form-control" type="text" id="datarecv" disabled />
+						<div class="input-group mt-3 mb-3">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							</div>
+							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>
 				</div>

--- a/html/echotest.html
+++ b/html/echotest.html
@@ -7,10 +7,10 @@
 <title>Janus WebRTC Server (multistream): Echo Test</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -25,7 +25,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
@@ -99,20 +99,20 @@
 							<div class="card-header">
 								<span class="card-title">Local Stream
 									<div class="btn-group btn-group-sm top-right hide">
-										<button class="btn btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
-										<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
+										<button class="btn btn-sm btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
+										<button class="btn btn-sm btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
 										<div class="btn-group btn-group-sm">
-											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-												Bandwidth<span class="caret"></span>
+											<button id="bitrateset" autocomplete="off" class="btn btn-sm btn-primary dropdown-toggle" data-bs-toggle="dropdown">
+												Bandwidth
 											</button>
-											<ul id="bitrate" class="dropdown-menu" role="menu">
-												<a class="dropdown-item" href="#" id="0">No limit</a>
-												<a class="dropdown-item" href="#" id="128">Cap to 128kbit</a>
-												<a class="dropdown-item" href="#" id="256">Cap to 256kbit</a>
-												<a class="dropdown-item" href="#" id="512">Cap to 512kbit</a>
-												<a class="dropdown-item" href="#" id="1024">Cap to 1mbit</a>
-												<a class="dropdown-item" href="#" id="1500">Cap to 1.5mbit</a>
-												<a class="dropdown-item" href="#" id="2000">Cap to 2mbit</a>
+											<ul id="bitrate" class="dropdown-menu">
+												<li><a class="dropdown-item" href="#" id="0">No limit</a></li>
+												<li><a class="dropdown-item" href="#" id="128">Cap to 128kbit</a></li>
+												<li><a class="dropdown-item" href="#" id="256">Cap to 256kbit</a></li>
+												<li><a class="dropdown-item" href="#" id="512">Cap to 512kbit</a></li>
+												<li><a class="dropdown-item" href="#" id="1024">Cap to 1mbit</a></li>
+												<li><a class="dropdown-item" href="#" id="1500">Cap to 1.5mbit</a></li>
+												<li><a class="dropdown-item" href="#" id="2000">Cap to 2mbit</a></li>
 											</ul>
 										</div>
 									</div>
@@ -121,23 +121,19 @@
 							<div class="card-body" id="videoleft"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled>
 						</div>
 					</div>
 					<div class="col-md-6">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Stream <span class="badge badge-primary hide" id="curres"></span> <span class="badge badge-info hide" id="curbitrate"></span></span>
+								<span class="card-title">Remote Stream <span class="badge bg-primary hide" id="curres"></span> <span class="badge bg-info hide" id="curbitrate"></span></span>
 							</div>
 							<div class="card-body" id="videoright"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>

--- a/html/echotest.html
+++ b/html/echotest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Echo Test</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/echotest.html
+++ b/html/echotest.html
@@ -27,7 +27,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
@@ -121,7 +121,7 @@
 							<div class="card-body" id="videoleft"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-up"></i></span>
 							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled>
 						</div>
 					</div>
@@ -133,7 +133,7 @@
 							<div class="card-body" id="videoright"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-down"></i></span>
 							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>

--- a/html/echotest.js
+++ b/html/echotest.js
@@ -12,7 +12,6 @@ var opaqueId = "echotest-"+Janus.randomString(12);
 var localTracks = {}, localVideos = 0,
 	remoteTracks = {}, remoteVideos = 0;
 var bitrateTimer = null;
-var spinner = null;
 
 var audioenabled = false;
 var videoenabled = false;
@@ -180,9 +179,6 @@ $(document).ready(function() {
 										if(result === "done") {
 											// The plugin closed the echo test
 											bootbox.alert("The Echo Test is over");
-											if(spinner)
-												spinner.stop();
-											spinner = null;
 											$('video').remove();
 											$('#waitingvideo').remove();
 											$('#toggleaudio').attr('disabled', true);
@@ -425,9 +421,6 @@ $(document).ready(function() {
 								},
 								oncleanup: function() {
 									Janus.log(" ::: Got a cleanup notification :::");
-									if(spinner)
-										spinner.stop();
-									spinner = null;
 									if(bitrateTimer)
 										clearInterval(bitrateTimer);
 									bitrateTimer = null;

--- a/html/echotest.js
+++ b/html/echotest.js
@@ -115,6 +115,13 @@ $(document).ready(function() {
 											success: function(jsep) {
 												Janus.debug("Got SDP!", jsep);
 												echotest.send({ message: body, jsep: jsep });
+												// Create a spinner waiting for the remote video
+												$('#videoright').html(
+													'<div class="text-center">' +
+													'	<div id="spinner" class="spinner-border" role="status">' +
+													'		<span class="visually-hidden">Loading...</span>' +
+													'	</div>' +
+													'</div>');
 											},
 											error: function(error) {
 												Janus.error("WebRTC error:", error);
@@ -320,6 +327,7 @@ $(document).ready(function() {
 										return;
 									}
 									// If we're here, a new track was added
+									$('#spinner').remove();
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;

--- a/html/echotest.js
+++ b/html/echotest.js
@@ -141,6 +141,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -187,8 +188,8 @@ $(document).ready(function() {
 											$('#toggleaudio').attr('disabled', true);
 											$('#togglevideo').attr('disabled', true);
 											$('#bitrate').attr('disabled', true);
-											$('#curbitrate').hide();
-											$('#curres').hide();
+											$('#curbitrate').addClass('hide');
+											$('#curres').addClass('hide');
 											return;
 										}
 										// Any loss?
@@ -261,7 +262,7 @@ $(document).ready(function() {
 										return;
 									}
 									if($('#videoleft video').length === 0) {
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 									}
 									if(track.kind === "audio") {
 										// We ignore local audio tracks, they'd generate echo anyway
@@ -326,7 +327,7 @@ $(document).ready(function() {
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 									}
 									if(track.kind === "audio") {
 										// New audio track: create a stream out of it, and use a hidden <audio> element
@@ -358,7 +359,7 @@ $(document).ready(function() {
 										Janus.attachMediaStream($('#peervideo' + mid).get(0), stream);
 										// FIXME we'll need this for additional videos too
 										if(!bitrateTimer) {
-											$('#curbitrate').removeClass('hide').show();
+											$('#curbitrate').removeClass('hide');
 											bitrateTimer = setInterval(function() {
 												if(!$("#peervideo" + mid).get(0))
 													return;
@@ -370,7 +371,7 @@ $(document).ready(function() {
 												let width = $("#peervideo" + mid).get(0).videoWidth;
 												let height = $("#peervideo" + mid).get(0).videoHeight;
 												if(width > 0 && height > 0)
-													$('#curres').removeClass('hide').text(width+'x'+height).show();
+													$('#curres').removeClass('hide').text(width+'x'+height).removeClass('hide');
 											}, 1000);
 										}
 									}
@@ -397,8 +398,9 @@ $(document).ready(function() {
 												$('#togglevideo').html("Enable video").removeClass("btn-danger").addClass("btn-success");
 											echotest.send({ message: { video: videoenabled }});
 										});
-									$('#toggleaudio').parent().removeClass('hide').show();
+									$('#toggleaudio').parent().removeClass('hide');
 									$('#bitrate a').click(function() {
+										$('.dropdown-toggle').dropdown('hide');
 										let id = $(this).attr("id");
 										let bitrate = parseInt(id)*1000;
 										if(bitrate === 0) {
@@ -414,7 +416,7 @@ $(document).ready(function() {
 								// eslint-disable-next-line no-unused-vars
 								ondataopen: function(label, protocol) {
 									Janus.log("The DataChannel is available!");
-									$('#videos').removeClass('hide').show();
+									$('#videos').removeClass('hide');
 									$('#datasend').removeAttr('disabled');
 								},
 								ondata: function(data) {
@@ -436,8 +438,8 @@ $(document).ready(function() {
 									$('#toggleaudio').attr('disabled', true);
 									$('#togglevideo').attr('disabled', true);
 									$('#bitrate').attr('disabled', true);
-									$('#curbitrate').hide();
-									$('#curres').hide();
+									$('#curbitrate').addClass('hide');
+									$('#curres').addClass('hide');
 									$('#datasend').attr('disabled', true);
 									simulcastStarted = false;
 									$('#simulcast').remove();
@@ -499,27 +501,21 @@ function addSimulcastSvcButtons(temporal) {
 	let what = (simulcastStarted ? 'simulcast' : 'SVC');
 	let layer = (simulcastStarted ? 'substream' : 'layer');
 	$('#curres').parent().append(
-		'<div id="simulcast" class="btn-group-vertical btn-group-vertical-xs pull-right">' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
-		'			<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality" style="width: 33%">SL 2</button>' +
-		'			<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality" style="width: 33%">SL 1</button>' +
-		'			<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality" style="width: 34%">SL 0</button>' +
-		'		</div>' +
+		'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
+		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs hide" style="width: 100%">' +
-		'			<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2" style="width: 34%">TL 2</button>' +
-		'			<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1" style="width: 33%">TL 1</button>' +
-		'			<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0" style="width: 33%">TL 0</button>' +
-		'		</div>' +
+		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	if(simulcastStarted && Janus.webRTCAdapter.browserDetails.browser !== "firefox") {
 		// Chromium-based browsers only have two temporal layers, when doing simulcast
 		$('#tl-2').remove();
-		$('#tl-1').css('width', '50%');
-		$('#tl-0').css('width', '50%');
 	}
 	// Enable the simulcast selection buttons
 	$('#sl-0').removeClass('btn-primary btn-success').addClass('btn-primary')

--- a/html/echotest.js
+++ b/html/echotest.js
@@ -148,7 +148,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -408,7 +408,7 @@ $(document).ready(function() {
 										} else {
 											Janus.log("Capping bandwidth to " + bitrate + " via REMB");
 										}
-										$('#bitrateset').html($(this).html() + '<span class="caret"></span>').parent().removeClass('open');
+										$('#bitrateset').text($(this).text()).parent().removeClass('open');
 										echotest.send({ message: { bitrate: bitrate }});
 										return false;
 									});
@@ -503,14 +503,14 @@ function addSimulcastSvcButtons(temporal) {
 	$('#curres').parent().append(
 		'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
 		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
-		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
-		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
-		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
 		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
-		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
-		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
-		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	if(simulcastStarted && Janus.webRTCAdapter.browserDetails.browser !== "firefox") {

--- a/html/echotest.js
+++ b/html/echotest.js
@@ -246,7 +246,7 @@ $(document).ready(function() {
 												if($('#videoleft .no-video-container').length === 0) {
 													$('#videoleft').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No webcam available</span>' +
 														'</div>');
 												}
@@ -271,7 +271,7 @@ $(document).ready(function() {
 											if($('#videoleft .no-video-container').length === 0) {
 												$('#videoleft').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}
@@ -314,7 +314,7 @@ $(document).ready(function() {
 												if($('#videoright .no-video-container').length === 0) {
 													$('#videoright').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No remote video available</span>' +
 														'</div>');
 												}
@@ -342,7 +342,7 @@ $(document).ready(function() {
 											if($('#videoright .no-video-container').length === 0) {
 												$('#videoright').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}

--- a/html/index.html
+++ b/html/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): About Janus</title>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script>

--- a/html/index.html
+++ b/html/index.html
@@ -6,32 +6,32 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): About Janus</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top a[href='index.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top a[href='index.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>About</h1>
 			</div>
-			<h3>Janus: the general purpose WebRTC server</h3>
+			<h3 class="mt-3">Janus: the general purpose WebRTC server</h3>
 			<div class="alert alert-warning">
 				<b>Note Well:</b> these are the demos and documentation for the <code>multistream</code> version
 				of Janus, which is a new version. If you want to check the previous version of

--- a/html/index.html
+++ b/html/index.html
@@ -6,7 +6,8 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): About Janus</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script>
 	$(function() {
 		$(".fixed-top").load("navbar.html", function() {
@@ -15,7 +16,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 </head>
 <body>

--- a/html/multiopus.html
+++ b/html/multiopus.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>

--- a/html/multiopus.html
+++ b/html/multiopus.html
@@ -27,7 +27,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
@@ -111,7 +111,7 @@
 							<div class="card-body" id="videoleft"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-up"></i></span>
 							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled>
 						</div>
 					</div>
@@ -123,7 +123,7 @@
 							<div class="card-body" id="videoright"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-down"></i></span>
 							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>

--- a/html/multiopus.html
+++ b/html/multiopus.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Multichannel Opus (surround)</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/multiopus.html
+++ b/html/multiopus.html
@@ -7,10 +7,10 @@
 <title>Janus WebRTC Server (multistream): Multichannel Opus (surround)</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -25,7 +25,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
@@ -92,8 +92,8 @@
 										<button class="btn btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
 										<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
 										<div class="btn-group btn-group-sm">
-											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-												Bandwidth<span class="caret"></span>
+											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">
+												Bandwidth
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
 												<a class="dropdown-item" href="#" id="0">No limit</a>
@@ -111,23 +111,19 @@
 							<div class="card-body" id="videoleft"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled>
 						</div>
 					</div>
 					<div class="col-md-6">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Stream <span class="badge badge-primary hide" id="curres"></span> <span class="badge badge-info hide" id="curbitrate"></span></span>
+								<span class="card-title">Remote Stream <span class="badge bg-primary hide" id="curres"></span> <span class="badge bg-info hide" id="curbitrate"></span></span>
 							</div>
 							<div class="card-body" id="videoright"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>

--- a/html/multiopus.html
+++ b/html/multiopus.html
@@ -7,8 +7,9 @@
 <title>Janus WebRTC Server (multistream): Multichannel Opus (surround)</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
@@ -17,34 +18,34 @@
 <script type="text/javascript" src="multiopus.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='multiopus.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='multiopus.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Multichannel Opus (surround)
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -81,49 +82,53 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="videos">
+			<div class="container mt-4 hide" id="videos">
 				<div class="row">
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Local Stream
-									<div class="btn-group btn-group-xs pull-right hide">
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Local Stream
+									<div class="btn-group btn-group-sm top-right hide">
 										<button class="btn btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
 										<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
-										<div class="btn-group btn-group-xs">
+										<div class="btn-group btn-group-sm">
 											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
 												Bandwidth<span class="caret"></span>
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
-												<li><a href="#" id="0">No limit</a></li>
-												<li><a href="#" id="128">Cap to 128kbit</a></li>
-												<li><a href="#" id="256">Cap to 256kbit</a></li>
-												<li><a href="#" id="512">Cap to 512kbit</a></li>
-												<li><a href="#" id="1024">Cap to 1mbit</a></li>
-												<li><a href="#" id="1500">Cap to 1.5mbit</a></li>
-												<li><a href="#" id="2000">Cap to 2mbit</a></li>
+												<a class="dropdown-item" href="#" id="0">No limit</a>
+												<a class="dropdown-item" href="#" id="128">Cap to 128kbit</a>
+												<a class="dropdown-item" href="#" id="256">Cap to 256kbit</a>
+												<a class="dropdown-item" href="#" id="512">Cap to 512kbit</a>
+												<a class="dropdown-item" href="#" id="1024">Cap to 1mbit</a>
+												<a class="dropdown-item" href="#" id="1500">Cap to 1.5mbit</a>
+												<a class="dropdown-item" href="#" id="2000">Cap to 2mbit</a>
 											</ul>
 										</div>
 									</div>
-								</h3>
+								</span>
 							</div>
-							<div class="panel-body" id="videoleft"></div>
+							<div class="card-body" id="videoleft"></div>
 						</div>
-						<div class="input-group margin-bottom-sm">
-							<span class="input-group-addon"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							<input class="form-control" type="text" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled></input>
+						<div class="input-group mt-3 mb-3">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							</div>
+							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(event);" disabled>
 						</div>
 					</div>
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Stream <span class="label label-primary hide" id="curres"></span> <span class="label label-info hide" id="curbitrate"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Stream <span class="badge badge-primary hide" id="curres"></span> <span class="badge badge-info hide" id="curbitrate"></span></span>
 							</div>
-							<div class="panel-body" id="videoright"></div>
+							<div class="card-body" id="videoright"></div>
 						</div>
-						<div class="input-group margin-bottom-sm">
-							<span class="input-group-addon"><i class="fa fa-cloud-download fa-fw"></i></span>
-							<input class="form-control" type="text" id="datarecv" disabled></input>
+						<div class="input-group mt-3 mb-3">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							</div>
+							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>
 				</div>

--- a/html/multiopus.js
+++ b/html/multiopus.js
@@ -97,6 +97,13 @@ $(document).ready(function() {
 											success: function(jsep) {
 												Janus.debug("Got SDP!", jsep);
 												echotest.send({ message: body, jsep: jsep });
+												// Create a spinner waiting for the remote video
+												$('#videoright').html(
+													'<div class="text-center">' +
+													'	<div id="spinner" class="spinner-border" role="status">' +
+													'		<span class="visually-hidden">Loading...</span>' +
+													'	</div>' +
+													'</div>');
 											},
 											error: function(error) {
 												Janus.error("WebRTC error:", error);
@@ -229,6 +236,7 @@ $(document).ready(function() {
 										return;
 									}
 									// If we're here, a new track was added
+									$('#spinner').remove();
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;

--- a/html/multiopus.js
+++ b/html/multiopus.js
@@ -223,7 +223,7 @@ $(document).ready(function() {
 												if($('#videoright .no-video-container').length === 0) {
 													$('#videoright').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No remote video available</span>' +
 														'</div>');
 												}
@@ -251,7 +251,7 @@ $(document).ready(function() {
 											if($('#videoright .no-video-container').length === 0) {
 												$('#videoright').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}

--- a/html/multiopus.js
+++ b/html/multiopus.js
@@ -123,6 +123,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -169,8 +170,8 @@ $(document).ready(function() {
 											$('#toggleaudio').attr('disabled', true);
 											$('#togglevideo').attr('disabled', true);
 											$('#bitrate').attr('disabled', true);
-											$('#curbitrate').hide();
-											$('#curres').hide();
+											$('#curbitrate').addClass('hide');
+											$('#curres').addClass('hide');
 											return;
 										}
 										// Any loss?
@@ -235,7 +236,7 @@ $(document).ready(function() {
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 									}
 									if(track.kind === "audio") {
 										// New audio track: create a stream out of it, and use a hidden <audio> element
@@ -267,7 +268,7 @@ $(document).ready(function() {
 										Janus.attachMediaStream($('#peervideo' + mid).get(0), stream);
 										// FIXME we'll need this for additional videos too
 										if(!bitrateTimer) {
-											$('#curbitrate').removeClass('hide').show();
+											$('#curbitrate').removeClass('hide');
 											bitrateTimer = setInterval(function() {
 												if(!$("#peervideo" + mid).get(0))
 													return;
@@ -279,7 +280,7 @@ $(document).ready(function() {
 												let width = $("#peervideo" + mid).get(0).videoWidth;
 												let height = $("#peervideo" + mid).get(0).videoHeight;
 												if(width > 0 && height > 0)
-													$('#curres').removeClass('hide').text(width+'x'+height).show();
+													$('#curres').removeClass('hide').text(width+'x'+height).removeClass('hide');
 											}, 1000);
 										}
 									}
@@ -306,8 +307,9 @@ $(document).ready(function() {
 												$('#togglevideo').html("Enable video").removeClass("btn-danger").addClass("btn-success");
 											echotest.send({ message: { video: videoenabled }});
 										});
-									$('#toggleaudio').parent().removeClass('hide').show();
+									$('#toggleaudio').parent().removeClass('hide');
 									$('#bitrate a').click(function() {
+										$('.dropdown-toggle').dropdown('hide');
 										let id = $(this).attr("id");
 										let bitrate = parseInt(id)*1000;
 										if(bitrate === 0) {
@@ -323,7 +325,7 @@ $(document).ready(function() {
 								// eslint-disable-next-line no-unused-vars
 								ondataopen: function(label, protocol) {
 									Janus.log("The DataChannel is available!");
-									$('#videos').removeClass('hide').show();
+									$('#videos').removeClass('hide');
 									$('#datasend').removeAttr('disabled');
 								},
 								ondata: function(data) {
@@ -345,8 +347,8 @@ $(document).ready(function() {
 									$('#toggleaudio').attr('disabled', true);
 									$('#togglevideo').attr('disabled', true);
 									$('#bitrate').attr('disabled', true);
-									$('#curbitrate').hide();
-									$('#curres').hide();
+									$('#curbitrate').addClass('hide');
+									$('#curres').addClass('hide');
 									$('#datasend').attr('disabled', true);
 									simulcastStarted = false;
 									$('#simulcast').remove();
@@ -416,27 +418,21 @@ function getQueryStringValue(name) {
 // Helpers to create Simulcast-related UI, if enabled
 function addSimulcastButtons(temporal) {
 	$('#curres').parent().append(
-		'<div id="simulcast" class="btn-group-vertical btn-group-vertical-xs pull-right">' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
-		'			<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality" style="width: 33%">SL 2</button>' +
-		'			<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality" style="width: 33%">SL 1</button>' +
-		'			<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality" style="width: 34%">SL 0</button>' +
-		'		</div>' +
+		'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
+		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs hide" style="width: 100%">' +
-		'			<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2" style="width: 34%">TL 2</button>' +
-		'			<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1" style="width: 33%">TL 1</button>' +
-		'			<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0" style="width: 33%">TL 0</button>' +
-		'		</div>' +
+		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {
 		// Chromium-based browsers only have two temporal layers
 		$('#tl-2').remove();
-		$('#tl-1').css('width', '50%');
-		$('#tl-0').css('width', '50%');
 	}
 	// Enable the simulcast selection buttons
 	$('#sl-0').removeClass('btn-primary btn-success').addClass('btn-primary')

--- a/html/multiopus.js
+++ b/html/multiopus.js
@@ -11,7 +11,6 @@ var opaqueId = "multiopus-"+Janus.randomString(12);
 
 var remoteTracks = {}, remoteVideos = 0;
 var bitrateTimer = null;
-var spinner = null;
 
 var audioenabled = false;
 var videoenabled = false;
@@ -162,9 +161,6 @@ $(document).ready(function() {
 										if(result === "done") {
 											// The plugin closed the echo test
 											bootbox.alert("The Echo Test is over");
-											if(spinner)
-												spinner.stop();
-											spinner = null;
 											$('video').remove();
 											$('#waitingvideo').remove();
 											$('#toggleaudio').attr('disabled', true);
@@ -334,9 +330,6 @@ $(document).ready(function() {
 								},
 								oncleanup: function() {
 									Janus.log(" ::: Got a cleanup notification :::");
-									if(spinner)
-										spinner.stop();
-									spinner = null;
 									if(bitrateTimer)
 										clearInterval(bitrateTimer);
 									bitrateTimer = null;

--- a/html/multiopus.js
+++ b/html/multiopus.js
@@ -130,7 +130,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -317,7 +317,7 @@ $(document).ready(function() {
 										} else {
 											Janus.log("Capping bandwidth to " + bitrate + " via REMB");
 										}
-										$('#bitrateset').html($(this).html() + '<span class="caret"></span>').parent().removeClass('open');
+										$('#bitrateset').text($(this).text()).parent().removeClass('open');
 										echotest.send({ message: { bitrate: bitrate }});
 										return false;
 									});
@@ -420,14 +420,14 @@ function addSimulcastButtons(temporal) {
 	$('#curres').parent().append(
 		'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
 		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
-		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
-		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
-		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
 		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
-		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
-		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
-		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {

--- a/html/mvideoroomtest.html
+++ b/html/mvideoroomtest.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>

--- a/html/mvideoroomtest.html
+++ b/html/mvideoroomtest.html
@@ -7,10 +7,10 @@
 <title>Janus WebRTC Server (multistream): Video Room Demo (multistream)</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -25,7 +25,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
@@ -66,12 +66,10 @@
 			</div>
 			<div class="container mt-4 hide" id="videojoin">
 				<div class="row">
-					<span class="badge badge-info" id="you"></span>
+					<span class="badge bg-info" id="you"></span>
 					<div class="col-md-12" id="controls">
 						<div class="input-group mt-3 mb-1 hide" id="registernow">
-							<div class="input-group-prepend">
-								<span class="input-group-text">@</span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
 							<input autocomplete="off" class="form-control" autocomplete="off" type="text" placeholder="Choose a display name" id="username" onkeypress="return checkEnter(this, event);"></input>
 							<span class="input-group-btn">
 								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>
@@ -85,11 +83,11 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Local Video <span class="badge badge-primary hide" id="publisher"></span>
+								<span class="card-title">Local Video <span class="badge bg-primary hide" id="publisher"></span>
 									<div class="btn-group btn-group-sm top-right hide">
 										<div class="btn-group btn-group-sm">
-											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-												Bandwidth<span class="caret"></span>
+											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">
+												Bandwidth
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
 												<a class="dropdown-item" href="#" id="0">No limit</a>
@@ -110,7 +108,7 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Video #1 <span class="badge badge-info hide" id="remote1"></span></span>
+								<span class="card-title">Remote Video #1 <span class="badge bg-info hide" id="remote1"></span></span>
 							</div>
 							<div class="card-body relative" id="videoremote1"></div>
 						</div>
@@ -118,7 +116,7 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Video #2 <span class="badge badge-info hide" id="remote2"></span></span>
+								<span class="card-title">Remote Video #2 <span class="badge bg-info hide" id="remote2"></span></span>
 							</div>
 							<div class="card-body relative" id="videoremote2"></div>
 						</div>
@@ -128,7 +126,7 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Video #3 <span class="badge badge-info hide" id="remote3"></span></span>
+								<span class="card-title">Remote Video #3 <span class="badge bg-info hide" id="remote3"></span></span>
 							</div>
 							<div class="card-body relative" id="videoremote3"></div>
 						</div>
@@ -136,7 +134,7 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Video #4 <span class="badge badge-info hide" id="remote4"></span></span>
+								<span class="card-title">Remote Video #4 <span class="badge bg-info hide" id="remote4"></span></span>
 							</div>
 							<div class="card-body relative" id="videoremote4"></div>
 						</div>
@@ -144,7 +142,7 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Video #5 <span class="badge badge-info hide" id="remote5"></span></span>
+								<span class="card-title">Remote Video #5 <span class="badge bg-info hide" id="remote5"></span></span>
 							</div>
 							<div class="card-body relative" id="videoremote5"></div>
 						</div>

--- a/html/mvideoroomtest.html
+++ b/html/mvideoroomtest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Video Room Demo (multistream)</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/mvideoroomtest.html
+++ b/html/mvideoroomtest.html
@@ -7,8 +7,9 @@
 <title>Janus WebRTC Server (multistream): Video Room Demo (multistream)</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
@@ -17,34 +18,34 @@
 <script type="text/javascript" src="mvideoroomtest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='mvideoroomtest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='mvideoroomtest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Video Room (multistream)
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -63,12 +64,14 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="videojoin">
+			<div class="container mt-4 hide" id="videojoin">
 				<div class="row">
-					<span class="label label-info" id="you"></span>
+					<span class="badge badge-info" id="you"></span>
 					<div class="col-md-12" id="controls">
-						<div class="input-group margin-bottom-md hide" id="registernow">
-							<span class="input-group-addon">@</span>
+						<div class="input-group mt-3 mb-1 hide" id="registernow">
+							<div class="input-group-prepend">
+								<span class="input-group-text">@</span>
+							</div>
 							<input autocomplete="off" class="form-control" autocomplete="off" type="text" placeholder="Choose a display name" id="username" onkeypress="return checkEnter(this, event);"></input>
 							<span class="input-group-btn">
 								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>
@@ -77,73 +80,73 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="videos">
+			<div class="container mt-4 hide" id="videos">
 				<div class="row">
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Local Video <span class="label label-primary hide" id="publisher"></span>
-									<div class="btn-group btn-group-xs pull-right hide">
-										<div class="btn-group btn-group-xs">
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Local Video <span class="badge badge-primary hide" id="publisher"></span>
+									<div class="btn-group btn-group-sm top-right hide">
+										<div class="btn-group btn-group-sm">
 											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
 												Bandwidth<span class="caret"></span>
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
-												<li><a href="#" id="0">No limit</a></li>
-												<li><a href="#" id="128">Cap to 128kbit</a></li>
-												<li><a href="#" id="256">Cap to 256kbit</a></li>
-												<li><a href="#" id="512">Cap to 512kbit</a></li>
-												<li><a href="#" id="1024">Cap to 1mbit</a></li>
-												<li><a href="#" id="1500">Cap to 1.5mbit</a></li>
-												<li><a href="#" id="2000">Cap to 2mbit</a></li>
+												<a class="dropdown-item" href="#" id="0">No limit</a>
+												<a class="dropdown-item" href="#" id="128">Cap to 128kbit</a>
+												<a class="dropdown-item" href="#" id="256">Cap to 256kbit</a>
+												<a class="dropdown-item" href="#" id="512">Cap to 512kbit</a>
+												<a class="dropdown-item" href="#" id="1024">Cap to 1mbit</a>
+												<a class="dropdown-item" href="#" id="1500">Cap to 1.5mbit</a>
+												<a class="dropdown-item" href="#" id="2000">Cap to 2mbit</a>
 											</ul>
 										</div>
 									</div>
-								</h3>
+								</span>
 							</div>
-							<div class="panel-body" id="videolocal"></div>
+							<div class="card-body" id="videolocal"></div>
 						</div>
 					</div>
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Video #1 <span class="label label-info hide" id="remote1"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Video #1 <span class="badge badge-info hide" id="remote1"></span></span>
 							</div>
-							<div class="panel-body relative" id="videoremote1"></div>
+							<div class="card-body relative" id="videoremote1"></div>
 						</div>
 					</div>
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Video #2 <span class="label label-info hide" id="remote2"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Video #2 <span class="badge badge-info hide" id="remote2"></span></span>
 							</div>
-							<div class="panel-body relative" id="videoremote2"></div>
+							<div class="card-body relative" id="videoremote2"></div>
 						</div>
 					</div>
 				</div>
 				<div class="row">
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Video #3 <span class="label label-info hide" id="remote3"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Video #3 <span class="badge badge-info hide" id="remote3"></span></span>
 							</div>
-							<div class="panel-body relative" id="videoremote3"></div>
+							<div class="card-body relative" id="videoremote3"></div>
 						</div>
 					</div>
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Video #4 <span class="label label-info hide" id="remote4"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Video #4 <span class="badge badge-info hide" id="remote4"></span></span>
 							</div>
-							<div class="panel-body relative" id="videoremote4"></div>
+							<div class="card-body relative" id="videoremote4"></div>
 						</div>
 					</div>
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Video #5 <span class="label label-info hide" id="remote5"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Video #5 <span class="badge badge-info hide" id="remote5"></span></span>
 							</div>
-							<div class="panel-body relative" id="videoremote5"></div>
+							<div class="card-body relative" id="videoremote5"></div>
 						</div>
 					</div>
 				</div>

--- a/html/mvideoroomtest.html
+++ b/html/mvideoroomtest.html
@@ -27,7 +27,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
@@ -69,7 +69,7 @@
 					<span class="badge bg-info" id="you"></span>
 					<div class="col-md-12" id="controls">
 						<div class="input-group mt-3 mb-1 hide" id="registernow">
-							<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-user"></i></span>
 							<input autocomplete="off" class="form-control" autocomplete="off" type="text" placeholder="Choose a display name" id="username" onkeypress="return checkEnter(this, event);"></input>
 							<span class="input-group-btn">
 								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>

--- a/html/mvideoroomtest.js
+++ b/html/mvideoroomtest.js
@@ -64,8 +64,8 @@ $(document).ready(function() {
 									Janus.log("Plugin attached! (" + sfutest.getPlugin() + ", id=" + sfutest.getId() + ")");
 									Janus.log("  -- This is a publisher/manager");
 									// Prepare the username registration
-									$('#videojoin').removeClass('hide').show();
-									$('#registernow').removeClass('hide').show();
+									$('#videojoin').removeClass('hide');
+									$('#registernow').removeClass('hide');
 									$('#register').click(registerUsername);
 									$('#username').focus();
 									$('#start').removeAttr('disabled').html("Stop")
@@ -84,6 +84,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -110,8 +111,9 @@ $(document).ready(function() {
 										return;
 									$('#publish').remove();
 									// This controls allows us to override the global room bitrate cap
-									$('#bitrate').parent().parent().removeClass('hide').show();
+									$('#bitrate').parent().parent().removeClass('hide');
 									$('#bitrate a').click(function() {
+										$('.dropdown-toggle').dropdown('hide');
 										let id = $(this).attr("id");
 										let bitrate = parseInt(id)*1000;
 										if(bitrate === 0) {
@@ -139,8 +141,8 @@ $(document).ready(function() {
 											mypvtid = msg["private_id"];
 											Janus.log("Successfully joined room " + msg["room"] + " with ID " + myid);
 											if(subscriber_mode) {
-												$('#videojoin').hide();
-												$('#videos').removeClass('hide').show();
+												$('#videojoin').addClass('hide');
+												$('#videos').removeClass('hide');
 											} else {
 												publishOwnFeed(true);
 											}
@@ -273,7 +275,7 @@ $(document).ready(function() {
 											// Video has been rejected
 											toastr.warning("Our video stream has been rejected, viewers won't see us");
 											// Hide the webcam video
-											$('#myvideo').hide();
+											$('#myvideo').addClass('hide');
 											$('#videolocal').append(
 												'<div class="no-video-container">' +
 													'<i class="fa fa-video-camera fa-5 no-video-icon" style="height: 100%;"></i>' +
@@ -323,7 +325,7 @@ $(document).ready(function() {
 										// We've been here already
 										return;
 									}
-									$('#videos').removeClass('hide').show();
+									$('#videos').removeClass('hide');
 									if($('#mute').length === 0) {
 										// Add a 'mute' button
 										$('#videolocal').append('<button class="btn btn-warning btn-xs" id="mute" style="position: absolute; bottom: 0px; left: 0px; margin: 15px;">Mute</button>');
@@ -423,7 +425,7 @@ function registerUsername() {
 		let username = $('#username').val();
 		if(username === "") {
 			$('#you')
-				.removeClass().addClass('label label-warning')
+				.removeClass().addClass('badge badge-warning')
 				.html("Insert your display name (e.g., pippo)");
 			$('#username').removeAttr('disabled');
 			$('#register').removeAttr('disabled').click(registerUsername);
@@ -431,7 +433,7 @@ function registerUsername() {
 		}
 		if(/[^a-zA-Z0-9]/.test(username)) {
 			$('#you')
-				.removeClass().addClass('label label-warning')
+				.removeClass().addClass('badge badge-warning')
 				.html('Input is not alphanumeric');
 			$('#username').removeAttr('disabled').val("");
 			$('#register').removeAttr('disabled').click(registerUsername);
@@ -569,7 +571,7 @@ function subscribeTo(sources) {
 							feeds[slot] = stream.id;
 							feedStreams[stream.id].slot = slot;
 							feedStreams[stream.id].remoteVideos = 0;
-							$('#remote' + slot).removeClass('hide').html(escapeXmlTags(stream.display)).show();
+							$('#remote' + slot).removeClass('hide').html(escapeXmlTags(stream.display)).removeClass('hide');
 							break;
 						}
 					}
@@ -643,7 +645,7 @@ function subscribeTo(sources) {
 									feeds[slot] = stream.id;
 									feedStreams[stream.id].slot = slot;
 									feedStreams[stream.id].remoteVideos = 0;
-									$('#remote' + slot).removeClass('hide').html(escapeXmlTags(stream.display)).show();
+									$('#remote' + slot).removeClass('hide').html(escapeXmlTags(stream.display)).removeClass('hide');
 									break;
 								}
 							}
@@ -839,12 +841,12 @@ function subscribeTo(sources) {
 					Janus.log("Created remote video stream:", stream);
 					$('#videoremote' + slot).append('<video class="rounded centered" id="remotevideo' + slot + '-' + mid + '" width=100% autoplay playsinline/>');
 					$('#videoremote' + slot).append(
-						'<span class="label label-primary hide" id="curres'+slot+'" style="position: absolute; bottom: 0px; left: 0px; margin: 15px;"></span>' +
-						'<span class="label label-info hide" id="curbitrate'+slot+'" style="position: absolute; bottom: 0px; right: 0px; margin: 15px;"></span>');
+						'<span class="badge badge-primary hide" id="curres'+slot+'" style="position: absolute; bottom: 0px; left: 0px; margin: 15px;"></span>' +
+						'<span class="badge badge-info hide" id="curbitrate'+slot+'" style="position: absolute; bottom: 0px; right: 0px; margin: 15px;"></span>');
 					Janus.attachMediaStream($('#remotevideo' + slot + '-' + mid).get(0), stream);
 					// Note: we'll need this for additional videos too
 					if(!bitrateTimer[slot]) {
-						$('#curbitrate' + slot).removeClass('hide').show();
+						$('#curbitrate' + slot).removeClass('hide');
 						bitrateTimer[slot] = setInterval(function() {
 							if(!$("#videoremote" + slot + ' video').get(0))
 								return;
@@ -860,7 +862,7 @@ function subscribeTo(sources) {
 									res += ' (simulcast)';
 								else if(svcStarted[slot])
 									res += ' (SVC)';
-								$('#curres' + slot).removeClass('hide').text(res).show();
+								$('#curres' + slot).removeClass('hide').text(res).removeClass('hide');
 							}
 						}, 1000);
 					}
@@ -892,7 +894,7 @@ function unsubscribeFrom(id) {
 	if(bitrateTimer[feed.slot])
 		clearInterval(bitrateTimer[feed.slot]);
 	bitrateTimer[feed.slot] = null;
-	$('#remote' + feed.slot).empty().hide();
+	$('#remote' + feed.slot).empty().addClass('hide');
 	$('#videoremote' + feed.slot).empty();
 	delete simulcastStarted[feed.slot];
 	delete svcStarted[feed.slot];
@@ -934,23 +936,23 @@ function addSimulcastSvcButtons(feed, temporal) {
 	let what = (simulcast ? 'simulcast' : 'SVC');
 	let layer = (simulcast ? 'substream' : 'layer');
 	$('#remote'+index).parent().append(
-		'<div id="simulcast'+index+'" class="btn-group-vertical btn-group-vertical-xs pull-right">' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
-		'			<button id="sl'+index+'-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality" style="width: 33%">SL 2</button>' +
-		'			<button id="sl'+index+'-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality" style="width: 33%">SL 1</button>' +
-		'			<button id="sl'+index+'-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality" style="width: 34%">SL 0</button>' +
-		'		</div>' +
+		'<div id="simulcast'+index+'" class="btn-group-vertical btn-group-xs top-right">' +
+		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
+		'		<button id="sl'+index+'-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl'+index+'-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl'+index+'-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs hide" style="width: 100%">' +
-		'			<button id="tl'+index+'-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2" style="width: 34%">TL 2</button>' +
-		'			<button id="tl'+index+'-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1" style="width: 33%">TL 1</button>' +
-		'			<button id="tl'+index+'-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0" style="width: 33%">TL 0</button>' +
-		'		</div>' +
+		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
+		'		<button id="tl'+index+'-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl'+index+'-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl'+index+'-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>'
 	);
+	if(simulcast && Janus.webRTCAdapter.browserDetails.browser !== "firefox") {
+		// Chromium-based browsers only have two temporal layers, when doing simulcast
+		$('#tl'+index+'-2').remove();
+	}
 	// Enable the simulcast selection buttons
 	$('#sl' + index + '-0').removeClass('btn-primary btn-success').addClass('btn-primary')
 		.unbind('click').click(function() {

--- a/html/mvideoroomtest.js
+++ b/html/mvideoroomtest.js
@@ -91,7 +91,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -121,7 +121,7 @@ $(document).ready(function() {
 										} else {
 											Janus.log("Capping bandwidth to " + bitrate + " via REMB");
 										}
-										$('#bitrateset').html($(this).html() + '<span class="caret"></span>').parent().removeClass('open');
+										$('#bitrateset').text($(this).text()).parent().removeClass('open');
 										sfutest.send({ message: { request: "configure", bitrate: bitrate }});
 										return false;
 									});
@@ -425,7 +425,7 @@ function registerUsername() {
 		let username = $('#username').val();
 		if(username === "") {
 			$('#you')
-				.removeClass().addClass('badge badge-warning')
+				.removeClass().addClass('badge bg-warning')
 				.html("Insert your display name (e.g., pippo)");
 			$('#username').removeAttr('disabled');
 			$('#register').removeAttr('disabled').click(registerUsername);
@@ -433,7 +433,7 @@ function registerUsername() {
 		}
 		if(/[^a-zA-Z0-9]/.test(username)) {
 			$('#you')
-				.removeClass().addClass('badge badge-warning')
+				.removeClass().addClass('badge bg-warning')
 				.html('Input is not alphanumeric');
 			$('#username').removeAttr('disabled').val("");
 			$('#register').removeAttr('disabled').click(registerUsername);
@@ -841,8 +841,8 @@ function subscribeTo(sources) {
 					Janus.log("Created remote video stream:", stream);
 					$('#videoremote' + slot).append('<video class="rounded centered" id="remotevideo' + slot + '-' + mid + '" width=100% autoplay playsinline/>');
 					$('#videoremote' + slot).append(
-						'<span class="badge badge-primary hide" id="curres'+slot+'" style="position: absolute; bottom: 0px; left: 0px; margin: 15px;"></span>' +
-						'<span class="badge badge-info hide" id="curbitrate'+slot+'" style="position: absolute; bottom: 0px; right: 0px; margin: 15px;"></span>');
+						'<span class="badge bg-primary hide" id="curres'+slot+'" style="position: absolute; bottom: 0px; left: 0px; margin: 15px;"></span>' +
+						'<span class="badge bg-info hide" id="curbitrate'+slot+'" style="position: absolute; bottom: 0px; right: 0px; margin: 15px;"></span>');
 					Janus.attachMediaStream($('#remotevideo' + slot + '-' + mid).get(0), stream);
 					// Note: we'll need this for additional videos too
 					if(!bitrateTimer[slot]) {
@@ -938,14 +938,14 @@ function addSimulcastSvcButtons(feed, temporal) {
 	$('#remote'+index).parent().append(
 		'<div id="simulcast'+index+'" class="btn-group-vertical btn-group-xs top-right">' +
 		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
-		'		<button id="sl'+index+'-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
-		'		<button id="sl'+index+'-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
-		'		<button id="sl'+index+'-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
+		'		<button id="sl'+index+'-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl'+index+'-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl'+index+'-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
 		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
-		'		<button id="tl'+index+'-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
-		'		<button id="tl'+index+'-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
-		'		<button id="tl'+index+'-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
+		'		<button id="tl'+index+'-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl'+index+'-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl'+index+'-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>'
 	);

--- a/html/mvideoroomtest.js
+++ b/html/mvideoroomtest.js
@@ -809,10 +809,6 @@ function subscribeTo(sources) {
 					return;
 				}
 				// If we're here, a new track was added
-				if(feed.spinner) {
-					feed.spinner.stop();
-					feed.spinner = null;
-				}
 				if($('#remotevideo' + slot + '-' + mid).length > 0)
 					return;
 				if(track.kind === "audio") {

--- a/html/mvideoroomtest.js
+++ b/html/mvideoroomtest.js
@@ -278,7 +278,7 @@ $(document).ready(function() {
 											$('#myvideo').addClass('hide');
 											$('#videolocal').append(
 												'<div class="no-video-container">' +
-													'<i class="fa fa-video-camera fa-5 no-video-icon" style="height: 100%;"></i>' +
+													'<i class="fa-solid fa-video fa-xl no-video-icon" style="height: 100%;"></i>' +
 													'<span class="no-video-text" style="font-size: 16px;">Video rejected, no webcam</span>' +
 												'</div>');
 										}
@@ -310,7 +310,7 @@ $(document).ready(function() {
 												if($('#videolocal .no-video-container').length === 0) {
 													$('#videolocal').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No webcam available</span>' +
 														'</div>');
 												}
@@ -341,7 +341,7 @@ $(document).ready(function() {
 											if($('#videolocal .no-video-container').length === 0) {
 												$('#videolocal').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}
@@ -797,7 +797,7 @@ function subscribeTo(sources) {
 							if($('#videoremote' + slot + ' .no-video-container').length === 0) {
 								$('#videoremote' + slot).append(
 									'<div class="no-video-container">' +
-										'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+										'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 										'<span class="no-video-text">No remote video available</span>' +
 									'</div>');
 							}
@@ -827,7 +827,7 @@ function subscribeTo(sources) {
 						if($('#videoremote' + slot + ' .no-video-container').length === 0) {
 							$('#videoremote' + slot).append(
 								'<div class="no-video-container">' +
-									'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+									'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 									'<span class="no-video-text">No remote video available</span>' +
 								'</div>');
 						}

--- a/html/navbar.html
+++ b/html/navbar.html
@@ -1,52 +1,51 @@
 <div class="container">
-	<div class="navbar-header">
-		<a class="navbar-brand" href="index.html">Janus (multistream)</a>
-		<button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-			<span class="icon-bar"></span>
-			<span class="icon-bar"></span>
-			<span class="icon-bar"></span>
-		</button>
-	</div>
-	<div class="navbar-collapse collapse">
-		<ul class="nav navbar-nav">
-			<li><a href="index.html">Home</a></li>
-			<li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Demos <b class="caret"></b></a>
-				<ul class="dropdown-menu">
-					<li><a href="demos.html">Index</a></li>
-					<li class="divider"></li>
-					<li><a href="echotest.html">Echo Test</a></li>
-					<li><a href="streamingtest.html">Streaming</a></li>
-					<li><a href="videocalltest.html">Video Call</a></li>
-					<li><a href="siptest.html">SIP Gateway</a></li>
-					<li><a href="videoroomtest.html">Video Room</a></li>
-					<li><a href="mvideoroomtest.html">Video Room (multistream)</a></li>
-					<li><a href="audiobridgetest.html">Audio Bridge</a></li>
-					<li><a href="textroomtest.html">Text Room</a></li>
-					<li><a href="recordplaytest.html">Recorder/Playout</a></li>
-					<li class="divider"></li>
-					<li><a href="screensharingtest.html">Screen Sharing</a></li>
-					<li><a href="nosiptest.html">NoSIP (SDP/RTP)</a></li>
-					<li class="divider"></li>
-					<li><a href="devicetest.html">Device Selection</a></li>
-					<li><a href="e2etest.html">End-to-end Encryption</a></li>
-					<li><a href="multiopus.html">Multichannel Opus (surround)</a></li>
-					<li><a href="canvas.html">Canvas Capture</a></li>
-					<li><a href="webaudio.html">Web Audio Processing</a></li>
-					<li><a href="virtualbg.html">Virtual Background</a></li>
-					<li class="divider"></li>
-					<li><a href="admin.html">Admin/Monitor</a></li>
-				</ul>
+	<a class="navbar-brand" href="index.html">Janus (multistream)</a>
+	<button type="button" class="navbar-toggler" data-toggle="collapse" data-target=".navbar-collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false">
+		<span class="navbar-toggler-icon"></span>
+	</button>
+	<div class="navbar-collapse collapse" id="navbarResponsive">
+		<ul class="navbar-nav">
+			<li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+			<li class="nav-item dropdown">
+				<a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="demos">Demos <b class="caret"></b></a>
+				<div class="dropdown-menu" aria-labelledby="demos">
+					<a class="dropdown-item" href="demos.html">Index</a>
+					<div class="dropdown-divider"></div>
+					<a class="dropdown-item" href="echotest.html">Echo Test</a>
+					<a class="dropdown-item" href="streamingtest.html">Streaming</a>
+					<a class="dropdown-item" href="videocalltest.html">Video Call</a>
+					<a class="dropdown-item" href="siptest.html">SIP Gateway</a>
+					<a class="dropdown-item" href="videoroomtest.html">Video Room</a>
+					<a class="dropdown-item" href="mvideoroomtest.html">Video Room (multistream)</a>
+					<a class="dropdown-item" href="audiobridgetest.html">Audio Bridge</a>
+					<a class="dropdown-item" href="textroomtest.html">Text Room</a>
+					<a class="dropdown-item" href="recordplaytest.html">Recorder/Playout</a>
+					<div class="dropdown-divider"></div>
+					<a class="dropdown-item" href="screensharingtest.html">Screen Sharing</a>
+					<a class="dropdown-item" href="nosiptest.html">NoSIP (SDP/RTP)</a>
+					<div class="dropdown-divider"></div>
+					<a class="dropdown-item" href="devicetest.html">Device Selection</a>
+					<a class="dropdown-item" href="e2etest.html">End-to-end Encryption</a>
+					<a class="dropdown-item" href="multiopus.html">Multichannel Opus (surround)</a>
+					<a class="dropdown-item" href="canvas.html">Canvas Capture</a>
+					<a class="dropdown-item" href="webaudio.html">Web Audio Processing</a>
+					<a class="dropdown-item" href="virtualbg.html">Virtual Background</a>
+					<div class="dropdown-divider"></div>
+					<a class="dropdown-item" href="admin.html">Admin/Monitor</a>
+				</div>
 			</li>
-			<li><a href="docs">Documentation</a></li>
-			<li><a href="citeus.html">Papers</a></li>
-			<li><a href="support.html">Need help?</a></li>
-			<li><a href="https://janus-legacy.conf.meetecho.com/">Janus (0.x)</a></li>
-			<li><a class="januscon" target="_blank" href="https://januscon.it">JanusCon!</a></li>
+			<li class="nav-item"><a class="nav-link" href="docs">Documentation</a></li>
+			<li class="nav-item"><a class="nav-link" href="citeus.html">Papers</a></li>
+			<li class="nav-item"><a class="nav-link" href="support.html">Need help?</a></li>
+			<li class="nav-item"><a class="nav-link" href="https://janus-legacy.conf.meetecho.com/">Janus (0.x)</a></li>
+			<li class="nav-item"><a class="nav-link januscon" target="_blank" href="https://januscon.it">JanusCon!</a></li>
 		</ul>
-		<div class="navbar-header navbar-right">
-			<ul class="nav navbar-nav">
-				<li><a target="_blank" href="https://www.meetecho.com" class="navbar-link meetecho-logo"><img src="meetecho-logo.png"/></a></li>
-			</ul>
-		</div>
+		<ul class="navbar-nav ml-auto">
+			<li class="nav-item">
+				<a class="nav-link meetecho-logo" target="_blank" href="https://www.meetecho.com">
+					<img src="meetecho-logo.png"/>
+				</a>
+			</li>
+		</ul>
 	</div>
 </div>

--- a/html/navbar.html
+++ b/html/navbar.html
@@ -1,13 +1,13 @@
 <div class="container">
 	<a class="navbar-brand" href="index.html">Janus (multistream)</a>
-	<button type="button" class="navbar-toggler" data-toggle="collapse" data-target=".navbar-collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false">
+	<button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
 		<span class="navbar-toggler-icon"></span>
 	</button>
 	<div class="navbar-collapse collapse" id="navbarResponsive">
 		<ul class="navbar-nav">
 			<li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
 			<li class="nav-item dropdown">
-				<a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="demos">Demos <b class="caret"></b></a>
+				<a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" id="demos">Demos</a>
 				<div class="dropdown-menu" aria-labelledby="demos">
 					<a class="dropdown-item" href="demos.html">Index</a>
 					<div class="dropdown-divider"></div>
@@ -40,7 +40,7 @@
 			<li class="nav-item"><a class="nav-link" href="https://janus-legacy.conf.meetecho.com/">Janus (0.x)</a></li>
 			<li class="nav-item"><a class="nav-link januscon" target="_blank" href="https://januscon.it">JanusCon!</a></li>
 		</ul>
-		<ul class="navbar-nav ml-auto">
+		<ul class="navbar-nav ms-auto">
 			<li class="nav-item">
 				<a class="nav-link meetecho-logo" target="_blank" href="https://www.meetecho.com">
 					<img src="meetecho-logo.png"/>

--- a/html/nosiptest.html
+++ b/html/nosiptest.html
@@ -26,7 +26,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 </head>
 <body>
 

--- a/html/nosiptest.html
+++ b/html/nosiptest.html
@@ -7,9 +7,10 @@
 <title>Janus WebRTC Server (multistream): NoSIP (SDP/RTP)</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>
@@ -23,7 +24,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 </head>

--- a/html/nosiptest.html
+++ b/html/nosiptest.html
@@ -8,7 +8,7 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -16,33 +16,33 @@
 <script type="text/javascript" src="nosiptest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='nosiptest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='nosiptest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: NoSIP (SDP/RTP)
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -69,29 +69,29 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="videos">
+			<div class="container mt-4 hide" id="videos">
 				<div class="row">
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Caller
-									<div class="btn-group btn-group-xs pull-right">
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Caller
+									<div class="btn-group btn-group-sm top-right">
 										<button class="btn btn-danger" autocomplete="off" id="togglevideo" disabled>Disable video</button>
 									</div>
-								</h3>
+								</span>
 							</div>
-							<div class="panel-body" id="videoleft"></div>
+							<div class="card-body" id="videoleft"></div>
 						</div>
-						<pre id="localsdp"></pre>
+						<pre class="card card-body bg-gray mt-3" id="localsdp"></pre>
 					</div>
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Callee</h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Callee</span>
 							</div>
-							<div class="panel-body" id="videoright"></div>
+							<div class="card-body" id="videoright"></div>
 						</div>
-						<pre id="remotesdp"></pre>
+						<pre class="card card-body bg-gray mt-3" id="remotesdp"></pre>
 					</div>
 				</div>
 			</div>

--- a/html/nosiptest.html
+++ b/html/nosiptest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): NoSIP (SDP/RTP)</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/nosiptest.html
+++ b/html/nosiptest.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>
 <script type="text/javascript" src="nosiptest.js"></script>

--- a/html/nosiptest.js
+++ b/html/nosiptest.js
@@ -13,7 +13,6 @@ var opaqueId = Janus.randomString(12);
 // The local and remote tracks only refer to the caller, though (we ignore the callee)
 var localTracks = {}, localVideos = 0,
 	remoteTracks = {}, remoteVideos = 0;
-var spinner = null;
 
 var callstarted = false, videoenabled = true;
 var srtp = undefined ; // use "sdes_mandatory" to test SRTP-SDES
@@ -318,9 +317,6 @@ $(document).ready(function() {
 								},
 								oncleanup: function() {
 									Janus.log("[caller]  ::: Got a cleanup notification :::");
-									if(spinner)
-										spinner.stop();
-									spinner = null;
 									$("#videoleft").empty().parent().unblock();
 									$('#videoright').empty();
 									$('#dtmf').parent().html("Remote UA");

--- a/html/nosiptest.js
+++ b/html/nosiptest.js
@@ -195,7 +195,7 @@ $(document).ready(function() {
 												if($('#videoleft .no-video-container').length === 0) {
 													$('#videoleft').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No webcam available</span>' +
 														'</div>');
 												}
@@ -220,7 +220,7 @@ $(document).ready(function() {
 											if($('#videoleft .no-video-container').length === 0) {
 												$('#videoleft').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}
@@ -259,7 +259,7 @@ $(document).ready(function() {
 												if($('#videoright .no-video-container').length === 0) {
 													$('#videoright').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No remote video available</span>' +
 														'</div>');
 												}
@@ -300,7 +300,7 @@ $(document).ready(function() {
 											if($('#videoright .no-video-container').length === 0) {
 												$('#videoright').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No remote video available</span>' +
 													'</div>');
 											}

--- a/html/nosiptest.js
+++ b/html/nosiptest.js
@@ -94,6 +94,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -210,7 +211,7 @@ $(document).ready(function() {
 										return;
 									}
 									if($('#videoleft video').length === 0) {
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 									}
 									if(track.kind === "audio") {
 										// We ignore local audio tracks, they'd generate echo anyway
@@ -271,7 +272,7 @@ $(document).ready(function() {
 										return;
 									// If we're here, a new track was added
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 										$('#videoright').parent().find('h3').html(
 											'Send DTMF: <span id="dtmf" class="btn-group btn-group-xs"></span>');
 										for(let i=0; i<12; i++) {
@@ -348,6 +349,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',

--- a/html/nosiptest.js
+++ b/html/nosiptest.js
@@ -101,7 +101,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -356,7 +356,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen

--- a/html/nosiptest.js
+++ b/html/nosiptest.js
@@ -75,6 +75,13 @@ $(document).ready(function() {
 														srtp: srtp
 													};
 													caller.send({ message: body, jsep: jsep });
+													// Create a spinner waiting for the remote video
+													$('#videoright').html(
+														'<div class="text-center">' +
+														'	<div id="spinner" class="spinner-border" role="status">' +
+														'		<span class="visually-hidden">Loading...</span>' +
+														'	</div>' +
+														'</div>');
 												},
 												error: function(error) {
 													Janus.error("WebRTC error:", error);
@@ -270,6 +277,7 @@ $(document).ready(function() {
 									if($('#peervideo' + mid).length > 0)
 										return;
 									// If we're here, a new track was added
+									$('#spinner').remove();
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										$('#videos').removeClass('hide');
 										$('#videoright').parent().find('h3').html(

--- a/html/recordplaytest.html
+++ b/html/recordplaytest.html
@@ -7,8 +7,9 @@
 <title>Janus WebRTC Server (multistream): Recorder/Playout Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -16,33 +17,33 @@
 <script type="text/javascript" src="recordplaytest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='recordplaytest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='recordplaytest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Recorder/Playout
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -61,46 +62,48 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="recordplay">
-				<div id="demo">
+			<div class="container mt-4 hide" id="recordplay">
+				<div id="demo" class="row">
 					<div class="col-md-6" id="controls">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Recorder/Playout</h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Recorder/Playout</span>
 							</div>
-							<div class="panel-body">
+							<div class="card-body">
 								<div class="btn-group btn-group-sm">
 									<button class="btn btn-danger" disabled autocomplete="off" id="record">Record</button>
 									<button class="btn btn-success" disabled autocomplete="off" id="play">Play</button>
 									<button class="btn btn-primary" disabled autocomplete="off" id="list">Update <i id="update-list" class="fa fa-refresh"></i></button>
 								</div>
 								<br/>
-								<div class="btn-group btn-group-sm" style="width: 100%">
-									<div class="btn-group btn-group-sm" style="width: 100%">
-										<button autocomplete="off" id="recset" class="btn btn-default dropdown-toggle" data-toggle="dropdown" style="width: 100%">
-											Recordings list<span class="caret"></span>
-										</button>
-										<ul id="recslist" class="dropdown-menu" role="menu" style="max-height: 300px; overflow: auto;">
-										</ul>
-									</div>
+								<div class="btn-group btn-group-sm w-100">
+									<button autocomplete="off" id="recset" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
+										Recordings list<span class="caret"></span>
+									</button>
+									<ul id="recslist" class="dropdown-menu" role="menu" style="max-height: 300px; overflow: auto;">
+									</ul>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div class="col-md-6 hide" id="video">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">
+					<div class="col-md-6 invisible" id="video">
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">
 									<span id="videotitle">Remote Video</span>
-									<button class="btn-xs btn-danger pull-right" autocomplete="off" id="stop">Stop</button>
-									<button class="btn-xs btn-primary pull-right" autocomplete="off" id="pause-resume">Pause</button>
-								</h3>
+									<div class="btn-group btn-group-sm top-right">
+										<button class="btn btn-primary" autocomplete="off" id="pause-resume">Pause</button>
+										<button class="btn btn-danger" autocomplete="off" id="stop">Stop</button>
+									</div>
+								</span>
 							</div>
-							<div class="panel-body" id="videobox"></div>
+							<div class="card-body" id="videobox"></div>
 						</div>
-						<div class="input-group margin-bottom-sm hide">
-							<span class="input-group-addon"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							<input class="form-control" type="text" placeholder="" autocomplete="off" id="datafield" onkeypress="return checkEnter(event);" disabled />
+						<div class="input-group mt-3 mb-3 hide">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							</div>
+							<input type="text" class="form-control" id="datafield" disabled>
 						</div>
 					</div>
 				</div>

--- a/html/recordplaytest.html
+++ b/html/recordplaytest.html
@@ -7,10 +7,10 @@
 <title>Janus WebRTC Server (multistream): Recorder/Playout Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>
@@ -24,7 +24,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 </head>
@@ -77,8 +77,8 @@
 								</div>
 								<br/>
 								<div class="btn-group btn-group-sm w-100">
-									<button autocomplete="off" id="recset" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
-										Recordings list<span class="caret"></span>
+									<button autocomplete="off" id="recset" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown">
+										Recordings list
 									</button>
 									<ul id="recslist" class="dropdown-menu" role="menu" style="max-height: 300px; overflow: auto;">
 									</ul>
@@ -100,9 +100,7 @@
 							<div class="card-body" id="videobox"></div>
 						</div>
 						<div class="input-group mt-3 mb-3 hide">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							<input type="text" class="form-control" id="datafield" disabled>
 						</div>
 					</div>

--- a/html/recordplaytest.html
+++ b/html/recordplaytest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Recorder/Playout Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/recordplaytest.html
+++ b/html/recordplaytest.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>
 <script type="text/javascript" src="recordplaytest.js"></script>

--- a/html/recordplaytest.html
+++ b/html/recordplaytest.html
@@ -26,7 +26,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 </head>
 <body>
 
@@ -73,7 +73,7 @@
 								<div class="btn-group btn-group-sm">
 									<button class="btn btn-danger" disabled autocomplete="off" id="record">Record</button>
 									<button class="btn btn-success" disabled autocomplete="off" id="play">Play</button>
-									<button class="btn btn-primary" disabled autocomplete="off" id="list">Update <i id="update-list" class="fa fa-refresh"></i></button>
+									<button class="btn btn-primary" disabled autocomplete="off" id="list">Update <i id="update-list" class="fa-solid fa-rotate"></i></button>
 								</div>
 								<br/>
 								<div class="btn-group btn-group-sm w-100">
@@ -100,7 +100,7 @@
 							<div class="card-body" id="videobox"></div>
 						</div>
 						<div class="input-group mt-3 mb-3 hide">
-							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-down"></i></span>
 							<input type="text" class="form-control" id="datafield" disabled>
 						</div>
 					</div>

--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -61,7 +61,7 @@ $(document).ready(function() {
 									recordplay = pluginHandle;
 									Janus.log("Plugin attached! (" + recordplay.getPlugin() + ", id=" + recordplay.getId() + ")");
 									// Prepare the name prompt
-									$('#recordplay').removeClass('hide').show();
+									$('#recordplay').removeClass('hide');
 									$('#start').removeAttr('disabled').html("Stop")
 										.click(function() {
 											$(this).attr('disabled', true);
@@ -79,6 +79,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -165,7 +166,7 @@ $(document).ready(function() {
 												}
 												// FIXME Reset status
 												$('#videobox').empty();
-												$('#video').hide();
+												$('#video').addClass('invisible');
 												recordingId = null;
 												recording = false;
 												playing = false;
@@ -184,7 +185,7 @@ $(document).ready(function() {
 										bootbox.alert(error);
 										// FIXME Reset status
 										$('#videobox').empty();
-										$('#video').hide();
+										$('#video').addClass('invisible');
 										recording = false;
 										playing = false;
 										recordplay.hangup();
@@ -240,10 +241,7 @@ $(document).ready(function() {
 									}
 									$('#videotitle').html("Recording...");
 									$('#stop').unbind('click').click(stopRecPlay);
-									$('#video').removeClass('hide').show();
-									if($('#videobox video').length === 0) {
-										$('#videos').removeClass('hide').show();
-									}
+									$('#video').removeClass('invisible');
 									if(track.kind === "audio") {
 										// We ignore local audio tracks, they'd generate echo anyway
 										if(localVideos === 0) {
@@ -311,7 +309,7 @@ $(document).ready(function() {
 									if($('#videobox audio').length === 0 && $('#videobox video').length === 0) {
 										$('#videotitle').html(selectedRecordingInfo);
 										$('#stop').unbind('click').click(stopRecPlay);
-										$('#video').removeClass('hide').show();
+										$('#video').removeClass('invisible');
 									}
 									if(track.kind === "audio") {
 										// New audio track: create a stream out of it, and use a hidden <audio> element
@@ -341,8 +339,8 @@ $(document).ready(function() {
 										Janus.attachMediaStream($('#thevideo' + mid).get(0), stream);
 										if($('#curres').length === 0) {
 											$('#videobox').append(
-												'<span class="label label-primary" id="curres' +'" style="position: absolute; bottom: 0px; left: 0px; margin: 15px;"></span>' +
-												'<span class="label label-info" id="curbw' +'" style="position: absolute; bottom: 0px; right: 0px; margin: 15px;"></span>');
+												'<span class="badge badge-primary bottom-left m-3" id="curres' +'"></span>' +
+												'<span class="badge badge-info bottom-right m-3" id="curbw' +'"></span>');
 											$('#thevideo' + mid).bind("playing", function () {
 												let width = this.videoWidth;
 												let height = this.videoHeight;
@@ -388,7 +386,7 @@ $(document).ready(function() {
 									delete recordplay.bitrateTimer;
 									$('#videobox').empty();
 									$("#videobox").parent().unblock();
-									$('#video').hide();
+									$('#video').addClass('invisible');
 									$('#datafield').attr('disabled', true).attr('placeholder', '').val('');
 									$('#datafield').parent().addClass('hide');
 									recording = false;
@@ -467,9 +465,10 @@ function updateRecsList() {
 			Janus.debug("Got a list of available recordings:", list);
 			for(let mp in list) {
 				Janus.debug("  >> [" + list[mp]["id"] + "] " + list[mp]["name"] + " (" + list[mp]["date"] + ")");
-				$('#recslist').append("<li><a href='#' id='" + list[mp]["id"] + "'>" + escapeXmlTags(list[mp]["name"]) + " [" + list[mp]["date"] + "]" + "</a></li>");
+				$('#recslist').append("<a class='dropdown-item' href='#' id='" + list[mp]["id"] + "'>" + escapeXmlTags(list[mp]["name"]) + " [" + list[mp]["date"] + "]" + "</a>");
 			}
 			$('#recslist a').unbind('click').click(function() {
+				$('.dropdown-toggle').dropdown('hide');
 				selectedRecording = $(this).attr("id");
 				selectedRecordingInfo = escapeXmlTags($(this).text());
 				$('#recset').html($(this).html()).parent().removeClass('open');

--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -86,7 +86,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -339,8 +339,8 @@ $(document).ready(function() {
 										Janus.attachMediaStream($('#thevideo' + mid).get(0), stream);
 										if($('#curres').length === 0) {
 											$('#videobox').append(
-												'<span class="badge badge-primary bottom-left m-3" id="curres' +'"></span>' +
-												'<span class="badge badge-info bottom-right m-3" id="curbw' +'"></span>');
+												'<span class="badge bg-primary bottom-left m-3" id="curres' +'"></span>' +
+												'<span class="badge bg-info bottom-right m-3" id="curbw' +'"></span>');
 											$('#thevideo' + mid).bind("playing", function () {
 												let width = this.videoWidth;
 												let height = this.videoHeight;

--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -11,7 +11,6 @@ var opaqueId = "recordplaytest-"+Janus.randomString(12);
 
 var localTracks = {}, localVideos = 0,
 	remoteTracks = {}, remoteVideos = 0;
-var spinner = null;
 var bandwidth = 1024 * 1024;
 
 var myname = null;
@@ -378,9 +377,6 @@ $(document).ready(function() {
 									Janus.log(" ::: Got a cleanup notification :::");
 									// FIXME Reset status
 									$('#waitingvideo').remove();
-									if(spinner)
-										spinner.stop();
-									spinner = null;
 									if(recordplay.bitrateTimer)
 										clearInterval(recordplay.bitrateTimer);
 									delete recordplay.bitrateTimer;

--- a/html/recordplaytest.js
+++ b/html/recordplaytest.js
@@ -224,7 +224,7 @@ $(document).ready(function() {
 												if($('#videobox .no-video-container').length === 0) {
 													$('#videobox').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No webcam available</span>' +
 														'</div>');
 												}
@@ -249,7 +249,7 @@ $(document).ready(function() {
 											if($('#videobox .no-video-container').length === 0) {
 												$('#videobox').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}
@@ -294,7 +294,7 @@ $(document).ready(function() {
 												if($('#videobox .no-video-container').length === 0) {
 													$('#videobox').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No remote video available</span>' +
 														'</div>');
 												}
@@ -323,7 +323,7 @@ $(document).ready(function() {
 											if($('#videobox .no-video-container').length === 0) {
 												$('#videobox').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No remote video available</span>' +
 													'</div>');
 											}

--- a/html/screensharingtest.html
+++ b/html/screensharingtest.html
@@ -26,7 +26,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 </head>
 <body>
 
@@ -71,7 +71,7 @@
 			<div class="container mt-5 hide" id="screenmenu">
 				<div class="row col-md-12">
 					<div class="input-group mt-3 mb-1 hide" id="createnow">
-						<span class="input-group-text"><i class="fa fa-users fa-1"></i></span>
+						<span class="input-group-text"><i class="fa-solid fa-users"></i></span>
 						<input class="form-control" type="text" placeholder="Insert a title for the session" autocomplete="off" id="desc" onkeypress="return checkEnterShare(this, event);" />
 						<span class="input-group-btn">
 							<button class="btn btn-success" autocomplete="off" id="create">Share your screen</button>
@@ -83,7 +83,7 @@
 				</div>
 				<div class="row col-md-12">
 					<div class="input-group mt-1 mb-1 hide" id="joinnow">
-						<span class="input-group-text"><i class="fa fa-play-circle fa-1"></i></span>
+						<span class="input-group-text"><i class="fa-solid fa-circle-play"></i></span>
 						<input class="form-control" type="text" placeholder="Insert the numeric session identifier" autocomplete="off" id="roomid" onkeypress="return checkEnterJoin(this, event);" />
 						<span class="input-group-btn">
 							<button class="btn btn-success" autocomplete="off" id="join">Join an existing session</button>

--- a/html/screensharingtest.html
+++ b/html/screensharingtest.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>
 <script type="text/javascript" src="screensharingtest.js"></script>

--- a/html/screensharingtest.html
+++ b/html/screensharingtest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Screen Sharing Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/screensharingtest.html
+++ b/html/screensharingtest.html
@@ -7,9 +7,10 @@
 <title>Janus WebRTC Server (multistream): Screen Sharing Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>
@@ -23,7 +24,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 </head>
@@ -70,9 +71,7 @@
 			<div class="container mt-5 hide" id="screenmenu">
 				<div class="row col-md-12">
 					<div class="input-group mt-3 mb-1 hide" id="createnow">
-						<div class="input-group-prepend">
-							<span class="input-group-text"><i class="fa fa-users fa-1"></i></span>
-						</div>
+						<span class="input-group-text"><i class="fa fa-users fa-1"></i></span>
 						<input class="form-control" type="text" placeholder="Insert a title for the session" autocomplete="off" id="desc" onkeypress="return checkEnterShare(this, event);" />
 						<span class="input-group-btn">
 							<button class="btn btn-success" autocomplete="off" id="create">Share your screen</button>
@@ -84,9 +83,7 @@
 				</div>
 				<div class="row col-md-12">
 					<div class="input-group mt-1 mb-1 hide" id="joinnow">
-						<div class="input-group-prepend">
-							<span class="input-group-text"><i class="fa fa-play-circle fa-1"></i></span>
-						</div>
+						<span class="input-group-text"><i class="fa fa-play-circle fa-1"></i></span>
 						<input class="form-control" type="text" placeholder="Insert the numeric session identifier" autocomplete="off" id="roomid" onkeypress="return checkEnterJoin(this, event);" />
 						<span class="input-group-btn">
 							<button class="btn btn-success" autocomplete="off" id="join">Join an existing session</button>
@@ -99,7 +96,7 @@
 					<div class="col-md-12">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Screen Capture <span class="badge badge-info" id="title"></span> <span class="badge badge-success" id="session"></span></span>
+								<span class="card-title">Screen Capture <span class="badge bg-info" id="title"></span> <span class="badge bg-success" id="session"></span></span>
 							</div>
 							<div class="card-body" id="screencapture"></div>
 						</div>

--- a/html/screensharingtest.html
+++ b/html/screensharingtest.html
@@ -8,7 +8,7 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -16,33 +16,33 @@
 <script type="text/javascript" src="screensharingtest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='screensharingtest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='screensharingtest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Screen Sharing
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -67,10 +67,12 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="screenmenu">
-				<div class="row">
-					<div class="input-group margin-bottom-md hide" id="createnow">
-						<span class="input-group-addon"><i class="fa fa-users fa-1"></i></span>
+			<div class="container mt-5 hide" id="screenmenu">
+				<div class="row col-md-12">
+					<div class="input-group mt-3 mb-1 hide" id="createnow">
+						<div class="input-group-prepend">
+							<span class="input-group-text"><i class="fa fa-users fa-1"></i></span>
+						</div>
 						<input class="form-control" type="text" placeholder="Insert a title for the session" autocomplete="off" id="desc" onkeypress="return checkEnterShare(this, event);" />
 						<span class="input-group-btn">
 							<button class="btn btn-success" autocomplete="off" id="create">Share your screen</button>
@@ -80,9 +82,11 @@
 				<div class="divider col-md-12">
 					<hr class="pull-left"/>or<hr class="pull-right"/>
 				</div>
-				<div class="row">
-					<div class="input-group margin-bottom-md hide" id="joinnow">
-						<span class="input-group-addon"><i class="fa fa-play-circle-o fa-1"></i></span>
+				<div class="row col-md-12">
+					<div class="input-group mt-1 mb-1 hide" id="joinnow">
+						<div class="input-group-prepend">
+							<span class="input-group-text"><i class="fa fa-play-circle fa-1"></i></span>
+						</div>
 						<input class="form-control" type="text" placeholder="Insert the numeric session identifier" autocomplete="off" id="roomid" onkeypress="return checkEnterJoin(this, event);" />
 						<span class="input-group-btn">
 							<button class="btn btn-success" autocomplete="off" id="join">Join an existing session</button>
@@ -90,14 +94,14 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="room">
+			<div class="container mt-4 hide" id="room">
 				<div class="row">
 					<div class="col-md-12">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Screen Capture <span class="label label-info" id="title"></span> <span class="label label-success" id="session"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Screen Capture <span class="badge badge-info" id="title"></span> <span class="badge badge-success" id="session"></span></span>
 							</div>
-							<div class="panel-body" id="screencapture"></div>
+							<div class="card-body" id="screencapture"></div>
 						</div>
 					</div>
 				</div>

--- a/html/screensharingtest.js
+++ b/html/screensharingtest.js
@@ -19,7 +19,6 @@ var source = null;
 
 var localTracks = {}, localVideos = 0,
 	remoteTracks = {}, remoteVideos = 0;
-var spinner = null;
 
 $(document).ready(function() {
 	// Initialize the library (all console debuggers enabled)
@@ -463,12 +462,6 @@ function newRemoteFeed(id, display) {
 				if(event) {
 					if(event === "attached") {
 						// Subscriber created and attached
-						if(!spinner) {
-							let target = document.getElementById('#screencapture');
-							spinner = new Spinner({top:100}).spin(target);
-						} else {
-							spinner.spin();
-						}
 						Janus.log("Successfully attached to feed " + id + " (" + display + ") in room " + msg["room"]);
 						$('#screenmenu').addClass('hide');
 						$('#room').removeClass('hide');
@@ -538,10 +531,6 @@ function newRemoteFeed(id, display) {
 					return;
 				}
 				// If we're here, a new track was added
-				if(spinner !== undefined && spinner !== null) {
-					spinner.stop();
-					spinner = null;
-				}
 				if(track.kind === "audio") {
 					// New audio track: create a stream out of it, and use a hidden <audio> element
 					let stream = new MediaStream([track]);
@@ -579,9 +568,6 @@ function newRemoteFeed(id, display) {
 			oncleanup: function() {
 				Janus.log(" ::: Got a cleanup notification (remote feed " + id + ") :::");
 				$('#waitingvideo').remove();
-				if(spinner)
-					spinner.stop();
-				spinner = null;
 				remoteFeed.remoteTracks = {};
 				remoteFeed.remoteVideos = 0;
 			}

--- a/html/screensharingtest.js
+++ b/html/screensharingtest.js
@@ -234,7 +234,7 @@ $(document).ready(function() {
 												if($('#screencapture .no-video-container').length === 0) {
 													$('#screencapture').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No webcam available</span>' +
 														'</div>');
 												}
@@ -258,7 +258,7 @@ $(document).ready(function() {
 											if($('#screencapture .no-video-container').length === 0) {
 												$('#screencapture').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}
@@ -528,7 +528,7 @@ function newRemoteFeed(id, display) {
 							if($('#screencapture .no-video-container').length === 0) {
 								$('#screencapture').append(
 									'<div class="no-video-container">' +
-										'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+										'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 										'<span class="no-video-text">No remote video available</span>' +
 									'</div>');
 							}
@@ -557,7 +557,7 @@ function newRemoteFeed(id, display) {
 						if($('#screencapture .no-video-container').length === 0) {
 							$('#screencapture').append(
 								'<div class="no-video-container">' +
-									'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+									'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 									'<span class="no-video-text">No remote video available</span>' +
 								'</div>');
 						}

--- a/html/screensharingtest.js
+++ b/html/screensharingtest.js
@@ -52,10 +52,10 @@ $(document).ready(function() {
 									screentest = pluginHandle;
 									Janus.log("Plugin attached! (" + screentest.getPlugin() + ", id=" + screentest.getId() + ")");
 									// Prepare the username registration
-									$('#screenmenu').removeClass('hide').show();
-									$('#createnow').removeClass('hide').show();
+									$('#screenmenu').removeClass('hide');
+									$('#createnow').removeClass('hide');
 									$('#create').click(preShareScreen);
-									$('#joinnow').removeClass('hide').show();
+									$('#joinnow').removeClass('hide');
 									$('#join').click(joinScreen);
 									$('#desc').focus();
 									$('#start').removeAttr('disabled').html("Stop")
@@ -74,6 +74,7 @@ $(document).ready(function() {
 										// Darken screen
 										$.blockUI({
 											message: '',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -248,8 +249,8 @@ $(document).ready(function() {
 										// We've been here already
 										return;
 									}
-									$('#screenmenu').hide();
-									$('#room').removeClass('hide').show();
+									$('#screenmenu').addClass('hide');
+									$('#room').removeClass('hide');
 									if(track.kind === "audio") {
 										// We ignore local audio tracks, they'd generate echo anyway
 										if(localVideos === 0) {
@@ -292,7 +293,7 @@ $(document).ready(function() {
 									Janus.log(" ::: Got a cleanup notification :::");
 									$('#screencapture').empty();
 									$("#screencapture").parent().unblock();
-									$('#room').hide();
+									$('#room').addClass('hide');
 									localTracks = {};
 									localVideos = 0;
 								}
@@ -469,8 +470,8 @@ function newRemoteFeed(id, display) {
 							spinner.spin();
 						}
 						Janus.log("Successfully attached to feed " + id + " (" + display + ") in room " + msg["room"]);
-						$('#screenmenu').hide();
-						$('#room').removeClass('hide').show();
+						$('#screenmenu').addClass('hide');
+						$('#room').removeClass('hide');
 					} else {
 						// What has just happened?
 					}

--- a/html/siptest.html
+++ b/html/siptest.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/blueimp-md5/2.6.0/js/md5.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>

--- a/html/siptest.html
+++ b/html/siptest.html
@@ -7,8 +7,9 @@
 <title>Janus WebRTC Server (multistream): SIP Gateway Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/blueimp-md5/2.6.0/js/md5.min.js"></script>
@@ -18,34 +19,34 @@
 <script type="text/javascript" src="siptest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='siptest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='siptest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: SIP Gateway
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -66,68 +67,81 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="sipcall">
+			<div class="container mt-4 hide" id="sipcall">
 				<div class="row">
-					<div class="col-md-12">
-						<div class="col-md-6 container hide" id="login">
-							<div class="input-group margin-bottom-sm">
-								<span class="input-group-addon"><i class="fa fa-cloud-upload fa-fw"></i></span>
-								<input class="form-control" type="text" placeholder="SIP Registrar (e.g., sip:host:port)" autocomplete="off" id="server" onkeypress="return checkEnter(this, event);" />
+					<div class="col-md-6 container invisible" id="login">
+						<div class="input-group mt-1 mb-1">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							</div>
-							<div class="input-group margin-bottom-sm">
-								<span class="input-group-addon"><i class="fa fa-user fa-fw"></i></span>
-								<input class="form-control" type="text" placeholder="SIP Identity (e.g., sip:goofy@example.com)" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
+							<input class="form-control" type="text" placeholder="SIP Registrar (e.g., sip:host:port)" autocomplete="off" id="server" onkeypress="return checkEnter(this, event);" />
+						</div>
+						<div class="input-group mt-1 mb-1">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
 							</div>
-							<div class="input-group margin-bottom-sm">
-								<span class="input-group-addon"><i class="fa fa-user-plus fa-fw"></i></span>
-								<input class="form-control" type="text" placeholder="Username (e.g., goofy, overrides the one in the SIP identity if provided)" autocomplete="off" id="authuser" onkeypress="return checkEnter(this, event);" />
+							<input class="form-control" type="text" placeholder="SIP Identity (e.g., sip:goofy@example.com)" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
+							<button id="addhelper" class="btn btn-xs btn-info hide" title="Add a new line">
+								<i class="fa fa-plus"></i>
+							</button>
+						</div>
+						<div class="input-group mt-1 mb-1">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-user-plus fa-fw"></i></span>
 							</div>
-							<div class="input-group margin-bottom-sm">
-								<span class="input-group-addon"><i class="fa fa-key fa-fw"></i></span>
-								<input class="form-control" type="password" placeholder="Secret (e.g., mysupersecretpassword)" autocomplete="off" id="password" onkeypress="return checkEnter(this, event);" />
+							<input class="form-control" type="text" placeholder="Username (e.g., goofy, overrides the one in the SIP identity if provided)" autocomplete="off" id="authuser" onkeypress="return checkEnter(this, event);" />
+						</div>
+						<div class="input-group mt-1 mb-1">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-key fa-fw"></i></span>
 							</div>
-							<div class="input-group margin-bottom-sm">
-								<span class="input-group-addon"><i class="fa fa-quote-right fa-fw"></i></span>
-								<input class="form-control" type="text" placeholder="Display name (e.g., Alice Smith)" autocomplete="off" id="displayname" onkeypress="return checkEnter(this, event);" />
+							<input class="form-control" type="password" placeholder="Secret (e.g., mysupersecretpassword)" autocomplete="off" id="password" onkeypress="return checkEnter(this, event);" />
+						</div>
+						<div class="input-group mt-1 mb-1">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-quote-right fa-fw"></i></span>
 							</div>
-							<div class="btn-group btn-group-sm" style="width: 100%">
-								<button class="btn btn-primary" autocomplete="off" id="register" style="width: 30%">Register</button>
-								<div class="btn-group btn-group-sm" style="width: 70%">
-									<button autocomplete="off" id="registerset" class="btn btn-default dropdown-toggle" data-toggle="dropdown" style="width: 100%">
-										Registration approach<span class="caret"></span>
-									</button>
-									<ul id="registerlist" class="dropdown-menu" role="menu">
-										<li><a href='#' id='secret'>Register using plain secret</a></li>
-										<li><a href='#' id='ha1secret'>Register using HA1 secret</a></li>
-										<li><a href='#' id='guest'>Register as a guest (no secret)</a></li>
-									</ul>
-								</div>
+							<input class="form-control" type="text" placeholder="Display name (e.g., Alice Smith)" autocomplete="off" id="displayname" onkeypress="return checkEnter(this, event);" />
+						</div>
+						<div class="btn-group btn-group-sm w-100">
+							<button class="btn btn-primary" autocomplete="off" id="register" style="width: 30%">Register</button>
+							<div class="btn-group btn-group-sm" style="width: 70%">
+								<button autocomplete="off" id="registerset" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" style="width: 100%">
+									Registration approach<span class="caret"></span>
+								</button>
+								<ul id="registerlist" class="dropdown-menu" role="menu">
+									<a class="dropdown-item" href='#' id='secret'>Register using plain secret</a>
+									<a class="dropdown-item" href='#' id='ha1secret'>Register using HA1 secret</a>
+									<a class="dropdown-item" href='#' id='guest'>Register as a guest (no secret)</a>
+								</ul>
 							</div>
 						</div>
-						<div class="col-md-6 container hide" id="phone">
-							<div class="input-group margin-bottom-sm">
-								<span class="input-group-addon"><i class="fa fa-phone fa-fw"></i></span>
-								<input class="form-control" type="text" placeholder="SIP URI to call (e.g., sip:1000@example.com)" autocomplete="off" id="peer" onkeypress="return checkEnter(this, event);" />
+					</div>
+					<div class="col-md-6 container invisible" id="phone">
+						<div class="input-group mt-1 mb-1">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-phone fa-fw"></i></span>
 							</div>
-							<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="call">Call</button> <input autocomplete="off" id="dovideo" type="checkbox" />Use Video
+							<input class="form-control" type="text" placeholder="SIP URI to call (e.g., sip:1000@example.com)" autocomplete="off" id="peer" onkeypress="return checkEnter(this, event);" />
 						</div>
+						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="call">Call</button> <input autocomplete="off" id="dovideo" type="checkbox" />Use Video
 					</div>
 				</div>
-				<div id="videos" class="hide">
+				<div id="videos" class="row mt-2 mb-2 hide">
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">You</h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">You</span>
 							</div>
-							<div class="panel-body" id="videoleft"></div>
+							<div class="card-body" id="videoleft"></div>
 						</div>
 					</div>
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote UA</h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote UA</span>
 							</div>
-							<div class="panel-body" id="videoright"></div>
+							<div class="card-body" id="videoright"></div>
 						</div>
 					</div>
 				</div>

--- a/html/siptest.html
+++ b/html/siptest.html
@@ -28,7 +28,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
@@ -71,26 +71,26 @@
 				<div class="row">
 					<div class="col-md-6 container invisible" id="login">
 						<div class="input-group mt-1 mb-1">
-							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-up"></i></span>
 							<input class="form-control" type="text" placeholder="SIP Registrar (e.g., sip:host:port)" autocomplete="off" id="server" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<div class="input-group mt-1 mb-1">
-							<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-user"></i></span>
 							<input class="form-control" type="text" placeholder="SIP Identity (e.g., sip:goofy@example.com)" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
 							<button id="addhelper" class="btn btn-xs btn-info hide" title="Add a new line">
-								<i class="fa fa-plus"></i>
+								<i class="fa-solid fa-plus"></i>
 							</button>
 						</div>
 						<div class="input-group mt-1 mb-1">
-							<span class="input-group-text"><i class="fa fa-user-plus fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-user-plus"></i></span>
 							<input class="form-control" type="text" placeholder="Username (e.g., goofy, overrides the one in the SIP identity if provided)" autocomplete="off" id="authuser" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<div class="input-group mt-1 mb-1">
-							<span class="input-group-text"><i class="fa fa-key fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-key"></i></span>
 							<input class="form-control" type="password" placeholder="Secret (e.g., mysupersecretpassword)" autocomplete="off" id="password" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<div class="input-group mt-1 mb-1">
-							<span class="input-group-text"><i class="fa fa-quote-right fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-quote-right"></i></span>
 							<input class="form-control" type="text" placeholder="Display name (e.g., Alice Smith)" autocomplete="off" id="displayname" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<div class="btn-group btn-group-sm w-100">
@@ -109,7 +109,7 @@
 					</div>
 					<div class="col-md-6 container invisible" id="phone">
 						<div class="input-group mt-1 mb-1">
-							<span class="input-group-text"><i class="fa fa-phone fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-phone"></i></span>
 							<input class="form-control" type="text" placeholder="SIP URI to call (e.g., sip:1000@example.com)" autocomplete="off" id="peer" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="call">Call</button> <input autocomplete="off" id="dovideo" type="checkbox" />Use Video

--- a/html/siptest.html
+++ b/html/siptest.html
@@ -111,7 +111,7 @@
 							<span class="input-group-text"><i class="fa-solid fa-phone"></i></span>
 							<input class="form-control" type="text" placeholder="SIP URI to call (e.g., sip:1000@example.com)" autocomplete="off" id="peer" onkeypress="return checkEnter(this, event);" />
 						</div>
-						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="call">Call</button> <input autocomplete="off" id="dovideo" type="checkbox" />Use Video
+						<button class="btn btn-success mb-1" autocomplete="off" id="call">Call</button> <input autocomplete="off" id="dovideo" type="checkbox" />Use Video
 					</div>
 				</div>
 				<div id="videos" class="row mt-2 mb-2 hide">

--- a/html/siptest.html
+++ b/html/siptest.html
@@ -7,10 +7,10 @@
 <title>Janus WebRTC Server (multistream): SIP Gateway Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/blueimp-md5/2.6.0/js/md5.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
@@ -26,7 +26,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
@@ -71,43 +71,33 @@
 				<div class="row">
 					<div class="col-md-6 container invisible" id="login">
 						<div class="input-group mt-1 mb-1">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							<input class="form-control" type="text" placeholder="SIP Registrar (e.g., sip:host:port)" autocomplete="off" id="server" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<div class="input-group mt-1 mb-1">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
 							<input class="form-control" type="text" placeholder="SIP Identity (e.g., sip:goofy@example.com)" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
 							<button id="addhelper" class="btn btn-xs btn-info hide" title="Add a new line">
 								<i class="fa fa-plus"></i>
 							</button>
 						</div>
 						<div class="input-group mt-1 mb-1">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-user-plus fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-user-plus fa-fw"></i></span>
 							<input class="form-control" type="text" placeholder="Username (e.g., goofy, overrides the one in the SIP identity if provided)" autocomplete="off" id="authuser" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<div class="input-group mt-1 mb-1">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-key fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-key fa-fw"></i></span>
 							<input class="form-control" type="password" placeholder="Secret (e.g., mysupersecretpassword)" autocomplete="off" id="password" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<div class="input-group mt-1 mb-1">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-quote-right fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-quote-right fa-fw"></i></span>
 							<input class="form-control" type="text" placeholder="Display name (e.g., Alice Smith)" autocomplete="off" id="displayname" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<div class="btn-group btn-group-sm w-100">
 							<button class="btn btn-primary" autocomplete="off" id="register" style="width: 30%">Register</button>
 							<div class="btn-group btn-group-sm" style="width: 70%">
-								<button autocomplete="off" id="registerset" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" style="width: 100%">
-									Registration approach<span class="caret"></span>
+								<button autocomplete="off" id="registerset" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" style="width: 100%">
+									Registration approach
 								</button>
 								<ul id="registerlist" class="dropdown-menu" role="menu">
 									<a class="dropdown-item" href='#' id='secret'>Register using plain secret</a>
@@ -119,9 +109,7 @@
 					</div>
 					<div class="col-md-6 container invisible" id="phone">
 						<div class="input-group mt-1 mb-1">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-phone fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-phone fa-fw"></i></span>
 							<input class="form-control" type="text" placeholder="SIP URI to call (e.g., sip:1000@example.com)" autocomplete="off" id="peer" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="call">Call</button> <input autocomplete="off" id="dovideo" type="checkbox" />Use Video

--- a/html/siptest.html
+++ b/html/siptest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): SIP Gateway Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/siptest.js
+++ b/html/siptest.js
@@ -468,7 +468,7 @@ $(document).ready(function() {
 												if($('#videoleft .no-video-container').length === 0) {
 													$('#videoleft').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No webcam available</span>' +
 														'</div>');
 												}
@@ -493,7 +493,7 @@ $(document).ready(function() {
 											if($('#videoleft .no-video-container').length === 0) {
 												$('#videoleft').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}
@@ -532,7 +532,7 @@ $(document).ready(function() {
 												if($('#videoright .no-video-container').length === 0) {
 													$('#videoright').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No remote video available</span>' +
 														'</div>');
 												}
@@ -547,9 +547,9 @@ $(document).ready(function() {
 										$('#videoright').parent().find('span').html(
 											'Send DTMF: <span id="dtmf" class="btn-group btn-group-xs"></span>' +
 											'<span id="ctrls" class="top-right btn-group btn-group-xs">' +
-												'<button id="msg" title="Send message" class="btn btn-info"><i class="fa fa-envelope"></i></button>' +
-												'<button id="info" title="Send INFO" class="btn btn-info"><i class="fa fa-info"></i></button>' +
-												'<button id="transfer" title="Transfer call" class="btn btn-info"><i class="fa fa-mail-forward"></i></button>' +
+												'<button id="msg" title="Send message" class="btn btn-info"><i class="fa-solid fa-envelope"></i></button>' +
+												'<button id="info" title="Send INFO" class="btn btn-info"><i class="fa-solid fa-info"></i></button>' +
+												'<button id="transfer" title="Transfer call" class="btn btn-info"><i class="fa-solid fa-share"></i></button>' +
 											'</span>');
 										for(let i=0; i<12; i++) {
 											if(i<10)
@@ -656,7 +656,7 @@ $(document).ready(function() {
 											if($('#videoright .no-video-container').length === 0) {
 												$('#videoright').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No remote video available</span>' +
 													'</div>');
 											}
@@ -1014,12 +1014,12 @@ function addHelper(helperCreated) {
 		'	<div class="row">' +
 		'		<div class="col-md-6 container">' +
 		'			<span class="badge bg-info">Helper #' + helperId +
-		'				<i class="fa fa-window-close" id="rmhelper' + helperId + '" style="cursor: pointer;" title="Remove this helper"></i>' +
+		'				<i class="fa-solid fa-rectangle-xmark" id="rmhelper' + helperId + '" style="cursor: pointer;" title="Remove this helper"></i>' +
 		'			</span>' +
 		'		</div>' +
 		'		<div class="col-md-6 container" id="phone' + helperId + '">' +
 		'			<div class="input-group mt-1 mb-1">' +
-		'				<span class="input-group-text"><i class="fa fa-phone fa-fw"></i></span>' +
+		'				<span class="input-group-text"><i class="fa-solid fa-phone"></i></span>' +
 		'				<input disabled class="form-control" type="text" placeholder="SIP URI to call (e.g., sip:1000@example.com)" autocomplete="off" id="peer' + helperId + '" onkeypress="return checkEnter(this, event, ' + helperId + ');"></input>' +
 		'			</div>' +
 		'			<button disabled class="btn btn-success margin-bottom-sm" autocomplete="off" id="call' + helperId + '">Call</button> <input autocomplete="off" id="dovideo' + helperId + '" type="checkbox">Use Video</input>' +
@@ -1435,7 +1435,7 @@ function addHelper(helperCreated) {
 							if($('#videoleft' + helperId + ' .no-video-container').length === 0) {
 								$('#videoleft' + helperId).append(
 									'<div class="no-video-container">' +
-										'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+										'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 										'<span class="no-video-text">No webcam available</span>' +
 									'</div>');
 							}
@@ -1460,7 +1460,7 @@ function addHelper(helperCreated) {
 						if($('#videoleft' + helperId + ' .no-video-container').length === 0) {
 							$('#videoleft' + helperId).append(
 								'<div class="no-video-container">' +
-									'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+									'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 									'<span class="no-video-text">No webcam available</span>' +
 								'</div>');
 						}
@@ -1499,7 +1499,7 @@ function addHelper(helperCreated) {
 							if($('#videoright' + helperId + ' .no-video-container').length === 0) {
 								$('#videoright').append(
 									'<div class="no-video-container">' +
-										'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+										'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 										'<span class="no-video-text">No remote video available</span>' +
 									'</div>');
 							}
@@ -1514,9 +1514,9 @@ function addHelper(helperCreated) {
 					$('#videoright' + helperId).parent().find('span').html(
 						'Send DTMF: <span id="dtmf' + helperId + '" class="btn-group btn-group-xs"></span>' +
 						'<span id="ctrls" class="top-right btn-group btn-group-xs">' +
-							'<button id="msg' + helperId + '" title="Send message" class="btn btn-info"><i class="fa fa-envelope"></i></button>' +
-							'<button id="info' + helperId + '" title="Send INFO" class="btn btn-info"><i class="fa fa-info"></i></button>' +
-							'<button id="transfer' + helperId + '" title="Transfer call" class="btn btn-info"><i class="fa fa-mail-forward"></i></button>' +
+							'<button id="msg' + helperId + '" title="Send message" class="btn btn-info"><i class="fa-solid fa-envelope"></i></button>' +
+							'<button id="info' + helperId + '" title="Send INFO" class="btn btn-info"><i class="fa-solid fa-info"></i></button>' +
+							'<button id="transfer' + helperId + '" title="Transfer call" class="btn btn-info"><i class="fa-solid fa-share"></i></button>' +
 						'</span>');
 					for(let i=0; i<12; i++) {
 						if(i<10)
@@ -1630,7 +1630,7 @@ function addHelper(helperCreated) {
 						if($('#videoright' + helperId + ' .no-video-container').length === 0) {
 							$('#videoright' + helperId).append(
 								'<div class="no-video-container">' +
-									'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+									'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 									'<span class="no-video-text">No remote video available</span>' +
 								'</div>');
 						}

--- a/html/siptest.js
+++ b/html/siptest.js
@@ -51,9 +51,10 @@ $(document).ready(function() {
 									sipcall = pluginHandle;
 									Janus.log("Plugin attached! (" + sipcall.getPlugin() + ", id=" + sipcall.getId() + ")");
 									// Prepare the username registration
-									$('#sipcall').removeClass('hide').show();
-									$('#login').removeClass('hide').show();
+									$('#sipcall').removeClass('hide');
+									$('#login').removeClass('invisible').removeClass('hide');
 									$('#registerlist a').unbind('click').click(function() {
+										$('.dropdown-toggle').dropdown('hide');
 										selectedApproach = $(this).attr("id");
 										$('#registerset').html($(this).html()).parent().removeClass('open');
 										if(selectedApproach === "guest") {
@@ -94,6 +95,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -164,24 +166,19 @@ $(document).ready(function() {
 										}
 										if(event === 'registered') {
 											Janus.log("Successfully registered as " + result["username"] + "!");
-											$('#you').removeClass('hide').show().text("Registered as '" + result["username"] + "'");
+											$('#you').removeClass('hide').text("Registered as '" + result["username"] + "'");
 											// TODO Enable buttons to call now
 											if(!registered) {
 												registered = true;
 												masterId = result["master_id"];
-												$('#server').parent().addClass('hide').hide();
-												$('#authuser').parent().addClass('hide').hide();
-												$('#displayname').parent().addClass('hide').hide();
-												$('#password').parent().addClass('hide').hide();
-												$('#register').parent().addClass('hide').hide();
-												$('#registerset').parent().addClass('hide').hide();
-												$('#username').parent().parent().append(
-													'<button id="addhelper" class="btn btn-xs btn-info pull-right" title="Add a new line">' +
-														'<i class="fa fa-plus"></i>' +
-													'</button>'
-												);
-												$('#addhelper').click(addHelper);
-												$('#phone').removeClass('hide').show();
+												$('#server').parent().addClass('hide');
+												$('#authuser').parent().addClass('hide');
+												$('#displayname').parent().addClass('hide');
+												$('#password').parent().addClass('hide');
+												$('#register').parent().addClass('hide');
+												$('#registerset').parent().addClass('hide');
+												$('#addhelper').removeClass('hide').click(addHelper);
+												$('#phone').removeClass('invisible').removeClass('hide');
 												$('#call').unbind('click').click(doCall);
 												$('#peer').focus();
 											}
@@ -487,7 +484,7 @@ $(document).ready(function() {
 										return;
 									}
 									if($('#videoleft video').length === 0) {
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 									}
 									if(track.kind === "audio") {
 										// We ignore local audio tracks, they'd generate echo anyway
@@ -546,10 +543,10 @@ $(document).ready(function() {
 									}
 									// If we're here, a new track was added
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
-										$('#videos').removeClass('hide').show();
-										$('#videoright').parent().find('h3').html(
+										$('#videos').removeClass('hide');
+										$('#videoright').parent().find('span').html(
 											'Send DTMF: <span id="dtmf" class="btn-group btn-group-xs"></span>' +
-											'<span id="ctrls" class="pull-right btn-group btn-group-xs">' +
+											'<span id="ctrls" class="top-right btn-group btn-group-xs">' +
 												'<button id="msg" title="Send message" class="btn btn-info"><i class="fa fa-envelope"></i></button>' +
 												'<button id="info" title="Send INFO" class="btn btn-info"><i class="fa fa-info"></i></button>' +
 												'<button id="transfer" title="Transfer call" class="btn btn-info"><i class="fa fa-mail-forward"></i></button>' +
@@ -585,7 +582,7 @@ $(document).ready(function() {
 												buttons: {
 													cancel: {
 														label: "Cancel",
-														className: "btn-default",
+														className: "btn-secondary",
 														callback: function() {
 															// Do nothing
 														}
@@ -613,7 +610,7 @@ $(document).ready(function() {
 												buttons: {
 													cancel: {
 														label: "Cancel",
-														className: "btn-default",
+														className: "btn-secondary",
 														callback: function() {
 															// Do nothing
 														}
@@ -679,7 +676,7 @@ $(document).ready(function() {
 									Janus.log(" ::: Got a cleanup notification :::");
 									$("#videoleft").empty().parent().unblock();
 									$('#videoright').empty();
-									$('#videos').hide();
+									$('#videos').addClass('hide');
 									$('#dtmf').parent().html("Remote UA");
 									if(sipcall) {
 										delete sipcall.callId;
@@ -1015,36 +1012,36 @@ function addHelper(helperCreated) {
 	$('.footer').before(
 		'<div class="container" id="sipcall' + helperId + '">' +
 		'	<div class="row">' +
-		'		<div class="col-md-12">' +
-		'			<div class="col-md-6 container">' +
-		'				<span class="label label-info">Helper #' + helperId +
-		'					<i class="fa fa-window-close" id="rmhelper' + helperId + '" style="cursor: pointer;" title="Remove this helper"></i>' +
-		'				</span>' +
-		'			</div>' +
-		'			<div class="col-md-6 container" id="phone' + helperId + '">' +
-		'				<div class="input-group margin-bottom-sm">' +
-		'					<span class="input-group-addon"><i class="fa fa-phone fa-fw"></i></span>' +
-		'					<input disabled class="form-control" type="text" placeholder="SIP URI to call (e.g., sip:1000@example.com)" autocomplete="off" id="peer' + helperId + '" onkeypress="return checkEnter(this, event, ' + helperId + ');"></input>' +
+		'		<div class="col-md-6 container">' +
+		'			<span class="badge badge-info">Helper #' + helperId +
+		'				<i class="fa fa-window-close" id="rmhelper' + helperId + '" style="cursor: pointer;" title="Remove this helper"></i>' +
+		'			</span>' +
+		'		</div>' +
+		'		<div class="col-md-6 container" id="phone' + helperId + '">' +
+		'			<div class="input-group mt-1 mb-1">' +
+		'				<div class="input-group-prepend">' +
+		'					<span class="input-group-text"><i class="fa fa-phone fa-fw"></i></span>' +
 		'				</div>' +
-		'				<button disabled class="btn btn-success margin-bottom-sm" autocomplete="off" id="call' + helperId + '">Call</button> <input autocomplete="off" id="dovideo' + helperId + '" type="checkbox">Use Video</input>' +
+		'				<input disabled class="form-control" type="text" placeholder="SIP URI to call (e.g., sip:1000@example.com)" autocomplete="off" id="peer' + helperId + '" onkeypress="return checkEnter(this, event, ' + helperId + ');"></input>' +
 		'			</div>' +
+		'			<button disabled class="btn btn-success margin-bottom-sm" autocomplete="off" id="call' + helperId + '">Call</button> <input autocomplete="off" id="dovideo' + helperId + '" type="checkbox">Use Video</input>' +
 		'		</div>' +
 		'	</div>' +
-		'	<div id="videos' + helperId + '" class="hide">' +
+		'	<div id="videos' + helperId + '" class="row mt-2 mb-2 hide">' +
 		'		<div class="col-md-6">' +
-		'			<div class="panel panel-default">' +
-		'				<div class="panel-heading">' +
-		'					<h3 class="panel-title">You</h3>' +
+		'			<div class="card">' +
+		'				<div class="card-header">' +
+		'					<span class="card-title">You</span>' +
 		'				</div>' +
-		'				<div class="panel-body" id="videoleft' + helperId + '"></div>' +
+		'				<div class="card-body" id="videoleft' + helperId + '"></div>' +
 		'			</div>' +
 		'		</div>' +
 		'		<div class="col-md-6">' +
-		'			<div class="panel panel-default">' +
-		'				<div class="panel-heading">' +
-		'					<h3 class="panel-title">Remote UA</h3>' +
+		'			<div class="card">' +
+		'				<div class="card-header">' +
+		'					<span class="card-title">Remote UA</span>' +
 		'				</div>' +
-		'				<div class="panel-body" id="videoright' + helperId + '"></div>' +
+		'				<div class="card-body" id="videoright' + helperId + '"></div>' +
 		'			</div>' +
 		'		</div>' +
 		'	</div>' +
@@ -1084,6 +1081,7 @@ function addHelper(helperCreated) {
 					// Darken screen and show hint
 					$.blockUI({
 						message: '<div><img src="up_arrow.png"/></div>',
+						baseZ: 3001,
 						css: {
 							border: 'none',
 							padding: '15px',
@@ -1455,7 +1453,7 @@ function addHelper(helperCreated) {
 					return;
 				}
 				if($('#videoleft' + helperId + ' video').length === 0) {
-					$('#videos' + helperId).removeClass('hide').show();
+					$('#videos' + helperId).removeClass('hide');
 				}
 				if(track.kind === "audio") {
 					// We ignore local audio tracks, they'd generate echo anyway
@@ -1514,10 +1512,10 @@ function addHelper(helperCreated) {
 				}
 				// If we're here, a new track was added
 				if($('#videoright' + helperId + ' audio').length === 0 && $('#videoright' + helperId + ' video').length === 0) {
-					$('#videos' + helperId).removeClass('hide').show();
-					$('#videoright' + helperId).parent().find('h3').html(
+					$('#videos' + helperId).removeClass('hide');
+					$('#videoright' + helperId).parent().find('span').html(
 						'Send DTMF: <span id="dtmf' + helperId + '" class="btn-group btn-group-xs"></span>' +
-						'<span id="ctrls" class="pull-right btn-group btn-group-xs">' +
+						'<span id="ctrls" class="top-right btn-group btn-group-xs">' +
 							'<button id="msg' + helperId + '" title="Send message" class="btn btn-info"><i class="fa fa-envelope"></i></button>' +
 							'<button id="info' + helperId + '" title="Send INFO" class="btn btn-info"><i class="fa fa-info"></i></button>' +
 							'<button id="transfer' + helperId + '" title="Transfer call" class="btn btn-info"><i class="fa fa-mail-forward"></i></button>' +
@@ -1553,7 +1551,7 @@ function addHelper(helperCreated) {
 							buttons: {
 								cancel: {
 									label: "Cancel",
-									className: "btn-default",
+									className: "btn-secondary",
 									callback: function() {
 										// Do nothing
 									}
@@ -1581,7 +1579,7 @@ function addHelper(helperCreated) {
 							buttons: {
 								cancel: {
 									label: "Cancel",
-									className: "btn-default",
+									className: "btn-secondary",
 									callback: function() {
 										// Do nothing
 									}
@@ -1654,7 +1652,7 @@ function addHelper(helperCreated) {
 				Janus.log("[Helper #" + helperId + "]  ::: Got a cleanup notification :::");
 				$('#videoleft' + helperId).empty().parent().unblock();
 				$('#videoleft' + helperId).empty();
-				$('#videos' + helperId).hide();
+				$('#videos' + helperId).addClass('hide');
 				$('#dtmf' + helperId).parent().html("Remote UA");
 				if(helpers[helperId] && helpers[helperId].sipcall) {
 					delete helpers[helperId].sipcall.callId;

--- a/html/siptest.js
+++ b/html/siptest.js
@@ -1022,7 +1022,7 @@ function addHelper(helperCreated) {
 		'				<span class="input-group-text"><i class="fa-solid fa-phone"></i></span>' +
 		'				<input disabled class="form-control" type="text" placeholder="SIP URI to call (e.g., sip:1000@example.com)" autocomplete="off" id="peer' + helperId + '" onkeypress="return checkEnter(this, event, ' + helperId + ');"></input>' +
 		'			</div>' +
-		'			<button disabled class="btn btn-success margin-bottom-sm" autocomplete="off" id="call' + helperId + '">Call</button> <input autocomplete="off" id="dovideo' + helperId + '" type="checkbox">Use Video</input>' +
+		'			<button disabled class="btn btn-success mb-1" autocomplete="off" id="call' + helperId + '">Call</button> <input autocomplete="off" id="dovideo' + helperId + '" type="checkbox">Use Video</input>' +
 		'		</div>' +
 		'	</div>' +
 		'	<div id="videos' + helperId + '" class="row mt-2 mb-2 hide">' +

--- a/html/siptest.js
+++ b/html/siptest.js
@@ -559,7 +559,7 @@ $(document).ready(function() {
 											else if(i == 11)
 												$('#dtmf').append('<button class="btn btn-info dtmf">*</button>');
 										}
-										$('.dtmf').click(function() {
+										$('#dtmf .dtmf').click(function() {
 											// Send DTMF tone (inband)
 											sipcall.dtmf({dtmf: { tones: $(this).text()}});
 											// Notice you can also send DTMF tones using SIP INFO
@@ -1526,7 +1526,7 @@ function addHelper(helperCreated) {
 						else if(i == 11)
 							$('#dtmf' + helperId).append('<button class="btn btn-info dtmf">*</button>');
 					}
-					$('.dtmf' + helperId).click(function() {
+					$('#dtmf' + helperId + ' .dtmf').click(function() {
 						// Send DTMF tone (inband)
 						helpers[helperId].sipcall.dtmf({dtmf: { tones: $(this).text()}});
 						// Notice you can also send DTMF tones using SIP INFO

--- a/html/siptest.js
+++ b/html/siptest.js
@@ -102,7 +102,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -1013,15 +1013,13 @@ function addHelper(helperCreated) {
 		'<div class="container" id="sipcall' + helperId + '">' +
 		'	<div class="row">' +
 		'		<div class="col-md-6 container">' +
-		'			<span class="badge badge-info">Helper #' + helperId +
+		'			<span class="badge bg-info">Helper #' + helperId +
 		'				<i class="fa fa-window-close" id="rmhelper' + helperId + '" style="cursor: pointer;" title="Remove this helper"></i>' +
 		'			</span>' +
 		'		</div>' +
 		'		<div class="col-md-6 container" id="phone' + helperId + '">' +
 		'			<div class="input-group mt-1 mb-1">' +
-		'				<div class="input-group-prepend">' +
-		'					<span class="input-group-text"><i class="fa fa-phone fa-fw"></i></span>' +
-		'				</div>' +
+		'				<span class="input-group-text"><i class="fa fa-phone fa-fw"></i></span>' +
 		'				<input disabled class="form-control" type="text" placeholder="SIP URI to call (e.g., sip:1000@example.com)" autocomplete="off" id="peer' + helperId + '" onkeypress="return checkEnter(this, event, ' + helperId + ');"></input>' +
 		'			</div>' +
 		'			<button disabled class="btn btn-success margin-bottom-sm" autocomplete="off" id="call' + helperId + '">Call</button> <input autocomplete="off" id="dovideo' + helperId + '" type="checkbox">Use Video</input>' +
@@ -1088,7 +1086,7 @@ function addHelper(helperCreated) {
 							backgroundColor: 'transparent',
 							color: '#aaa',
 							top: '10px',
-							left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+							left: '100px'
 						} });
 				} else {
 					// Restore screen

--- a/html/streamingtest.html
+++ b/html/streamingtest.html
@@ -26,7 +26,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
@@ -72,7 +72,7 @@
 					<div class="col-md-6">
 						<div class="card w-100">
 							<div class="card-header">
-								<span class="card-title">Streams <i id="update-streams" class="fa fa-refresh" title="Update list of streams" style="cursor: pointer;"></i></span>
+								<span class="card-title">Streams <i id="update-streams" class="fa-solid fa-rotate" title="Update list of streams" style="cursor: pointer;"></i></span>
 							</div>
 							<div class="card-body" id="list">
 								<div class="btn-group btn-group-sm">
@@ -89,7 +89,7 @@
 						</div>
 						<div class="card mt-4 w-100 hide" id="info">
 							<div class="card-header">
-								<span class="card-title"><i class="fa fa-info-circle"></i> Metadata</span>
+								<span class="card-title"><i class="fa-solid fa-circle-info"></i> Metadata</span>
 							</div>
 							<div class="card-body">
 								<pre id="metadata" class="card card-body bg-gray mt-3"></pre>

--- a/html/streamingtest.html
+++ b/html/streamingtest.html
@@ -10,7 +10,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>

--- a/html/streamingtest.html
+++ b/html/streamingtest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Streaming Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>

--- a/html/streamingtest.html
+++ b/html/streamingtest.html
@@ -7,7 +7,8 @@
 <title>Janus WebRTC Server (multistream): Streaming Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
@@ -16,34 +17,34 @@
 <script type="text/javascript" src="streamingtest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='streamingtest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='streamingtest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Streaming
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -66,39 +67,37 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="streams">
-				<div class="col-md-6">
-					<div class="row">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Streams <i id="update-streams" class="fa fa-refresh" title="Update list of streams" style="cursor: pointer;"></i></h3>
+			<div class="container mt-4 hide" id="streams">
+				<div class="row">
+					<div class="col-md-6">
+						<div class="card w-100">
+							<div class="card-header">
+								<span class="card-title">Streams <i id="update-streams" class="fa fa-refresh" title="Update list of streams" style="cursor: pointer;"></i></span>
 							</div>
-							<div class="panel-body" id="list">
+							<div class="card-body" id="list">
 								<div class="btn-group btn-group-sm">
-									<button class="btn btn-primary" autocomplete="off" id="watch">Watch or Listen</button>
+									<button class="btn btn-primary" autocomplete="off" id="watch">Watch</button>
 									<div class="btn-group btn-group-sm">
-										<button autocomplete="off" id="streamset" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+										<button autocomplete="off" id="streamset" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
 											Streams list<span class="caret"></span>
 										</button>
-										<ul id="streamslist" class="dropdown-menu" role="menu">
+										<ul id="streamslist" class="dropdown-menu" role="menu" style="max-height: 300px; overflow: auto;">
 										</ul>
 									</div>
 								</div>
 							</div>
 						</div>
-					</div>
-					<div class="row hide" id="info">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title"><i class="fa fa-info-circle"></i> Metadata</h3>
+						<div class="card mt-4 w-100 hide" id="info">
+							<div class="card-header">
+								<span class="card-title"><i class="fa fa-info-circle"></i> Metadata</span>
 							</div>
-							<div class="panel-body">
-								<pre id="metadata" style="word-break: break-word;"></pre>
+							<div class="card-body">
+								<pre id="metadata" class="card card-body bg-gray mt-3"></pre>
 							</div>
 						</div>
 					</div>
-				</div>
-				<div class="col-md-6" id="videos">
+					<div class="col-md-6" id="videos">
+					</div>
 				</div>
 			</div>
 		</div>

--- a/html/streamingtest.html
+++ b/html/streamingtest.html
@@ -7,9 +7,9 @@
 <title>Janus WebRTC Server (multistream): Streaming Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -24,7 +24,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
@@ -78,8 +78,8 @@
 								<div class="btn-group btn-group-sm">
 									<button class="btn btn-primary" autocomplete="off" id="watch">Watch</button>
 									<div class="btn-group btn-group-sm">
-										<button autocomplete="off" id="streamset" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
-											Streams list<span class="caret"></span>
+										<button autocomplete="off" id="streamset" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown">
+											Streams list
 										</button>
 										<ul id="streamslist" class="dropdown-menu" role="menu" style="max-height: 300px; overflow: auto;">
 										</ul>

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -482,9 +482,9 @@ function addPanel(panelId, mid, desc) {
 		'	<div class="card w-100">' +
 		'		<div class="card-header">' +
 		'			<span class="card-title">' + (desc ? desc : "Stream") +
-		'				<span class="badge badge-info hide" id="status' + mid + '"></span>' +
-		'				<span class="badge badge-primary hide" id="curres' + mid + '"></span>' +
-		'				<span class="badge badge-info hide" id="curbitrate' + mid + '"></span>' +
+		'				<span class="badge bg-info hide" id="status' + mid + '"></span>' +
+		'				<span class="badge bg-primary hide" id="curres' + mid + '"></span>' +
+		'				<span class="badge bg-info hide" id="curbitrate' + mid + '"></span>' +
 		'			</span>' +
 		'		</div>' +
 		'		<div class="card-body" id="mstream' + panelId + '"></div>' +
@@ -498,14 +498,14 @@ function addSimulcastButtons(mid) {
 	$('#curres'+mid).parent().append(
 		'<div id="simulcast'+mid+'" class="btn-group-vertical btn-group-xs top-right">' +
 		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
-		'		<button id="m-'+mid+'-sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
-		'		<button id="m-'+mid+'-sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
-		'		<button id="m-'+mid+'-sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
+		'		<button id="m-'+mid+'-sl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="m-'+mid+'-sl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="m-'+mid+'-sl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
 		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
-		'		<button id="m-'+mid+'-tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
-		'		<button id="m-'+mid+'-tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
-		'		<button id="m-'+mid+'-tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
+		'		<button id="m-'+mid+'-tl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="m-'+mid+'-tl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="m-'+mid+'-tl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	// Enable the simulcast selection buttons
@@ -618,15 +618,15 @@ function addSvcButtons(mid) {
 		'<div id="svc'+mid+'" class="btn-group-vertical btn-group-vertical-xs top-right">' +
 		'	<div class"row">' +
 		'		<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
-		'			<button id="m-'+mid+'-sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal resolution">SL 1</button>' +
-		'			<button id="m-'+mid+'-sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to low resolution">SL 0</button>' +
+		'			<button id="m-'+mid+'-sl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to normal resolution">SL 1</button>' +
+		'			<button id="m-'+mid+'-sl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to low resolution">SL 0</button>' +
 		'		</div>' +
 		'	</div>' +
 		'	<div class"row">' +
 		'		<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
-		'			<button id="m-'+mid+'-tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2 (high FPS)">TL 2</button>' +
-		'			<button id="m-'+mid+'-tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1 (medium FPS)">TL 1</button>' +
-		'			<button id="m-'+mid+'-tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0 (low FPS)">TL 0</button>' +
+		'			<button id="m-'+mid+'-tl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 2 (high FPS)">TL 2</button>' +
+		'			<button id="m-'+mid+'-tl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 1 (medium FPS)">TL 1</button>' +
+		'			<button id="m-'+mid+'-tl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 0 (low FPS)">TL 0</button>' +
 		'		</div>' +
 		'	</div>' +
 		'</div>'

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -11,7 +11,6 @@ var opaqueId = "streamingtest-"+Janus.randomString(12);
 
 var remoteTracks = {}, remoteVideos = 0, dataMid = null;
 var bitrateTimer = {};
-var spinner = {};
 
 var simulcastStarted = {}, svcStarted = {};
 
@@ -229,12 +228,9 @@ $(document).ready(function() {
 											}, 1000);
 										}
 									}
-									// Play the stream and hide the spinner when we get a playing event
+									// Play the stream when we get a playing event
 									$("#remotevideo" + mid).bind("playing", function (ev) {
 										$('.waitingvideo').remove();
-										if(spinner[mid])
-											spinner[mid].stop();
-										spinner[mid] = null;
 										if(!this.videoWidth)
 											return;
 										$('#'+ev.target.id).removeClass('hide');
@@ -261,11 +257,6 @@ $(document).ready(function() {
 									$('#mstream' + dataMid).append(
 										'<input class="form-control" type="text" id="datarecv" disabled></input>'
 									);
-									for(let i in spinner) {
-										if(spinner[i])
-											spinner[i].stop();
-									}
-									spinner = {};
 								},
 								ondata: function(data) {
 									Janus.debug("We got data from the DataChannel!", data);
@@ -277,11 +268,6 @@ $(document).ready(function() {
 									for(let i in bitrateTimer)
 										clearInterval(bitrateTimer[i]);
 									bitrateTimer = {};
-									for(let i in spinner) {
-										if(spinner[i])
-											spinner[i].stop();
-									}
-									spinner = {};
 									simulcastStarted = false;
 									remoteTracks = {};
 									remoteVideos = 0;
@@ -412,14 +398,6 @@ function startStream() {
 			// No remote video yet
 			$('#mstream0').append('<video class="rounded centered waitingvideo" id="waitingvideo0" width="100%" height="100%" />');
 		}
-		if(mid) {
-			if(spinner[mid] == null) {
-				let target = document.getElementById('mstream0');
-				spinner[mid] = new Spinner({top:100}).spin(target);
-			} else {
-				spinner[mid].spin();
-			}
-		}
 		dataMid = "0";
 	} else {
 		// Multistream mountpoint, create a panel for each stream
@@ -432,12 +410,6 @@ function startStream() {
 				addPanel(mid, mid, label);
 				// No remote media yet
 				$('#mstream'+mid).append('<video class="rounded centered waitingvideo" id="waitingvideo'+mid+'" width="100%" height="100%" />');
-			}
-			if(spinner[mid] == null) {
-				let target = document.getElementById('mstream'+mid);
-				spinner[mid] = new Spinner({top:100}).spin(target);
-			} else {
-				spinner[mid].spin();
 			}
 			if(type === 'data')
 				dataMid = mid;

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -184,6 +184,7 @@ $(document).ready(function() {
 									if($('#remotevideo' + mid).length > 0)
 										return;
 									// If we're here, a new track was added
+									$('#spinner' + mid).remove();
 									let stream = null;
 									if(track.kind === "audio") {
 										// New audio track: create a stream out of it, and use a hidden <audio> element
@@ -265,6 +266,7 @@ $(document).ready(function() {
 								oncleanup: function() {
 									Janus.log(" ::: Got a cleanup notification :::");
 									$('#videos').empty();
+									$('#info').addClass('hide');
 									for(let i in bitrateTimer)
 										clearInterval(bitrateTimer[i]);
 									bitrateTimer = {};
@@ -459,7 +461,13 @@ function addPanel(panelId, mid, desc) {
 		'				<span class="badge bg-info hide" id="curbitrate' + mid + '"></span>' +
 		'			</span>' +
 		'		</div>' +
-		'		<div class="card-body" id="mstream' + panelId + '"></div>' +
+		'		<div class="card-body" id="mstream' + panelId + '">' +
+		'			<div class="text-center">' +
+		'				<div id="spinner' + mid + '" class="spinner-border" role="status">' +
+		'					<span class="visually-hidden">Loading...</span>' +
+		'				</div>' +
+		'			</div>' +
+		'		</div>' +
 		'	</div>' +
 		'</div>'
 	);

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -85,9 +85,9 @@ $(document).ready(function() {
 										if(result["status"]) {
 											let status = result["status"];
 											if(status === 'starting')
-												$('#status').removeClass('hide').text("Starting, please wait...").show();
+												$('#status').removeClass('hide').text("Starting, please wait...").removeClass('hide');
 											else if(status === 'started')
-												$('#status').removeClass('hide').text("Started").show();
+												$('#status').removeClass('hide').text("Started").removeClass('hide');
 											else if(status === 'stopped')
 												stopStream();
 										} else if(msg["streaming"] === "event") {
@@ -214,7 +214,7 @@ $(document).ready(function() {
 										$('#remotevideo'+mid).get(0).volume = 0;
 										// Use a custom timer for this stream
 										if(!bitrateTimer[mid]) {
-											$('#curbitrate'+mid).removeClass('hide').show();
+											$('#curbitrate'+mid).removeClass('hide');
 											bitrateTimer[mid] = setInterval(function() {
 												if(!$("#remotevideo" + mid).get(0))
 													return;
@@ -225,7 +225,7 @@ $(document).ready(function() {
 												let width = $("#remotevideo" + mid).get(0).videoWidth;
 												let height = $("#remotevideo" + mid).get(0).videoHeight;
 												if(width > 0 && height > 0)
-													$('#curres'+mid).removeClass('hide').text(width+'x'+height).show();
+													$('#curres'+mid).removeClass('hide').text(width+'x'+height).removeClass('hide');
 											}, 1000);
 										}
 									}
@@ -237,16 +237,16 @@ $(document).ready(function() {
 										spinner[mid] = null;
 										if(!this.videoWidth)
 											return;
-										$('#'+ev.target.id).removeClass('hide').show();
+										$('#'+ev.target.id).removeClass('hide');
 										let width = this.videoWidth;
 										let height = this.videoHeight;
-										$('#curres'+mid).removeClass('hide').text(width+'x'+height).show();
+										$('#curres'+mid).removeClass('hide').text(width+'x'+height).removeClass('hide');
 										if(Janus.webRTCAdapter.browserDetails.browser === "firefox") {
 											// Firefox Stable has a bug: width and height are not immediately available after a playing
 											setTimeout(function() {
 												let width = $('#'+ev.target.id).get(0).videoWidth;
 												let height = $('#'+ev.target.id).get(0).videoHeight;
-												$('#curres'+mid).removeClass('hide').text(width+'x'+height).show();
+												$('#curres'+mid).removeClass('hide').text(width+'x'+height).removeClass('hide');
 											}, 2000);
 										}
 									});
@@ -288,7 +288,7 @@ $(document).ready(function() {
 									dataMid = null;
 									$('#streamset').removeAttr('disabled');
 									$('#streamslist').removeAttr('disabled');
-									$('#watch').html("Watch or Listen").removeAttr('disabled')
+									$('#watch').html("Watch").removeAttr('disabled')
 										.unbind('click').click(startStream);
 								}
 							});
@@ -320,7 +320,7 @@ function updateStreamsList() {
 			return;
 		}
 		if(result["list"]) {
-			$('#streams').removeClass('hide').show();
+			$('#streams').removeClass('hide');
 			$('#streamslist').empty();
 			$('#watch').attr('disabled', true).unbind('click');
 			let list = result["list"];
@@ -337,7 +337,7 @@ function updateStreamsList() {
 			streamsList = {};
 			for(let mp in list) {
 				Janus.debug("  >> [" + list[mp]["id"] + "] " + list[mp]["description"] + " (" + list[mp]["type"] + ")");
-				$('#streamslist').append("<li><a href='#' id='" + list[mp]["id"] + "'>" + escapeXmlTags(list[mp]["description"]) + " (" + list[mp]["type"] + ")" + "</a></li>");
+				$('#streamslist').append("<a class='dropdown-item' href='#' id='" + list[mp]["id"] + "'>" + escapeXmlTags(list[mp]["description"]) + " (" + list[mp]["type"] + ")" + "</a>");
 				// Check the nature of the available streams, and if there are some multistream ones
 				list[mp].legacy = true;
 				if(list[mp].media) {
@@ -359,6 +359,7 @@ function updateStreamsList() {
 				streamsList[list[mp]["id"]] = list[mp];
 			}
 			$('#streamslist a').unbind('click').click(function() {
+				$('.dropdown-toggle').dropdown('hide');
 				selectedStream = $(this).attr("id");
 				$('#streamset').html($(this).html()).parent().removeClass('open');
 				$('#list .dropdown-backdrop').remove();
@@ -372,7 +373,7 @@ function updateStreamsList() {
 
 function getStreamInfo() {
 	$('#metadata').empty();
-	$('#info').addClass('hide').hide();
+	$('#info').addClass('hide');
 	if(!selectedStream || !streamsList[selectedStream])
 		return;
 	// Send a request for more info on the mountpoint we subscribed to
@@ -380,7 +381,7 @@ function getStreamInfo() {
 	streaming.send({ message: body, success: function(result) {
 		if(result && result.info && result.info.metadata) {
 			$('#metadata').html(escapeXmlTags(result.info.metadata));
-			$('#info').removeClass('hide').show();
+			$('#info').removeClass('hide');
 		}
 	}});
 }
@@ -477,16 +478,16 @@ function escapeXmlTags(value) {
 // Helper to add a new panel to the 'videos' div
 function addPanel(panelId, mid, desc) {
 	$('#videos').append(
-		'<div class="row" id="panel' + panelId + '">' +
-		'	<div class="panel panel-default">' +
-		'		<div class="panel-heading">' +
-		'			<h3 class="panel-title">' + (desc ? desc : "Stream") +
-		'				<span class="label label-info hide" id="status' + mid + '"></span>' +
-		'				<span class="label label-primary hide" id="curres' + mid + '"></span>' +
-		'				<span class="label label-info hide" id="curbitrate' + mid + '"></span>' +
-		'			</h3>' +
+		'<div class="row mb-3" id="panel' + panelId + '">' +
+		'	<div class="card w-100">' +
+		'		<div class="card-header">' +
+		'			<span class="card-title">' + (desc ? desc : "Stream") +
+		'				<span class="badge badge-info hide" id="status' + mid + '"></span>' +
+		'				<span class="badge badge-primary hide" id="curres' + mid + '"></span>' +
+		'				<span class="badge badge-info hide" id="curbitrate' + mid + '"></span>' +
+		'			</span>' +
 		'		</div>' +
-		'		<div class="panel-body" id="mstream' + panelId + '"></div>' +
+		'		<div class="card-body" id="mstream' + panelId + '"></div>' +
 		'	</div>' +
 		'</div>'
 	);
@@ -495,20 +496,16 @@ function addPanel(panelId, mid, desc) {
 // Helpers to create Simulcast-related UI, if enabled
 function addSimulcastButtons(mid) {
 	$('#curres'+mid).parent().append(
-		'<div id="simulcast'+mid+'" class="btn-group-vertical btn-group-vertical-xs pull-right">' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
-		'			<button id="m-'+mid+'-sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality" style="width: 33%">SL 2</button>' +
-		'			<button id="m-'+mid+'-sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality" style="width: 33%">SL 1</button>' +
-		'			<button id="m-'+mid+'-sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality" style="width: 34%">SL 0</button>' +
-		'		</div>' +
+		'<div id="simulcast'+mid+'" class="btn-group-vertical btn-group-xs top-right">' +
+		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
+		'		<button id="m-'+mid+'-sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="m-'+mid+'-sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="m-'+mid+'-sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs hide" style="width: 100%">' +
-		'			<button id="m-'+mid+'-tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2" style="width: 34%">TL 2</button>' +
-		'			<button id="m-'+mid+'-tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1" style="width: 33%">TL 1</button>' +
-		'			<button id="m-'+mid+'-tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0" style="width: 33%">TL 0</button>' +
-		'		</div>' +
+		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
+		'		<button id="m-'+mid+'-tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="m-'+mid+'-tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="m-'+mid+'-tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	// Enable the simulcast selection buttons
@@ -618,18 +615,18 @@ function addSvcButtons(mid) {
 	if($('#svc').length > 0)
 		return;
 	$('#curres'+mid).parent().append(
-		'<div id="svc'+mid+'" class="btn-group-vertical btn-group-vertical-xs pull-right">' +
+		'<div id="svc'+mid+'" class="btn-group-vertical btn-group-vertical-xs top-right">' +
 		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
-		'			<button id="m-'+mid+'-sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal resolution" style="width: 50%">SL 1</button>' +
-		'			<button id="m-'+mid+'-sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to low resolution" style="width: 50%">SL 0</button>' +
+		'		<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
+		'			<button id="m-'+mid+'-sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal resolution">SL 1</button>' +
+		'			<button id="m-'+mid+'-sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to low resolution">SL 0</button>' +
 		'		</div>' +
 		'	</div>' +
 		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
-		'			<button id="m-'+mid+'-tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2 (high FPS)" style="width: 34%">TL 2</button>' +
-		'			<button id="m-'+mid+'-tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1 (medium FPS)" style="width: 33%">TL 1</button>' +
-		'			<button id="m-'+mid+'-tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0 (low FPS)" style="width: 33%">TL 0</button>' +
+		'		<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
+		'			<button id="m-'+mid+'-tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2 (high FPS)">TL 2</button>' +
+		'			<button id="m-'+mid+'-tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1 (medium FPS)">TL 1</button>' +
+		'			<button id="m-'+mid+'-tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0 (low FPS)">TL 0</button>' +
 		'		</div>' +
 		'	</div>' +
 		'</div>'

--- a/html/streamingtest.js
+++ b/html/streamingtest.js
@@ -173,7 +173,7 @@ $(document).ready(function() {
 												if($('#'+mstreamId+' .no-video-container').length === 0) {
 													$('#'+mstreamId).append(
 														'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No remote video available</span>' +
 													'</div>');
 												}
@@ -198,7 +198,7 @@ $(document).ready(function() {
 											if($('#'+mstreamId+' .no-video-container').length === 0) {
 												$('#'+mstreamId).append(
 													'<div class="no-video-container audioonly">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}

--- a/html/support.html
+++ b/html/support.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Support</title>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script>

--- a/html/support.html
+++ b/html/support.html
@@ -6,7 +6,8 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Support</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script>
 	$(function() {
 		$(".fixed-top").load("navbar.html", function() {
@@ -15,7 +16,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 </head>
 <body>

--- a/html/support.html
+++ b/html/support.html
@@ -6,29 +6,29 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Support</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top a[href='support.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top a[href='support.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Support</h1>
 			</div>
 		</div>
@@ -48,7 +48,7 @@
 			think we can be of help, just <a href="https://www.meetecho.com/en/#contact">contact us!</a></p>
 		</div>
 	</div>
-	<div class="container well">
+	<div class="container card card-body bg-gray">
 		<div class="row">
 			<div class="col-md-6">
 				<h3>Commercial Support</h3>

--- a/html/textroomtest.html
+++ b/html/textroomtest.html
@@ -26,7 +26,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 </head>
 <body>
 
@@ -73,7 +73,7 @@
 					<span class="badge bg-info" id="you"></span>
 					<div class="col-md-12" id="controls">
 						<div class="input-group mt-3 mb-1 hide" id="registernow">
-							<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-user"></i></span>
 							<input class="form-control" type="text" placeholder="Choose a display name" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
 							<span class="input-group-btn">
 								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>
@@ -104,7 +104,7 @@
 							</div>
 							<div class="card-footer">
 								<div class="input-group mt-3 mb-3">
-									<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+									<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-up"></i></span>
 									<input class="form-control" type="text" placeholder="Write a chatroom message" autocomplete="off" id="datasend" onkeypress="return checkEnter(this, event);" disabled />
 								</div>
 							</div>

--- a/html/textroomtest.html
+++ b/html/textroomtest.html
@@ -7,9 +7,10 @@
 <title>Janus WebRTC Server (multistream): Text Room</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>
@@ -23,7 +24,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 </head>
@@ -69,12 +70,10 @@
 			</div>
 			<div class="container mt-4 hide" id="roomjoin">
 				<div class="row">
-					<span class="badge badge-info" id="you"></span>
+					<span class="badge bg-info" id="you"></span>
 					<div class="col-md-12" id="controls">
 						<div class="input-group mt-3 mb-1 hide" id="registernow">
-							<div class="input-group-prepend">
-								<span class="input-group-text">@</span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
 							<input class="form-control" type="text" placeholder="Choose a display name" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
 							<span class="input-group-btn">
 								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>
@@ -88,7 +87,7 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Participants <span class="badge badge-info hide" id="participant"></span></span>
+								<span class="card-title">Participants <span class="badge bg-info hide" id="participant"></span></span>
 							</div>
 							<div class="card-body">
 								<ul id="list" class="list-group">
@@ -105,9 +104,7 @@
 							</div>
 							<div class="card-footer">
 								<div class="input-group mt-3 mb-3">
-									<div class="input-group-prepend">
-										<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-									</div>
+									<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 									<input class="form-control" type="text" placeholder="Write a chatroom message" autocomplete="off" id="datasend" onkeypress="return checkEnter(this, event);" disabled />
 								</div>
 							</div>

--- a/html/textroomtest.html
+++ b/html/textroomtest.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>
 <script type="text/javascript" src="textroomtest.js"></script>

--- a/html/textroomtest.html
+++ b/html/textroomtest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Text Room</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/textroomtest.html
+++ b/html/textroomtest.html
@@ -8,7 +8,7 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -16,33 +16,33 @@
 <script type="text/javascript" src="textroomtest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='textroomtest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='textroomtest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Text Room
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -67,12 +67,14 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="roomjoin">
+			<div class="container mt-4 hide" id="roomjoin">
 				<div class="row">
-					<span class="label label-info" id="you"></span>
+					<span class="badge badge-info" id="you"></span>
 					<div class="col-md-12" id="controls">
-						<div class="input-group margin-bottom-md hide" id="registernow">
-							<span class="input-group-addon">@</span>
+						<div class="input-group mt-3 mb-1 hide" id="registernow">
+							<div class="input-group-prepend">
+								<span class="input-group-text">@</span>
+							</div>
 							<input class="form-control" type="text" placeholder="Choose a display name" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
 							<span class="input-group-btn">
 								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>
@@ -81,29 +83,31 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="room">
+			<div class="container mt-4 hide" id="room">
 				<div class="row">
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Participants <span class="label label-info hide" id="participant"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Participants <span class="badge badge-info hide" id="participant"></span></span>
 							</div>
-							<div class="panel-body">
+							<div class="card-body">
 								<ul id="list" class="list-group">
 								</ul>
 							</div>
 						</div>
 					</div>
 					<div class="col-md-8">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Public Chatroom</h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Public Chatroom</span>
 							</div>
-							<div class="panel-body relative" style="overflow-x: auto;" id="chatroom">
+							<div class="card-body relative" style="overflow-x: auto;" id="chatroom">
 							</div>
-							<div class="panel-footer">
-								<div class="input-group margin-bottom-sm">
-									<span class="input-group-addon"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<div class="card-footer">
+								<div class="input-group mt-3 mb-3">
+									<div class="input-group-prepend">
+										<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+									</div>
 									<input class="form-control" type="text" placeholder="Write a chatroom message" autocomplete="off" id="datasend" onkeypress="return checkEnter(this, event);" disabled />
 								</div>
 							</div>

--- a/html/textroomtest.js
+++ b/html/textroomtest.js
@@ -100,8 +100,8 @@ $(document).ready(function() {
 								ondataopen: function(label, protocol) {
 									Janus.log("The DataChannel is available!");
 									// Prompt for a display name to join the default room
-									$('#roomjoin').removeClass('hide').show();
-									$('#registernow').removeClass('hide').show();
+									$('#roomjoin').removeClass('hide');
+									$('#registernow').removeClass('hide');
 									$('#register').click(registerUsername);
 									$('#username').focus();
 								},
@@ -229,7 +229,7 @@ function registerUsername() {
 		let username = $('#username').val();
 		if(username === "") {
 			$('#you')
-				.removeClass().addClass('label label-warning')
+				.removeClass().addClass('badge badge-warning')
 				.html("Insert your display name (e.g., pippo)");
 			$('#username').removeAttr('disabled');
 			$('#register').removeAttr('disabled').click(registerUsername);
@@ -264,9 +264,9 @@ function registerUsername() {
 				return;
 			}
 			// We're in
-			$('#roomjoin').hide();
-			$('#room').removeClass('hide').show();
-			$('#participant').removeClass('hide').html(myusername).show();
+			$('#roomjoin').addClass('hide');
+			$('#room').removeClass('hide');
+			$('#participant').removeClass('hide').html(myusername).removeClass('hide');
 			$('#chatroom').css('height', ($(window).height()-420)+"px");
 			$('#datasend').removeAttr('disabled');
 			// Any participants already in?

--- a/html/textroomtest.js
+++ b/html/textroomtest.js
@@ -229,7 +229,7 @@ function registerUsername() {
 		let username = $('#username').val();
 		if(username === "") {
 			$('#you')
-				.removeClass().addClass('badge badge-warning')
+				.removeClass().addClass('badge bg-warning')
 				.html("Insert your display name (e.g., pippo)");
 			$('#username').removeAttr('disabled');
 			$('#register').removeAttr('disabled').click(registerUsername);

--- a/html/videocalltest.html
+++ b/html/videocalltest.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>

--- a/html/videocalltest.html
+++ b/html/videocalltest.html
@@ -88,14 +88,14 @@
 							<span class="input-group-text"><i class="fa-solid fa-user"></i></span>
 							<input class="form-control" type="text" placeholder="Choose a username" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
 						</div>
-						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="register">Register</button> <span class="hide badge bg-info" id="youok"></span>
+						<button class="btn btn-success mb-1" autocomplete="off" id="register">Register</button> <span class="hide badge bg-info" id="youok"></span>
 					</div>
 					<div class="col-md-6 container invisible" id="phone">
 						<div class="input-group mt-3 mb-1">
 							<span class="input-group-text"><i class="fa-solid fa-phone"></i></span>
 							<input class="form-control" type="text" placeholder="Who should we call?" autocomplete="off" id="peer" onkeypress="return checkEnter(this, event);" />
 						</div>
-						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="call">Call</button>
+						<button class="btn btn-success mb-1" autocomplete="off" id="call">Call</button>
 					</div>
 				</div>
 				<div id="videos" class="row mt-4 hide">

--- a/html/videocalltest.html
+++ b/html/videocalltest.html
@@ -27,7 +27,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
@@ -86,14 +86,14 @@
 				<div class="row mt-4">
 					<div class="col-md-6 container invisible" id="login">
 						<div class="input-group mt-3 mb-1">
-							<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-user"></i></span>
 							<input class="form-control" type="text" placeholder="Choose a username" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="register">Register</button> <span class="hide badge bg-info" id="youok"></span>
 					</div>
 					<div class="col-md-6 container invisible" id="phone">
 						<div class="input-group mt-3 mb-1">
-							<span class="input-group-text"><i class="fa fa-phone fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-phone"></i></span>
 							<input class="form-control" type="text" placeholder="Who should we call?" autocomplete="off" id="peer" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="call">Call</button>
@@ -127,7 +127,7 @@
 							<div class="card-body" id="videoleft"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-up"></i></span>
 							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(this, event);" disabled>
 						</div>
 					</div>
@@ -143,7 +143,7 @@
 							<div class="card-body" id="videoright"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-cloud-arrow-down"></i></span>
 							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>

--- a/html/videocalltest.html
+++ b/html/videocalltest.html
@@ -7,10 +7,10 @@
 <title>Janus WebRTC Server (multistream): Video Call Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -25,7 +25,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
@@ -86,18 +86,14 @@
 				<div class="row mt-4">
 					<div class="col-md-6 container invisible" id="login">
 						<div class="input-group mt-3 mb-1">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
 							<input class="form-control" type="text" placeholder="Choose a username" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
 						</div>
-						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="register">Register</button> <span class="hide badge badge-info" id="youok"></span>
+						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="register">Register</button> <span class="hide badge bg-info" id="youok"></span>
 					</div>
 					<div class="col-md-6 container invisible" id="phone">
 						<div class="input-group mt-3 mb-1">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-phone fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-phone fa-fw"></i></span>
 							<input class="form-control" type="text" placeholder="Who should we call?" autocomplete="off" id="peer" onkeypress="return checkEnter(this, event);" />
 						</div>
 						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="call">Call</button>
@@ -112,8 +108,8 @@
 										<button class="btn btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
 										<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
 										<div class="btn-group btn-group-sm">
-											<button autocomplete="off" id="bitrateset" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-												Bandwidth<span class="caret"></span>
+											<button autocomplete="off" id="bitrateset" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">
+												Bandwidth
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
 												<a class="dropdown-item" href="#" id="0">No limit</a>
@@ -131,9 +127,7 @@
 							<div class="card-body" id="videoleft"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(this, event);" disabled>
 						</div>
 					</div>
@@ -141,17 +135,15 @@
 						<div class="card">
 							<div class="card-header">
 								<span class="card-title">Remote Stream
-									<span class="badge badge-info hide" id="callee"></span>
-									<span class="badge badge-primary hide" id="curres"></span>
-									<span class="badge badge-info hide" id="curbitrate"></span>
+									<span class="badge bg-info hide" id="callee"></span>
+									<span class="badge bg-primary hide" id="curres"></span>
+									<span class="badge bg-info hide" id="curbitrate"></span>
 								</span>
 							</div>
 							<div class="card-body" id="videoright"></div>
 						</div>
 						<div class="input-group mt-3 mb-3">
-							<div class="input-group-prepend">
-								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
 							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>

--- a/html/videocalltest.html
+++ b/html/videocalltest.html
@@ -7,8 +7,9 @@
 <title>Janus WebRTC Server (multistream): Video Call Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
@@ -17,34 +18,34 @@
 <script type="text/javascript" src="videocalltest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='videocalltest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='videocalltest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Video Call
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -82,66 +83,76 @@
 				</div>
 			</div>
 			<div class="container hide" id="videocall">
-				<div class="row">
-					<div class="col-md-12">
-						<div class="col-md-6 container hide" id="login">
-							<div class="input-group margin-bottom-sm">
-								<span class="input-group-addon"><i class="fa fa-user fa-fw"></i></span>
-								<input class="form-control" type="text" placeholder="Choose a username" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
+				<div class="row mt-4">
+					<div class="col-md-6 container invisible" id="login">
+						<div class="input-group mt-3 mb-1">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
 							</div>
-							<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="register">Register</button> <span class="hide label label-info" id="youok"></span>
+							<input class="form-control" type="text" placeholder="Choose a username" autocomplete="off" id="username" onkeypress="return checkEnter(this, event);" />
 						</div>
-						<div class="col-md-6 container hide" id="phone">
-							<div class="input-group margin-bottom-sm">
-								<span class="input-group-addon"><i class="fa fa-phone fa-fw"></i></span>
-								<input class="form-control" type="text" placeholder="Who should we call?" autocomplete="off" id="peer" onkeypress="return checkEnter(this, event);" />
-							</div>
-							<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="call">Call</button>
-						</div>
+						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="register">Register</button> <span class="hide badge badge-info" id="youok"></span>
 					</div>
-				<div/>
-				<div id="videos" class="hide">
+					<div class="col-md-6 container invisible" id="phone">
+						<div class="input-group mt-3 mb-1">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-phone fa-fw"></i></span>
+							</div>
+							<input class="form-control" type="text" placeholder="Who should we call?" autocomplete="off" id="peer" onkeypress="return checkEnter(this, event);" />
+						</div>
+						<button class="btn btn-success margin-bottom-sm" autocomplete="off" id="call">Call</button>
+					</div>
+				</div>
+				<div id="videos" class="row mt-4 hide">
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Local Stream
-									<div class="btn-group btn-group-xs pull-right hide">
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Local Stream
+									<div class="btn-group btn-group-sm top-right hide">
 										<button class="btn btn-danger" autocomplete="off" id="toggleaudio">Disable audio</button>
 										<button class="btn btn-danger" autocomplete="off" id="togglevideo">Disable video</button>
-										<div class="btn-group btn-group-xs">
+										<div class="btn-group btn-group-sm">
 											<button autocomplete="off" id="bitrateset" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
 												Bandwidth<span class="caret"></span>
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
-												<li><a href="#" id="0">No limit</a></li>
-												<li><a href="#" id="128">Cap to 128kbit</a></li>
-												<li><a href="#" id="256">Cap to 256kbit</a></li>
-												<li><a href="#" id="512">Cap to 512kbit</a></li>
-												<li><a href="#" id="1024">Cap to 1mbit</a></li>
-												<li><a href="#" id="1500">Cap to 1.5mbit</a></li>
-												<li><a href="#" id="2000">Cap to 2mbit</a></li>
+												<a class="dropdown-item" href="#" id="0">No limit</a>
+												<a class="dropdown-item" href="#" id="128">Cap to 128kbit</a>
+												<a class="dropdown-item" href="#" id="256">Cap to 256kbit</a>
+												<a class="dropdown-item" href="#" id="512">Cap to 512kbit</a>
+												<a class="dropdown-item" href="#" id="1024">Cap to 1mbit</a>
+												<a class="dropdown-item" href="#" id="1500">Cap to 1.5mbit</a>
+												<a class="dropdown-item" href="#" id="2000">Cap to 2mbit</a>
 											</ul>
 										</div>
 									</div>
-								</h3>
+								</span>
 							</div>
-							<div class="panel-body" id="videoleft"></div>
+							<div class="card-body" id="videoleft"></div>
 						</div>
-						<div class="input-group margin-bottom-sm">
-							<span class="input-group-addon"><i class="fa fa-cloud-upload fa-fw"></i></span>
-							<input class="form-control" type="text" placeholder="Write a DataChannel message to your peer" autocomplete="off" id="datasend" onkeypress="return checkEnter(this, event);" disabled />
+						<div class="input-group mt-3 mb-3">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							</div>
+							<input type="text" class="form-control" placeholder="Write a DataChannel message" autocomplete="off" id="datasend" onkeypress="return checkEnter(this, event);" disabled>
 						</div>
 					</div>
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Stream <span class="label label-info hide" id="callee"></span> <span class="label label-primary hide" id="curres"></span> <span class="label label-info hide" id="curbitrate"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Stream
+									<span class="badge badge-info hide" id="callee"></span>
+									<span class="badge badge-primary hide" id="curres"></span>
+									<span class="badge badge-info hide" id="curbitrate"></span>
+								</span>
 							</div>
-							<div class="panel-body" id="videoright"></div>
+							<div class="card-body" id="videoright"></div>
 						</div>
-						<div class="input-group margin-bottom-sm">
-							<span class="input-group-addon"><i class="fa fa-cloud-download fa-fw"></i></span>
-							<input class="form-control" type="text" id="datarecv" disabled />
+						<div class="input-group mt-3 mb-3">
+							<div class="input-group-prepend">
+								<span class="input-group-text"><i class="fa fa-cloud-upload fa-fw"></i></span>
+							</div>
+							<input type="text" class="form-control" id="datarecv" disabled>
 						</div>
 					</div>
 				</div>

--- a/html/videocalltest.html
+++ b/html/videocalltest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Video Call Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/videocalltest.js
+++ b/html/videocalltest.js
@@ -12,7 +12,6 @@ var opaqueId = "videocalltest-"+Janus.randomString(12);
 var localTracks = {}, localVideos = 0,
 	remoteTracks = {}, remoteVideos = 0;
 var bitrateTimer = null;
-var spinner = null;
 
 var audioenabled = false;
 var videoenabled = false;
@@ -227,8 +226,6 @@ $(document).ready(function() {
 												// Reset status
 												bootbox.hideAll();
 												videocall.hangup();
-												if(spinner)
-													spinner.stop();
 												$('#waitingvideo').remove();
 												$('#videos').addClass('hide');
 												$('#peer').removeAttr('disabled').val('');
@@ -265,8 +262,6 @@ $(document).ready(function() {
 										}
 										// TODO Reset status
 										videocall.hangup();
-										if(spinner)
-											spinner.stop();
 										$('#waitingvideo').remove();
 										$('#videos').addClass('hide');
 										$('#peer').removeAttr('disabled').val('');

--- a/html/videocalltest.js
+++ b/html/videocalltest.js
@@ -308,7 +308,7 @@ $(document).ready(function() {
 												if($('#videoleft .no-video-container').length === 0) {
 													$('#videoleft').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No webcam available</span>' +
 														'</div>');
 												}
@@ -333,7 +333,7 @@ $(document).ready(function() {
 											if($('#videoleft .no-video-container').length === 0) {
 												$('#videoleft').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}
@@ -376,7 +376,7 @@ $(document).ready(function() {
 												if($('#videoright .no-video-container').length === 0) {
 													$('#videoright').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No remote video available</span>' +
 														'</div>');
 												}
@@ -405,7 +405,7 @@ $(document).ready(function() {
 											if($('#videoright .no-video-container').length === 0) {
 												$('#videoright').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}

--- a/html/videocalltest.js
+++ b/html/videocalltest.js
@@ -82,7 +82,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -470,7 +470,7 @@ $(document).ready(function() {
 										} else {
 											Janus.log("Capping bandwidth to " + bitrate + " via REMB");
 										}
-										$('#bitrateset').html($(this).html() + '<span class="caret"></span>').parent().removeClass('open');
+										$('#bitrateset').text($(this).text()).parent().removeClass('open');
 										videocall.send({ message: { request: "set", bitrate: bitrate }});
 										return false;
 									});
@@ -649,14 +649,14 @@ function addSimulcastButtons(temporal) {
 	$('#curres').parent().append(
 		'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
 		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
-		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
-		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
-		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
 		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
-		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
-		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
-		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {

--- a/html/videocalltest.js
+++ b/html/videocalltest.js
@@ -383,6 +383,7 @@ $(document).ready(function() {
 									if($('#peervideo' + mid).length > 0)
 										return;
 									// If we're here, a new track was added
+									$('#spinner').remove();
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;
@@ -592,6 +593,13 @@ function doCall() {
 				Janus.debug("Got SDP!", jsep);
 				let body = { request: "call", username: $('#peer').val() };
 				videocall.send({ message: body, jsep: jsep });
+				// Create a spinner waiting for the remote video
+				$('#videoright').html(
+					'<div class="text-center">' +
+					'	<div id="spinner" class="spinner-border" role="status">' +
+					'		<span class="visually-hidden">Loading...</span>' +
+					'	</div>' +
+					'</div>');
 			},
 			error: function(error) {
 				Janus.error("WebRTC error...", error);

--- a/html/videocalltest.js
+++ b/html/videocalltest.js
@@ -54,9 +54,9 @@ $(document).ready(function() {
 									videocall = pluginHandle;
 									Janus.log("Plugin attached! (" + videocall.getPlugin() + ", id=" + videocall.getId() + ")");
 									// Prepare the username registration
-									$('#videocall').removeClass('hide').show();
-									$('#login').removeClass('hide').show();
-									$('#registernow').removeClass('hide').show();
+									$('#videocall').removeClass('hide');
+									$('#login').removeClass('invisible');
+									$('#registernow').removeClass('hide');
 									$('#register').click(registerUsername);
 									$('#username').focus();
 									$('#start').removeAttr('disabled').html("Stop")
@@ -75,6 +75,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -117,11 +118,11 @@ $(document).ready(function() {
 											if(event === 'registered') {
 												myusername = escapeXmlTags(result["username"]);
 												Janus.log("Successfully registered as " + myusername + "!");
-												$('#youok').removeClass('hide').show().html("Registered as '" + myusername + "'");
+												$('#youok').removeClass('hide').html("Registered as '" + myusername + "'");
 												// Get a list of available peers, just for fun
 												videocall.send({ message: { request: "list" }});
 												// Enable buttons to call now
-												$('#phone').removeClass('hide').show();
+												$('#phone').removeClass('invisible');
 												$('#call').unbind('click').click(doCall);
 												$('#peer').focus();
 											} else if(event === 'calling') {
@@ -229,7 +230,7 @@ $(document).ready(function() {
 												if(spinner)
 													spinner.stop();
 												$('#waitingvideo').remove();
-												$('#videos').hide();
+												$('#videos').addClass('hide');
 												$('#peer').removeAttr('disabled').val('');
 												$('#call').removeAttr('disabled').html('Call')
 													.removeClass("btn-danger").addClass("btn-success")
@@ -237,8 +238,8 @@ $(document).ready(function() {
 												$('#toggleaudio').attr('disabled', true);
 												$('#togglevideo').attr('disabled', true);
 												$('#bitrate').attr('disabled', true);
-												$('#curbitrate').hide();
-												$('#curres').hide();
+												$('#curbitrate').addClass('hide');
+												$('#curres').addClass('hide');
 											} else if(event === "simulcast") {
 												// Is simulcast in place?
 												let substream = result["substream"];
@@ -267,7 +268,7 @@ $(document).ready(function() {
 										if(spinner)
 											spinner.stop();
 										$('#waitingvideo').remove();
-										$('#videos').hide();
+										$('#videos').addClass('hide');
 										$('#peer').removeAttr('disabled').val('');
 										$('#call').removeAttr('disabled').html('Call')
 											.removeClass("btn-danger").addClass("btn-success")
@@ -275,8 +276,8 @@ $(document).ready(function() {
 										$('#toggleaudio').attr('disabled', true);
 										$('#togglevideo').attr('disabled', true);
 										$('#bitrate').attr('disabled', true);
-										$('#curbitrate').hide();
-										$('#curres').hide();
+										$('#curbitrate').addClass('hide');
+										$('#curres').addClass('hide');
 										if(bitrateTimer)
 											clearInterval(bitrateTimer);
 										bitrateTimer = null;
@@ -323,7 +324,7 @@ $(document).ready(function() {
 										return;
 									}
 									if($('#videoleft video').length === 0) {
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 									}
 									if(track.kind === "audio") {
 										// We ignore local audio tracks, they'd generate echo anyway
@@ -390,7 +391,7 @@ $(document).ready(function() {
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 									}
 									if(track.kind === "audio") {
 										// New audio track: create a stream out of it, and use a hidden <audio> element
@@ -420,7 +421,7 @@ $(document).ready(function() {
 										Janus.attachMediaStream($('#peervideo' + mid).get(0), stream);
 										// Note: we'll need this for additional videos too
 										if(!bitrateTimer) {
-											$('#curbitrate').removeClass('hide').show();
+											$('#curbitrate').removeClass('hide');
 											bitrateTimer = setInterval(function() {
 												if(!$("#peervideo" + mid).get(0))
 													return;
@@ -432,7 +433,7 @@ $(document).ready(function() {
 												let width = $("#peervideo" + mid).get(0).videoWidth;
 												let height = $("#peervideo" + mid).get(0).videoHeight;
 												if(width > 0 && height > 0)
-													$('#curres').removeClass('hide').text(width+'x'+height).show();
+													$('#curres').removeClass('hide').text(width+'x'+height).removeClass('hide');
 											}, 1000);
 										}
 									}
@@ -459,8 +460,9 @@ $(document).ready(function() {
 												$('#togglevideo').html("Enable video").removeClass("btn-danger").addClass("btn-success");
 											videocall.send({ message: { request: "set", video: videoenabled }});
 										});
-									$('#toggleaudio').parent().removeClass('hide').show();
+									$('#toggleaudio').parent().removeClass('hide');
 									$('#bitrate a').removeAttr('disabled').click(function() {
+										$('.dropdown-toggle').dropdown('hide');
 										let id = $(this).attr("id");
 										let bitrate = parseInt(id)*1000;
 										if(bitrate === 0) {
@@ -476,7 +478,7 @@ $(document).ready(function() {
 								// eslint-disable-next-line no-unused-vars
 								ondataopen: function(label, protocol) {
 									Janus.log("The DataChannel is available!");
-									$('#videos').removeClass('hide').show();
+									$('#videos').removeClass('hide');
 									$('#datasend').removeAttr('disabled');
 								},
 								ondata: function(data) {
@@ -487,20 +489,20 @@ $(document).ready(function() {
 									Janus.log(" ::: Got a cleanup notification :::");
 									$("#videoleft").empty().parent().unblock();
 									$('#videoright').empty();
-									$('#callee').empty().hide();
+									$('#callee').empty().addClass('hide');
 									yourusername = null;
-									$('#curbitrate').hide();
-									$('#curres').hide();
-									$('#videos').hide();
+									$('#curbitrate').addClass('hide');
+									$('#curres').addClass('hide');
+									$('#videos').addClass('hide');
 									$('#toggleaudio').attr('disabled', true);
 									$('#togglevideo').attr('disabled', true);
 									$('#bitrate').attr('disabled', true);
-									$('#curbitrate').hide();
-									$('#curres').hide();
+									$('#curbitrate').addClass('hide');
+									$('#curres').addClass('hide');
 									if(bitrateTimer)
 										clearInterval(bitrateTimer);
 									bitrateTimer = null;
-									$('#videos').hide();
+									$('#videos').addClass('hide');
 									simulcastStarted = false;
 									$('#simulcast').remove();
 									$('#peer').removeAttr('disabled').val('');
@@ -645,27 +647,21 @@ function escapeXmlTags(value) {
 // Helpers to create Simulcast-related UI, if enabled
 function addSimulcastButtons(temporal) {
 	$('#curres').parent().append(
-		'<div id="simulcast" class="btn-group-vertical btn-group-vertical-xs pull-right">' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
-		'			<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality" style="width: 33%">SL 2</button>' +
-		'			<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality" style="width: 33%">SL 1</button>' +
-		'			<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality" style="width: 34%">SL 0</button>' +
-		'		</div>' +
+		'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
+		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs hide" style="width: 100%">' +
-		'			<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2" style="width: 34%">TL 2</button>' +
-		'			<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1" style="width: 33%">TL 1</button>' +
-		'			<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0" style="width: 33%">TL 0</button>' +
-		'		</div>' +
+		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {
 		// Chromium-based browsers only have two temporal layers
 		$('#tl-2').remove();
-		$('#tl-1').css('width', '50%');
-		$('#tl-0').css('width', '50%');
 	}
 	// Enable the simulcast selection buttons
 	$('#sl-0').removeClass('btn-primary btn-success').addClass('btn-primary')

--- a/html/videoroomtest.html
+++ b/html/videoroomtest.html
@@ -27,7 +27,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
@@ -89,7 +89,7 @@
 					<span class="badge bg-info" id="you"></span>
 					<div class="col-md-12" id="controls">
 						<div class="input-group mt-3 mb-1 hide" id="registernow">
-							<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
+							<span class="input-group-text"><i class="fa-solid fa-user"></i></span>
 							<input autocomplete="off" class="form-control" type="text" placeholder="Choose a display name" id="username" onkeypress="return checkEnter(this, event);" />
 							<span class="input-group-btn">
 								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>

--- a/html/videoroomtest.html
+++ b/html/videoroomtest.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>

--- a/html/videoroomtest.html
+++ b/html/videoroomtest.html
@@ -7,10 +7,10 @@
 <title>Janus WebRTC Server (multistream): Video Room Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -25,7 +25,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
@@ -86,12 +86,10 @@
 			</div>
 			<div class="container mt-4 hide" id="videojoin">
 				<div class="row">
-					<span class="badge badge-info" id="you"></span>
+					<span class="badge bg-info" id="you"></span>
 					<div class="col-md-12" id="controls">
 						<div class="input-group mt-3 mb-1 hide" id="registernow">
-							<div class="input-group-prepend">
-								<span class="input-group-text">@</span>
-							</div>
+							<span class="input-group-text"><i class="fa fa-user fa-fw"></i></span>
 							<input autocomplete="off" class="form-control" type="text" placeholder="Choose a display name" id="username" onkeypress="return checkEnter(this, event);" />
 							<span class="input-group-btn">
 								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>
@@ -105,11 +103,11 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Local Video <span class="badge badge-primary hide" id="publisher"></span>
+								<span class="card-title">Local Video <span class="badge bg-primary hide" id="publisher"></span>
 									<div class="btn-group btn-group-sm top-right hide">
 										<div class="btn-group btn-group-sm">
-											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-												Bandwidth<span class="caret"></span>
+											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">
+												Bandwidth
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
 												<a class="dropdown-item" href="#" id="0">No limit</a>
@@ -130,7 +128,7 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Video #1 <span class="badge badge-info hide" id="remote1"></span></span>
+								<span class="card-title">Remote Video #1 <span class="badge bg-info hide" id="remote1"></span></span>
 							</div>
 							<div class="card-body relative" id="videoremote1"></div>
 						</div>
@@ -138,7 +136,7 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Video #2 <span class="badge badge-info hide" id="remote2"></span></span>
+								<span class="card-title">Remote Video #2 <span class="badge bg-info hide" id="remote2"></span></span>
 							</div>
 							<div class="card-body relative" id="videoremote2"></div>
 						</div>
@@ -148,7 +146,7 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Video #3 <span class="badge badge-info hide" id="remote3"></span></span>
+								<span class="card-title">Remote Video #3 <span class="badge bg-info hide" id="remote3"></span></span>
 							</div>
 							<div class="card-body relative" id="videoremote3"></div>
 						</div>
@@ -156,7 +154,7 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Video #4 <span class="badge badge-info hide" id="remote4"></span></span>
+								<span class="card-title">Remote Video #4 <span class="badge bg-info hide" id="remote4"></span></span>
 							</div>
 							<div class="card-body relative" id="videoremote4"></div>
 						</div>
@@ -164,7 +162,7 @@
 					<div class="col-md-4">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Video #5 <span class="badge badge-info hide" id="remote5"></span></span>
+								<span class="card-title">Remote Video #5 <span class="badge bg-info hide" id="remote5"></span></span>
 							</div>
 							<div class="card-body relative" id="videoremote5"></div>
 						</div>

--- a/html/videoroomtest.html
+++ b/html/videoroomtest.html
@@ -7,8 +7,9 @@
 <title>Janus WebRTC Server (multistream): Video Room Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
@@ -17,34 +18,34 @@
 <script type="text/javascript" src="videoroomtest.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='videoroomtest.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='videoroomtest.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Video Room
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
 						<h3>Demo details</h3>
@@ -83,12 +84,14 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="videojoin">
+			<div class="container mt-4 hide" id="videojoin">
 				<div class="row">
-					<span class="label label-info" id="you"></span>
+					<span class="badge badge-info" id="you"></span>
 					<div class="col-md-12" id="controls">
-						<div class="input-group margin-bottom-md hide" id="registernow">
-							<span class="input-group-addon">@</span>
+						<div class="input-group mt-3 mb-1 hide" id="registernow">
+							<div class="input-group-prepend">
+								<span class="input-group-text">@</span>
+							</div>
 							<input autocomplete="off" class="form-control" type="text" placeholder="Choose a display name" id="username" onkeypress="return checkEnter(this, event);" />
 							<span class="input-group-btn">
 								<button class="btn btn-success" autocomplete="off" id="register">Join the room</button>
@@ -97,73 +100,73 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="videos">
+			<div class="container mt-4 hide" id="videos">
 				<div class="row">
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Local Video <span class="label label-primary hide" id="publisher"></span>
-									<div class="btn-group btn-group-xs pull-right hide">
-										<div class="btn-group btn-group-xs">
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Local Video <span class="badge badge-primary hide" id="publisher"></span>
+									<div class="btn-group btn-group-sm top-right hide">
+										<div class="btn-group btn-group-sm">
 											<button id="bitrateset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
 												Bandwidth<span class="caret"></span>
 											</button>
 											<ul id="bitrate" class="dropdown-menu" role="menu">
-												<li><a href="#" id="0">No limit</a></li>
-												<li><a href="#" id="128">Cap to 128kbit</a></li>
-												<li><a href="#" id="256">Cap to 256kbit</a></li>
-												<li><a href="#" id="512">Cap to 512kbit</a></li>
-												<li><a href="#" id="1024">Cap to 1mbit</a></li>
-												<li><a href="#" id="1500">Cap to 1.5mbit</a></li>
-												<li><a href="#" id="2000">Cap to 2mbit</a></li>
+												<a class="dropdown-item" href="#" id="0">No limit</a>
+												<a class="dropdown-item" href="#" id="128">Cap to 128kbit</a>
+												<a class="dropdown-item" href="#" id="256">Cap to 256kbit</a>
+												<a class="dropdown-item" href="#" id="512">Cap to 512kbit</a>
+												<a class="dropdown-item" href="#" id="1024">Cap to 1mbit</a>
+												<a class="dropdown-item" href="#" id="1500">Cap to 1.5mbit</a>
+												<a class="dropdown-item" href="#" id="2000">Cap to 2mbit</a>
 											</ul>
 										</div>
 									</div>
-								</h3>
+								</span>
 							</div>
-							<div class="panel-body" id="videolocal"></div>
+							<div class="card-body" id="videolocal"></div>
 						</div>
 					</div>
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Video #1 <span class="label label-info hide" id="remote1"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Video #1 <span class="badge badge-info hide" id="remote1"></span></span>
 							</div>
-							<div class="panel-body relative" id="videoremote1"></div>
+							<div class="card-body relative" id="videoremote1"></div>
 						</div>
 					</div>
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Video #2 <span class="label label-info hide" id="remote2"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Video #2 <span class="badge badge-info hide" id="remote2"></span></span>
 							</div>
-							<div class="panel-body relative" id="videoremote2"></div>
+							<div class="card-body relative" id="videoremote2"></div>
 						</div>
 					</div>
 				</div>
 				<div class="row">
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Video #3 <span class="label label-info hide" id="remote3"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Video #3 <span class="badge badge-info hide" id="remote3"></span></span>
 							</div>
-							<div class="panel-body relative" id="videoremote3"></div>
+							<div class="card-body relative" id="videoremote3"></div>
 						</div>
 					</div>
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Video #4 <span class="label label-info hide" id="remote4"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Video #4 <span class="badge badge-info hide" id="remote4"></span></span>
 							</div>
-							<div class="panel-body relative" id="videoremote4"></div>
+							<div class="card-body relative" id="videoremote4"></div>
 						</div>
 					</div>
 					<div class="col-md-4">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Video #5 <span class="label label-info hide" id="remote5"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Video #5 <span class="badge badge-info hide" id="remote5"></span></span>
 							</div>
-							<div class="panel-body relative" id="videoremote5"></div>
+							<div class="card-body relative" id="videoremote5"></div>
 						</div>
 					</div>
 				</div>

--- a/html/videoroomtest.html
+++ b/html/videoroomtest.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Video Room Demo</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -276,7 +276,7 @@ $(document).ready(function() {
 											$('#myvideo').addClass('hide');
 											$('#videolocal').append(
 												'<div class="no-video-container">' +
-													'<i class="fa fa-video-camera fa-5 no-video-icon" style="height: 100%;"></i>' +
+													'<i class="fa-solid fa-video fa-xl no-video-icon" style="height: 100%;"></i>' +
 													'<span class="no-video-text" style="font-size: 16px;">Video rejected, no webcam</span>' +
 												'</div>');
 										}
@@ -307,7 +307,7 @@ $(document).ready(function() {
 												if($('#videolocal .no-video-container').length === 0) {
 													$('#videolocal').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No webcam available</span>' +
 														'</div>');
 												}
@@ -338,7 +338,7 @@ $(document).ready(function() {
 											if($('#videolocal .no-video-container').length === 0) {
 												$('#videolocal').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}
@@ -692,7 +692,7 @@ function newRemoteFeed(id, display, streams) {
 							if($('#videoremote'+remoteFeed.rfindex + ' .no-video-container').length === 0) {
 								$('#videoremote'+remoteFeed.rfindex).append(
 									'<div class="no-video-container">' +
-										'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+										'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 										'<span class="no-video-text">No remote video available</span>' +
 									'</div>');
 							}
@@ -720,7 +720,7 @@ function newRemoteFeed(id, display, streams) {
 						if($('#videoremote'+remoteFeed.rfindex + ' .no-video-container').length === 0) {
 							$('#videoremote'+remoteFeed.rfindex).append(
 								'<div class="no-video-container">' +
-									'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+									'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 									'<span class="no-video-text">No remote video available</span>' +
 								'</div>');
 						}

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -602,12 +602,6 @@ function newRemoteFeed(id, display, streams) {
 								break;
 							}
 						}
-						if(!remoteFeed.spinner) {
-							let target = document.getElementById('videoremote'+remoteFeed.rfindex);
-							remoteFeed.spinner = new Spinner({top:100}).spin(target);
-						} else {
-							remoteFeed.spinner.spin();
-						}
 						Janus.log("Successfully attached to feed in room " + msg["room"]);
 						$('#remote'+remoteFeed.rfindex).removeClass('hide').html(remoteFeed.rfdisplay).removeClass('hide');
 					} else if(event === "event") {
@@ -702,10 +696,6 @@ function newRemoteFeed(id, display, streams) {
 					return;
 				}
 				// If we're here, a new track was added
-				if(remoteFeed.spinner) {
-					remoteFeed.spinner.stop();
-					remoteFeed.spinner = null;
-				}
 				if($('#remotevideo' + remoteFeed.rfindex + '-' + mid).length > 0)
 					return;
 				if(track.kind === "audio") {
@@ -763,9 +753,6 @@ function newRemoteFeed(id, display, streams) {
 			},
 			oncleanup: function() {
 				Janus.log(" ::: Got a cleanup notification (remote feed " + id + ") :::");
-				if(remoteFeed.spinner)
-					remoteFeed.spinner.stop();
-				remoteFeed.spinner = null;
 				$('#remotevideo'+remoteFeed.rfindex).remove();
 				$('#waitingvideo'+remoteFeed.rfindex).remove();
 				$('#novideo'+remoteFeed.rfindex).remove();

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -64,8 +64,8 @@ $(document).ready(function() {
 									Janus.log("Plugin attached! (" + sfutest.getPlugin() + ", id=" + sfutest.getId() + ")");
 									Janus.log("  -- This is a publisher/manager");
 									// Prepare the username registration
-									$('#videojoin').removeClass('hide').show();
-									$('#registernow').removeClass('hide').show();
+									$('#videojoin').removeClass('hide');
+									$('#registernow').removeClass('hide');
 									$('#register').click(registerUsername);
 									$('#username').focus();
 									$('#start').removeAttr('disabled').html("Stop")
@@ -84,6 +84,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -110,8 +111,9 @@ $(document).ready(function() {
 										return;
 									$('#publish').remove();
 									// This controls allows us to override the global room bitrate cap
-									$('#bitrate').parent().parent().removeClass('hide').show();
+									$('#bitrate').parent().parent().removeClass('hide');
 									$('#bitrate a').click(function() {
+										$('.dropdown-toggle').dropdown('hide');
 										let id = $(this).attr("id");
 										let bitrate = parseInt(id)*1000;
 										if(bitrate === 0) {
@@ -139,8 +141,8 @@ $(document).ready(function() {
 											mypvtid = msg["private_id"];
 											Janus.log("Successfully joined room " + msg["room"] + " with ID " + myid);
 											if(subscriber_mode) {
-												$('#videojoin').hide();
-												$('#videos').removeClass('hide').show();
+												$('#videojoin').addClass('hide');
+												$('#videos').removeClass('hide');
 											} else {
 												publishOwnFeed(true);
 											}
@@ -211,7 +213,7 @@ $(document).ready(function() {
 												}
 												if(remoteFeed) {
 													Janus.debug("Feed " + remoteFeed.rfid + " (" + remoteFeed.rfdisplay + ") has left the room, detaching");
-													$('#remote'+remoteFeed.rfindex).empty().hide();
+													$('#remote'+remoteFeed.rfindex).empty().addClass('hide');
 													$('#videoremote'+remoteFeed.rfindex).empty();
 													feeds[remoteFeed.rfindex] = null;
 													remoteFeed.detach();
@@ -235,7 +237,7 @@ $(document).ready(function() {
 												}
 												if(remoteFeed) {
 													Janus.debug("Feed " + remoteFeed.rfid + " (" + remoteFeed.rfdisplay + ") has left the room, detaching");
-													$('#remote'+remoteFeed.rfindex).empty().hide();
+													$('#remote'+remoteFeed.rfindex).empty().addClass('hide');
 													$('#videoremote'+remoteFeed.rfindex).empty();
 													feeds[remoteFeed.rfindex] = null;
 													remoteFeed.detach();
@@ -271,7 +273,7 @@ $(document).ready(function() {
 											// Video has been rejected
 											toastr.warning("Our video stream has been rejected, viewers won't see us");
 											// Hide the webcam video
-											$('#myvideo').hide();
+											$('#myvideo').addClass('hide');
 											$('#videolocal').append(
 												'<div class="no-video-container">' +
 													'<i class="fa fa-video-camera fa-5 no-video-icon" style="height: 100%;"></i>' +
@@ -320,13 +322,13 @@ $(document).ready(function() {
 										// We've been here already
 										return;
 									}
-									$('#videos').removeClass('hide').show();
+									$('#videos').removeClass('hide');
 									if($('#mute').length === 0) {
 										// Add a 'mute' button
-										$('#videolocal').append('<button class="btn btn-warning btn-xs" id="mute" style="position: absolute; bottom: 0px; left: 0px; margin: 15px;">Mute</button>');
+										$('#videolocal').append('<button class="btn btn-warning btn-sm bottom-left m-2" id="mute">Mute</button>');
 										$('#mute').click(toggleMute);
 										// Add an 'unpublish' button
-										$('#videolocal').append('<button class="btn btn-warning btn-xs" id="unpublish" style="position: absolute; bottom: 0px; right: 0px; margin: 15px;">Unpublish</button>');
+										$('#videolocal').append('<button class="btn btn-warning btn-sm bottom-right m-2" id="unpublish">Unpublish</button>');
 										$('#unpublish').click(unpublishOwnFeed);
 									}
 									if(track.kind === "audio") {
@@ -420,7 +422,7 @@ function registerUsername() {
 		let username = $('#username').val();
 		if(username === "") {
 			$('#you')
-				.removeClass().addClass('label label-warning')
+				.removeClass().addClass('badge badge-warning')
 				.html("Insert your display name (e.g., pippo)");
 			$('#username').removeAttr('disabled');
 			$('#register').removeAttr('disabled').click(registerUsername);
@@ -428,7 +430,7 @@ function registerUsername() {
 		}
 		if(/[^a-zA-Z0-9]/.test(username)) {
 			$('#you')
-				.removeClass().addClass('label label-warning')
+				.removeClass().addClass('badge badge-warning')
 				.html('Input is not alphanumeric');
 			$('#username').removeAttr('disabled').val("");
 			$('#register').removeAttr('disabled').click(registerUsername);
@@ -607,7 +609,7 @@ function newRemoteFeed(id, display, streams) {
 							remoteFeed.spinner.spin();
 						}
 						Janus.log("Successfully attached to feed in room " + msg["room"]);
-						$('#remote'+remoteFeed.rfindex).removeClass('hide').html(remoteFeed.rfdisplay).show();
+						$('#remote'+remoteFeed.rfindex).removeClass('hide').html(remoteFeed.rfdisplay).removeClass('hide');
 					} else if(event === "event") {
 						// Check if we got a simulcast-related event from this publisher
 						let substream = msg["substream"];
@@ -732,12 +734,12 @@ function newRemoteFeed(id, display, streams) {
 					Janus.log("Created remote video stream:", stream);
 					$('#videoremote'+remoteFeed.rfindex).append('<video class="rounded centered" id="remotevideo' + remoteFeed.rfindex + '-' + mid + '" width=100% autoplay playsinline/>');
 					$('#videoremote'+remoteFeed.rfindex).append(
-						'<span class="label label-primary hide" id="curres'+remoteFeed.rfindex+'" style="position: absolute; bottom: 0px; left: 0px; margin: 15px;"></span>' +
-						'<span class="label label-info hide" id="curbitrate'+remoteFeed.rfindex+'" style="position: absolute; bottom: 0px; right: 0px; margin: 15px;"></span>');
+						'<span class="badge badge-primary bottom-left m-3 hide" id="curres'+remoteFeed.rfindex+'"></span>' +
+						'<span class="badge badge-info bottom-right m-3 hide" id="curbitrate'+remoteFeed.rfindex+'"></span>');
 					Janus.attachMediaStream($('#remotevideo' + remoteFeed.rfindex + '-' + mid).get(0), stream);
 					// Note: we'll need this for additional videos too
 					if(!bitrateTimer[remoteFeed.rfindex]) {
-						$('#curbitrate'+remoteFeed.rfindex).removeClass('hide').show();
+						$('#curbitrate'+remoteFeed.rfindex).removeClass('hide');
 						bitrateTimer[remoteFeed.rfindex] = setInterval(function() {
 							if(!$("#videoremote" + remoteFeed.rfindex + ' video').get(0))
 								return;
@@ -753,7 +755,7 @@ function newRemoteFeed(id, display, streams) {
 									res += ' (simulcast)';
 								else if(remoteFeed.svcStarted)
 									res += ' (SVC)';
-								$('#curres'+remoteFeed.rfindex).removeClass('hide').text(res).show();
+								$('#curres'+remoteFeed.rfindex).removeClass('hide').text(res).removeClass('hide');
 							}
 						}, 1000);
 					}
@@ -805,28 +807,22 @@ function addSimulcastSvcButtons(feed, temporal) {
 	let what = (simulcast ? 'simulcast' : 'SVC');
 	let layer = (simulcast ? 'substream' : 'layer');
 	$('#remote'+index).parent().append(
-		'<div id="simulcast'+index+'" class="btn-group-vertical btn-group-vertical-xs pull-right">' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
-		'			<button id="sl'+index+'-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality" style="width: 33%">SL 2</button>' +
-		'			<button id="sl'+index+'-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality" style="width: 33%">SL 1</button>' +
-		'			<button id="sl'+index+'-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality" style="width: 34%">SL 0</button>' +
-		'		</div>' +
+		'<div id="simulcast'+index+'" class="btn-group-vertical btn-group-xs top-right">' +
+		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
+		'		<button id="sl'+index+'-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl'+index+'-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl'+index+'-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs hide" style="width: 100%">' +
-		'			<button id="tl'+index+'-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2" style="width: 34%">TL 2</button>' +
-		'			<button id="tl'+index+'-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1" style="width: 33%">TL 1</button>' +
-		'			<button id="tl'+index+'-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0" style="width: 33%">TL 0</button>' +
-		'		</div>' +
+		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
+		'		<button id="tl'+index+'-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl'+index+'-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl'+index+'-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>'
 	);
 	if(simulcast && Janus.webRTCAdapter.browserDetails.browser !== "firefox") {
 		// Chromium-based browsers only have two temporal layers, when doing simulcast
 		$('#tl'+index+'-2').remove();
-		$('#tl'+index+'-1').css('width', '50%');
-		$('#tl'+index+'-0').css('width', '50%');
 	}
 	// Enable the simulcast/SVC selection buttons
 	$('#sl' + index + '-0').removeClass('btn-primary btn-success').addClass('btn-primary')

--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -64,8 +64,8 @@ $(document).ready(function() {
 									Janus.log("Plugin attached! (" + sfutest.getPlugin() + ", id=" + sfutest.getId() + ")");
 									Janus.log("  -- This is a publisher/manager");
 									// Prepare the username registration
-									$('#videojoin').removeClass('hide');
-									$('#registernow').removeClass('hide');
+									$('#videojoin').removeClass('hide').removeClass('hide');
+									$('#registernow').removeClass('hide').removeClass('hide');
 									$('#register').click(registerUsername);
 									$('#username').focus();
 									$('#start').removeAttr('disabled').html("Stop")
@@ -91,7 +91,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -111,7 +111,7 @@ $(document).ready(function() {
 										return;
 									$('#publish').remove();
 									// This controls allows us to override the global room bitrate cap
-									$('#bitrate').parent().parent().removeClass('hide');
+									$('#bitrate').parent().parent().removeClass('hide').removeClass('hide');
 									$('#bitrate a').click(function() {
 										$('.dropdown-toggle').dropdown('hide');
 										let id = $(this).attr("id");
@@ -121,7 +121,7 @@ $(document).ready(function() {
 										} else {
 											Janus.log("Capping bandwidth to " + bitrate + " via REMB");
 										}
-										$('#bitrateset').html($(this).html() + '<span class="caret"></span>').parent().removeClass('open');
+										$('#bitrateset').text($(this).text()).parent().removeClass('open');
 										sfutest.send({ message: { request: "configure", bitrate: bitrate }});
 										return false;
 									});
@@ -142,7 +142,7 @@ $(document).ready(function() {
 											Janus.log("Successfully joined room " + msg["room"] + " with ID " + myid);
 											if(subscriber_mode) {
 												$('#videojoin').addClass('hide');
-												$('#videos').removeClass('hide');
+												$('#videos').removeClass('hide').removeClass('hide');
 											} else {
 												publishOwnFeed(true);
 											}
@@ -322,7 +322,7 @@ $(document).ready(function() {
 										// We've been here already
 										return;
 									}
-									$('#videos').removeClass('hide');
+									$('#videos').removeClass('hide').removeClass('hide');
 									if($('#mute').length === 0) {
 										// Add a 'mute' button
 										$('#videolocal').append('<button class="btn btn-warning btn-sm bottom-left m-2" id="mute">Mute</button>');
@@ -422,7 +422,7 @@ function registerUsername() {
 		let username = $('#username').val();
 		if(username === "") {
 			$('#you')
-				.removeClass().addClass('badge badge-warning')
+				.removeClass().addClass('badge bg-warning')
 				.html("Insert your display name (e.g., pippo)");
 			$('#username').removeAttr('disabled');
 			$('#register').removeAttr('disabled').click(registerUsername);
@@ -430,7 +430,7 @@ function registerUsername() {
 		}
 		if(/[^a-zA-Z0-9]/.test(username)) {
 			$('#you')
-				.removeClass().addClass('badge badge-warning')
+				.removeClass().addClass('badge bg-warning')
 				.html('Input is not alphanumeric');
 			$('#username').removeAttr('disabled').val("");
 			$('#register').removeAttr('disabled').click(registerUsername);
@@ -734,12 +734,12 @@ function newRemoteFeed(id, display, streams) {
 					Janus.log("Created remote video stream:", stream);
 					$('#videoremote'+remoteFeed.rfindex).append('<video class="rounded centered" id="remotevideo' + remoteFeed.rfindex + '-' + mid + '" width=100% autoplay playsinline/>');
 					$('#videoremote'+remoteFeed.rfindex).append(
-						'<span class="badge badge-primary bottom-left m-3 hide" id="curres'+remoteFeed.rfindex+'"></span>' +
-						'<span class="badge badge-info bottom-right m-3 hide" id="curbitrate'+remoteFeed.rfindex+'"></span>');
+						'<span class="badge bg-primary bottom-left m-3 hide" id="curres'+remoteFeed.rfindex+'"></span>' +
+						'<span class="badge bg-info bottom-right m-3 hide" id="curbitrate'+remoteFeed.rfindex+'"></span>');
 					Janus.attachMediaStream($('#remotevideo' + remoteFeed.rfindex + '-' + mid).get(0), stream);
 					// Note: we'll need this for additional videos too
 					if(!bitrateTimer[remoteFeed.rfindex]) {
-						$('#curbitrate'+remoteFeed.rfindex).removeClass('hide');
+						$('#curbitrate'+remoteFeed.rfindex).removeClass('hide').removeClass('hide');
 						bitrateTimer[remoteFeed.rfindex] = setInterval(function() {
 							if(!$("#videoremote" + remoteFeed.rfindex + ' video').get(0))
 								return;
@@ -809,14 +809,14 @@ function addSimulcastSvcButtons(feed, temporal) {
 	$('#remote'+index).parent().append(
 		'<div id="simulcast'+index+'" class="btn-group-vertical btn-group-xs top-right">' +
 		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
-		'		<button id="sl'+index+'-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
-		'		<button id="sl'+index+'-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
-		'		<button id="sl'+index+'-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
+		'		<button id="sl'+index+'-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl'+index+'-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl'+index+'-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
 		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
-		'		<button id="tl'+index+'-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
-		'		<button id="tl'+index+'-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
-		'		<button id="tl'+index+'-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
+		'		<button id="tl'+index+'-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl'+index+'-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl'+index+'-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>'
 	);

--- a/html/virtualbg.html
+++ b/html/virtualbg.html
@@ -8,9 +8,9 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@mediapipe/selfie_segmentation/selfie_segmentation.js" crossorigin="anonymous"></script>
@@ -26,7 +26,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
@@ -80,8 +80,8 @@
 									<span class="card-title">Local Stream
 										<div class="btn-group btn-group-sm top-right hide">
 											<div class="btn-group btn-group-sm">
-												<button id="backgroundset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-													Background<span class="caret"></span>
+												<button id="backgroundset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">
+													Background
 												</button>
 												<ul id="background" class="dropdown-menu" role="menu">
 													<a class="dropdown-item" href="#" id="synthwave">Synthwave</a>
@@ -104,7 +104,7 @@
 					<div class="col-md-6">
 						<div class="card">
 							<div class="card-header">
-								<span class="card-title">Remote Stream <span class="badge badge-primary hide" id="curres"></span> <span class="badge badge-info hide" id="curbitrate"></span></span>
+								<span class="card-title">Remote Stream <span class="badge bg-primary hide" id="curres"></span> <span class="badge bg-info hide" id="curbitrate"></span></span>
 							</div>
 							<div class="card-body" id="videoright"></div>
 						</div>

--- a/html/virtualbg.html
+++ b/html/virtualbg.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@mediapipe/selfie_segmentation/selfie_segmentation.js" crossorigin="anonymous"></script>
 <script type="text/javascript" src="settings.js" ></script>

--- a/html/virtualbg.html
+++ b/html/virtualbg.html
@@ -8,7 +8,8 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
@@ -18,37 +19,37 @@
 <script type="text/javascript" src="virtualbg.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='virtualbg.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='virtualbg.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Virtual Background
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
-						<h3>Demo details</h3>
+						<h3 class="mt-3">Demo details</h3>
 						<p>This is a variant of the Echo Test and Canvas demos meant to
 						 showcase how you can use libraries like
 						 <a href="https://google.github.io/mediapipe/" target="_blank">MediaPipe</a>
@@ -70,30 +71,30 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="videos">
+			<div class="container mt-4 hide" id="videos">
 				<div class="row">
 					<div class="col-md-6" id="self">
 						<div class="row">
-							<div class="panel panel-default">
-								<div class="panel-heading">
-									<h3 class="panel-title">Local Stream
-										<div class="btn-group btn-group-xs pull-right hide">
-											<div class="btn-group btn-group-xs">
+							<div class="card">
+								<div class="card-header">
+									<span class="card-title">Local Stream
+										<div class="btn-group btn-group-sm top-right hide">
+											<div class="btn-group btn-group-sm">
 												<button id="backgroundset" autocomplete="off" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
 													Background<span class="caret"></span>
 												</button>
 												<ul id="background" class="dropdown-menu" role="menu">
-													<li><a href="#" id="synthwave">Synthwave</a></li>
-													<li><a href="#" id="office">Office</a></li>
-													<li><a href="#" id="brickwall">Brick Wall</a></li>
-													<li><a href="#" id="blur">Blur</a></li>
-													<li><a href="#" id="none">None</a></li>
+													<a class="dropdown-item" href="#" id="synthwave">Synthwave</a>
+													<a class="dropdown-item" href="#" id="office">Office</a>
+													<a class="dropdown-item" href="#" id="brickwall">Brick Wall</a>
+													<a class="dropdown-item" href="#" id="blur">Blur</a>
+													<a class="dropdown-item" href="#" id="none">None</a>
 												</ul>
 											</div>
 										</div>
-									</h3>
+									</span>
 								</div>
-								<div class="panel-body" id="videoleft">
+								<div class="card-body" id="videoleft">
 									<video class="rounded centered hide" id="myvideo" width="100%" height="100%" muted="muted"></video>
 									<canvas id="canvas" class="hide" width="640" height="480" style="display: block; margin: auto; padding: 0"></canvas>
 								</div>
@@ -101,11 +102,11 @@
 						</div>
 					</div>
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Stream <span class="label label-primary hide" id="curres"></span> <span class="label label-info hide" id="curbitrate"></span></h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Stream <span class="badge badge-primary hide" id="curres"></span> <span class="badge badge-info hide" id="curbitrate"></span></span>
 							</div>
-							<div class="panel-body" id="videoright"></div>
+							<div class="card-body" id="videoright"></div>
 						</div>
 					</div>
 				</div>

--- a/html/virtualbg.html
+++ b/html/virtualbg.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Virtual Background</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/virtualbg.html
+++ b/html/virtualbg.html
@@ -28,7 +28,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>

--- a/html/virtualbg.js
+++ b/html/virtualbg.js
@@ -257,6 +257,7 @@ $(document).ready(function() {
 										return;
 									}
 									// If we're here, a new track was added
+									$('#spinner').remove();
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;
@@ -461,6 +462,13 @@ function createCanvas() {
 						success: function(jsep) {
 							Janus.debug("Got SDP!", jsep);
 							echotest.send({ message: body, jsep: jsep });
+							// Create a spinner waiting for the remote video
+							$('#videoright').html(
+								'<div class="text-center">' +
+								'	<div id="spinner" class="spinner-border" role="status">' +
+								'		<span class="visually-hidden">Loading...</span>' +
+								'	</div>' +
+								'</div>');
 						},
 						error: function(error) {
 							Janus.error("WebRTC error:", error);

--- a/html/virtualbg.js
+++ b/html/virtualbg.js
@@ -13,7 +13,6 @@ var opaqueId = "canvas-"+Janus.randomString(12);
 var localTracks = {}, localVideos = 0,
 	remoteTracks = {}, remoteVideos = 0;
 var bitrateTimer = null;
-var spinner = null;
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
 var acodec = (getQueryStringValue("acodec") !== "" ? getQueryStringValue("acodec") : null);
@@ -130,9 +129,6 @@ $(document).ready(function() {
 										if(result === "done") {
 											// The plugin closed the echo test
 											bootbox.alert("The Echo Test is over");
-											if(spinner)
-												spinner.stop();
-											spinner = null;
 											$('video').remove();
 											$('#waitingvideo').remove();
 											$('#peervideo').remove();
@@ -327,9 +323,6 @@ $(document).ready(function() {
 								},
 								oncleanup: function() {
 									Janus.log(" ::: Got a cleanup notification :::");
-									if(spinner)
-										spinner.stop();
-									spinner = null;
 									if(bitrateTimer)
 										clearInterval(bitrateTimer);
 									bitrateTimer = null;

--- a/html/virtualbg.js
+++ b/html/virtualbg.js
@@ -183,7 +183,7 @@ $(document).ready(function() {
 												if($('#videoleft .no-video-container').length === 0) {
 													$('#videoleft').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No webcam available</span>' +
 														'</div>');
 												}
@@ -208,7 +208,7 @@ $(document).ready(function() {
 											if($('#videoleft .no-video-container').length === 0) {
 												$('#videoleft').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}
@@ -251,7 +251,7 @@ $(document).ready(function() {
 												if($('#videoright .no-video-container').length === 0) {
 													$('#videoright').append(
 														'<div class="no-video-container">' +
-															'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+															'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 															'<span class="no-video-text">No remote video available</span>' +
 														'</div>');
 												}
@@ -279,7 +279,7 @@ $(document).ready(function() {
 											if($('#videoright .no-video-container').length === 0) {
 												$('#videoright').append(
 													'<div class="no-video-container">' +
-														'<i class="fa fa-video-camera fa-5 no-video-icon"></i>' +
+														'<i class="fa-solid fa-video fa-xl no-video-icon"></i>' +
 														'<span class="no-video-text">No webcam available</span>' +
 													'</div>');
 											}

--- a/html/virtualbg.js
+++ b/html/virtualbg.js
@@ -98,7 +98,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen
@@ -321,7 +321,7 @@ $(document).ready(function() {
 										bg = $(this).attr("id");
 										if(bg !== 'none')
 											image.src = images[bg];
-										$('#backgroundset').html($(this).html() + '<span class="caret"></span>').parent().removeClass('open');
+										$('#backgroundset').text($(this).text()).parent().removeClass('open');
 										return false;
 									});
 								},
@@ -488,14 +488,14 @@ function addSimulcastButtons(temporal) {
 	$('#curres').parent().append(
 		'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
 		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
-		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
-		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
-		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
 		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
-		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
-		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
-		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-bs-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {

--- a/html/virtualbg.js
+++ b/html/virtualbg.js
@@ -91,6 +91,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',
@@ -136,8 +137,8 @@ $(document).ready(function() {
 											$('#waitingvideo').remove();
 											$('#peervideo').remove();
 											$('#background').attr('disabled', true);
-											$('#curbitrate').hide();
-											$('#curres').hide();
+											$('#curbitrate').addClass('hide');
+											$('#curres').addClass('hide');
 											return;
 										}
 										// Any loss?
@@ -198,7 +199,7 @@ $(document).ready(function() {
 										return;
 									}
 									if($('#videoleft video').length === 0) {
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 									}
 									if(track.kind === "audio") {
 										// We ignore local audio tracks, they'd generate echo anyway
@@ -263,7 +264,7 @@ $(document).ready(function() {
 									let addButtons = false;
 									if($('#videoright audio').length === 0 && $('#videoright video').length === 0) {
 										addButtons = true;
-										$('#videos').removeClass('hide').show();
+										$('#videos').removeClass('hide');
 									}
 									if(track.kind === "audio") {
 										// New audio track: create a stream out of it, and use a hidden <audio> element
@@ -295,7 +296,7 @@ $(document).ready(function() {
 										Janus.attachMediaStream($('#peervideo' + mid).get(0), stream);
 										// FIXME we'll need this for additional videos too
 										if(!bitrateTimer) {
-											$('#curbitrate').removeClass('hide').show();
+											$('#curbitrate').removeClass('hide');
 											bitrateTimer = setInterval(function() {
 												if(!$("#peervideo" + mid).get(0))
 													return;
@@ -307,15 +308,16 @@ $(document).ready(function() {
 												let width = $("#peervideo" + mid).get(0).videoWidth;
 												let height = $("#peervideo" + mid).get(0).videoHeight;
 												if(width > 0 && height > 0)
-													$('#curres').removeClass('hide').text(width+'x'+height).show();
+													$('#curres').removeClass('hide').text(width+'x'+height).removeClass('hide');
 											}, 1000);
 										}
 									}
 									if(!addButtons)
 										return;
 									// Enable background image selector
-									$('#background').parent().parent().removeClass('hide').show();
+									$('#background').parent().parent().removeClass('hide');
 									$('#background a').click(function() {
+										$('.dropdown-toggle').dropdown('hide');
 										bg = $(this).attr("id");
 										if(bg !== 'none')
 											image.src = images[bg];
@@ -336,8 +338,8 @@ $(document).ready(function() {
 									$("#videoleft").empty().parent().unblock();
 									$('#videoright').empty();
 									$('#background').attr('disabled', true);
-									$('#curbitrate').hide();
-									$('#curres').hide();
+									$('#curbitrate').addClass('hide');
+									$('#curres').addClass('hide');
 									remoteTracks = {};
 									remoteVideos = 0;
 								}
@@ -484,27 +486,21 @@ function createCanvas() {
 // Helpers to create Simulcast-related UI, if enabled
 function addSimulcastButtons(temporal) {
 	$('#curres').parent().append(
-		'<div id="simulcast" class="btn-group-vertical btn-group-vertical-xs pull-right">' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs" style="width: 100%">' +
-		'			<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality" style="width: 33%">SL 2</button>' +
-		'			<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality" style="width: 33%">SL 1</button>' +
-		'			<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality" style="width: 34%">SL 0</button>' +
-		'		</div>' +
+		'<div id="simulcast" class="btn-group-vertical btn-group-xs top-right">' +
+		'	<div class="btn-group btn-group-xs d-flex" style="width: 100%">' +
+		'		<button id="sl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to higher quality">SL 2</button>' +
+		'		<button id="sl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to normal quality">SL 1</button>' +
+		'		<button id="sl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Switch to lower quality">SL 0</button>' +
 		'	</div>' +
-		'	<div class"row">' +
-		'		<div class="btn-group btn-group-xs hide" style="width: 100%">' +
-		'			<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2" style="width: 34%">TL 2</button>' +
-		'			<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1" style="width: 33%">TL 1</button>' +
-		'			<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0" style="width: 33%">TL 0</button>' +
-		'		</div>' +
+		'	<div class="btn-group btn-group-xs d-flex hide" style="width: 100%">' +
+		'		<button id="tl-2" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 2">TL 2</button>' +
+		'		<button id="tl-1" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 1">TL 1</button>' +
+		'		<button id="tl-0" type="button" class="btn btn-primary" data-toggle="tooltip" title="Cap to temporal layer 0">TL 0</button>' +
 		'	</div>' +
 		'</div>');
 	if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {
 		// Chromium-based browsers only have two temporal layers
 		$('#tl-2').remove();
-		$('#tl-1').css('width', '50%');
-		$('#tl-0').css('width', '50%');
 	}
 	// Enable the simulcast selection buttons
 	$('#sl-0').removeClass('btn-primary btn-success').addClass('btn-primary')

--- a/html/webaudio.html
+++ b/html/webaudio.html
@@ -7,10 +7,10 @@
 <title>Janus WebRTC Server (multistream): Web Audio Processing</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
@@ -25,7 +25,7 @@
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
@@ -72,33 +72,23 @@
 							</div>
 							<div class="card-body">
 								<div class="input-group mb-2">
-									<div class="input-group-prepend w-25">
-										<span class="input-group-text w-100">Threshold</span>
-									</div>
+									<span class="input-group-text w-100">Threshold</span>
 									<input type="text" class="form-control" id="threshold" name="threshold" placeholder="Threshold" value="" onkeypress="return checkEnter(event);" disabled></input>
 								</div>
 								<div class="input-group mt-2 mb-2">
-									<div class="input-group-prepend w-25">
-										<span class="input-group-text w-100">Knee</span>
-									</div>
+									<span class="input-group-text w-100">Knee</span>
 									<input type="text" class="form-control" id="knee" name="knee" placeholder="Knee" value="" onkeypress="return checkEnter(event);" disabled></input>
 								</div>
 								<div class="input-group mt-2 mb-2">
-									<div class="input-group-prepend w-25">
-										<span class="input-group-text w-100">Ratio</span>
-									</div>
+									<span class="input-group-text w-100">Ratio</span>
 									<input type="text" class="form-control" id="ratio" name="ratio" placeholder="Ratio" value="" onkeypress="return checkEnter(event);" disabled></input>
 								</div>
 								<div class="input-group mt-2 mb-2">
-									<div class="input-group-prepend w-25">
-										<span class="input-group-text w-100">Attack</span>
-									</div>
+									<span class="input-group-text w-100">Attack</span>
 									<input type="text" class="form-control" id="attack" name="attack" placeholder="Attack" value="" onkeypress="return checkEnter(event);" disabled></input>
 								</div>
 								<div class="input-group mt-2 mb-2">
-									<div class="input-group-prepend w-25">
-										<span class="input-group-text w-100">Release</span>
-									</div>
+									<span class="input-group-text w-100">Release</span>
 									<input type="text" class="form-control" id="release" name="release" placeholder="Release" value="" onkeypress="return checkEnter(event);" disabled></input>
 								</div>
 							</div>

--- a/html/webaudio.html
+++ b/html/webaudio.html
@@ -11,7 +11,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/6.0.0/bootbox.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
 <script type="text/javascript" src="settings.js" ></script>
 <script type="text/javascript" src="janus.js" ></script>

--- a/html/webaudio.html
+++ b/html/webaudio.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Janus WebRTC Server (multistream): Web Audio Processing</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.2/js/bootstrap.min.js"></script>

--- a/html/webaudio.html
+++ b/html/webaudio.html
@@ -27,7 +27,7 @@
 </script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>

--- a/html/webaudio.html
+++ b/html/webaudio.html
@@ -7,8 +7,9 @@
 <title>Janus WebRTC Server (multistream): Web Audio Processing</title>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.2.3/adapter.min.js" ></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js" ></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js"></script>
@@ -17,37 +18,37 @@
 <script type="text/javascript" src="webaudio.js"></script>
 <script>
 	$(function() {
-		$(".navbar-static-top").load("navbar.html", function() {
-			$(".navbar-static-top li.dropdown").addClass("active");
-			$(".navbar-static-top a[href='webaudio.html']").parent().addClass("active");
+		$(".fixed-top").load("navbar.html", function() {
+			$(".fixed-top li.dropdown").addClass("active");
+			$(".fixed-top a[href='webaudio.html']").addClass("active");
 		});
 		$(".footer").load("footer.html");
 	});
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/cerulean/bootstrap.min.css" type="text/css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.2/cerulean/bootstrap.min.css" type="text/css"/>
 <link rel="stylesheet" href="css/demo.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css"/>
 </head>
 <body>
 
-<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 1001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/meetecho/janus-gateway"><img style="position: absolute; top: 0; left: 0; border: 0; z-index: 2001;" src="forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<nav class="navbar navbar-default navbar-static-top">
-</nav>
+<div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+</div>
 
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-			<div class="page-header">
+			<div class="pb-2 mt-4 mb-2 border-bottom">
 				<h1>Plugin Demo: Web Audio Processing
-					<button class="btn btn-default" autocomplete="off" id="start">Start</button>
+					<button class="btn btn-secondary" autocomplete="off" id="start">Start</button>
 				</h1>
 			</div>
-			<div class="container" id="details">
+			<div class="container mt-5" id="details">
 				<div class="row">
 					<div class="col-md-12">
-						<h3>Demo details</h3>
+						<h3 class="mt-3">Demo details</h3>
 						<p>This is a variant of the Echo Test demo meant to showcase how you can use the
 						<a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a>
 						to manipulate the audio from the microphone, before sending it to Janus,
@@ -62,43 +63,53 @@
 					</div>
 				</div>
 			</div>
-			<div class="container hide" id="demo">
+			<div class="container mt-4 hide" id="demo">
 				<div class="row">
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Local Stream (compressor)</h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Local Stream (compressor)</span>
 							</div>
-							<div class="panel-body">
-								<div class="input-group margin-bottom-sm" style="width: 100%;">
-									<label for="threshold">Threshold</label>
+							<div class="card-body">
+								<div class="input-group mb-2">
+									<div class="input-group-prepend w-25">
+										<span class="input-group-text w-100">Threshold</span>
+									</div>
 									<input type="text" class="form-control" id="threshold" name="threshold" placeholder="Threshold" value="" onkeypress="return checkEnter(event);" disabled></input>
 								</div>
-								<div class="input-group margin-bottom-sm" style="width: 100%;">
-									<label for="knee">Knee</label>
+								<div class="input-group mt-2 mb-2">
+									<div class="input-group-prepend w-25">
+										<span class="input-group-text w-100">Knee</span>
+									</div>
 									<input type="text" class="form-control" id="knee" name="knee" placeholder="Knee" value="" onkeypress="return checkEnter(event);" disabled></input>
 								</div>
-								<div class="input-group margin-bottom-sm" style="width: 100%;">
-									<label for="ratio">Ratio</label>
+								<div class="input-group mt-2 mb-2">
+									<div class="input-group-prepend w-25">
+										<span class="input-group-text w-100">Ratio</span>
+									</div>
 									<input type="text" class="form-control" id="ratio" name="ratio" placeholder="Ratio" value="" onkeypress="return checkEnter(event);" disabled></input>
 								</div>
-								<div class="input-group margin-bottom-sm" style="width: 100%;">
-									<label for="attack">Attack</label>
+								<div class="input-group mt-2 mb-2">
+									<div class="input-group-prepend w-25">
+										<span class="input-group-text w-100">Attack</span>
+									</div>
 									<input type="text" class="form-control" id="attack" name="attack" placeholder="Attack" value="" onkeypress="return checkEnter(event);" disabled></input>
 								</div>
-								<div class="input-group margin-bottom-sm" style="width: 100%;">
-									<label for="attack">Release</label>
+								<div class="input-group mt-2 mb-2">
+									<div class="input-group-prepend w-25">
+										<span class="input-group-text w-100">Release</span>
+									</div>
 									<input type="text" class="form-control" id="release" name="release" placeholder="Release" value="" onkeypress="return checkEnter(event);" disabled></input>
 								</div>
 							</div>
 						</div>
 					</div>
 					<div class="col-md-6">
-						<div class="panel panel-default">
-							<div class="panel-heading">
-								<h3 class="panel-title">Remote Stream (visualizer)</h3>
+						<div class="card">
+							<div class="card-header">
+								<span class="card-title">Remote Stream (visualizer)</span>
 							</div>
-							<div class="panel-body" id="remote">
+							<div class="card-body" id="remote">
 							</div>
 						</div>
 					</div>

--- a/html/webaudio.js
+++ b/html/webaudio.js
@@ -93,7 +93,7 @@ $(document).ready(function() {
 												backgroundColor: 'transparent',
 												color: '#aaa',
 												top: '10px',
-												left: (navigator.mozGetUserMedia ? '-100px' : '300px')
+												left: '100px'
 											} });
 									} else {
 										// Restore screen

--- a/html/webaudio.js
+++ b/html/webaudio.js
@@ -152,6 +152,7 @@ $(document).ready(function() {
 										return;
 									}
 									// If we're here, a new track was added
+									$('#spinner').remove();
 									if(track.kind === "audio") {
 										// New audio track: create a stream out of it, and use a hidden <audio> element
 										let stream = new MediaStream([track]);
@@ -309,6 +310,13 @@ function setupWebAudioDemo() {
 						Janus.debug("Got SDP!", jsep);
 						let body = { audio: true, video: true };
 						echotest.send({ message: body, jsep: jsep });
+						// Create a spinner waiting for the remote video
+						$('#remote').html(
+							'<div class="text-center">' +
+							'	<div id="spinner" class="spinner-border" role="status">' +
+							'		<span class="visually-hidden">Loading...</span>' +
+							'	</div>' +
+							'</div>');
 					},
 					error: function(error) {
 						Janus.error("WebRTC error:", error);

--- a/html/webaudio.js
+++ b/html/webaudio.js
@@ -86,6 +86,7 @@ $(document).ready(function() {
 										// Darken screen and show hint
 										$.blockUI({
 											message: '<div><img src="up_arrow.png"/></div>',
+											baseZ: 3001,
 											css: {
 												border: 'none',
 												padding: '15px',


### PR DESCRIPTION
This is a proper refactoring of all the demos and the generated documentation so that it uses more up-to-date stuff, specifically Bootstrap 5.x, which #3295 and #3296 did incorrectly. The patch also updates font-awesome to 6.x, so it already includes (and actually expands, since there was stuff that was incorrect there too) #3298. Notice I will only do this for master: all the 0.x demo/docs will remain as they are.

This required a huge effort, since I first needed to migrate to Bootstrap 4.x (which took quite a while), and from there to 5.x (less problematic but still not a walk in the park). I tried testing all demos in multiple scenarios, but obviously I couldn't test _everything_, so please give them a go yourself too just to ensure I didn't break anything in the process. From a functional perspective, everything should be there.

Before merging, I'll try to also try and take advantage of a few things that Bootstrap has, but that we're relying on external libraries for, like spinners and toasts. Ideally that should help us getting closer to get rid of jQuery, even though that will take longer, and will done (in case) in a separate PR, since we depend on it for some stuff (BlockUI, all selectors, all html appends/prepends and maybe a few other things).

Feedback welcome!