### PR TITLE
Update demo of streaming

### DIFF
--- a/html/demos/streaming.js
+++ b/html/demos/streaming.js
@@ -252,10 +252,10 @@ $(document).ready(function() {
 									if (playPromise !== undefined) {
 										playPromise
 											.then(function() {
-												Janus.log('start playing')
+												Janus.log('Start playing')
 											})
 											.catch(function(error) => {
-												Janus.error('failed to play', error)
+												Janus.error('Failed to play', error)
 											});
 									}
 									$('#remotevideo' + mid).get(0).volume = 1;

--- a/html/demos/streaming.js
+++ b/html/demos/streaming.js
@@ -248,14 +248,14 @@ $(document).ready(function() {
 										}
 									});
 									Janus.attachMediaStream($('#remotevideo' + mid).get(0), stream);
-									var playPromise = $('#remotevideo' + mid).get(0).play();
+									let playPromise = $('#remotevideo' + mid).get(0).play();
 									if (playPromise !== undefined) {
 										playPromise
-											.then(_ => {
-												console.log('start playing')
+											.then(function() {
+												Janus.log('start playing')
 											})
-											.catch(error => {
-												console.log('failed to play', error)
+											.catch(function(error) => {
+												Janus.log('failed to play', error)
 											});
 									}
 									$('#remotevideo' + mid).get(0).volume = 1;

--- a/html/demos/streaming.js
+++ b/html/demos/streaming.js
@@ -355,13 +355,9 @@ function updateStreamsList() {
 				// Keep track of all the available streams
 				streamsList[list[mp]["id"]] = list[mp];
 			}
-			$('#streamslist a').unbind('click').click(function() {
-				$('.dropdown-toggle').dropdown('hide');
+			$('#streamslist a').on("click", function() {
 				selectedStream = $(this).attr("id");
-				$('#streamset').html($(this).html()).parent().removeClass('open');
-				$('#list .dropdown-backdrop').remove();
-				return false;
-
+				$('#streamset').html($(this).html());
 			});
 			$('#watch').removeAttr('disabled').unbind('click').click(startStream);
 		}

--- a/html/demos/streaming.js
+++ b/html/demos/streaming.js
@@ -248,7 +248,16 @@ $(document).ready(function() {
 										}
 									});
 									Janus.attachMediaStream($('#remotevideo' + mid).get(0), stream);
-									$('#remotevideo' + mid).get(0).play();
+									var playPromise = $('#remotevideo' + mid).get(0).play();
+									if (playPromise !== undefined) {
+										playPromise
+											.then(_ => {
+												console.log('start playing')
+											})
+											.catch(error => {
+												console.log('failed to play', error)
+											});
+									}
 									$('#remotevideo' + mid).get(0).volume = 1;
 								},
 								// eslint-disable-next-line no-unused-vars

--- a/html/demos/streaming.js
+++ b/html/demos/streaming.js
@@ -252,7 +252,7 @@ $(document).ready(function() {
 									if (playPromise !== undefined) {
 										playPromise
 											.then(function() {
-												Janus.log('Start playing')
+												Janus.log('Started playing')
 											})
 											.catch(function(error) => {
 												Janus.error('Failed to play', error)

--- a/html/demos/streaming.js
+++ b/html/demos/streaming.js
@@ -355,7 +355,7 @@ function updateStreamsList() {
 				// Keep track of all the available streams
 				streamsList[list[mp]["id"]] = list[mp];
 			}
-			$('#streamslist a').on("click", function() {
+			$('#streamslist a').off('click').on('click', function() {
 				selectedStream = $(this).attr("id");
 				$('#streamset').html($(this).html());
 			});

--- a/html/demos/streaming.js
+++ b/html/demos/streaming.js
@@ -255,7 +255,7 @@ $(document).ready(function() {
 												Janus.log('start playing')
 											})
 											.catch(function(error) => {
-												Janus.log('failed to play', error)
+												Janus.error('failed to play', error)
 											});
 									}
 									$('#remotevideo' + mid).get(0).volume = 1;

--- a/html/demos/streaming.js
+++ b/html/demos/streaming.js
@@ -254,7 +254,7 @@ $(document).ready(function() {
 											.then(function() {
 												Janus.log('Started playing')
 											})
-											.catch(function(error) => {
+											.catch(function(error) {
 												Janus.error('Failed to play', error)
 											});
 									}


### PR DESCRIPTION
I had troubles on streaming example so I resolved them.

# play() for video tag.
```
ERROR
The play() request was interrupted because the media was removed from the document. https://goo.gl/LdLk22
```
I applied promise to avoid this error as mentioned on https://goo.gl/LdLk22 .
https://github.com/meetecho/janus-gateway/commit/15f864f1a31300edb55119e4e0b1356298a10691

# Can not call dropdown with using webpack.
```
jquery__WEBPACK_IMPORTED_MODULE_1___default(...)(...).dropdown is not a function
TypeError: jquery__WEBPACK_IMPORTED_MODULE_1___default(...)(...).dropdown is not a function
```
The toggle action of bootstrap is not needed to handle manually so I remove hiding action at clicking.
https://github.com/meetecho/janus-gateway/commit/15f864f1a31300edb55119e4e0b1356298a10691