### PR TITLE
Don't call close_pc in SIP plugin if there was no SDP (fixes #3332)

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -1411,6 +1411,7 @@ janus_ice_handle *janus_ice_handle_create(void *core_session, const char *opaque
 	handle->queued_candidates = g_async_queue_new();
 	handle->queued_packets = g_async_queue_new();
 	janus_mutex_init(&handle->mutex);
+	janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALERT);
 	janus_session_handles_insert(session, handle);
 	return handle;
 }

--- a/src/plugins/plugin.h
+++ b/src/plugins/plugin.h
@@ -401,7 +401,8 @@ struct janus_callbacks {
 
 	/*! \brief Callback to ask the core to close a WebRTC PeerConnection
 	 * \note A call to this method will result in the core invoking the hangup_media
-	 * callback on this plugin when done
+	 * callback on this plugin when done, but only if a PeerConnection had been
+	 * created or was in the process of being negotiated (SDP exchanged)
 	 * @param[in] handle The plugin/gateway session that the PeerConnection is related to */
 	void (* const close_pc)(janus_plugin_session *handle);
 	/*! \brief Callback to ask the core to get rid of a plugin/gateway session


### PR DESCRIPTION
You can refer to the comments in #3332 for a more comprehensive discussion around the need for this fix.
I'll backport to `0.x` as well, once this is merged.