### PR TITLE
Remove "nice_debug" option and "set_libnice_debug" API from Janus

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,6 @@ or on the command line:
                                   (experimental)  (default=off)
 	-O, --ipv6-link-local         Whether IPv6 link-local candidates should be
                                   gathered as well  (default=off)
-	-l, --libnice-debug           Whether to enable libnice debugging or not
-                                  (default=off)
 	-f, --full-trickle            Do full-trickle instead of half-trickle
                                   (default=off)
 	-I, --ice-lite                Whether to enable the ICE Lite mode or not

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -281,12 +281,11 @@ media: {
 # sticking to 0.1.18 until the issue is addressed upstream). Finally,
 # you can also enable ICE-TCP support (beware that this may lead to problems
 # if you do not enable ICE Lite as well), choose which interfaces should
-# be used for gathering candidates, and enable or disable the
-# internal libnice debugging, if needed.
+# be used for gathering candidates.
 nat: {
 	#stun_server = "stun.voip.eutelia.it"
 	#stun_port = 3478
-	nice_debug = false
+	#nice_debug = "nice_debug option is NOT SUPPORTED ANYMORE! Please set NICE_DEBUG and G_MESSAGES_DEBUG env vars when starting Janus"
 	#full_trickle = true
 	#ice_nomination = "regular"
 	#ice_consent_freshness = true

--- a/html/demos/admin.js
+++ b/html/demos/admin.js
@@ -486,20 +486,6 @@ function updateSettings() {
 								setLogColors(!settings["log_colors"]);
 						});
 					});
-				} else if(k === 'libnice_debug') {
-					$('#'+k).append('<button id="' + k + '_button" type="button" class="btn btn-xs"></button>');
-					$('#'+k + "_button")
-						.addClass(!settings[k] ? "btn-success" : "btn-danger")
-						.html(!settings[k] ? "Enable libnice debug" : "Disable libnice debug");
-					$('#'+k + "_button").click(function() {
-						let text = (!settings["libnice_debug"] ?
-							"Are you sure you want to enable the libnice debug?<br/>This will print the a very verbose debug of every libnice-related operation on the console"
-							: "Are you sure you want to disable the libnice debug?");
-						bootbox.confirm(text, function(result) {
-							if(result)
-								setLibniceDebug(!settings["libnice_debug"]);
-						});
-					});
 				}
 			}
 		},
@@ -546,11 +532,6 @@ function setLogTimestamps(enable) {
 
 function setLogColors(enable) {
 	let request = { "janus": "set_log_colors", "colors": enable, "transaction": randomString(12), "admin_secret": secret };
-	sendSettingsRequest(request);
-}
-
-function setLibniceDebug(enable) {
-	let request = { "janus": "set_libnice_debug", "debug": enable, "transaction": randomString(12), "admin_secret": secret };
 	sendSettingsRequest(request);
 }
 

--- a/src/ice.c
+++ b/src/ice.c
@@ -319,33 +319,6 @@ void janus_ice_stop_static_event_loops(void) {
 	janus_mutex_unlock(&event_loops_mutex);
 }
 
-/* libnice debugging */
-static gboolean janus_ice_debugging_enabled;
-gboolean janus_ice_is_ice_debugging_enabled(void) {
-	return janus_ice_debugging_enabled;
-}
-void janus_ice_debugging_enable(void) {
-	JANUS_LOG(LOG_VERB, "Enabling libnice debugging...\n");
-	if(g_getenv("NICE_DEBUG") == NULL) {
-		JANUS_LOG(LOG_WARN, "No NICE_DEBUG environment variable set, setting maximum debug\n");
-		g_setenv("NICE_DEBUG", "all", TRUE);
-	}
-	if(g_getenv("G_MESSAGES_DEBUG") == NULL) {
-		JANUS_LOG(LOG_WARN, "No G_MESSAGES_DEBUG environment variable set, setting maximum debug\n");
-		g_setenv("G_MESSAGES_DEBUG", "all", TRUE);
-	}
-	JANUS_LOG(LOG_VERB, "Debugging NICE_DEBUG=%s G_MESSAGES_DEBUG=%s\n",
-		g_getenv("NICE_DEBUG"), g_getenv("G_MESSAGES_DEBUG"));
-	janus_ice_debugging_enabled = TRUE;
-	nice_debug_enable(strstr(g_getenv("NICE_DEBUG"), "all") || strstr(g_getenv("NICE_DEBUG"), "stun"));
-}
-void janus_ice_debugging_disable(void) {
-	JANUS_LOG(LOG_VERB, "Disabling libnice debugging...\n");
-	janus_ice_debugging_enabled = FALSE;
-	nice_debug_disable(TRUE);
-}
-
-
 /* NAT 1:1 stuff */
 static gboolean nat_1_1_enabled = FALSE;
 static gboolean keep_private_host = FALSE;
@@ -1062,9 +1035,6 @@ void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean full_trickle, 
 		}
 #endif
 	}
