### PR TITLE
rtcp: fix FIR parsing

### DIFF
--- a/src/rtcp.c
+++ b/src/rtcp.c
@@ -1154,6 +1154,12 @@ gboolean janus_rtcp_has_fir(char *packet, int len) {
 		switch(rtcp->type) {
 			case RTCP_FIR:
 				return TRUE;
+			case RTCP_PSFB: {
+				gint fmt = rtcp->rc;
+				if(fmt == 4)
+					return TRUE;
+				break;
+			}
 			default:
 				break;
 		}


### PR DESCRIPTION
FIR RTCP packets sent by GStreamer were not handled by Janus but PLI ones are.

According to https://www.rfc-editor.org/rfc/rfc5104#section-4.3.1 FIR are PSFB packets with FMT=4 so I'm now parsing them as we do with PLI.