### PR TITLE
feat: An attempt to forward a handle's media stream with multiple threads for videoroom.

### DIFF
--- a/src/ice.h
+++ b/src/ice.h
@@ -343,7 +343,6 @@ enum {
 	SEQ_RECVED
 };
 
-
 /*! \brief Janus ICE handle */
 struct janus_ice_handle {
 	/*! \brief Opaque pointer to the core/peer session */
@@ -370,6 +369,10 @@ struct janus_ice_handle {
 	GMainLoop *mainloop;
 	/*! \brief In case static event loops are used, opaque pointer to the loop */
 	void *static_event_loop;
+	/*! \brief wsw Number of helper threads for relaying purpose*/
+	int helper_threads;
+	/*! \brief wsw List of helper threads, if any*/
+	GList* threads;
 	/*! \brief GLib thread for the handle and libnice */
 	GThread *thread;
 	/*! \brief GLib sources for outgoing traffic, recurring RTCP, and stats (and optionally TWCC) */
@@ -423,6 +426,20 @@ struct janus_ice_handle {
 	/*! \brief Reference counter for this instance */
 	janus_refcount ref;
 };
+
+/*\brief Janus ICE janus_relay_helper*/
+typedef struct janus_relay_helper {
+	struct janus_ice_handle* handle;
+	guint id;
+	GThread* thread;
+	GSource* source;
+	GMainContext* mainctx;
+	GMainLoop* mainloop;
+	GAsyncQueue* queued_packets;
+	volatile gint destroyed;
+	janus_mutex mutex;
+	janus_refcount ref;
+} janus_relay_helper;
 
 /*! \brief Janus handle WebRTC PeerConnection */
 struct janus_ice_peerconnection {


### PR DESCRIPTION
Hi, this PR tries to add multithreaded packet forwarding support for videoroom.

I found that when a meeting is distributed by multiple people, if a handle forwards multiple media streams in the same thread, the "Discarding too old outgoing packet" situation will occur, then the whole server stucks. I wonder if this problem can be tackled with multiple threads forwarding a single handle's media stream on sufficient server resources. So this PR is an attempt to forward a handle's media stream with multiple threads.