### PR TITLE
Add note about freeing transaction in handle_message

### DIFF
--- a/src/plugins/plugin.h
+++ b/src/plugins/plugin.h
@@ -283,10 +283,10 @@ struct janus_plugin {
 	 * @param[out] error An integer that may contain information about any error */
 	void (* const create_session)(janus_plugin_session *handle, int *error);
 	/*! \brief Method to handle an incoming message/request from a peer
-	 * @note The Janus core increases the references to both the \c message and \c jsep
-	 * json_t objects. This means that you'll have to decrease your own
+	 * @note The Janus core leaves ownership of both the \c message and \c jsep
+	 * json_t objects to plugins. This means that you'll have to decrease your own
 	 * reference yourself with a \c json_decref when you're done with them.
-	 * You'll also have to free \c transaction with \c g_free.
+	 * You'll also have to free \c transaction with \c g_free
 	 * @param[in] handle The plugin/gateway session used for this peer
 	 * @param[in] transaction The transaction identifier for this message/request
 	 * @param[in] message The json_t object containing the message/request JSON
@@ -360,7 +360,7 @@ struct janus_callbacks {
 	/*! \brief Callback to push events/messages to a peer
 	 * @note The Janus core increases the references to both the \c message and \c jsep
 	 * json_t objects. This means that you'll have to decrease your own
-	 * reference yourself with a \c json_decref after calling \c push_event.
+	 * reference yourself with a \c json_decref after calling \c push_event
 	 * @param[in] handle The plugin/gateway session used for this peer
 	 * @param[in] plugin The plugin instance that is sending the message/event
 	 * @param[in] transaction The transaction identifier this message refers to

--- a/src/plugins/plugin.h
+++ b/src/plugins/plugin.h
@@ -283,6 +283,10 @@ struct janus_plugin {
 	 * @param[out] error An integer that may contain information about any error */
 	void (* const create_session)(janus_plugin_session *handle, int *error);
 	/*! \brief Method to handle an incoming message/request from a peer
+	 * @note The Janus core increases the references to both the \c message and \c jsep
+	 * json_t objects. This means that you'll have to decrease your own
+	 * reference yourself with a \c json_decref when you're done with them.
+	 * You'll also have to free \c transaction with \c g_free.
 	 * @param[in] handle The plugin/gateway session used for this peer
 	 * @param[in] transaction The transaction identifier for this message/request
 	 * @param[in] message The json_t object containing the message/request JSON
@@ -354,9 +358,9 @@ struct janus_plugin {
 /*! \brief Callbacks to contact the Janus core */
 struct janus_callbacks {
 	/*! \brief Callback to push events/messages to a peer
-	 * @note The Janus core increases the references to both the message and jsep
+	 * @note The Janus core increases the references to both the \c message and \c jsep
 	 * json_t objects. This means that you'll have to decrease your own
-	 * reference yourself with a \c json_decref after calling push_event.
+	 * reference yourself with a \c json_decref after calling \c push_event.
 	 * @param[in] handle The plugin/gateway session used for this peer
 	 * @param[in] plugin The plugin instance that is sending the message/event
 	 * @param[in] transaction The transaction identifier this message refers to


### PR DESCRIPTION
Add note about freeing transaction after calling `push_event` in plugin interface documentation.

The only place this was mentioned seems to be in this comment in the `janus.c`
https://github.com/meetecho/janus-gateway/blob/9be6a74452e27c5ae295f39dd1e2d710c25e44df/src/janus.c#L1759
and in plugin implementation like
https://github.com/meetecho/janus-gateway/blob/9be6a74452e27c5ae295f39dd1e2d710c25e44df/src/plugins/janus_textroom.c#L1261-L1265

We had a memory leak for this in the rust sfu plugin I fixed in
https://github.com/networked-aframe/janus-plugin-sfu/pull/11/commits/4226d0091b386576d221988c76e11c0d0ef7d215
that only showed in ASan output when specifying loop_events option.
The original creator of the plugin probably overlooked this because this was not documented in `plugin.h`.