-	/* libnice debugging is disabled unless explicitly stated */
-	nice_debug_disable(TRUE);
-
 	/*! \note The RTP/RTCP port range configuration may be just a placeholder: for
 	 * instance, libnice supports this since 0.1.0, but the 0.1.3 on Fedora fails
 	 * when linking with an undefined reference to \c nice_agent_set_port_range

--- a/src/ice.h
+++ b/src/ice.h
@@ -231,13 +231,6 @@ void janus_ice_event_set_combine_media_stats(gboolean combine_media_stats_to_one
  * @returns true to combine events */
 gboolean janus_ice_event_get_combine_media_stats(void);
 
-/*! \brief Method to check whether libnice debugging has been enabled (http://nice.freedesktop.org/libnice/libnice-Debug-messages.html)
- * @returns True if libnice debugging is enabled, FALSE otherwise */
-gboolean janus_ice_is_ice_debugging_enabled(void);
-/*! \brief Method to enable libnice debugging (http://nice.freedesktop.org/libnice/libnice-Debug-messages.html) */
-void janus_ice_debugging_enable(void);
-/*! \brief Method to disable libnice debugging (the default) */
-void janus_ice_debugging_disable(void);
 /*! \brief Method to enable opaque ID in Janus API responses/events */
 void janus_enable_opaqueid_in_api(void);
 /*! \brief Method to check whether opaque ID have to be added to Janus API responses/events

--- a/src/mainpage.dox
+++ b/src/mainpage.dox
@@ -2341,7 +2341,6 @@ const token = getJanusToken('janus', ['janus.plugin.videoroom']);
  * - \c set_refcount_debug: selectively enable/disable a live debugging of
  * the reference counters in Janus on the fly (useful if you're experiencing
  * memory leaks in the Janus structures and want to investigate them);
- * - \c set_libnice_debug: selectively enable/disable libnice debugging;
  * - \c set_min_nack_queue: change the value of the min NACK queue window;
  * - \c set_no_media_timer: change the value of the no-media timer property;
  * - \c set_slowlink_threshold: change the value of the slowlink-threshold property.

--- a/src/options.c
+++ b/src/options.c
@@ -36,7 +36,6 @@ gboolean janus_options_parse(janus_options *options, int argc, char *argv[]) {
 		{ "ice-ignore-list", 'X', 0, G_OPTION_ARG_STRING, &options->ice_ignore_list, "Comma-separated list of interfaces or IP addresses to ignore for ICE gathering; partial strings are supported (e.g., vmnet8,192.168.0.1,10.0.0.1 or vmnet,192.168., default=vmnet)", "list" },
 		{ "ipv6-candidates", '6', 0, G_OPTION_ARG_NONE, &options->ipv6_candidates, "Whether to enable IPv6 candidates or not", NULL },
 		{ "ipv6-link-local", 'O', 0, G_OPTION_ARG_NONE, &options->ipv6_link_local, "Whether IPv6 link-local candidates should be gathered as well", NULL },
-		{ "libnice-debug", 'l', 0, G_OPTION_ARG_NONE, &options->libnice_debug, "Whether to enable libnice debugging or not", NULL },
 		{ "full-trickle", 'f', 0, G_OPTION_ARG_NONE, &options->full_trickle, "Do full-trickle instead of half-trickle", NULL },
 		{ "ice-lite", 'I', 0, G_OPTION_ARG_NONE, &options->ice_lite, "Whether to enable the ICE Lite mode or not", NULL },
 		{ "ice-tcp", 'T', 0, G_OPTION_ARG_NONE, &options->ice_tcp, "Whether to enable ICE-TCP or not (warning: only works with ICE Lite)", NULL },

--- a/src/options.h
+++ b/src/options.h
@@ -35,7 +35,6 @@ typedef struct janus_options {
 	const char *ice_ignore_list;
 	gboolean ipv6_candidates;
 	gboolean ipv6_link_local;
-	gboolean libnice_debug;
 	gboolean full_trickle;
 	gboolean ice_lite;
 	gboolean ice_tcp;


### PR DESCRIPTION
To enable libnice logging:
- Set `NICE_DEBUG` env var to `all` or one of these values https://gitlab.freedesktop.org/libnice/libnice/-/blob/ae3eb16fd7d1237353bf64e899c612b8a63bca8a/agent/debug.c#L59
- Set `G_MESSAGES_DEBUG` env var to `all` or one of these values https://gitlab.freedesktop.org/libnice/libnice/-/blob/ae3eb16fd7d1237353bf64e899c612b8a63bca8a/agent/debug.c#L67

E.g.
```
NICE_DEBUG=nice G_MESSAGES_DEBUG=libnice /path/to/janus/bin
```