### PR TITLE
Fix memory leak (free the descriptor)

### DIFF
--- a/src/record.c
+++ b/src/record.c
@@ -74,6 +74,8 @@ static void janus_recorder_free(const janus_refcount *recorder_ref) {
 	recorder->codec = NULL;
 	g_free(recorder->fmtp);
 	recorder->fmtp = NULL;
+	g_free(recorder->description);
+	recorder->description = NULL;
 	if(recorder->extensions != NULL)
 		g_hash_table_destroy(recorder->extensions);
 	janus_mutex_destroy(&recorder->mutex);


### PR DESCRIPTION
Noticed a memory leak in record.c, here is a small patch.
If someone needs libasan trace log with specific lines that pointed to this descriptor, I can post it here or paste it somewhere (it's a nice 8 lines stacktrace from which you only need 3.5)