### PR TITLE
Fix possible deadlock on udp socket opening error on rtp_forward

### DIFF
--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -5839,6 +5839,7 @@ static json_t *janus_videoroom_process_synchronous_request(janus_videoroom_sessi
 			if(publisher->udp_sock <= 0 ||
 					(!ipv6_disabled && setsockopt(publisher->udp_sock, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) != 0)) {
 				janus_mutex_unlock(&publisher->rtp_forwarders_mutex);
+				janus_mutex_unlock(&publisher->streams_mutex);
 				janus_refcount_decrease(&publisher->ref);
 				janus_mutex_unlock(&videoroom->mutex);
 				janus_refcount_decrease(&videoroom->ref);


### PR DESCRIPTION
this possibly fixes https://github.com/meetecho/janus-gateway/issues/3463 introduced by https://github.com/meetecho/janus-gateway/commit/d014cff9cf1d4cac75e2e2862f695c2d2096aeda