### PR TITLE
Cleanup remote publishers on videoroom destroy

### DIFF
--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -13769,7 +13769,7 @@ static void *janus_videoroom_remote_publisher_thread(void *user_data) {
 
 	/* Loop */
 	int num = 0, i = 0;
-	while(!g_atomic_int_get(&publisher->remote_leaving) && !g_atomic_int_get(&publisher->destroyed)) {
+	while(!g_atomic_int_get(&publisher->remote_leaving) && !g_atomic_int_get(&publisher->destroyed) && !g_atomic_int_get(&videoroom->destroyed)) {
 		/* Prepare poll */
 		num = 0;
 		if(publisher->remote_fd != -1) {


### PR DESCRIPTION
As I described here: https://janus.discourse.group/t/add-remote-publisher-and-room-destroy/1452/1 janus continues listening ports if remove_remote_publisher wasn't called before room destroy. 

We tested it on our production servers and seems like all is good - ports are freeing and memory isn't leeking.