### PR TITLE
Ship speexdsp's jitter buffer as part of local AudioBridge dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ A couple of plugins depend on a few more libraries:
 
 * [Sofia-SIP](https://github.com/freeswitch/sofia-sip) (only needed for the SIP plugin)
 * [libopus](https://opus-codec.org/) (only needed for the AudioBridge plugin)
-* [speexdsp](https://www.speex.org/) (only needed for AudioBridge plugin)
 * [libogg](https://xiph.org/ogg/) (needed for the VoiceMail plugin and/or post-processor, and optionally AudioBridge and Streaming plugins)
 * [libcurl](https://curl.haxx.se/libcurl/) (only needed if you are interested in RTSP support in the Streaming plugin or in the sample Event Handler plugin)
 * [Lua](https://www.lua.org/download.html) (only needed for the Lua plugin)
@@ -52,7 +51,7 @@ All of those libraries are usually available on most of the most common distribu
     yum install libmicrohttpd-devel jansson-devel \
        openssl-devel libsrtp-devel sofia-sip-devel glib2-devel \
        opus-devel libogg-devel libcurl-devel pkgconfig \
-       speexdsp-devel libconfig-devel libtool autoconf automake
+       libconfig-devel libtool autoconf automake
 
 Notice that you may have to `yum install epel-release` as well if you're attempting an installation on a CentOS machine instead.
 
@@ -61,7 +60,7 @@ On Ubuntu or Debian, it would require something like this:
 	apt install libmicrohttpd-dev libjansson-dev \
 		libssl-dev libsofia-sip-ua-dev libglib2.0-dev \
 		libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev \
-		libspeexdsp-dev libconfig-dev pkg-config libtool automake
+		libconfig-dev pkg-config libtool automake
 
 * *Note:* please notice that libopus may not be available out of the box on your distro. In that case, you'll have to [install it manually](https://www.opus-codec.org).
 
@@ -219,7 +218,7 @@ since it is a GNU makefile. `./configure` can be run without arguments since the
 Note that the `configure.ac` is coded to use openssl in base. If you wish to use openssl from ports or any other ssl you must change `configure.ac` accordingly.
 
 	pkg install libsrtp2 libusrsctp jansson libnice libmicrohttpd libwebsockets curl opus sofia-sip libogg jansson libnice libconfig \
-        speexdsp libtool gmake autoconf autoconf-wrapper glib
+        libtool gmake autoconf autoconf-wrapper glib
 
 
 ### Building on MacOS
@@ -229,7 +228,7 @@ First of all, you can use `brew` to install most of the dependencies:
 
 	brew install jansson libnice openssl srtp libusrsctp libmicrohttpd \
 		libwebsockets cmake rabbitmq-c sofia-sip opus libogg curl glib \
-		speexdsp libconfig pkg-config autoconf automake libtool
+		libconfig pkg-config autoconf automake libtool
 
 For what concerns libwebsockets, though, make sure that the installed version is higher than `2.4.1`, or you might encounter the problems described in [this post](https://groups.google.com/forum/#!topic/meetecho-janus/HsFaEXBz4Cg). If `brew` doesn't provide a more recent version, you'll have to install the library manually.
 

--- a/configure.ac
+++ b/configure.ac
@@ -790,15 +790,18 @@ AC_SUBST([SOFIA_LIBS])
 PKG_CHECK_MODULES([OPUS],
                   [
                    opus
-                   speexdsp
                   ],
                   [
                     AS_IF([test "x$enable_plugin_audiobridge" = "xmaybe"],
-                          [enable_plugin_audiobridge=yes])
+                          [
+                           AC_DEFINE(FLOATING_POINT)
+                           AC_DEFINE([EXPORT], [], [Symbol visibility prefix])
+                           enable_plugin_audiobridge=yes
+                          ])
                   ],
                   [
                     AS_IF([test "x$enable_plugin_audiobridge" = "xyes"],
-                          [AC_MSG_ERROR([libopus or libspeexdsp not found. See README.md for installation instructions or use --disable-plugin-audiobridge])])
+                          [AC_MSG_ERROR([libopus not found. See README.md for installation instructions or use --disable-plugin-audiobridge])])
                   ])
 AC_SUBST([OPUS_CFLAGS])
 AC_SUBST([OPUS_LIBS])

--- a/configure.ac
+++ b/configure.ac
@@ -794,9 +794,12 @@ PKG_CHECK_MODULES([OPUS],
                   [
                     AS_IF([test "x$enable_plugin_audiobridge" = "xmaybe"],
                           [
+                           enable_plugin_audiobridge=yes
+                          ])
+                    AS_IF([test "x$enable_plugin_audiobridge" = "xyes"],
+                          [
                            AC_DEFINE(FLOATING_POINT)
                            AC_DEFINE([EXPORT], [], [Symbol visibility prefix])
-                           enable_plugin_audiobridge=yes
                           ])
                   ],
                   [

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -396,7 +396,10 @@ plugins_libadd = \
 
 if ENABLE_PLUGIN_AUDIOBRIDGE
 plugin_LTLIBRARIES += plugins/libjanus_audiobridge.la
-plugins_libjanus_audiobridge_la_SOURCES = plugins/janus_audiobridge.c
+plugins_libjanus_audiobridge_la_SOURCES = plugins/janus_audiobridge.c \
+	plugins/audiobridge-deps/jitter.c plugins/audiobridge-deps/arch.h \
+	plugins/audiobridge-deps/os_support.h plugins/audiobridge-deps/speex/speex_jitter.h \
+	plugins/audiobridge-deps/speex/speexdsp_types.h plugins/audiobridge-deps/speex/speexdsp_config_types.h
 plugins_libjanus_audiobridge_la_CFLAGS = $(plugins_cflags) $(OPUS_CFLAGS) $(OGG_CFLAGS) $(LIBSRTP_CFLAGS)
 plugins_libjanus_audiobridge_la_LDFLAGS = $(plugins_ldflags) $(OPUS_LDFLAGS) $(OPUS_LIBS) $(OGG_LDFLAGS) $(OGG_LIBS)
 plugins_libjanus_audiobridge_la_LIBADD = $(plugins_libadd) $(OPUS_LIBADD) $(OGG_LIBADD)

--- a/src/mainpage.dox
+++ b/src/mainpage.dox
@@ -107,7 +107,6 @@
  * - \b nanomsg: https://nanomsg.org/ (\c optional, Nanomsg)
  * - \b Sofia-SIP: https://github.com/freeswitch/sofia-sip (\c optional, only needed for the SIP plugin)
  * - \b libopus: http://opus-codec.org/ (\c optional, only needed for the AudioBridge plugin)
- * - \b speexdsp: http://www.speex.org/ (\c optional, only needed for the AudioBridge plugin)
  * - \b libogg: http://xiph.org/ogg/ (\c optional, only needed for the AudioBridge and Streaming plugins)
  * - \b libcurl: https://curl.haxx.se/libcurl/ (\c optional, only needed for the TURN REST API,
  * RTSP support in the Streaming plugin and the sample Event Handler plugin)
@@ -3885,7 +3884,6 @@ ldd janus | grep asan
  * - \b nanomsg: https://nanomsg.org/ (\c optional, Nanomsg)
  * - \b Sofia-SIP: https://github.com/freeswitch/sofia-sip (\c optional, only needed for the SIP plugin)
  * - \b libopus: http://opus-codec.org/ (\c optional, only needed for the AudioBridge plugin)
- * - \b speexdsp: http://www.speex.org/ (\c optional, only needed for the AudioBridge plugin)
  * - \b libogg: http://xiph.org/ogg/ (\c optional, only needed for the AudioBridge and Streaming plugins)
  * - \b libcurl: https://curl.haxx.se/libcurl/ (\c optional, only needed for the TURN REST API,
  * RTSP support in the Streaming plugin and the sample Event Handler plugin)

--- a/src/plugins/audiobridge-deps/COPYING
+++ b/src/plugins/audiobridge-deps/COPYING
@@ -1,0 +1,35 @@
+Copyright 2002-2008 	Xiph.org Foundation
+Copyright 2002-2008 	Jean-Marc Valin
+Copyright 2005-2007	Analog Devices Inc.
+Copyright 2005-2008	Commonwealth Scientific and Industrial Research
+                        Organisation (CSIRO)
+Copyright 1993, 2002, 2006 David Rowe
+Copyright 2003 		EpicGames
+Copyright 1992-1994	Jutta Degener, Carsten Bormann
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of the Xiph.org Foundation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/plugins/audiobridge-deps/arch.h
+++ b/src/plugins/audiobridge-deps/arch.h
@@ -1,0 +1,232 @@
+/* Copyright (C) 2003 Jean-Marc Valin */
+/**
+   @file arch.h
+   @brief Various architecture definitions Speex
+*/
+/*
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   - Neither the name of the Xiph.org Foundation nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef ARCH_H
+#define ARCH_H
+
+/* A couple test to catch stupid option combinations */
+#ifdef FIXED_POINT
+
+#ifdef FLOATING_POINT
+#error You cannot compile as floating point and fixed point at the same time
+#endif
+#ifdef USE_SSE
+#error SSE is only for floating-point
+#endif
+#if defined(ARM4_ASM) + defined(ARM5E_ASM) + defined(BFIN_ASM) > 1
+#error Make up your mind. What CPU do you have?
+#endif
+#ifdef VORBIS_PSYCHO
+#error Vorbis-psy model currently not implemented in fixed-point
+#endif
+
+#else
+
+#ifndef FLOATING_POINT
+#error You now need to define either FIXED_POINT or FLOATING_POINT
+#endif
+#if defined(ARM4_ASM) || defined(ARM5E_ASM) || defined(BFIN_ASM)
+#error I suppose you can have a [ARM4/ARM5E/Blackfin] that has float instructions?
+#endif
+#ifdef FIXED_DEBUG
+#error "Don't you think enabling fixed-point is a good thing to do if you want to debug that?"
+#endif
+
+
+#endif
+
+#ifndef OUTSIDE_SPEEX
+#include "speex/speexdsp_types.h"
+#endif
+
+#define ABS(x) ((x) < 0 ? (-(x)) : (x))      /**< Absolute integer value. */
+#define ABS16(x) ((x) < 0 ? (-(x)) : (x))    /**< Absolute 16-bit value.  */
+#define MIN16(a,b) ((a) < (b) ? (a) : (b))   /**< Maximum 16-bit value.   */
+#define MAX16(a,b) ((a) > (b) ? (a) : (b))   /**< Maximum 16-bit value.   */
+#define ABS32(x) ((x) < 0 ? (-(x)) : (x))    /**< Absolute 32-bit value.  */
+#define MIN32(a,b) ((a) < (b) ? (a) : (b))   /**< Maximum 32-bit value.   */
+#define MAX32(a,b) ((a) > (b) ? (a) : (b))   /**< Maximum 32-bit value.   */
+
+#ifdef FIXED_POINT
+
+typedef spx_int16_t spx_word16_t;
+typedef spx_int32_t spx_word32_t;
+typedef spx_word32_t spx_mem_t;
+typedef spx_word16_t spx_coef_t;
+typedef spx_word16_t spx_lsp_t;
+typedef spx_word32_t spx_sig_t;
+
+#define Q15ONE 32767
+
+#define LPC_SCALING  8192
+#define SIG_SCALING  16384
+#define LSP_SCALING  8192.
+#define GAMMA_SCALING 32768.
+#define GAIN_SCALING 64
+#define GAIN_SCALING_1 0.015625
+
+#define LPC_SHIFT    13
+#define LSP_SHIFT    13
+#define SIG_SHIFT    14
+#define GAIN_SHIFT   6
+
+#define WORD2INT(x) ((x) < -32767 ? -32768 : ((x) > 32766 ? 32767 : (x)))
+
+#define VERY_SMALL 0
+#define VERY_LARGE32 ((spx_word32_t)2147483647)
+#define VERY_LARGE16 ((spx_word16_t)32767)
+#define Q15_ONE ((spx_word16_t)32767)
+
+
+#ifdef FIXED_DEBUG
+#include "fixed_debug.h"
+#else
+
+#include "fixed_generic.h"
+
+#ifdef ARM5E_ASM
+#include "fixed_arm5e.h"
+#elif defined(ARM4_ASM)
+#include "fixed_arm4.h"
+#elif defined(BFIN_ASM)
+#include "fixed_bfin.h"
+#endif
+
+#endif
+
+
+#else
+
+typedef float spx_mem_t;
+typedef float spx_coef_t;
+typedef float spx_lsp_t;
+typedef float spx_sig_t;
+typedef float spx_word16_t;
+typedef float spx_word32_t;
+
+#define Q15ONE 1.0f
+#define LPC_SCALING  1.f
+#define SIG_SCALING  1.f
+#define LSP_SCALING  1.f
+#define GAMMA_SCALING 1.f
+#define GAIN_SCALING 1.f
+#define GAIN_SCALING_1 1.f
+
+
+#define VERY_SMALL 1e-15f
+#define VERY_LARGE32 1e15f
+#define VERY_LARGE16 1e15f
+#define Q15_ONE ((spx_word16_t)1.f)
+
+#define QCONST16(x,bits) (x)
+#define QCONST32(x,bits) (x)
+
+#define NEG16(x) (-(x))
+#define NEG32(x) (-(x))
+#define EXTRACT16(x) (x)
+#define EXTEND32(x) (x)
+#define SHR16(a,shift) (a)
+#define SHL16(a,shift) (a)
+#define SHR32(a,shift) (a)
+#define SHL32(a,shift) (a)
+#define PSHR16(a,shift) (a)
+#define PSHR32(a,shift) (a)
+#define VSHR32(a,shift) (a)
+#define SATURATE16(x,a) (x)
+#define SATURATE32(x,a) (x)
+#define SATURATE32PSHR(x,shift,a) (x)
+
+#define PSHR(a,shift)       (a)
+#define SHR(a,shift)       (a)
+#define SHL(a,shift)       (a)
+#define SATURATE(x,a) (x)
+
+#define ADD16(a,b) ((a)+(b))
+#define SUB16(a,b) ((a)-(b))
+#define ADD32(a,b) ((a)+(b))
+#define SUB32(a,b) ((a)-(b))
+#define MULT16_16_16(a,b)     ((a)*(b))
+#define MULT16_32_32(a,b)     ((a)*(b))
+#define MULT16_16(a,b)     ((spx_word32_t)(a)*(spx_word32_t)(b))
+#define MAC16_16(c,a,b)     ((c)+(spx_word32_t)(a)*(spx_word32_t)(b))
+
+#define MULT16_32_Q15(a,b)     ((a)*(b))
+#define MULT16_32_P15(a,b)     ((a)*(b))
+
+#define MAC16_32_Q15(c,a,b)     ((c)+(a)*(b))
+
+#define MAC16_16_Q11(c,a,b)     ((c)+(a)*(b))
+#define MAC16_16_Q13(c,a,b)     ((c)+(a)*(b))
+#define MAC16_16_P13(c,a,b)     ((c)+(a)*(b))
+#define MULT16_16_Q11_32(a,b)     ((a)*(b))
+#define MULT16_16_Q13(a,b)     ((a)*(b))
+#define MULT16_16_Q14(a,b)     ((a)*(b))
+#define MULT16_16_Q15(a,b)     ((a)*(b))
+#define MULT16_16_P15(a,b)     ((a)*(b))
+#define MULT16_16_P13(a,b)     ((a)*(b))
+#define MULT16_16_P14(a,b)     ((a)*(b))
+
+#define DIV32_16(a,b)     (((spx_word32_t)(a))/(spx_word16_t)(b))
+#define PDIV32_16(a,b)     (((spx_word32_t)(a))/(spx_word16_t)(b))
+#define DIV32(a,b)     (((spx_word32_t)(a))/(spx_word32_t)(b))
+#define PDIV32(a,b)     (((spx_word32_t)(a))/(spx_word32_t)(b))
+
+#define WORD2INT(x) ((x) < -32767.5f ? -32768 : \
+                    ((x) > 32766.5f ? 32767 : (spx_int16_t)floor(.5 + (x))))
+#endif
+
+
+#if defined(CONFIG_TI_C54X) || defined(CONFIG_TI_C55X)
+
+/* 2 on TI C5x DSP */
+#define BYTES_PER_CHAR 2
+#define BITS_PER_CHAR 16
+#define LOG2_BITS_PER_CHAR 4
+
+#else
+
+#define BYTES_PER_CHAR 1
+#define BITS_PER_CHAR 8
+#define LOG2_BITS_PER_CHAR 3
+
+#endif
+
+
+
+#ifdef FIXED_DEBUG
+extern long long spx_mips;
+#endif
+
+
+#endif

--- a/src/plugins/audiobridge-deps/jitter.c
+++ b/src/plugins/audiobridge-deps/jitter.c
@@ -1,0 +1,839 @@
+/* Copyright (C) 2002 Jean-Marc Valin
+   File: speex_jitter.h
+
+   Adaptive jitter buffer for Speex
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   - Neither the name of the Xiph.org Foundation nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+/*
+TODO:
+- Add short-term estimate
+- Defensive programming
+  + warn when last returned < last desired (begative buffering)
+  + warn if update_delay not called between get() and tick() or is called twice in a row
+- Linked list structure for holding the packets instead of the current fixed-size array
+  + return memory to a pool
+  + allow pre-allocation of the pool
+  + optional max number of elements
+- Statistics
+  + drift
+  + loss
+  + late
+  + jitter
+  + buffering delay
+*/
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+
+#include "arch.h"
+#include "speex/speex_jitter.h"
+#include "os_support.h"
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+#define SPEEX_JITTER_MAX_BUFFER_SIZE 200   /**< Maximum number of packets in jitter buffer */
+
+#define TSUB(a,b) ((spx_int32_t)((a)-(b)))
+
+#define GT32(a,b) (((spx_int32_t)((a)-(b)))>0)
+#define GE32(a,b) (((spx_int32_t)((a)-(b)))>=0)
+#define LT32(a,b) (((spx_int32_t)((a)-(b)))<0)
+#define LE32(a,b) (((spx_int32_t)((a)-(b)))<=0)
+
+#define ROUND_DOWN(x, step) ((x)<0 ? ((x)-(step)+1)/(step)*(step) : (x)/(step)*(step))
+
+#define MAX_TIMINGS 40
+#define MAX_BUFFERS 3
+#define TOP_DELAY 40
+
+/** Buffer that keeps the time of arrival of the latest packets */
+struct TimingBuffer {
+   int filled;                         /**< Number of entries occupied in "timing" and "counts"*/
+   int curr_count;                     /**< Number of packet timings we got (including those we discarded) */
+   spx_int32_t timing[MAX_TIMINGS];    /**< Sorted list of all timings ("latest" packets first) */
+   spx_int16_t counts[MAX_TIMINGS];    /**< Order the packets were put in (will be used for short-term estimate) */
+};
+
+static void tb_init(struct TimingBuffer *tb)
+{
+   tb->filled = 0;
+   tb->curr_count = 0;
+}
+
+/* Add the timing of a new packet to the TimingBuffer */
+static void tb_add(struct TimingBuffer *tb, spx_int16_t timing)
+{
+   int pos;
+   /* Discard packet that won't make it into the list because they're too early */
+   if (tb->filled >= MAX_TIMINGS && timing >= tb->timing[tb->filled-1])
+   {
+      tb->curr_count++;
+      return;
+   }
+
+   /* Find where the timing info goes in the sorted list */
+   pos = 0;
+   /* FIXME: Do bisection instead of linear search */
+   while (pos<tb->filled && timing >= tb->timing[pos])
+   {
+      pos++;
+   }
+
+   speex_assert(pos <= tb->filled && pos < MAX_TIMINGS);
+
+   /* Shift everything so we can perform the insertion */
+   if (pos < tb->filled)
+   {
+      int move_size = tb->filled-pos;
+      if (tb->filled == MAX_TIMINGS)
+         move_size -= 1;
+      SPEEX_MOVE(&tb->timing[pos+1], &tb->timing[pos], move_size);
+      SPEEX_MOVE(&tb->counts[pos+1], &tb->counts[pos], move_size);
+   }
+   /* Insert */
+   tb->timing[pos] = timing;
+   tb->counts[pos] = tb->curr_count;
+
+   tb->curr_count++;
+   if (tb->filled<MAX_TIMINGS)
+      tb->filled++;
+}
+
+
+
+/** Jitter buffer structure */
+struct JitterBuffer_ {
+   spx_uint32_t pointer_timestamp;                             /**< Timestamp of what we will *get* next */
+   spx_uint32_t last_returned_timestamp;                       /**< Useful for getting the next packet with the same timestamp (for fragmented media) */
+   spx_uint32_t next_stop;                                     /**< Estimated time the next get() will be called */
+
+   spx_int32_t buffered;                                       /**< Amount of data we think is still buffered by the application (timestamp units)*/
+
+   JitterBufferPacket packets[SPEEX_JITTER_MAX_BUFFER_SIZE];   /**< Packets stored in the buffer */
+   spx_uint32_t arrival[SPEEX_JITTER_MAX_BUFFER_SIZE];         /**< Packet arrival time (0 means it was late, even though it's a valid timestamp) */
+
+   void (*destroy) (void *);                                   /**< Callback for destroying a packet */
+
+   spx_int32_t delay_step;                                     /**< Size of the steps when adjusting buffering (timestamp units) */
+   spx_int32_t concealment_size;                               /**< Size of the packet loss concealment "units" */
+   int reset_state;                                            /**< True if state was just reset        */
+   int buffer_margin;                                          /**< How many frames we want to keep in the buffer (lower bound) */
+   int late_cutoff;                                            /**< How late must a packet be for it not to be considered at all */
+   int interp_requested;                                       /**< An interpolation is requested by speex_jitter_update_delay() */
+   int auto_adjust;                                            /**< Whether to automatically adjust the delay at any time */
+
+   struct TimingBuffer _tb[MAX_BUFFERS];                       /**< Don't use those directly */
+   struct TimingBuffer *timeBuffers[MAX_BUFFERS];              /**< Storing arrival time of latest frames so we can compute some stats */
+   int window_size;                                            /**< Total window over which the late frames are counted */
+   int subwindow_size;                                         /**< Sub-window size for faster computation  */
+   int max_late_rate;                                          /**< Absolute maximum amount of late packets tolerable (in percent) */
+   int latency_tradeoff;                                       /**< Latency equivalent of losing one percent of packets */
+   int auto_tradeoff;                                          /**< Latency equivalent of losing one percent of packets (automatic default) */
+
+   int lost_count;                                             /**< Number of consecutive lost packets  */
+};
+
+/** Based on available data, this computes the optimal delay for the jitter buffer.
+   The optimised function is in timestamp units and is:
+   cost = delay + late_factor*[number of frames that would be late if we used that delay]
+   @param tb Array of buffers
+   @param late_factor Equivalent cost of a late frame (in timestamp units)
+ */
+static spx_int16_t compute_opt_delay(JitterBuffer *jitter)
+{
+   int i;
+   spx_int16_t opt=0;
+   spx_int32_t best_cost=0x7fffffff;
+   int late = 0;
+   int pos[MAX_BUFFERS];
+   int tot_count;
+   float late_factor;
+   int penalty_taken = 0;
+   int best = 0;
+   int worst = 0;
+   spx_int32_t deltaT;
+   struct TimingBuffer *tb;
+
+   tb = jitter->_tb;
+
+   /* Number of packet timings we have received (including those we didn't keep) */
+   tot_count = 0;
+   for (i=0;i<MAX_BUFFERS;i++)
+      tot_count += tb[i].curr_count;
+   if (tot_count==0)
+      return 0;
+
+   /* Compute cost for one lost packet */
+   if (jitter->latency_tradeoff != 0)
+      late_factor = jitter->latency_tradeoff * 100.0f / tot_count;
+   else
+      late_factor = jitter->auto_tradeoff * jitter->window_size/tot_count;
+
+   /*fprintf(stderr, "late_factor = %f\n", late_factor);*/
+   for (i=0;i<MAX_BUFFERS;i++)
+      pos[i] = 0;
+
+   /* Pick the TOP_DELAY "latest" packets (doesn't need to actually be late
+      for the current settings) */
+   for (i=0;i<TOP_DELAY;i++)
+   {
+      int j;
+      int next=-1;
+      int latest = 32767;
+      /* Pick latest amoung all sub-windows */
+      for (j=0;j<MAX_BUFFERS;j++)
+      {
+         if (pos[j] < tb[j].filled && tb[j].timing[pos[j]] < latest)
+         {
+            next = j;
+            latest = tb[j].timing[pos[j]];
+         }
+      }
+      if (next != -1)
+      {
+         spx_int32_t cost;
+
+         if (i==0)
+            worst = latest;
+         best = latest;
+         latest = ROUND_DOWN(latest, jitter->delay_step);
+         pos[next]++;
+
+         /* Actual cost function that tells us how bad using this delay would be */
+         cost = -latest + late_factor*late;
+         /*fprintf(stderr, "cost %d = %d + %f * %d\n", cost, -latest, late_factor, late);*/
+         if (cost < best_cost)
+         {
+            best_cost = cost;
+            opt = latest;
+         }
+      } else {
+         break;
+      }
+
+      /* For the next timing we will consider, there will be one more late packet to count */
+      late++;
+      /* Two-frame penalty if we're going to increase the amount of late frames (hysteresis) */
+      if (latest >= 0 && !penalty_taken)
+      {
+         penalty_taken = 1;
+         late+=4;
+      }
+   }
+
+   deltaT = best-worst;
+   /* This is a default "automatic latency tradeoff" when none is provided */
+   jitter->auto_tradeoff = 1 + deltaT/TOP_DELAY;
+   /*fprintf(stderr, "auto_tradeoff = %d (%d %d %d)\n", jitter->auto_tradeoff, best, worst, i);*/
+
+   /* FIXME: Compute a short-term estimate too and combine with the long-term one */
+
+   /* Prevents reducing the buffer size when we haven't really had much data */
+   if (tot_count < TOP_DELAY && opt > 0)
+      return 0;
+   return opt;
+}
+
+
+/** Initialise jitter buffer */
+EXPORT JitterBuffer *jitter_buffer_init(int step_size)
+{
+   JitterBuffer *jitter = (JitterBuffer*)speex_alloc(sizeof(JitterBuffer));
+   if (jitter)
+   {
+      int i;
+      spx_int32_t tmp;
+      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+         jitter->packets[i].data=NULL;
+      jitter->delay_step = step_size;
+      jitter->concealment_size = step_size;
+      /*FIXME: Should this be 0 or 1?*/
+      jitter->buffer_margin = 0;
+      jitter->late_cutoff = 50;
+      jitter->destroy = NULL;
+      jitter->latency_tradeoff = 0;
+      jitter->auto_adjust = 1;
+      tmp = 4;
+      jitter_buffer_ctl(jitter, JITTER_BUFFER_SET_MAX_LATE_RATE, &tmp);
+      jitter_buffer_reset(jitter);
+   }
+   return jitter;
+}
+
+/** Reset jitter buffer */
+EXPORT void jitter_buffer_reset(JitterBuffer *jitter)
+{
+   int i;
+   for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+   {
+      if (jitter->packets[i].data)
+      {
+         if (jitter->destroy)
+            jitter->destroy(jitter->packets[i].data);
+         else
+            speex_free(jitter->packets[i].data);
+         jitter->packets[i].data = NULL;
+      }
+   }
+   /* Timestamp is actually undefined at this point */
+   jitter->pointer_timestamp = 0;
+   jitter->next_stop = 0;
+   jitter->reset_state = 1;
+   jitter->lost_count = 0;
+   jitter->buffered = 0;
+   jitter->auto_tradeoff = 32000;
+
+   for (i=0;i<MAX_BUFFERS;i++)
+   {
+      tb_init(&jitter->_tb[i]);
+      jitter->timeBuffers[i] = &jitter->_tb[i];
+   }
+   /*fprintf (stderr, "reset\n");*/
+}
+
+/** Destroy jitter buffer */
+EXPORT void jitter_buffer_destroy(JitterBuffer *jitter)
+{
+   jitter_buffer_reset(jitter);
+   speex_free(jitter);
+}
+
+/** Take the following timing into consideration for future calculations */
+static void update_timings(JitterBuffer *jitter, spx_int32_t timing)
+{
+   if (timing < -32767)
+      timing = -32767;
+   if (timing > 32767)
+      timing = 32767;
+   /* If the current sub-window is full, perform a rotation and discard oldest sub-widow */
+   if (jitter->timeBuffers[0]->curr_count >= jitter->subwindow_size)
+   {
+      int i;
+      /*fprintf(stderr, "Rotate buffer\n");*/
+      struct TimingBuffer *tmp = jitter->timeBuffers[MAX_BUFFERS-1];
+      for (i=MAX_BUFFERS-1;i>=1;i--)
+         jitter->timeBuffers[i] = jitter->timeBuffers[i-1];
+      jitter->timeBuffers[0] = tmp;
+      tb_init(jitter->timeBuffers[0]);
+   }
+   tb_add(jitter->timeBuffers[0], timing);
+}
+
+/** Compensate all timings when we do an adjustment of the buffering */
+static void shift_timings(JitterBuffer *jitter, spx_int16_t amount)
+{
+   int i, j;
+   for (i=0;i<MAX_BUFFERS;i++)
+   {
+      for (j=0;j<jitter->timeBuffers[i]->filled;j++)
+         jitter->timeBuffers[i]->timing[j] += amount;
+   }
+}
+
+
+/** Put one packet into the jitter buffer */
+EXPORT void jitter_buffer_put(JitterBuffer *jitter, const JitterBufferPacket *packet)
+{
+   int i,j;
+   int late;
+   /*fprintf (stderr, "put packet %d %d\n", timestamp, span);*/
+
+   /* Cleanup buffer (remove old packets that weren't played) */
+   if (!jitter->reset_state)
+   {
+      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+      {
+         /* Make sure we don't discard a "just-late" packet in case we want to play it next (if we interpolate). */
+         if (jitter->packets[i].data && LE32(jitter->packets[i].timestamp + jitter->packets[i].span, jitter->pointer_timestamp))
+         {
+            /*fprintf (stderr, "cleaned (not played)\n");*/
+            if (jitter->destroy)
+               jitter->destroy(jitter->packets[i].data);
+            else
+               speex_free(jitter->packets[i].data);
+            jitter->packets[i].data = NULL;
+         }
+      }
+   }
+
+   /*fprintf(stderr, "arrival: %d %d %d\n", packet->timestamp, jitter->next_stop, jitter->pointer_timestamp);*/
+   /* Check if packet is late (could still be useful though) */
+   if (!jitter->reset_state && LT32(packet->timestamp, jitter->next_stop))
+   {
+      update_timings(jitter, ((spx_int32_t)packet->timestamp) - ((spx_int32_t)jitter->next_stop) - jitter->buffer_margin);
+      late = 1;
+   } else {
+      late = 0;
+   }
+
+   /* For some reason, the consumer has failed the last 20 fetches. Make sure this packet is
+    * used to resync. */
+   if (jitter->lost_count>20)
+   {
+      jitter_buffer_reset(jitter);
+   }
+
+   /* Only insert the packet if it's not hopelessly late (i.e. totally useless) */
+   if (jitter->reset_state || GE32(packet->timestamp+packet->span+jitter->delay_step, jitter->pointer_timestamp))
+   {
+
+      /*Find an empty slot in the buffer*/
+      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+      {
+         if (jitter->packets[i].data==NULL)
+            break;
+      }
+
+      /*No place left in the buffer, need to make room for it by discarding the oldest packet */
+      if (i==SPEEX_JITTER_MAX_BUFFER_SIZE)
+      {
+         int earliest=jitter->packets[0].timestamp;
+         i=0;
+         for (j=1;j<SPEEX_JITTER_MAX_BUFFER_SIZE;j++)
+         {
+            if (!jitter->packets[i].data || LT32(jitter->packets[j].timestamp,earliest))
+            {
+               earliest = jitter->packets[j].timestamp;
+               i=j;
+            }
+         }
+         if (jitter->destroy)
+            jitter->destroy(jitter->packets[i].data);
+         else
+            speex_free(jitter->packets[i].data);
+         jitter->packets[i].data=NULL;
+         /*fprintf (stderr, "Buffer is full, discarding earliest frame %d (currently at %d)\n", timestamp, jitter->pointer_timestamp);*/
+      }
+
+      /* Copy packet in buffer */
+      if (jitter->destroy)
+      {
+         jitter->packets[i].data = packet->data;
+      } else {
+         jitter->packets[i].data=(char*)speex_alloc(packet->len);
+         for (j=0;j<packet->len;j++)
+            jitter->packets[i].data[j]=packet->data[j];
+      }
+      jitter->packets[i].timestamp=packet->timestamp;
+      jitter->packets[i].span=packet->span;
+      jitter->packets[i].len=packet->len;
+      jitter->packets[i].sequence=packet->sequence;
+      jitter->packets[i].user_data=packet->user_data;
+      if (jitter->reset_state || late)
+         jitter->arrival[i] = 0;
+      else
+         jitter->arrival[i] = jitter->next_stop;
+   }
+
+
+}
+
+/** Get one packet from the jitter buffer */
+EXPORT int jitter_buffer_get(JitterBuffer *jitter, JitterBufferPacket *packet, spx_int32_t desired_span, spx_int32_t *start_offset)
+{
+   int i;
+   unsigned int j;
+   spx_int16_t opt;
+
+   if (start_offset != NULL)
+      *start_offset = 0;
+
+   /* Syncing on the first call */
+   if (jitter->reset_state)
+   {
+      int found = 0;
+      /* Find the oldest packet */
+      spx_uint32_t oldest=0;
+      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+      {
+         if (jitter->packets[i].data && (!found || LT32(jitter->packets[i].timestamp,oldest)))
+         {
+            oldest = jitter->packets[i].timestamp;
+            found = 1;
+         }
+      }
+      if (found)
+      {
+         jitter->reset_state=0;
+         jitter->pointer_timestamp = oldest;
+         jitter->next_stop = oldest;
+      } else {
+         packet->timestamp = 0;
+         packet->span = jitter->interp_requested;
+         return JITTER_BUFFER_MISSING;
+      }
+   }
+
+
+   jitter->last_returned_timestamp = jitter->pointer_timestamp;
+
+   if (jitter->interp_requested != 0)
+   {
+      packet->timestamp = jitter->pointer_timestamp;
+      packet->span = jitter->interp_requested;
+
+      /* Increment the pointer because it got decremented in the delay update */
+      jitter->pointer_timestamp += jitter->interp_requested;
+      packet->len = 0;
+      /*fprintf (stderr, "Deferred interpolate\n");*/
+
+      jitter->interp_requested = 0;
+
+      jitter->buffered = packet->span - desired_span;
+
+      return JITTER_BUFFER_INSERTION;
+   }
+
+   /* Searching for the packet that fits best */
+
+   /* Search the buffer for a packet with the right timestamp and spanning the whole current chunk */
+   for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+   {
+      if (jitter->packets[i].data && jitter->packets[i].timestamp==jitter->pointer_timestamp && GE32(jitter->packets[i].timestamp+jitter->packets[i].span,jitter->pointer_timestamp+desired_span))
+         break;
+   }
+
+   /* If no match, try for an "older" packet that still spans (fully) the current chunk */
+   if (i==SPEEX_JITTER_MAX_BUFFER_SIZE)
+   {
+      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+      {
+         if (jitter->packets[i].data && LE32(jitter->packets[i].timestamp, jitter->pointer_timestamp) && GE32(jitter->packets[i].timestamp+jitter->packets[i].span,jitter->pointer_timestamp+desired_span))
+            break;
+      }
+   }
+
+   /* If still no match, try for an "older" packet that spans part of the current chunk */
+   if (i==SPEEX_JITTER_MAX_BUFFER_SIZE)
+   {
+      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+      {
+         if (jitter->packets[i].data && LE32(jitter->packets[i].timestamp, jitter->pointer_timestamp) && GT32(jitter->packets[i].timestamp+jitter->packets[i].span,jitter->pointer_timestamp))
+            break;
+      }
+   }
+
+   /* If still no match, try for earliest packet possible */
+   if (i==SPEEX_JITTER_MAX_BUFFER_SIZE)
+   {
+      int found = 0;
+      spx_uint32_t best_time=0;
+      int best_span=0;
+      int besti=0;
+      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+      {
+         /* check if packet starts within current chunk */
+         if (jitter->packets[i].data && LT32(jitter->packets[i].timestamp,jitter->pointer_timestamp+desired_span) && GE32(jitter->packets[i].timestamp,jitter->pointer_timestamp))
+         {
+            if (!found || LT32(jitter->packets[i].timestamp,best_time) || (jitter->packets[i].timestamp==best_time && GT32(jitter->packets[i].span,best_span)))
+            {
+               best_time = jitter->packets[i].timestamp;
+               best_span = jitter->packets[i].span;
+               besti = i;
+               found = 1;
+            }
+         }
+      }
+      if (found)
+      {
+         i=besti;
+         /*fprintf (stderr, "incomplete: %d %d %d %d\n", jitter->packets[i].timestamp, jitter->pointer_timestamp, chunk_size, jitter->packets[i].span);*/
+      }
+   }
+
+   /* If we find something */
+   if (i!=SPEEX_JITTER_MAX_BUFFER_SIZE)
+   {
+      spx_int32_t offset;
+
+      /* We (obviously) haven't lost this packet */
+      jitter->lost_count = 0;
+
+      /* In this case, 0 isn't as a valid timestamp */
+      if (jitter->arrival[i] != 0)
+      {
+         update_timings(jitter, ((spx_int32_t)jitter->packets[i].timestamp) - ((spx_int32_t)jitter->arrival[i]) - jitter->buffer_margin);
+      }
+
+
+      /* Copy packet */
+      if (jitter->destroy)
+      {
+         packet->data = jitter->packets[i].data;
+         packet->len = jitter->packets[i].len;
+      } else {
+         if (jitter->packets[i].len > packet->len)
+         {
+            speex_warning_int("jitter_buffer_get(): packet too large to fit. Size is", jitter->packets[i].len);
+         } else {
+            packet->len = jitter->packets[i].len;
+         }
+         for (j=0;j<packet->len;j++)
+            packet->data[j] = jitter->packets[i].data[j];
+         /* Remove packet */
+         speex_free(jitter->packets[i].data);
+      }
+      jitter->packets[i].data = NULL;
+      /* Set timestamp and span (if requested) */
+      offset = (spx_int32_t)jitter->packets[i].timestamp-(spx_int32_t)jitter->pointer_timestamp;
+      if (start_offset != NULL)
+         *start_offset = offset;
+      else if (offset != 0)
+         speex_warning_int("jitter_buffer_get() discarding non-zero start_offset", offset);
+
+      packet->timestamp = jitter->packets[i].timestamp;
+      jitter->last_returned_timestamp = packet->timestamp;
+
+      packet->span = jitter->packets[i].span;
+      packet->sequence = jitter->packets[i].sequence;
+      packet->user_data = jitter->packets[i].user_data;
+      /* Point to the end of the current packet */
+      jitter->pointer_timestamp = jitter->packets[i].timestamp+jitter->packets[i].span;
+
+      jitter->buffered = packet->span - desired_span;
+
+      if (start_offset != NULL)
+         jitter->buffered += *start_offset;
+
+      return JITTER_BUFFER_OK;
+   }
+
+
+   /* If we haven't found anything worth returning */
+
+   /*fprintf (stderr, "not found\n");*/
+   jitter->lost_count++;
+   /*fprintf (stderr, "m");*/
+   /*fprintf (stderr, "lost_count = %d\n", jitter->lost_count);*/
+
+   opt = compute_opt_delay(jitter);
+
+   /* Should we force an increase in the buffer or just do normal interpolation? */
+   if (opt < 0)
+   {
+      /* Need to increase buffering */
+
+      /* Shift histogram to compensate */
+      shift_timings(jitter, -opt);
+
+      packet->timestamp = jitter->pointer_timestamp;
+      packet->span = -opt;
+      /* Don't move the pointer_timestamp forward */
+      packet->len = 0;
+
+      jitter->buffered = packet->span - desired_span;
+      return JITTER_BUFFER_INSERTION;
+      /*jitter->pointer_timestamp -= jitter->delay_step;*/
+      /*fprintf (stderr, "Forced to interpolate\n");*/
+   } else {
+      /* Normal packet loss */
+      packet->timestamp = jitter->pointer_timestamp;
+
+      desired_span = ROUND_DOWN(desired_span, jitter->concealment_size);
+      packet->span = desired_span;
+      jitter->pointer_timestamp += desired_span;
+      packet->len = 0;
+
+      jitter->buffered = packet->span - desired_span;
+      return JITTER_BUFFER_MISSING;
+      /*fprintf (stderr, "Normal loss\n");*/
+   }
+
+
+}
+
+EXPORT int jitter_buffer_get_another(JitterBuffer *jitter, JitterBufferPacket *packet)
+{
+   int i, j;
+   for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+   {
+      if (jitter->packets[i].data && jitter->packets[i].timestamp==jitter->last_returned_timestamp)
+         break;
+   }
+   if (i!=SPEEX_JITTER_MAX_BUFFER_SIZE)
+   {
+      /* Copy packet */
+      packet->len = jitter->packets[i].len;
+      if (jitter->destroy)
+      {
+         packet->data = jitter->packets[i].data;
+      } else {
+         for (j=0;j<packet->len;j++)
+            packet->data[j] = jitter->packets[i].data[j];
+         /* Remove packet */
+         speex_free(jitter->packets[i].data);
+      }
+      jitter->packets[i].data = NULL;
+      packet->timestamp = jitter->packets[i].timestamp;
+      packet->span = jitter->packets[i].span;
+      packet->sequence = jitter->packets[i].sequence;
+      packet->user_data = jitter->packets[i].user_data;
+      return JITTER_BUFFER_OK;
+   } else {
+      packet->data = NULL;
+      packet->len = 0;
+      packet->span = 0;
+      return JITTER_BUFFER_MISSING;
+   }
+}
+
+/* Let the jitter buffer know it's the right time to adjust the buffering delay to the network conditions */
+static int _jitter_buffer_update_delay(JitterBuffer *jitter, JitterBufferPacket *packet, spx_int32_t *start_offset)
+{
+   spx_int16_t opt = compute_opt_delay(jitter);
+   /*fprintf(stderr, "opt adjustment is %d ", opt);*/
+
+   if (opt < 0)
+   {
+      shift_timings(jitter, -opt);
+
+      jitter->pointer_timestamp += opt;
+      jitter->interp_requested = -opt;
+      /*fprintf (stderr, "Decision to interpolate %d samples\n", -opt);*/
+   } else if (opt > 0)
+   {
+      shift_timings(jitter, -opt);
+      jitter->pointer_timestamp += opt;
+      /*fprintf (stderr, "Decision to drop %d samples\n", opt);*/
+   }
+
+   return opt;
+}
+
+/* Let the jitter buffer know it's the right time to adjust the buffering delay to the network conditions */
+EXPORT int jitter_buffer_update_delay(JitterBuffer *jitter, JitterBufferPacket *packet, spx_int32_t *start_offset)
+{
+   /* If the programmer calls jitter_buffer_update_delay() directly,
+      automatically disable auto-adjustment */
+   jitter->auto_adjust = 0;
+
+   return _jitter_buffer_update_delay(jitter, packet, start_offset);
+}
+
+/** Get pointer timestamp of jitter buffer */
+EXPORT int jitter_buffer_get_pointer_timestamp(JitterBuffer *jitter)
+{
+   return jitter->pointer_timestamp;
+}
+
+EXPORT void jitter_buffer_tick(JitterBuffer *jitter)
+{
+   /* Automatically-adjust the buffering delay if requested */
+   if (jitter->auto_adjust)
+      _jitter_buffer_update_delay(jitter, NULL, NULL);
+
+   if (jitter->buffered >= 0)
+   {
+      jitter->next_stop = jitter->pointer_timestamp - jitter->buffered;
+   } else {
+      jitter->next_stop = jitter->pointer_timestamp;
+      speex_warning_int("jitter buffer sees negative buffering, your code might be broken. Value is ", jitter->buffered);
+   }
+   jitter->buffered = 0;
+}
+
+EXPORT void jitter_buffer_remaining_span(JitterBuffer *jitter, spx_uint32_t rem)
+{
+   /* Automatically-adjust the buffering delay if requested */
+   if (jitter->auto_adjust)
+      _jitter_buffer_update_delay(jitter, NULL, NULL);
+
+   if (jitter->buffered < 0)
+      speex_warning_int("jitter buffer sees negative buffering, your code might be broken. Value is ", jitter->buffered);
+   jitter->next_stop = jitter->pointer_timestamp - rem;
+}
+
+
+/* Used like the ioctl function to control the jitter buffer parameters */
+EXPORT int jitter_buffer_ctl(JitterBuffer *jitter, int request, void *ptr)
+{
+   int count, i;
+   switch(request)
+   {
+      case JITTER_BUFFER_SET_MARGIN:
+         jitter->buffer_margin = *(spx_int32_t*)ptr;
+         break;
+      case JITTER_BUFFER_GET_MARGIN:
+         *(spx_int32_t*)ptr = jitter->buffer_margin;
+         break;
+      case JITTER_BUFFER_GET_AVALIABLE_COUNT:
+         count = 0;
+         for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+         {
+            if (jitter->packets[i].data && LE32(jitter->pointer_timestamp, jitter->packets[i].timestamp))
+            {
+               count++;
+            }
+         }
+         *(spx_int32_t*)ptr = count;
+         break;
+      case JITTER_BUFFER_SET_DESTROY_CALLBACK:
+         jitter->destroy = (void (*) (void *))ptr;
+         break;
+      case JITTER_BUFFER_GET_DESTROY_CALLBACK:
+         *(void (**) (void *))ptr = jitter->destroy;
+         break;
+      case JITTER_BUFFER_SET_DELAY_STEP:
+         jitter->delay_step = *(spx_int32_t*)ptr;
+         break;
+      case JITTER_BUFFER_GET_DELAY_STEP:
+         *(spx_int32_t*)ptr = jitter->delay_step;
+         break;
+      case JITTER_BUFFER_SET_CONCEALMENT_SIZE:
+         jitter->concealment_size = *(spx_int32_t*)ptr;
+         break;
+      case JITTER_BUFFER_GET_CONCEALMENT_SIZE:
+         *(spx_int32_t*)ptr = jitter->concealment_size;
+         break;
+      case JITTER_BUFFER_SET_MAX_LATE_RATE:
+         jitter->max_late_rate = *(spx_int32_t*)ptr;
+         jitter->window_size = 100*TOP_DELAY/jitter->max_late_rate;
+         jitter->subwindow_size = jitter->window_size/MAX_BUFFERS;
+         break;
+      case JITTER_BUFFER_GET_MAX_LATE_RATE:
+         *(spx_int32_t*)ptr = jitter->max_late_rate;
+         break;
+      case JITTER_BUFFER_SET_LATE_COST:
+         jitter->latency_tradeoff = *(spx_int32_t*)ptr;
+         break;
+      case JITTER_BUFFER_GET_LATE_COST:
+         *(spx_int32_t*)ptr = jitter->latency_tradeoff;
+         break;
+      default:
+         speex_warning_int("Unknown jitter_buffer_ctl request: ", request);
+         return -1;
+   }
+   return 0;
+}
+

--- a/src/plugins/audiobridge-deps/jitter.c
+++ b/src/plugins/audiobridge-deps/jitter.c
@@ -454,6 +454,13 @@ EXPORT void jitter_buffer_put(JitterBuffer *jitter, const JitterBufferPacket *pa
          jitter->arrival[i] = 0;
       else
          jitter->arrival[i] = jitter->next_stop;
+   } else {
+	  /* The original version of libspeex-dsp leaks packets when we
+	   * get here, since the application has no way of knowing whether
+	   * a packet was actually queued or not: as such, when this
+	   * happens, we destroy the packet that was passed ourselves */
+      if (jitter->destroy)
+         jitter->destroy(packet->data);
    }
 
 

--- a/src/plugins/audiobridge-deps/jitter.c
+++ b/src/plugins/audiobridge-deps/jitter.c
@@ -365,7 +365,7 @@ static void shift_timings(JitterBuffer *jitter, spx_int16_t amount)
 /** Put one packet into the jitter buffer */
 EXPORT void jitter_buffer_put(JitterBuffer *jitter, const JitterBufferPacket *packet)
 {
-   int i,j;
+   spx_uint32_t i,j;
    int late;
    /*fprintf (stderr, "put packet %d %d\n", timestamp, span);*/
 
@@ -682,7 +682,7 @@ EXPORT int jitter_buffer_get(JitterBuffer *jitter, JitterBufferPacket *packet, s
 
 EXPORT int jitter_buffer_get_another(JitterBuffer *jitter, JitterBufferPacket *packet)
 {
-   int i, j;
+   spx_uint32_t i, j;
    for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
    {
       if (jitter->packets[i].data && jitter->packets[i].timestamp==jitter->last_returned_timestamp)

--- a/src/plugins/audiobridge-deps/os_support.h
+++ b/src/plugins/audiobridge-deps/os_support.h
@@ -1,0 +1,169 @@
+/* Copyright (C) 2007 Jean-Marc Valin
+
+   File: os_support.h
+   This is the (tiny) OS abstraction layer. Aside from math.h, this is the
+   only place where system headers are allowed.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+   INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef OS_SUPPORT_H
+#define OS_SUPPORT_H
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#ifdef OS_SUPPORT_CUSTOM
+#include "os_support_custom.h"
+#endif
+
+/** Speex wrapper for calloc. To do your own dynamic allocation, all you need to do is replace this function, speex_realloc and speex_free
+    NOTE: speex_alloc needs to CLEAR THE MEMORY */
+#ifndef OVERRIDE_SPEEX_ALLOC
+static inline void *speex_alloc (int size)
+{
+   /* WARNING: this is not equivalent to malloc(). If you want to use malloc()
+      or your own allocator, YOU NEED TO CLEAR THE MEMORY ALLOCATED. Otherwise
+      you will experience strange bugs */
+   return calloc(size,1);
+}
+#endif
+
+/** Same as speex_alloc, except that the area is only needed inside a Speex call (might cause problem with wideband though) */
+#ifndef OVERRIDE_SPEEX_ALLOC_SCRATCH
+static inline void *speex_alloc_scratch (int size)
+{
+   /* Scratch space doesn't need to be cleared */
+   return calloc(size,1);
+}
+#endif
+
+/** Speex wrapper for realloc. To do your own dynamic allocation, all you need to do is replace this function, speex_alloc and speex_free */
+#ifndef OVERRIDE_SPEEX_REALLOC
+static inline void *speex_realloc (void *ptr, int size)
+{
+   return realloc(ptr, size);
+}
+#endif
+
+/** Speex wrapper for calloc. To do your own dynamic allocation, all you need to do is replace this function, speex_realloc and speex_alloc */
+#ifndef OVERRIDE_SPEEX_FREE
+static inline void speex_free (void *ptr)
+{
+   free(ptr);
+}
+#endif
+
+/** Same as speex_free, except that the area is only needed inside a Speex call (might cause problem with wideband though) */
+#ifndef OVERRIDE_SPEEX_FREE_SCRATCH
+static inline void speex_free_scratch (void *ptr)
+{
+   free(ptr);
+}
+#endif
+
+/** Copy n elements from src to dst. The 0* term provides compile-time type checking  */
+#ifndef OVERRIDE_SPEEX_COPY
+#define SPEEX_COPY(dst, src, n) (memcpy((dst), (src), (n)*sizeof(*(dst)) + 0*((dst)-(src)) ))
+#endif
+
+/** Copy n elements from src to dst, allowing overlapping regions. The 0* term
+    provides compile-time type checking */
+#ifndef OVERRIDE_SPEEX_MOVE
+#define SPEEX_MOVE(dst, src, n) (memmove((dst), (src), (n)*sizeof(*(dst)) + 0*((dst)-(src)) ))
+#endif
+
+/** For n elements worth of memory, set every byte to the value of c, starting at address dst */
+#ifndef OVERRIDE_SPEEX_MEMSET
+#define SPEEX_MEMSET(dst, c, n) (memset((dst), (c), (n)*sizeof(*(dst))))
+#endif
+
+
+#ifndef OVERRIDE_SPEEX_FATAL
+static inline void _speex_fatal(const char *str, const char *file, int line)
+{
+   fprintf (stderr, "Fatal (internal) error in %s, line %d: %s\n", file, line, str);
+   exit(1);
+}
+#endif
+
+#ifndef OVERRIDE_SPEEX_WARNING
+static inline void speex_warning(const char *str)
+{
+#ifndef DISABLE_WARNINGS
+   fprintf (stderr, "warning: %s\n", str);
+#endif
+}
+#endif
+
+#ifndef OVERRIDE_SPEEX_WARNING_INT
+static inline void speex_warning_int(const char *str, int val)
+{
+#ifndef DISABLE_WARNINGS
+   fprintf (stderr, "warning: %s %d\n", str, val);
+#endif
+}
+#endif
+
+#ifndef OVERRIDE_SPEEX_NOTIFY
+static inline void speex_notify(const char *str)
+{
+#ifndef DISABLE_NOTIFICATIONS
+   fprintf (stderr, "notification: %s\n", str);
+#endif
+}
+#endif
+
+#ifndef OVERRIDE_SPEEX_PUTC
+/** Speex wrapper for putc */
+static inline void _speex_putc(int ch, void *file)
+{
+   FILE *f = (FILE *)file;
+   fprintf(f, "%c", ch);
+}
+#endif
+
+#define speex_fatal(str) _speex_fatal(str, __FILE__, __LINE__);
+#define speex_assert(cond) {if (!(cond)) {speex_fatal("assertion failed: " #cond);}}
+
+#ifndef RELEASE
+static inline void print_vec(float *vec, int len, char *name)
+{
+   int i;
+   printf ("%s ", name);
+   for (i=0;i<len;i++)
+      printf (" %f", vec[i]);
+   printf ("\n");
+}
+#endif
+
+#endif
+

--- a/src/plugins/audiobridge-deps/speex/speex_jitter.h
+++ b/src/plugins/audiobridge-deps/speex/speex_jitter.h
@@ -1,0 +1,197 @@
+/* Copyright (C) 2002 Jean-Marc Valin */
+/**
+   @file speex_jitter.h
+   @brief Adaptive jitter buffer for Speex
+*/
+/*
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   - Neither the name of the Xiph.org Foundation nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef SPEEX_JITTER_H
+#define SPEEX_JITTER_H
+/** @defgroup JitterBuffer JitterBuffer: Adaptive jitter buffer
+ *  This is the jitter buffer that reorders UDP/RTP packets and adjusts the buffer size
+ * to maintain good quality and low latency.
+ *  @{
+ */
+
+#include "speexdsp_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Generic adaptive jitter buffer state */
+struct JitterBuffer_;
+
+/** Generic adaptive jitter buffer state */
+typedef struct JitterBuffer_ JitterBuffer;
+
+/** Definition of an incoming packet */
+typedef struct _JitterBufferPacket JitterBufferPacket;
+
+/** Definition of an incoming packet */
+struct _JitterBufferPacket {
+   char        *data;       /**< Data bytes contained in the packet */
+   spx_uint32_t len;        /**< Length of the packet in bytes */
+   spx_uint32_t timestamp;  /**< Timestamp for the packet */
+   spx_uint32_t span;       /**< Time covered by the packet (same units as timestamp) */
+   spx_uint16_t sequence;   /**< RTP Sequence number if available (0 otherwise) */
+   spx_uint32_t user_data;  /**< Put whatever data you like here (it's ignored by the jitter buffer) */
+};
+
+/** Packet has been retrieved */
+#define JITTER_BUFFER_OK 0
+/** Packet is lost or is late */
+#define JITTER_BUFFER_MISSING 1
+/** A "fake" packet is meant to be inserted here to increase buffering */
+#define JITTER_BUFFER_INSERTION 2
+/** There was an error in the jitter buffer */
+#define JITTER_BUFFER_INTERNAL_ERROR -1
+/** Invalid argument */
+#define JITTER_BUFFER_BAD_ARGUMENT -2
+
+
+/** Set minimum amount of extra buffering required (margin) */
+#define JITTER_BUFFER_SET_MARGIN 0
+/** Get minimum amount of extra buffering required (margin) */
+#define JITTER_BUFFER_GET_MARGIN 1
+/* JITTER_BUFFER_SET_AVAILABLE_COUNT wouldn't make sense */
+
+/** Get the amount of available packets currently buffered */
+#define JITTER_BUFFER_GET_AVAILABLE_COUNT 3
+/** Included because of an early misspelling (will remove in next release) */
+#define JITTER_BUFFER_GET_AVALIABLE_COUNT 3
+
+/** Assign a function to destroy unused packet. When setting that, the jitter
+    buffer no longer copies packet data. */
+#define JITTER_BUFFER_SET_DESTROY_CALLBACK 4
+/**  */
+#define JITTER_BUFFER_GET_DESTROY_CALLBACK 5
+
+/** Tell the jitter buffer to only adjust the delay in multiples of the step parameter provided */
+#define JITTER_BUFFER_SET_DELAY_STEP 6
+/**  */
+#define JITTER_BUFFER_GET_DELAY_STEP 7
+
+/** Tell the jitter buffer to only do concealment in multiples of the size parameter provided */
+#define JITTER_BUFFER_SET_CONCEALMENT_SIZE 8
+#define JITTER_BUFFER_GET_CONCEALMENT_SIZE 9
+
+/** Absolute max amount of loss that can be tolerated regardless of the delay. Typical loss
+    should be half of that or less. */
+#define JITTER_BUFFER_SET_MAX_LATE_RATE 10
+#define JITTER_BUFFER_GET_MAX_LATE_RATE 11
+
+/** Equivalent cost of one percent late packet in timestamp units */
+#define JITTER_BUFFER_SET_LATE_COST 12
+#define JITTER_BUFFER_GET_LATE_COST 13
+
+
+/** Initialises jitter buffer
+ *
+ * @param step_size Starting value for the size of concleanment packets and delay
+       adjustment steps. Can be changed at any time using JITTER_BUFFER_SET_DELAY_STEP
+       and JITTER_BUFFER_GET_CONCEALMENT_SIZE.
+ * @return Newly created jitter buffer state
+ */
+JitterBuffer *jitter_buffer_init(int step_size);
+
+/** Restores jitter buffer to its original state
+ *
+ * @param jitter Jitter buffer state
+ */
+void jitter_buffer_reset(JitterBuffer *jitter);
+
+/** Destroys jitter buffer
+ *
+ * @param jitter Jitter buffer state
+ */
+void jitter_buffer_destroy(JitterBuffer *jitter);
+
+/** Put one packet into the jitter buffer
+ *
+ * @param jitter Jitter buffer state
+ * @param packet Incoming packet
+*/
+void jitter_buffer_put(JitterBuffer *jitter, const JitterBufferPacket *packet);
+
+/** Get one packet from the jitter buffer
+ *
+ * @param jitter Jitter buffer state
+ * @param packet Returned packet
+ * @param desired_span Number of samples (or units) we wish to get from the buffer (no guarantee)
+ * @param current_timestamp Timestamp for the returned packet
+*/
+int jitter_buffer_get(JitterBuffer *jitter, JitterBufferPacket *packet, spx_int32_t desired_span, spx_int32_t *start_offset);
+
+/** Used right after jitter_buffer_get() to obtain another packet that would have the same timestamp.
+ * This is mainly useful for media where a single "frame" can be split into several packets.
+ *
+ * @param jitter Jitter buffer state
+ * @param packet Returned packet
+ */
+int jitter_buffer_get_another(JitterBuffer *jitter, JitterBufferPacket *packet);
+
+/** Get pointer timestamp of jitter buffer
+ *
+ * @param jitter Jitter buffer state
+*/
+int jitter_buffer_get_pointer_timestamp(JitterBuffer *jitter);
+
+/** Advance by one tick
+ *
+ * @param jitter Jitter buffer state
+*/
+void jitter_buffer_tick(JitterBuffer *jitter);
+
+/** Telling the jitter buffer about the remaining data in the application buffer
+ * @param jitter Jitter buffer state
+ * @param rem Amount of data buffered by the application (timestamp units)
+ */
+void jitter_buffer_remaining_span(JitterBuffer *jitter, spx_uint32_t rem);
+
+/** Used like the ioctl function to control the jitter buffer parameters
+ *
+ * @param jitter Jitter buffer state
+ * @param request ioctl-type request (one of the JITTER_BUFFER_* macros)
+ * @param ptr Data exchanged to-from function
+ * @return 0 if no error, -1 if request in unknown
+*/
+int jitter_buffer_ctl(JitterBuffer *jitter, int request, void *ptr);
+
+int jitter_buffer_update_delay(JitterBuffer *jitter, JitterBufferPacket *packet, spx_int32_t *start_offset);
+
+/* @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/plugins/audiobridge-deps/speex/speexdsp_config_types.h
+++ b/src/plugins/audiobridge-deps/speex/speexdsp_config_types.h
@@ -1,0 +1,12 @@
+#ifndef __SPEEX_TYPES_H__
+#define __SPEEX_TYPES_H__
+
+#include <stdint.h>
+
+typedef int16_t spx_int16_t;
+typedef uint16_t spx_uint16_t;
+typedef int32_t spx_int32_t;
+typedef uint32_t spx_uint32_t;
+
+#endif
+

--- a/src/plugins/audiobridge-deps/speex/speexdsp_types.h
+++ b/src/plugins/audiobridge-deps/speex/speexdsp_types.h
@@ -1,0 +1,126 @@
+/* speexdsp_types.h taken from libogg */
+/********************************************************************
+ *                                                                  *
+ * THIS FILE IS PART OF THE OggVorbis SOFTWARE CODEC SOURCE CODE.   *
+ * USE, DISTRIBUTION AND REPRODUCTION OF THIS LIBRARY SOURCE IS     *
+ * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
+ * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
+ *                                                                  *
+ * THE OggVorbis SOURCE CODE IS (C) COPYRIGHT 1994-2002             *
+ * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ *                                                                  *
+ ********************************************************************
+
+ function: #ifdef jail to whip a few platforms into the UNIX ideal.
+ last mod: $Id: os_types.h 7524 2004-08-11 04:20:36Z conrad $
+
+ ********************************************************************/
+/**
+   @file speexdsp_types.h
+   @brief Speex types
+*/
+#ifndef _SPEEX_TYPES_H
+#define _SPEEX_TYPES_H
+
+#if defined(_WIN32)
+
+#  if defined(__CYGWIN__)
+#    include <_G_config.h>
+     typedef _G_int32_t spx_int32_t;
+     typedef _G_uint32_t spx_uint32_t;
+     typedef _G_int16_t spx_int16_t;
+     typedef _G_uint16_t spx_uint16_t;
+#  elif defined(__MINGW32__)
+     typedef short spx_int16_t;
+     typedef unsigned short spx_uint16_t;
+     typedef int spx_int32_t;
+     typedef unsigned int spx_uint32_t;
+#  elif defined(__MWERKS__)
+     typedef int spx_int32_t;
+     typedef unsigned int spx_uint32_t;
+     typedef short spx_int16_t;
+     typedef unsigned short spx_uint16_t;
+#  else
+     /* MSVC/Borland */
+     typedef __int32 spx_int32_t;
+     typedef unsigned __int32 spx_uint32_t;
+     typedef __int16 spx_int16_t;
+     typedef unsigned __int16 spx_uint16_t;
+#  endif
+
+#elif defined(__MACOS__)
+
+#  include <sys/types.h>
+   typedef SInt16 spx_int16_t;
+   typedef UInt16 spx_uint16_t;
+   typedef SInt32 spx_int32_t;
+   typedef UInt32 spx_uint32_t;
+
+#elif (defined(__APPLE__) && defined(__MACH__)) /* MacOS X Framework build */
+
+#  include <sys/types.h>
+   typedef int16_t spx_int16_t;
+   typedef u_int16_t spx_uint16_t;
+   typedef int32_t spx_int32_t;
+   typedef u_int32_t spx_uint32_t;
+
+#elif defined(__BEOS__)
+
+   /* Be */
+#  include <inttypes.h>
+   typedef int16_t spx_int16_t;
+   typedef u_int16_t spx_uint16_t;
+   typedef int32_t spx_int32_t;
+   typedef u_int32_t spx_uint32_t;
+
+#elif defined (__EMX__)
+
+   /* OS/2 GCC */
+   typedef short spx_int16_t;
+   typedef unsigned short spx_uint16_t;
+   typedef int spx_int32_t;
+   typedef unsigned int spx_uint32_t;
+
+#elif defined (DJGPP)
+
+   /* DJGPP */
+   typedef short spx_int16_t;
+   typedef int spx_int32_t;
+   typedef unsigned int spx_uint32_t;
+
+#elif defined(R5900)
+
+   /* PS2 EE */
+   typedef int spx_int32_t;
+   typedef unsigned spx_uint32_t;
+   typedef short spx_int16_t;
+
+#elif defined(__SYMBIAN32__)
+
+   /* Symbian GCC */
+   typedef signed short spx_int16_t;
+   typedef unsigned short spx_uint16_t;
+   typedef signed int spx_int32_t;
+   typedef unsigned int spx_uint32_t;
+
+#elif defined(CONFIG_TI_C54X) || defined (CONFIG_TI_C55X)
+
+   typedef short spx_int16_t;
+   typedef unsigned short spx_uint16_t;
+   typedef long spx_int32_t;
+   typedef unsigned long spx_uint32_t;
+
+#elif defined(CONFIG_TI_C6X)
+
+   typedef short spx_int16_t;
+   typedef unsigned short spx_uint16_t;
+   typedef int spx_int32_t;
+   typedef unsigned int spx_uint32_t;
+
+#else
+
+#include "speexdsp_config_types.h"
+
+#endif
+
+#endif  /* _SPEEX_TYPES_H */

--- a/src/plugins/janus_audiobridge.c
+++ b/src/plugins/janus_audiobridge.c
@@ -1131,8 +1131,7 @@ room-<unique room ID>: {
 #endif
 /* We ship our own version of the libspeex-dsp jitter buffer, since
  * the one available out of the box comes with a nasty memory leak */
-#include "speex/speex_jitter.h"
-#define GE32(a,b) (((spx_int32_t)((a)-(b)))>=0)
+#include "audiobridge-deps/speex/speex_jitter.h"
 
 #include <arpa/inet.h>
 #include <net/if.h>
@@ -5917,9 +5916,6 @@ void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, janus_plugin_r
 			jbp.timestamp = ntohl(rtp->timestamp);
 			jbp.span = (participant->codec == JANUS_AUDIOCODEC_OPUS ? 960 : 160);
 			jitter_buffer_put(participant->jitter, &jbp);
-			if(!GE32(jbp.timestamp + jbp.span + jbp.span, jitter_buffer_get_pointer_timestamp(participant->jitter))) {
-				janus_audiobridge_buffer_packet_destroy(pkt);
-			}
 			janus_mutex_unlock(&participant->qmutex);
 		}
 	}

--- a/src/plugins/janus_audiobridge.c
+++ b/src/plugins/janus_audiobridge.c
@@ -1129,7 +1129,9 @@ room-<unique room ID>: {
 #ifdef HAVE_LIBOGG
 #include <ogg/ogg.h>
 #endif
-#include <speex/speex_jitter.h>
+/* We ship our own version of the libspeex-dsp jitter buffer, since
+ * the one available out of the box comes with a nasty memory leak */
+#include "speex/speex_jitter.h"
 #define GE32(a,b) (((spx_int32_t)((a)-(b)))>=0)
 
 #include <arpa/inet.h>


### PR DESCRIPTION
Some time ago, in #3214 we modified the AudioBridge plugin to use the jitter buffer provided by [SpeexDSP](https://gitlab.xiph.org/xiph/speexdsp).

This was quite successful and greatly improved the audio experience, but we soon found out that the library comes with a nasty memory leak under some circumstances, specifically when dealing with very late packets. Some projects addressed this by forking the library and applying a fix themselves (e.g., like [here](https://github.com/xpilot-project/speexdsp/commit/36e68e3e33f72c328da8097a6c55662e6068b221)), while we initially chose to fix this externally instead, by mimicking the same check SpeexDSP performs internally that leads to the leak (see a15e3fdfc6049927de9748d88e7fac3b19a3455d and ad326e0cd3f1debc725a3156cf20bcb20fda2323). We found out that under very specific circumstances that's not enough, though, and so we decided to just include the relevant jitter buffer files as part of the repo, specifically as part of local AudioBridge dependencies.

This allowed us to

1. get rid of the `speexdsp` dependency (we only needed the jitter buffer, not everything else);
2. fix the memory leak directly in the library.

We'll probably take advantage of this to also fix a few other slightly problematic behaviours, but my main priority at the moment is fixing the leak in a consistent and reliable manner.

Not sure if this will cause problems to existing deployments, e.g., due to symbol clashes if you don't do a `make clean`. Please make sure you test this, to ensure it works as expected and that it doesn't introduce regressions (which I doubt it will, but that's the point of testing). Should this all work nicely, I'll backport to `0.x` after merging.