### PR TITLE
Sip module - get sip password from external url

### DIFF
--- a/conf/janus.plugin.sip.jcfg.sample
+++ b/conf/janus.plugin.sip.jcfg.sample
@@ -52,4 +52,9 @@ general: {
 	# engine (default 32000 milliseconds)
 	sip_timer_t1x64 = 32000
 
+	# Set password retrieval on private url from web_session_id (Avoiding to expose reusable sip credentials)
+	# if web_session_id is defined, the sip password will be retrieved at $sip_passwd_url/$web_session_id
+	get_sip_passwd_from_url = false
+	#sip_passwd_url = "https://mydomain.com"
+
 }

--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -2921,7 +2921,7 @@ static void janus_sip_hangup_media_internal(janus_plugin_session *handle) {
 }
 
 /* Function called by libcurl to write the data received */
-static size_t curl_write_callback(void *data, size_t size, size_t nmemb, void *userp) {
+static size_t curl_write_cb(void *data, size_t size, size_t nmemb, void *userp) {
     size_t total_size = size * nmemb;
     struct curl_response_buffer *mem = (struct curl_response_buffer *)userp;
 
@@ -3298,7 +3298,7 @@ static void *janus_sip_handler(void *data) {
 						/* Initialize the memory chunk */
 						struct curl_response_buffer chunk = {0};
 						curl_easy_setopt(curl_handle, CURLOPT_URL, url);
-						curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, curl_write_callback);
+						curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, curl_write_cb);
 						curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
 						curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, "Janus SIP Plugin/0.0.9");
 						curl_easy_setopt(curl_handle, CURLOPT_FOLLOWLOCATION, 1L);


### PR DESCRIPTION
Hello,

We wanted to avoid end user to see SIP password in flows.

The idea here would be to retrieve a web_session_id from webrtc client and to get the associated sip_password from http request (accessible only from Janus).

hope this could be helpfull for other people and avoid SIP credentials leak.

Tell me if there is anything i can enhance as my C skills are pretty low.
