### PR TITLE
[0.x] Optimize NACKs handling

### DIFF
--- a/fuzzers/rtcp_fuzzer.c
+++ b/fuzzers/rtcp_fuzzer.c
@@ -66,10 +66,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	janus_rtcp_remove_nacks((char *)copy_data[idx++], size);
 	/* Functions that allocate new memory */
 	char *output_data = janus_rtcp_filter((char *)data, size, &newlen);
-	GQueue *queue = janus_rtcp_get_nacks((char *)data, size);
+	GQueue *queue = g_queue_new();
+	janus_rtcp_get_nacks((char *)data, size, queue);
 
 	/* Free resources */
 	g_free(output_data);
-	if (queue) g_queue_free(queue);
+	g_queue_free(queue);
 	return 0;
 }

--- a/fuzzers/rtcp_fuzzer.c
+++ b/fuzzers/rtcp_fuzzer.c
@@ -66,10 +66,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	janus_rtcp_remove_nacks((char *)copy_data[idx++], size);
 	/* Functions that allocate new memory */
 	char *output_data = janus_rtcp_filter((char *)data, size, &newlen);
-	GSList *list = janus_rtcp_get_nacks((char *)data, size);
+	GQueue *queue = janus_rtcp_get_nacks((char *)data, size);
 
 	/* Free resources */
 	g_free(output_data);
-	if (list) g_slist_free(list);
+	if (queue) g_queue_free(queue);
 	return 0;
 }

--- a/ice.c
+++ b/ice.c
@@ -1887,9 +1887,8 @@ static void janus_ice_component_free(const janus_refcount *component_ref) {
 		g_queue_free(component->video_retransmit_buffer);
 		g_hash_table_destroy(component->video_retransmit_seqs);
 	}
