### PR TITLE
Cleanup thread resources when lua/duktape async event helper ends

### DIFF
--- a/src/plugins/janus_duktape.c
+++ b/src/plugins/janus_duktape.c
@@ -413,6 +413,7 @@ static void *janus_duktape_async_event_helper(void *data) {
 	g_free(asev->transaction);
 	janus_refcount_decrease(&asev->session->ref);
 	g_free(asev);
+	g_thread_unref(g_thread_self());
 	return NULL;
 }
 

--- a/src/plugins/janus_lua.c
+++ b/src/plugins/janus_lua.c
@@ -413,6 +413,7 @@ static void *janus_lua_async_event_helper(void *data) {
 	g_free(asev->transaction);
 	janus_refcount_decrease(&asev->session->ref);
 	g_free(asev);
+	g_thread_unref(g_thread_self());
 	return NULL;
 }
 


### PR DESCRIPTION
While debugging #3408 we found a thread memory leak due to a missing `g_thread_unref` when handling async events in the lua plugin.

**UPDATE**: did the same fix on the duktape plugin too.