### PR TITLE
Fixed broken faststart when postprocessing AV1 recordings (fixes #3315)

### DIFF
--- a/src/postprocessing/pp-av1.c
+++ b/src/postprocessing/pp-av1.c
@@ -55,6 +55,10 @@ int janus_pp_av1_create(char *destination, char *metadata, gboolean faststart, c
 		return -1;
 	}
 
+	char filename[1024];
+	snprintf(filename, sizeof(filename), "%s", destination);
+	fctx->url = g_strdup(filename);
+
 	vStream = janus_pp_new_video_avstream(fctx, AV_CODEC_ID_AV1, max_width, max_height);
 	if(vStream == NULL) {
 		JANUS_LOG(LOG_ERR, "Error adding stream\n");


### PR DESCRIPTION
This fixes #3315. It replicates what has been done in adea15f but for AV1 post-processing.