### PR TITLE
audiobridge: cleanup participant's queue and jitter buffer when muted…

### DIFF
--- a/src/plugins/janus_audiobridge.c
+++ b/src/plugins/janus_audiobridge.c
@@ -4429,6 +4429,13 @@ static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_s
 		g_hash_table_iter_init(&iter, audiobridge->participants);
 		while(g_hash_table_iter_next(&iter, NULL, &value)) {
 			janus_audiobridge_participant *p = value;
+			if(p->muted != audiobridge->muted) {
+				/* Clear the queued packets waiting to be handled */
+				janus_mutex_lock(&p->qmutex);
+				janus_audiobridge_participant_clear_jitter_buffer(p);
+				janus_audiobridge_participant_clear_inbuf(p);
+				janus_mutex_unlock(&p->qmutex);
+			}
 			if(g_atomic_int_get(&p->paused_events))
 				continue;
 			JANUS_LOG(LOG_VERB, "Notifying participant %s (%s)\n", p->user_id_str, p->display ? p->display : "??");

--- a/src/plugins/janus_audiobridge.c
+++ b/src/plugins/janus_audiobridge.c
@@ -4277,6 +4277,7 @@ static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_s
 			goto prepare_response;
 		}
 
+		janus_mutex_lock(&participant->qmutex);
 		if(participant->muted == muted) {
 			/* If someone trying to mute an already muted user, or trying to unmute a user that is not mute),
 			then we should do nothing */
@@ -4286,12 +4287,12 @@ static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_s
 			json_object_set_new(response, "audiobridge", json_string("success"));
 
 			/* Done */
+			janus_mutex_unlock(&participant->qmutex);
 			janus_mutex_unlock(&audiobridge->mutex);
 			janus_refcount_decrease(&audiobridge->ref);
 			goto prepare_response;
 		}
 
-		janus_mutex_lock(&participant->qmutex);
 		participant->muted = muted;
 		JANUS_LOG(LOG_VERB, "Setting muted property: %s (room %s, user %s)\n",
 			participant->muted ? "true" : "false", participant->room->room_id_str, participant->user_id_str);
@@ -4429,13 +4430,13 @@ static json_t *janus_audiobridge_process_synchronous_request(janus_audiobridge_s
 		g_hash_table_iter_init(&iter, audiobridge->participants);
 		while(g_hash_table_iter_next(&iter, NULL, &value)) {
 			janus_audiobridge_participant *p = value;
+			janus_mutex_lock(&p->qmutex);
 			if(p->muted != audiobridge->muted) {
 				/* Clear the queued packets waiting to be handled */
-				janus_mutex_lock(&p->qmutex);
 				janus_audiobridge_participant_clear_jitter_buffer(p);
 				janus_audiobridge_participant_clear_inbuf(p);
-				janus_mutex_unlock(&p->qmutex);
 			}
+			janus_mutex_unlock(&p->qmutex);
 			if(g_atomic_int_get(&p->paused_events))
 				continue;
 			JANUS_LOG(LOG_VERB, "Notifying participant %s (%s)\n", p->user_id_str, p->display ? p->display : "??");
@@ -7146,10 +7147,10 @@ static void *janus_audiobridge_handler(void *data) {
 			if(muted || display || (participant->stereo && spatial) || denoise) {
 				if(muted) {
 					janus_mutex_lock(&participant->qmutex);
-					participant->muted = json_is_true(muted);
-					JANUS_LOG(LOG_VERB, "Setting muted property: %s (room %s, user %s)\n",
-						participant->muted ? "true" : "false", participant->room->room_id_str, participant->user_id_str);
-					if(participant->muted) {
+					if (participant->muted != json_is_true(muted)) {
+						participant->muted = json_is_true(muted);
+						JANUS_LOG(LOG_VERB, "Setting muted property: %s (room %s, user %s)\n",
+							participant->muted ? "true" : "false", participant->room->room_id_str, participant->user_id_str);
 						/* Clear the queued packets waiting to be handled */
 						janus_audiobridge_participant_clear_jitter_buffer(participant);
 						janus_audiobridge_participant_clear_inbuf(participant);
@@ -7632,8 +7633,8 @@ static void *janus_audiobridge_handler(void *data) {
 			g_free(participant->display);
 			participant->display = display_text ? g_strdup(display_text) : NULL;
 			participant->room = audiobridge;
-			participant->muted = muted ? json_is_true(muted) : FALSE;	/* When switching to a new room, you're unmuted by default */
 			janus_mutex_lock(&participant->qmutex);
+			participant->muted = muted ? json_is_true(muted) : FALSE;	/* When switching to a new room, you're unmuted by default */
 			janus_audiobridge_participant_clear_jitter_buffer(participant);
 			janus_audiobridge_participant_clear_inbuf(participant);
 			janus_mutex_unlock(&participant->qmutex);

--- a/src/plugins/janus_audiobridge.c
+++ b/src/plugins/janus_audiobridge.c
@@ -7147,7 +7147,7 @@ static void *janus_audiobridge_handler(void *data) {
 			if(muted || display || (participant->stereo && spatial) || denoise) {
 				if(muted) {
 					janus_mutex_lock(&participant->qmutex);
-					if (participant->muted != json_is_true(muted)) {
+					if(participant->muted != json_is_true(muted)) {
 						participant->muted = json_is_true(muted);
 						JANUS_LOG(LOG_VERB, "Setting muted property: %s (room %s, user %s)\n",
 							participant->muted ? "true" : "false", participant->room->room_id_str, participant->user_id_str);

--- a/src/plugins/janus_audiobridge.c
+++ b/src/plugins/janus_audiobridge.c
@@ -7633,6 +7633,10 @@ static void *janus_audiobridge_handler(void *data) {
 			participant->display = display_text ? g_strdup(display_text) : NULL;
 			participant->room = audiobridge;
 			participant->muted = muted ? json_is_true(muted) : FALSE;	/* When switching to a new room, you're unmuted by default */
+			janus_mutex_lock(&participant->qmutex);
+			janus_audiobridge_participant_clear_jitter_buffer(participant);
+			janus_audiobridge_participant_clear_inbuf(participant);
+			janus_mutex_unlock(&participant->qmutex);
 			if(suspended && json_is_true(suspended)) {
 				janus_mutex_lock(&participant->suspend_cond_mutex);
 				g_atomic_int_set(&participant->suspended, 1);


### PR DESCRIPTION
… property changes or the whole room is muted

This patch will cleanup participant's buffers (both the encoder queue and jitter buffer) when the `muted` status changes, the whole room `muted` status is changed through the `mute_room` API or the user changes room with the `changeroom` API.
The rationale is to avoid having spurious packets in the buffers when users get unmuted.