### PR TITLE
videoroom: Release some references created by remote publishers

### DIFF
--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -2753,7 +2753,7 @@ static void janus_videoroom_publisher_destroy(janus_videoroom_publisher *p) {
 		janus_mutex_unlock(&p->rtp_forwarders_mutex);
 		janus_mutex_unlock(&p->streams_mutex);
 		/* Release dummy session of the forwarder */
-		if(p->session && p->session->handle == NULL)
+		if(p->remote && p->session)
 			janus_videoroom_session_destroy(p->session);
 		janus_refcount_decrease(&p->ref);
 	}


### PR DESCRIPTION
~~Fixed some cases where the `rtp_forwarders` map was created without the destructor function. This resulted in the forwarders not being released when the publisher got destroyed.~~