### PR TITLE
Fixed broken faststart when postprocessing AV1 recordings

### DIFF
--- a/src/postprocessing/pp-av1.c
+++ b/src/postprocessing/pp-av1.c
@@ -55,6 +55,10 @@ int janus_pp_av1_create(char *destination, char *metadata, gboolean faststart, c
 		return -1;
 	}
 
+	char filename[1024];
+	snprintf(filename, sizeof(filename), "%s", destination);
+	fctx->url = g_strdup(filename);
+
 	vStream = janus_pp_new_video_avstream(fctx, AV_CODEC_ID_AV1, max_width, max_height);
 	if(vStream == NULL) {
 		JANUS_LOG(LOG_ERR, "Error adding stream\n");

--- a/src/postprocessing/pp-av1.c
+++ b/src/postprocessing/pp-av1.c
@@ -528,7 +528,8 @@ void janus_pp_av1_close(void) {
 	if(fctx != NULL) {
 		av_write_trailer(fctx);
 		avio_close(fctx->pb);
-		avformat_free_context(fctx);
 		g_free(fctx->url);
+		fctx->url = NULL;
+		avformat_free_context(fctx);
 	}
 }

--- a/src/postprocessing/pp-av1.c
+++ b/src/postprocessing/pp-av1.c
@@ -529,5 +529,6 @@ void janus_pp_av1_close(void) {
 		av_write_trailer(fctx);
 		avio_close(fctx->pb);
 		avformat_free_context(fctx);
+		g_free(fctx->url);
 	}
 }

--- a/src/postprocessing/pp-av1.c
+++ b/src/postprocessing/pp-av1.c
@@ -55,9 +55,7 @@ int janus_pp_av1_create(char *destination, char *metadata, gboolean faststart, c
 		return -1;
 	}
 
-	char filename[1024];
-	snprintf(filename, sizeof(filename), "%s", destination);
-	fctx->url = g_strdup(filename);
+	fctx->url = g_strdup(destination);
 
 	vStream = janus_pp_new_video_avstream(fctx, AV_CODEC_ID_AV1, max_width, max_height);
 	if(vStream == NULL) {


### PR DESCRIPTION
This fixes #3315. It replicates what has been done in adea15f24b04301c6a925800c923fa2835fda7e6 but for AV1 post-processing. (And re-opens #3316 without typo in the branch name)