### PR TITLE
Fix getBitrate()

### DIFF
--- a/html/demos/janus.js
+++ b/html/demos/janus.js
@@ -3045,7 +3045,7 @@ function Janus(gatewayCallbacks) {
 									return;
 								let inStats = false;
 								// Check if these are statistics on incoming media
-								if((res.mediaType === "video" || res.id.toLowerCase().indexOf("video") > -1) &&
+								if((res.kind === "video" || res.id.toLowerCase().indexOf("video") > -1) &&
 										res.type === "inbound-rtp" && res.id.indexOf("rtcp") < 0) {
 									// New stats
 									inStats = true;

--- a/html/demos/janus.js
+++ b/html/demos/janus.js
@@ -3045,7 +3045,7 @@ function Janus(gatewayCallbacks) {
 									return;
 								let inStats = false;
 								// Check if these are statistics on incoming media
-								if((res.kind === "video" || res.id.toLowerCase().indexOf("video") > -1) &&
+								if((res.mediaType === "video" || res.kind === "video" || res.id.toLowerCase().indexOf("video") > -1) &&
 										res.type === "inbound-rtp" && res.id.indexOf("rtcp") < 0) {
 									// New stats
 									inStats = true;


### PR DESCRIPTION
Since "mediaType" property seems deprecated as it was renamed to "kind" (https://developer.mozilla.org/en-US/docs/Web/API/RTCInboundRtpStreamStats), i would like to introduce small change in janus.js getBitrate function, so that it will return the correct values when called on iPhones and iPads