### PR TITLE
Fix type error

### DIFF
--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -36,7 +36,7 @@ declare namespace JanusJS {
 		init: () => void;
 	}
 
-	type GetScreenCallback = (error?, sourceId?) => void
+	type GetScreenCallback = (error:string, sourceId:string) => void
 
 	type HttpApiCallOption = {
 		async: boolean,


### PR DESCRIPTION
Fixes #3506

This PR resolves TypeScript compilation errors caused by missing explicit types in the GetScreenCallback type definition in janus.d.ts.

Issue Details:
Problem: The GetScreenCallback type was defined as:

type GetScreenCallback = (error?, sourceId?) => void;
This caused TypeScript errors (TS7006) when compiling in strict mode, as the parameters error and sourceId implicitly had the any type.

Solution: The parameters have been updated with explicit types to ensure compatibility with strict TypeScript settings:
type GetScreenCallback = (error:string, sourceId:string) => void