### PR TITLE
Options to block startup unless RabbitMQ Transport / Event Handler are connected

### DIFF
--- a/conf/janus.eventhandler.rabbitmqevh.jcfg.sample
+++ b/conf/janus.eventhandler.rabbitmqevh.jcfg.sample
@@ -21,6 +21,7 @@ general: {
 	route_key = "janus-events"		# Routing key to use when publishing messages
 	#exchange_type = "fanout" 		# Rabbitmq exchange_type can be one of the available types: direct, topic, headers and fanout (fanout by defualt).
 	#heartbeat = 60 				# Defines the seconds without communication that should pass before considering the TCP connection unreachable.
+	#block_startup_until_connected = true # Whether to block the server from starting until a connection to the RabbitMQ server is established.
 	#declare_outgoing_queue = true # By default (for backwards compatibility), we declare an outgoing queue. Set this to false to disable that behavior
 
 	#ssl_enable = false				# Whether ssl support must be enabled

--- a/conf/janus.transport.rabbitmq.jcfg.sample
+++ b/conf/janus.transport.rabbitmq.jcfg.sample
@@ -35,6 +35,7 @@ general: {
 	#queue_autodelete = false			# Whether or not incoming queue should autodelete after janus disconnects from RabbitMQ
 	#queue_exclusive = false			# Whether or not incoming queue should only allow one subscriber
 	#heartbeat = 60 				# Defines the seconds without communication that should pass before considering the TCP connection unreachable.
+	#block_startup_until_connected = true # Whether to block the server from starting until a connection to the RabbitMQ server is established.
 
 	#ssl_enabled = false				# Whether ssl support must be enabled
 	#ssl_verify_peer = true				# Whether peer verification must be enabled


### PR DESCRIPTION
We have been doing some failure scenario planning inside our staging Kubernetes environment and have noticed that if our Janus instances come up before RabbitMQ, they will happily start even though an error is logged to the console.

These changes bring in new options to both RabbitMQ locations: `block_startup_until_connected`. Setting this to true in either or both of the respective configuration files will cause the server to infinitely loop until RabbitMQ becomes available.

As a side note - it doesn't appear we can get these Transport / Event plugins status information externally. Is that something thats possible?