### PR TITLE
janus-pp-rec: improve DTX detection

### DIFF
--- a/src/postprocessing/janus-pp-rec.c
+++ b/src/postprocessing/janus-pp-rec.c
@@ -1310,6 +1310,7 @@ int main(int argc, char *argv[]) {
 
 					/* Update current packet ts with new ts */
 					tmp->ts = new_ts;
+					tmp->restamped = 1;
 
 					JANUS_LOG(LOG_WARN, "Timestamp gap detected. Restamping packets from here. Seq: %d\n", tmp->seq);
 					JANUS_LOG(LOG_INFO, "latency=%.2f mavg=%.2f original_ts=%.ld new_ts=%.ld offset=%.ld\n", current_latency, moving_avg_latency, original_ts, tmp->ts, restamping_offset);

--- a/src/postprocessing/pp-rtp.h
+++ b/src/postprocessing/pp-rtp.h
@@ -57,17 +57,18 @@ typedef struct janus_pp_rtp_header_extension {
 
 typedef struct janus_pp_frame_packet {
 	janus_pp_rtp_header *header; /* Pointer to RTP header */
-	int version;	/* Version of the .mjr file (2=has timestamps) */
-	uint32_t p_ts;	/* Packet timestamp as saved by Janus (if available) */
-	uint16_t seq;	/* RTP Sequence number */
-	uint64_t ts;	/* RTP Timestamp */
-	uint16_t len;	/* Length of the data */
-	int pt;			/* Payload type of the data */
-	long offset;	/* Offset of the data in the file */
-	int skip;		/* Bytes to skip, besides the RTP header */
-	uint8_t drop;	/* Whether this packet can be dropped (e.g., padding)*/
-	int audiolevel;	/* Value of audio level in RTP extension, if parsed */
-	int rotation;	/* Value of rotation in RTP extension, if parsed */
+	int version;		/* Version of the .mjr file (2=has timestamps) */
+	uint32_t p_ts;		/* Packet timestamp as saved by Janus (if available) */
+	uint16_t seq;		/* RTP Sequence number */
+	uint64_t ts;		/* RTP Timestamp */
+	uint16_t len;		/* Length of the data */
+	int pt;				/* Payload type of the data */
+	long offset;		/* Offset of the data in the file */
+	int skip;			/* Bytes to skip, besides the RTP header */
+	uint8_t drop;	  	/* Whether this packet can be dropped (e.g., padding)*/
+	uint8_t restamped;	/* Whether this packet has been restamped */
+	int audiolevel;		/* Value of audio level in RTP extension, if parsed */
+	int rotation;		/* Value of rotation in RTP extension, if parsed */
 	struct janus_pp_frame_packet *next;
 	struct janus_pp_frame_packet *prev;
 } janus_pp_frame_packet;


### PR DESCRIPTION
This patch improves opus DTX detection in janus-pp-rec by considering as DTX those packets with a plen greater than 20 ms.
We are aware that WebRTC/opus supports plen up to 60ms, but historically janus-pp-rec has only been capable of processing 20ms packets so we're not introducing any regression from that perspective.

Since pp-rec restamping (`-r`) artificially introduces larger timestamp gaps, we mark restamped packets in the first loop of janus-pp-rec in order not to confuse them with DTX packets.


