### PR TITLE
FIx type declaration file for `getBitrate`.

### DIFF
--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -359,7 +359,7 @@ declare namespace JanusJS {
 		isVideoMuted(): boolean;
 		muteVideo(): void;
 		unmuteVideo(): void;
-		getBitrate(): string;
+		getBitrate(mid? :string): string;
 		setMaxBitrate(bitrate: number): void;
 		send(message: PluginMessage): void;
 		data(params: PluginDataParam): void;


### PR DESCRIPTION

This PR modifies the type definition of the 'getBitrate' function, referencing the following documentation.

> getBitrate(mid): gets a verbose description of the currently received video stream bitrate (optional mid to specify the stream, first video stream if missing);

https://janus.conf.meetecho.com/docs/JS.html