### PR TITLE
Change the way call-IDs are tracked in the SIP plugin (fixes #3404)

### DIFF
--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -5410,7 +5410,7 @@ void janus_sip_sofia_callback(nua_event_t event, int status, char const *phrase,
 						/* External caller, create a new mapping */
 						call = g_malloc0(sizeof(janus_sip_call));
 						call->callee = session;
-						g_hash_table_insert(callids, session->callid, call);
+						g_hash_table_insert(callids, g_strdup(session->callid), call);
 					}
 				}
 				janus_mutex_unlock(&sessions_mutex);


### PR DESCRIPTION
This PR is an attempt to address the problem @ycherniavskyi reported in issue #3404. We have to thank Yurii for this fix as well, as his company, @WebTrit, sponsored the effort to investigate the issue and come up with a potential solution. Thanks, guys!

Coming to the core of the issue, Yurii identified an inconsistency in how Call-IDs were used as ways to address sessions in the SIP plugin, that would occur specifically when caller and callee were handled by the same Janus instance, and so the map would be overwritten. This could cause problems in two specific cases:

1. When using event handlers to notify incoming/outgoing SIP messages to an external backend (e.g., Homer) and mapping them to the plugin session (and so Janus handle) they belonged to.
2. When doing attended SIP transfers to fill in the `Replaces` header properly.

This PR introduces a new kind of mapping where we don't map the call-ID to a single session, but instead map it to a new structure that can keep track of both a caller and a callee, by keeping track of caller tags too. That structure is only updated with info on sessions handled by the Janus instance, and allows us to track both parties in a call from the same call-ID. This allowed us to solve the two problems above in two separate ways:

1. For event handlers, we find the mapping from call-ID, and then check From/To headers to find the right session looking at tags in the request.
2. For attended transfers, we limit the scope of lookups to sessions handled by the session implementing the transfer: in fact, transfers in Janus rely on the concept of master/helper sessions to implement multiple lines, and limiting the scope to those lines allows us to avoid ambiguities.

As usual, while this PR is currently for `master`, I'll backport it to `0.x` once it's merged. I tested the PR briefly and it seems to work, but of course my ability to test SIP deployments (and those use cases in particular) is limited. I'm looking forward to feedback, to ensure that first of all this fixes the two problems we mentioned, but also that we're not introducing regressions with these changes. If you use SIP extensively in your deployments, please make sure to test this and give us all the feedback we need to make sure it's merged as soon as possible.