-	if(component->nacks_queue != NULL) {
+	if(component->nacks_queue != NULL)
 		g_queue_free(component->nacks_queue);
-	}
 	if(component->candidates != NULL) {
 		GSList *i = NULL, *candidates = component->candidates;
 		for(i = candidates; i; i = i->next) {
@@ -3316,9 +3315,8 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 
 				/* Now let's see if there are any NACKs to handle */
 				gint64 now = janus_get_monotonic_time();
-				if(component->nacks_queue == NULL) {
+				if(component->nacks_queue == NULL)
 					component->nacks_queue = g_queue_new();
-				}
 				GQueue *nacks = component->nacks_queue;
 				janus_rtcp_get_nacks(buf, buflen, nacks);
 				guint nacks_count = g_queue_get_length(nacks);

--- a/ice.c
+++ b/ice.c
@@ -3327,7 +3327,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 					GQueue *queue = (retransmit_seqs != NULL ? nacks : NULL);
 					int retransmits_cnt = 0;
 					janus_mutex_lock(&component->mutex);
-					while(g_queue_get_length(queue) > 0) {
+					while(queue != NULL && g_queue_get_length(queue) > 0) {
 						unsigned int seqnr = GPOINTER_TO_UINT(g_queue_pop_tail(queue));
 						JANUS_LOG(LOG_DBG, "[%"SCNu64"]   >> %u\n", handle->handle_id, seqnr);
 						int in_rb = 0;

--- a/ice.c
+++ b/ice.c
@@ -1884,6 +1884,9 @@ static void janus_ice_component_free(const janus_refcount *component_ref) {
 		g_queue_free(component->video_retransmit_buffer);
 		g_hash_table_destroy(component->video_retransmit_seqs);
 	}
+	if(component->nacks_queue != NULL) {
+		g_queue_free(component->nacks_queue);
+	}
 	if(component->candidates != NULL) {
 		GSList *i = NULL, *candidates = component->candidates;
 		for(i = candidates; i; i = i->next) {
@@ -3310,7 +3313,8 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 
 				/* Now let's see if there are any NACKs to handle */
 				gint64 now = janus_get_monotonic_time();
-				GQueue *nacks = janus_rtcp_get_nacks(buf, buflen);
+				GQueue *nacks = component->nacks_queue;
+				janus_rtcp_get_nacks(buf, buflen, nacks);
 				guint nacks_count = g_queue_get_length(nacks);
 				if(nacks_count && ((!video && component->do_audio_nacks) || (video && component->do_video_nacks))) {
 					/* Handle NACK */
@@ -3389,8 +3393,6 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 						component->in_stats.audio.nacks += nacks_count;
 					}
 					janus_mutex_unlock(&component->mutex);
-					g_queue_free(nacks);
-					nacks = NULL;
 				}
 				if(component->retransmit_recent_cnt &&
 						now - component->retransmit_log_ts > 5*G_USEC_PER_SEC) {
@@ -5272,6 +5274,9 @@ static gboolean janus_ice_outgoing_traffic_handle(janus_ice_handle *handle, janu
 							g_queue_push_tail(component->video_retransmit_buffer, p);
 							/* Insert in the table too, for quick lookup */
 							g_hash_table_insert(component->video_retransmit_seqs, GUINT_TO_POINTER(seq), p);
+						}
+						if(component->nacks_queue == NULL) {
+							component->nacks_queue = g_queue_new();
 						}
 					} else {
 						janus_ice_free_rtp_packet(p);

--- a/ice.c
+++ b/ice.c
@@ -3334,7 +3334,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 						} else {
 							/* Should we retransmit this packet? */
 							if((p->last_retransmit > 0) && (now-p->last_retransmit < MAX_NACK_IGNORE)) {
-								JANUS_LOG(LOG_HUGE, "[%"SCNu64"]   >> >> Packet %u was retransmitted just %"SCNi64"ms ago, skipping\n", handle->handle_id, seqnr, now-p->last_retransmit);
+								JANUS_LOG(LOG_HUGE, "[%"SCNu64"]   >> >> Packet %u was retransmitted just %"SCNi64"us ago, skipping\n", handle->handle_id, seqnr, now-p->last_retransmit);
 								g_queue_pop_tail(queue);
 								continue;
 							}

--- a/ice.c
+++ b/ice.c
@@ -642,8 +642,8 @@ static void janus_ice_free_queued_packet(janus_ice_queued_packet *pkt) {
 /* Minimum and maximum value, in milliseconds, for the NACK queue/retransmissions (default=200ms/1000ms) */
 #define DEFAULT_MIN_NACK_QUEUE	200
 #define DEFAULT_MAX_NACK_QUEUE	1000
-/* Maximum ignore count after retransmission (200ms) */
-#define MAX_NACK_IGNORE			200000
+/* Maximum ignore count after retransmission (100ms) */
+#define MAX_NACK_IGNORE			100000
 
 static gboolean nack_optimizations = FALSE;
 void janus_set_nack_optimizations_enabled(gboolean optimize) {
@@ -3290,10 +3290,10 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 				}
 				if(rtcp_ctx && rtcp_ctx->rtt != rtt) {
 					/* Check the current RTT, to see if we need to update the size of the queue: we take
-					 * the highest RTT (audio or video) and add 100ms just to be conservative */
+					 * the highest RTT (audio or video) and add some space just to be conservative */
 					uint32_t audio_rtt = janus_rtcp_context_get_rtt(stream->audio_rtcp_ctx),
 						video_rtt = janus_rtcp_context_get_rtt(stream->video_rtcp_ctx[0]);
-					uint16_t nack_queue_ms = (audio_rtt > video_rtt ? audio_rtt : video_rtt) + 100;
+					uint16_t nack_queue_ms = (audio_rtt > video_rtt ? audio_rtt : video_rtt) + MAX_NACK_IGNORE;
 					if(nack_queue_ms > DEFAULT_MAX_NACK_QUEUE)
 						nack_queue_ms = DEFAULT_MAX_NACK_QUEUE;
 					else if(nack_queue_ms < min_nack_queue)

--- a/ice.h
+++ b/ice.h
@@ -597,7 +597,7 @@ struct janus_ice_component {
 	GQueue *audio_retransmit_buffer, *video_retransmit_buffer;
 	/*! \brief HashTable of retransmittable sequence numbers, in case we receive NACKs */
 	GHashTable *audio_retransmit_seqs, *video_retransmit_seqs;
-	/*! \brief Helper queues for storing requested packets from NACKs */
+	/*! \brief Helper queue for storing requested packets from NACKs */
 	GQueue *nacks_queue;
 	/*! \brief Current sequence number for the RFC4588 rtx SSRC session */
 	guint16 rtx_seq_number;

--- a/ice.h
+++ b/ice.h
@@ -597,6 +597,8 @@ struct janus_ice_component {
 	GQueue *audio_retransmit_buffer, *video_retransmit_buffer;
 	/*! \brief HashTable of retransmittable sequence numbers, in case we receive NACKs */
 	GHashTable *audio_retransmit_seqs, *video_retransmit_seqs;
+	/*! \brief Helper queues for storing requested packets from NACKs */
+	GQueue *nacks_queue;
 	/*! \brief Current sequence number for the RFC4588 rtx SSRC session */
 	guint16 rtx_seq_number;
 	/*! \brief Last time a log message about sending retransmits was printed */

--- a/plugins/plugin.h
+++ b/plugins/plugin.h
@@ -171,7 +171,7 @@ janus_plugin *create(void) {
  * Janus instance or it will crash.
  *
  */
-#define JANUS_PLUGIN_API_VERSION	19
+#define JANUS_PLUGIN_API_VERSION	18
 
 /*! \brief Initialization of all plugin properties to NULL
  *

--- a/plugins/plugin.h
+++ b/plugins/plugin.h
@@ -171,7 +171,7 @@ janus_plugin *create(void) {
  * Janus instance or it will crash.
  *
  */
-#define JANUS_PLUGIN_API_VERSION	18
+#define JANUS_PLUGIN_API_VERSION	20
 
 /*! \brief Initialization of all plugin properties to NULL
  *

--- a/rtcp.c
+++ b/rtcp.c
@@ -1195,12 +1195,12 @@ gboolean janus_rtcp_has_pli(char *packet, int len) {
 	return FALSE;
 }
 
-GSList *janus_rtcp_get_nacks(char *packet, int len) {
+GQueue *janus_rtcp_get_nacks(char *packet, int len) {
 	if(packet == NULL || len == 0)
 		return NULL;
 	janus_rtcp_header *rtcp = (janus_rtcp_header *)packet;
 	/* FIXME Get list of sequence numbers we should send again */
-	GSList *list = NULL;
+	GQueue *queue = g_queue_new();
 	int total = len;
 	gboolean error = FALSE;
 	while(rtcp) {
@@ -1232,13 +1232,13 @@ GSList *janus_rtcp_get_nacks(char *packet, int len) {
 					for(i=0; i< nacks; i++) {
 						nack = (janus_rtcp_nack *)rtcpfb->fci + i;
 						pid = ntohs(nack->pid);
-						list = g_slist_prepend(list, GUINT_TO_POINTER(pid));
+						g_queue_push_head(queue, GUINT_TO_POINTER(pid));
 						blp = ntohs(nack->blp);
 						memset(bitmask, 0, 20);
 						for(j=0; j<16; j++) {
 							bitmask[j] = (blp & ( 1 << j )) >> j ? '1' : '0';
 							if((blp & ( 1 << j )) >> j)
-								list = g_slist_prepend(list, GUINT_TO_POINTER(pid+j+1));
+								g_queue_push_head(queue, GUINT_TO_POINTER(pid+j+1));
 						}
 						bitmask[16] = '\n';
 						JANUS_LOG(LOG_DBG, "[%d] %"SCNu16" / %s\n", i, pid, bitmask);
@@ -1256,12 +1256,11 @@ GSList *janus_rtcp_get_nacks(char *packet, int len) {
 			break;
 		rtcp = (janus_rtcp_header *)((uint32_t*)rtcp + length + 1);
 	}
-	if (error && list) {
-		g_slist_free(list);
-		list = NULL;
+	if (error && queue) {
+		g_queue_free(queue);
+		queue = NULL;
 	}
-	list = g_slist_reverse(list);
-	return list;
+	return queue;
 }
 
 int janus_rtcp_remove_nacks(char *packet, int len) {

--- a/rtcp.c
+++ b/rtcp.c
@@ -1255,9 +1255,8 @@ void janus_rtcp_get_nacks(char *packet, int len, GQueue *nacks_queue) {
 			break;
 		rtcp = (janus_rtcp_header *)((uint32_t*)rtcp + length + 1);
 	}
-	if (error) {
+	if(error)
 		g_queue_clear(nacks_queue);
-	}
 }
 
 int janus_rtcp_remove_nacks(char *packet, int len) {

--- a/rtcp.h
+++ b/rtcp.h
@@ -327,8 +327,7 @@ uint32_t janus_rtcp_context_get_out_media_link_quality(janus_rtcp_context *ctx);
 /*! \brief Method to swap Report Blocks and move media RB in first position in case rtx SSRC comes first
  * @param[in] packet The message data
  * @param[in] len The message data length in bytes
- * @param[in] rtx_ssrc The rtx SSRC
- * @returns The receiver SSRC, or 0 in case of error */
+ * @param[in] rtx_ssrc */
 void janus_rtcp_swap_report_blocks(char *packet, int len, uint32_t rtx_ssrc);
 /*! \brief Method to quickly retrieve the sender SSRC (needed for demuxing RTCP in BUNDLE)
  * @param[in] packet The message data
@@ -451,8 +450,8 @@ gboolean janus_rtcp_has_pli(char *packet, int len);
 /*! \brief Method to parse an RTCP NACK message
  * @param[in] packet The message data
  * @param[in] len The message data length in bytes
- * @returns A queue of janus_nack elements containing the sequence numbers to send again */
-GQueue *janus_rtcp_get_nacks(char *packet, int len);
+ * @param[in,out] nacks_queue The queue used to store the requested packets */
+void janus_rtcp_get_nacks(char *packet, int len, GQueue *nacks_queue);
 
 /*! \brief Method to remove an RTCP NACK message
  * @param[in] packet The message data

--- a/rtcp.h
+++ b/rtcp.h
@@ -327,7 +327,7 @@ uint32_t janus_rtcp_context_get_out_media_link_quality(janus_rtcp_context *ctx);
 /*! \brief Method to swap Report Blocks and move media RB in first position in case rtx SSRC comes first
  * @param[in] packet The message data
  * @param[in] len The message data length in bytes
- * @param[in] rtx_ssrc */
+ * @param[in] rtx_ssrc The rtx SSRC */
 void janus_rtcp_swap_report_blocks(char *packet, int len, uint32_t rtx_ssrc);
 /*! \brief Method to quickly retrieve the sender SSRC (needed for demuxing RTCP in BUNDLE)
  * @param[in] packet The message data
@@ -450,7 +450,7 @@ gboolean janus_rtcp_has_pli(char *packet, int len);
 /*! \brief Method to parse an RTCP NACK message
  * @param[in] packet The message data
  * @param[in] len The message data length in bytes
- * @param[in,out] nacks_queue The queue used to store the requested packets */
+ * @param[in,out] nacks_queue The queue containing the sequence numbers to send again */
 void janus_rtcp_get_nacks(char *packet, int len, GQueue *nacks_queue);
 
 /*! \brief Method to remove an RTCP NACK message

--- a/rtcp.h
+++ b/rtcp.h
@@ -451,8 +451,8 @@ gboolean janus_rtcp_has_pli(char *packet, int len);
 /*! \brief Method to parse an RTCP NACK message
  * @param[in] packet The message data
  * @param[in] len The message data length in bytes
- * @returns A list of janus_nack elements containing the sequence numbers to send again */
-GSList *janus_rtcp_get_nacks(char *packet, int len);
+ * @returns A queue of janus_nack elements containing the sequence numbers to send again */
+GQueue *janus_rtcp_get_nacks(char *packet, int len);
 
 /*! \brief Method to remove an RTCP NACK message
  * @param[in] packet The message data

--- a/rtp.h
+++ b/rtp.h
@@ -62,6 +62,7 @@ typedef struct janus_rtp_packet {
 	gint length;
 	gint64 created;
 	gint64 last_retransmit;
+	gint64 current_backoff;
 	janus_plugin_rtp_extensions extensions;
 } janus_rtp_packet;
 


### PR DESCRIPTION
This PR includes a set of optimizations for NACKs handling.
We identified some inefficient code paths that could potentially cause some performance issues when the server receives a high number of NACK requests.
Once completed this, a similar effort will be done on 1.x too.

**TODO**
- [x]  replace g_list with g_queue to only use O(1) operations and avoid full list  scanning
- [x]  use a pre-allocated queue per component
<del> reduce memory allocations when preparing packets to retransmit </del>
- [x] add a backoff algo when retransmitting the same packet multiple times