### PR TITLE
AudioBridge - PlainRTP Participant - Recognize RFC2833 DTMF and publish 'dtmf' event

### DIFF
--- a/src/rtp.c
+++ b/src/rtp.c
@@ -35,6 +35,13 @@ gboolean janus_is_rtp(char *buf, guint len) {
 	return ((header->type < 64) || (header->type >= 96));
 }
 
+gboolean janus_is_rfc2833_payload_type(int payload_type){
+	if( 96 > payload_type || 127 < payload_type) {
+		return FALSE;
+	}
+	return TRUE;
+}
+
 char *janus_rtp_payload(char *buf, int len, int *plen) {
 	if(!buf || len < 12)
 		return NULL;

--- a/src/rtp.h
+++ b/src/rtp.h
@@ -154,6 +154,10 @@ int janus_videocodec_pt(janus_videocodec vcodec);
  * @param[in] len Length of the buffer to inspect */
 gboolean janus_is_rtp(char *buf, guint len);
 
+/*! \brief Helper method to validate if payload type might be a RFC2833 (dtmf) between 96 and 127
+ * @param[in] int Payload_Type */
+gboolean janus_is_rfc2833_payload_type(int payload_type);
+
 /*! \brief Helper to quickly access the RTP payload, skipping header and extensions
  * @param[in] buf The packet data
  * @param[in] len The packet data length in bytes


### PR DESCRIPTION
This pull request adds support for handling RFC2833 DTMF signals from plain RTP participants in the AudioBridge plugin.

When a participant sends a DTMF signal using RFC2833, Janus will now emit the following event:
```
{
  "audiobridge": "event",
  "room": <numeric ID of the room>,
  "id": <unique ID assigned to the participant>,
  "result": {
    "event": "dtmf",
    "signal": "<DTMF signal received, values: 1-9, *, #, A-D>",
    "duration": <duration of the DTMF signal>
  }
}
```
To enable recognition of RFC2833 DTMF signals, the RTP payload type for DTMF must be specified using the `dtmf_pt` field in the `rtp` object of the `join` and/or `configure` request:
```
{
  "request": "join",
  ...
  "rtp": {
    ...
    "dtmf_pt": <RFC2833 RTP payload type used to receive DTMF signals (optional)>
  }
}
```