### PR TITLE
Use pkt sequence number to compute timestamp for jitterbuffer packets

### DIFF
--- a/src/plugins/janus_audiobridge.c
+++ b/src/plugins/janus_audiobridge.c
@@ -6179,8 +6179,8 @@ void janus_audiobridge_incoming_rtp(janus_plugin_session *handle, janus_plugin_r
 			JitterBufferPacket jbp = {0};
 			jbp.data = (char *)pkt;
 			jbp.len = 0;
-			jbp.timestamp = ntohl(rtp->timestamp);
 			jbp.span = (participant->codec == JANUS_AUDIOCODEC_OPUS ? 960 : 160);
+			jbp.timestamp = (uint32_t)ntohs(rtp->seq_number) * jbp.span;
 			jitter_buffer_put(participant->jitter, &jbp);
 			janus_mutex_unlock(&participant->qmutex);
 		}


### PR DESCRIPTION
When using the bare RTP timestamp as jitter buffer packet timestamp, UBSan detected some potential overflows in [speex internal method](https://github.com/meetecho/janus-gateway/blob/e4f6632202db7be72838a049c7b50b732025dc09/src/plugins/audiobridge-deps/jitter.c#L396) `update_timings`.
This PR tries to address the issue by using a jb packet timestamp computed as `packet seqnum * packet span`, in order to prevent potential sums not fitting `int32` ranges. 