### PR TITLE
[0.x] [audiobridge] jitter buffer: manually update internal delay and set a max size

### DIFF
--- a/plugins/audiobridge-deps/jitter.c
+++ b/plugins/audiobridge-deps/jitter.c
@@ -140,6 +140,7 @@ struct JitterBuffer_ {
 
    spx_int32_t buffered;                                       /**< Amount of data we think is still buffered by the application (timestamp units)*/
 
+   spx_uint32_t buffer_size;
    JitterBufferPacket packets[SPEEX_JITTER_MAX_BUFFER_SIZE];   /**< Packets stored in the buffer */
    spx_uint32_t arrival[SPEEX_JITTER_MAX_BUFFER_SIZE];         /**< Packet arrival time (0 means it was late, even though it's a valid timestamp) */
 
@@ -265,7 +266,6 @@ static spx_int16_t compute_opt_delay(JitterBuffer *jitter)
    return opt;
 }
 
-
 /** Initialise jitter buffer */
 EXPORT JitterBuffer *jitter_buffer_init(int step_size)
 {
@@ -284,6 +284,7 @@ EXPORT JitterBuffer *jitter_buffer_init(int step_size)
       jitter->destroy = NULL;
       jitter->latency_tradeoff = 0;
       jitter->auto_adjust = 1;
+      jitter->buffer_size = SPEEX_JITTER_MAX_BUFFER_SIZE;
       tmp = 4;
       jitter_buffer_ctl(jitter, JITTER_BUFFER_SET_MAX_LATE_RATE, &tmp);
       jitter_buffer_reset(jitter);
@@ -372,7 +373,7 @@ EXPORT void jitter_buffer_put(JitterBuffer *jitter, const JitterBufferPacket *pa
    /* Cleanup buffer (remove old packets that weren't played) */
    if (!jitter->reset_state)
    {
-      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+      for (i=0;i<jitter->buffer_size;i++)
       {
          /* Make sure we don't discard a "just-late" packet in case we want to play it next (if we interpolate). */
          if (jitter->packets[i].data && LE32(jitter->packets[i].timestamp + jitter->packets[i].span, jitter->pointer_timestamp))
@@ -409,18 +410,18 @@ EXPORT void jitter_buffer_put(JitterBuffer *jitter, const JitterBufferPacket *pa
    {
 
       /*Find an empty slot in the buffer*/
-      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+      for (i=0;i<jitter->buffer_size;i++)
       {
          if (jitter->packets[i].data==NULL)
             break;
       }
 
       /*No place left in the buffer, need to make room for it by discarding the oldest packet */
-      if (i==SPEEX_JITTER_MAX_BUFFER_SIZE)
+      if (i==jitter->buffer_size)
       {
          int earliest=jitter->packets[0].timestamp;
          i=0;
-         for (j=1;j<SPEEX_JITTER_MAX_BUFFER_SIZE;j++)
+         for (j=1;j<jitter->buffer_size;j++)
          {
             if (!jitter->packets[i].data || LT32(jitter->packets[j].timestamp,earliest))
             {
@@ -469,7 +470,7 @@ EXPORT void jitter_buffer_put(JitterBuffer *jitter, const JitterBufferPacket *pa
 /** Get one packet from the jitter buffer */
 EXPORT int jitter_buffer_get(JitterBuffer *jitter, JitterBufferPacket *packet, spx_int32_t desired_span, spx_int32_t *start_offset)
 {
-   int i;
+   spx_uint32_t i;
    unsigned int j;
    spx_int16_t opt;
 
@@ -482,7 +483,7 @@ EXPORT int jitter_buffer_get(JitterBuffer *jitter, JitterBufferPacket *packet, s
       int found = 0;
       /* Find the oldest packet */
       spx_uint32_t oldest=0;
-      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+      for (i=0;i<jitter->buffer_size;i++)
       {
          if (jitter->packets[i].data && (!found || LT32(jitter->packets[i].timestamp,oldest)))
          {
@@ -518,23 +519,22 @@ EXPORT int jitter_buffer_get(JitterBuffer *jitter, JitterBufferPacket *packet, s
       jitter->interp_requested = 0;
 
       jitter->buffered = packet->span - desired_span;
-
       return JITTER_BUFFER_INSERTION;
    }
 
    /* Searching for the packet that fits best */
 
    /* Search the buffer for a packet with the right timestamp and spanning the whole current chunk */
-   for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+   for (i=0;i<jitter->buffer_size;i++)
    {
       if (jitter->packets[i].data && jitter->packets[i].timestamp==jitter->pointer_timestamp && GE32(jitter->packets[i].timestamp+jitter->packets[i].span,jitter->pointer_timestamp+desired_span))
          break;
    }
 
    /* If no match, try for an "older" packet that still spans (fully) the current chunk */
-   if (i==SPEEX_JITTER_MAX_BUFFER_SIZE)
+   if (i==jitter->buffer_size)
    {
-      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+      for (i=0;i<jitter->buffer_size;i++)
       {
          if (jitter->packets[i].data && LE32(jitter->packets[i].timestamp, jitter->pointer_timestamp) && GE32(jitter->packets[i].timestamp+jitter->packets[i].span,jitter->pointer_timestamp+desired_span))
             break;
@@ -542,9 +542,9 @@ EXPORT int jitter_buffer_get(JitterBuffer *jitter, JitterBufferPacket *packet, s
    }
 
    /* If still no match, try for an "older" packet that spans part of the current chunk */
-   if (i==SPEEX_JITTER_MAX_BUFFER_SIZE)
+   if (i==jitter->buffer_size)
    {
-      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+      for (i=0;i<jitter->buffer_size;i++)
       {
          if (jitter->packets[i].data && LE32(jitter->packets[i].timestamp, jitter->pointer_timestamp) && GT32(jitter->packets[i].timestamp+jitter->packets[i].span,jitter->pointer_timestamp))
             break;
@@ -552,13 +552,13 @@ EXPORT int jitter_buffer_get(JitterBuffer *jitter, JitterBufferPacket *packet, s
    }
 
    /* If still no match, try for earliest packet possible */
-   if (i==SPEEX_JITTER_MAX_BUFFER_SIZE)
+   if (i==jitter->buffer_size)
    {
       int found = 0;
       spx_uint32_t best_time=0;
       int best_span=0;
       int besti=0;
-      for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+      for (i=0;i<jitter->buffer_size;i++)
       {
          /* check if packet starts within current chunk */
          if (jitter->packets[i].data && LT32(jitter->packets[i].timestamp,jitter->pointer_timestamp+desired_span) && GE32(jitter->packets[i].timestamp,jitter->pointer_timestamp))
@@ -580,7 +580,7 @@ EXPORT int jitter_buffer_get(JitterBuffer *jitter, JitterBufferPacket *packet, s
    }
 
    /* If we find something */
-   if (i!=SPEEX_JITTER_MAX_BUFFER_SIZE)
+   if (i!=jitter->buffer_size)
    {
       spx_int32_t offset;
 
@@ -683,12 +683,12 @@ EXPORT int jitter_buffer_get(JitterBuffer *jitter, JitterBufferPacket *packet, s
 EXPORT int jitter_buffer_get_another(JitterBuffer *jitter, JitterBufferPacket *packet)
 {
    spx_uint32_t i, j;
-   for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+   for (i=0;i<jitter->buffer_size;i++)
    {
       if (jitter->packets[i].data && jitter->packets[i].timestamp==jitter->last_returned_timestamp)
          break;
    }
-   if (i!=SPEEX_JITTER_MAX_BUFFER_SIZE)
+   if (i!=jitter->buffer_size)
    {
       /* Copy packet */
       packet->len = jitter->packets[i].len;
@@ -785,7 +785,8 @@ EXPORT void jitter_buffer_remaining_span(JitterBuffer *jitter, spx_uint32_t rem)
 /* Used like the ioctl function to control the jitter buffer parameters */
 EXPORT int jitter_buffer_ctl(JitterBuffer *jitter, int request, void *ptr)
 {
-   int count, i;
+   int count;
+   spx_uint32_t i;
    switch(request)
    {
       case JITTER_BUFFER_SET_MARGIN:
@@ -796,7 +797,7 @@ EXPORT int jitter_buffer_ctl(JitterBuffer *jitter, int request, void *ptr)
          break;
       case JITTER_BUFFER_GET_AVALIABLE_COUNT:
          count = 0;
-         for (i=0;i<SPEEX_JITTER_MAX_BUFFER_SIZE;i++)
+         for (i=0;i<jitter->buffer_size;i++)
          {
             if (jitter->packets[i].data && LE32(jitter->pointer_timestamp, jitter->packets[i].timestamp))
             {
@@ -836,6 +837,11 @@ EXPORT int jitter_buffer_ctl(JitterBuffer *jitter, int request, void *ptr)
          break;
       case JITTER_BUFFER_GET_LATE_COST:
          *(spx_int32_t*)ptr = jitter->latency_tradeoff;
+         break;
+      case JITTER_BUFFER_SET_LIMIT:
+         spx_int32_t buffer_size = *(spx_int32_t*)ptr;
+         jitter->buffer_size = (buffer_size > 1 && buffer_size <= SPEEX_JITTER_MAX_BUFFER_SIZE) ? buffer_size : SPEEX_JITTER_MAX_BUFFER_SIZE;
+         jitter_buffer_reset(jitter);
          break;
       default:
          speex_warning_int("Unknown jitter_buffer_ctl request: ", request);

--- a/plugins/audiobridge-deps/jitter.c
+++ b/plugins/audiobridge-deps/jitter.c
@@ -266,6 +266,7 @@ static spx_int16_t compute_opt_delay(JitterBuffer *jitter)
    return opt;
 }
 
+
 /** Initialise jitter buffer */
 EXPORT JitterBuffer *jitter_buffer_init(int step_size)
 {

--- a/plugins/audiobridge-deps/speex/speex_jitter.h
+++ b/plugins/audiobridge-deps/speex/speex_jitter.h
@@ -113,6 +113,8 @@ struct _JitterBufferPacket {
 #define JITTER_BUFFER_SET_LATE_COST 12
 #define JITTER_BUFFER_GET_LATE_COST 13
 
+#define JITTER_BUFFER_SET_LIMIT 101
+
 
 /** Initialises jitter buffer
  *

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -8511,6 +8511,7 @@ static void *janus_audiobridge_participant_thread(void *data) {
 					jitter_buffer_update_delay(participant->jitter, NULL, NULL);
 					jitter_ticks = 0;
 				}
+				jitter_buffer_tick(participant->jitter);
 				if(ret != JITTER_BUFFER_OK) {
 					/* No packet in the jitter buffer? Move on the talking detection, if needed */
 					janus_audiobridge_participant_istalking(session, participant, NULL, NULL);
@@ -8626,7 +8627,6 @@ static void *janus_audiobridge_participant_thread(void *data) {
 					}
 					participant->inbuf = g_list_append(participant->inbuf, pkt);
 				}
-				jitter_buffer_tick(participant->jitter);
 			}
 		}
 		if(locked)

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -2162,7 +2162,7 @@ static int janus_audiobridge_resample(int16_t *input, int input_num, int input_r
 
 /* Jitter Buffer and queue-in settings */
 #define JITTER_BUFFER_MIN_PACKETS 2
-#define JITTER_BUFFER_MAX_PACKETS 40
+#define JITTER_BUFFER_MAX_PACKETS 50
 #define JITTER_BUFFER_CHECK_USECS 1*G_USEC_PER_SEC
 #define QUEUE_IN_MAX_PACKETS 4
 
@@ -5827,21 +5827,6 @@ void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, janus_plugin_r
 		if(participant->jitter) {
 			janus_audiobridge_buffer_packet *pkt = janus_audiobridge_buffer_packet_create(packet);
 			janus_mutex_lock(&participant->qmutex);
-			/* Limit the size of the jitter buffer */
-			gint64 now = janus_get_monotonic_time();
-			if(participant->jitter_next_check == 0) {
-				/* Schedule next check */
-				participant->jitter_next_check = now + JITTER_BUFFER_CHECK_USECS;
-			} else if(now >= participant->jitter_next_check) {
-				spx_int32_t count = 0;
-				jitter_buffer_ctl(participant->jitter, JITTER_BUFFER_GET_AVALIABLE_COUNT, &count);
-				if(count > JITTER_BUFFER_MAX_PACKETS) {
-					JANUS_LOG(LOG_WARN, "Jitter buffer contains too many packets, clearing now (count=%d)\n", count);
-					janus_audiobridge_participant_clear_jitter_buffer(participant);
-				}
-				/* Schedule next check */
-				participant->jitter_next_check = now + JITTER_BUFFER_CHECK_USECS;
-			}
 			JitterBufferPacket jbp = {0};
 			jbp.data = (char *)pkt;
 			jbp.len = 0;
@@ -6361,8 +6346,10 @@ static void *janus_audiobridge_handler(void *data) {
 				jitter_buffer_ctl(participant->jitter, JITTER_BUFFER_SET_DESTROY_CALLBACK, &janus_audiobridge_buffer_packet_destroy);
 				spx_int32_t min_buffer_size = participant->codec == JANUS_AUDIOCODEC_OPUS ? (JITTER_BUFFER_MIN_PACKETS * 960) : (JITTER_BUFFER_MIN_PACKETS * 160);
 				jitter_buffer_ctl(participant->jitter, JITTER_BUFFER_SET_MARGIN, &min_buffer_size);
-				//spx_int32_t max_buffer_size = JITTER_BUFFER_MAX_PACKETS;
-				//jitter_buffer_ctl(participant->jitter, JITTER_BUFFER_SET_LIMIT, &max_buffer_size);
+				spx_int32_t max_buffer_size = JITTER_BUFFER_MAX_PACKETS;
+				jitter_buffer_ctl(participant->jitter, JITTER_BUFFER_SET_LIMIT, &max_buffer_size);
+				/* disable automatic adjustment */
+				jitter_buffer_update_delay(participant->jitter, NULL, NULL);
 				participant->inbuf = NULL;
 				participant->outbuf = NULL;
 				participant->encoder = NULL;
@@ -8491,6 +8478,7 @@ static void *janus_audiobridge_participant_thread(void *data) {
 	janus_audiobridge_buffer_packet *bpkt = NULL;
 	janus_audiobridge_rtp_relay_packet *pkt = NULL;
 	janus_audiobridge_rtp_relay_packet *mixedpkt = NULL;
+	int jitter_ticks = 0;
 	janus_rtp_header *rtp = NULL;
 	gint64 now = janus_get_monotonic_time(), before = now;
 	gboolean first = TRUE, use_fec = FALSE;
@@ -8517,7 +8505,12 @@ static void *janus_audiobridge_participant_thread(void *data) {
 			before += 20000;
 			if(participant->jitter) {
 				ret = jitter_buffer_get(participant->jitter, &jbp, participant->codec == JANUS_AUDIOCODEC_OPUS ? 960 : 160, NULL);
-				jitter_buffer_tick(participant->jitter);
+				jitter_ticks++;
+				/* Adjust the buffer size every 50 ticks (~1 second) */
+				if(jitter_ticks == JITTER_BUFFER_MAX_PACKETS) {
+					jitter_buffer_update_delay(participant->jitter, NULL, NULL);
+					jitter_ticks = 0;
+				}
 				if(ret != JITTER_BUFFER_OK) {
 					/* No packet in the jitter buffer? Move on the talking detection, if needed */
 					janus_audiobridge_participant_istalking(session, participant, NULL, NULL);
@@ -8633,6 +8626,7 @@ static void *janus_audiobridge_participant_thread(void *data) {
 					}
 					participant->inbuf = g_list_append(participant->inbuf, pkt);
 				}
+				jitter_buffer_tick(participant->jitter);
 			}
 		}
 		if(locked)

--- a/plugins/janus_audiobridge.c
+++ b/plugins/janus_audiobridge.c
@@ -6361,6 +6361,8 @@ static void *janus_audiobridge_handler(void *data) {
 				jitter_buffer_ctl(participant->jitter, JITTER_BUFFER_SET_DESTROY_CALLBACK, &janus_audiobridge_buffer_packet_destroy);
 				spx_int32_t min_buffer_size = participant->codec == JANUS_AUDIOCODEC_OPUS ? (JITTER_BUFFER_MIN_PACKETS * 960) : (JITTER_BUFFER_MIN_PACKETS * 160);
 				jitter_buffer_ctl(participant->jitter, JITTER_BUFFER_SET_MARGIN, &min_buffer_size);
+				//spx_int32_t max_buffer_size = JITTER_BUFFER_MAX_PACKETS;
+				//jitter_buffer_ctl(participant->jitter, JITTER_BUFFER_SET_LIMIT, &max_buffer_size);
 				participant->inbuf = NULL;
 				participant->outbuf = NULL;
 				participant->encoder = NULL;


### PR DESCRIPTION
**Context**
We observed that speex jitter buffer suffered from a "stuck" delay evaluation in very difficult network scenarios.
When network delay/jitter have huge oscillations and then go back to a stable state, the buffer might potentially end up in a status where it's unable to update its internal delay anymore.
The effect is that even in optimal conditions, the buffer will add a de-jittering delay. This can be tested by conditioning the network link and observing the `buffer-in` value through the Admin API. The expected result is a low `buffer-in` when network conditions are restored.
As a consequence, we implemented a workaround in the audiobridge some time ago that once in a while checked the buffer length did not exceed a `JITTER_BUFFER_MAX_PACKETS` length. If that happened, we requested a jitter buffer reset.

**Findings**
We discovered that this behavior could be triggered by frequent calls to `jitter_buffer_delay_update` under high network variance. That function basically recalculates the buffer internal delay.
By default the buffer is auto-adjusting and the delay is updated anytime a `jitter_buffer_tick` is invoked. We issue a buffer tick any time a participant audio packet must be added to the mix, so every ~20ms we indirectly update the jitter internal delay. By collecting examples of how the library is used, we found out that many implementations switched to manual updates through condition-related `jitter_buffer_delay_update` calls.

**The PR**
This patch is twofold:
1) in speex library code: add an interface to set an internal max length in place of the hard-coded 200.
2) in audiobridge code: it sets buffer max size to `JITTER_BUFFER_MAX_PACKETS`, disables automatic buffer delay adjusting and performs a `jitter_buffer_delay_update` every `JITTER_BUFFER_MAX_PACKETS` ticks.

With these changes we are unable to reproduce the issue but given its nature and the difficult steps for reproducing it, we'd like to collect some feedback from people interested in improving the audiobridge experience.

