### PR TITLE
Upgrade python websockets version to fix the Vulnerability CWE 208

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,2 @@
-websockets==8.1
+websockets==9.1
 aiortc==0.9.26

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,2 @@
-websockets==9.1
+websockets==10.0
 aiortc==0.9.26


### PR DESCRIPTION
There is vulnerability found in python websocket package 
https://cwe.mitre.org/data/definitions/208.html
The issue is fixed here https://security.archlinux.org/CVE-2021-33880
