### PR TITLE
Cleanup of initialized mutexes

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -36,7 +36,7 @@
 /* Hash table to contain the tokens to match */
 static GHashTable *tokens = NULL, *allowed_plugins = NULL;
 static gboolean auth_enabled = FALSE;
-static janus_mutex mutex;
+static janus_mutex mutex = JANUS_MUTEX_INITIALIZER;
 static char *auth_secret = NULL;
 
 static void janus_auth_free_token(char *token) {
@@ -59,7 +59,6 @@ void janus_auth_init(gboolean enabled, const char *secret) {
 	} else {
 		JANUS_LOG(LOG_INFO, "Token based authentication disabled\n");
 	}
-	janus_mutex_init(&mutex);
 }
 
 gboolean janus_auth_is_enabled(void) {

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -560,6 +560,8 @@ void janus_dtls_srtp_cleanup(void) {
 		ssl_ctx = NULL;
 	}
 #if JANUS_USE_OPENSSL_PRE_1_1_API && !defined(HAVE_BORINGSSL)
+	for(l = 0; l < CRYPTO_num_locks(); l++) {
+		pthread_mutex_destroy(&janus_dtls_locks[l]);
 	g_free(janus_dtls_locks);
 #endif
 }

--- a/src/events/janus_gelfevh.c
+++ b/src/events/janus_gelfevh.c
@@ -91,7 +91,7 @@ static int compression = 6; /* Z_DEFAULT_COMPRESSION */
 static volatile gint initialized = 0, stopping = 0;
 static GThread *handler_thread;
 static void *janus_gelfevh_handler(void *data);
-static janus_mutex evh_mutex;
+static janus_mutex evh_mutex = JANUS_MUTEX_INITIALIZER;
 
 /* JSON serialization options */
 static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
@@ -384,7 +384,6 @@ done:
 
 	/* Initialize the events queue */
 	events = g_async_queue_new_full((GDestroyNotify) janus_gelfevh_event_free);
-	janus_mutex_init(&evh_mutex);
 
 	g_atomic_int_set(&initialized, 1);
 

--- a/src/events/janus_nanomsgevh.c
+++ b/src/events/janus_nanomsgevh.c
@@ -20,7 +20,6 @@
 
 #include "../debug.h"
 #include "../config.h"
-#include "../mutex.h"
 #include "../utils.h"
 #include "../events.h"
 

--- a/src/events/janus_rabbitmqevh.c
+++ b/src/events/janus_rabbitmqevh.c
@@ -109,7 +109,7 @@ static amqp_connection_state_t rmq_conn;
 static amqp_channel_t rmq_channel = 0;
 static amqp_bytes_t rmq_exchange;
 
-static janus_mutex mutex;
+static janus_mutex mutex = JANUS_MUTEX_INITIALIZER;
 
 static char *rmqhost = NULL;
 static char *vhost = NULL, *username = NULL, *password = NULL;
@@ -298,8 +298,6 @@ int janus_rabbitmqevh_init(const char *config_path) {
 		goto error;
 	}
 
-	janus_mutex_init(&mutex);
-
 	/* Initialize the events queue */
 	events = g_async_queue_new_full((GDestroyNotify) janus_rabbitmqevh_event_free);
 	g_atomic_int_set(&initialized, 1);
@@ -460,7 +458,6 @@ void janus_rabbitmqevh_destroy(void) {
 	g_free(ssl_cert_file);
 	g_free(ssl_key_file);
 
-	janus_mutex_destroy(&mutex);
 	g_atomic_int_set(&initialized, 0);
 	g_atomic_int_set(&stopping, 0);
 	JANUS_LOG(LOG_INFO, "%s destroyed!\n", JANUS_RABBITMQEVH_NAME);

--- a/src/events/janus_sampleevh.c
+++ b/src/events/janus_sampleevh.c
@@ -76,7 +76,7 @@ janus_eventhandler *create(void) {
 static volatile gint initialized = 0, stopping = 0;
 static GThread *handler_thread;
 static void *janus_sampleevh_handler(void *data);
-static janus_mutex evh_mutex;
+static janus_mutex evh_mutex = JANUS_MUTEX_INITIALIZER;
 
 /* JSON serialization options */
 static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
@@ -252,7 +252,6 @@ int janus_sampleevh_init(const char *config_path) {
 
 	/* Initialize the events queue */
 	events = g_async_queue_new_full((GDestroyNotify) janus_sampleevh_event_free);
-	janus_mutex_init(&evh_mutex);
 
 	g_atomic_int_set(&initialized, 1);
 

--- a/src/ice.c
+++ b/src/ice.c
@@ -789,7 +789,7 @@ void janus_ice_relay_rtcp_internal(janus_ice_handle *handle, janus_ice_peerconne
 
 /* Map of active plugin sessions */
 static GHashTable *plugin_sessions;
-static janus_mutex plugin_sessions_mutex;
+static janus_mutex plugin_sessions_mutex = JANUS_MUTEX_INITIALIZER;
 gboolean janus_plugin_session_is_alive(janus_plugin_session *plugin_session) {
 	if(plugin_session == NULL || plugin_session < (janus_plugin_session *)0x1000 ||
 			g_atomic_int_get(&plugin_session->stopped))
@@ -1085,7 +1085,6 @@ void janus_ice_init(gboolean ice_lite, gboolean ice_tcp, gboolean full_trickle, 
 
 	/* We keep track of plugin sessions to avoid problems */
 	plugin_sessions = g_hash_table_new_full(NULL, NULL, NULL, (GDestroyNotify)janus_plugin_session_dereference);
-	janus_mutex_init(&plugin_sessions_mutex);
 
 #ifdef HAVE_TURNRESTAPI
 	/* Initialize the TURN REST API client stack, whether we're going to use it or not */
@@ -1628,6 +1627,7 @@ static void janus_ice_handle_free(const janus_refcount *handle_ref) {
 	}
 	g_free(handle->opaque_id);
 	g_free(handle->token);
+	janus_mutex_destroy(&handle->mutex);
 	g_free(handle);
 }
 

--- a/src/ice.c
+++ b/src/ice.c
@@ -1864,8 +1864,8 @@ static void janus_ice_peerconnection_free(const janus_refcount *pc_ref) {
 	pc->rtx_payload_types_rev = NULL;
 	if(pc->nacks_queue != NULL)
 		g_queue_free(pc->nacks_queue);
+	janus_mutex_destroy(&pc->mutex);
 	g_free(pc);
-	pc = NULL;
 }
 
 janus_ice_peerconnection_medium *janus_ice_peerconnection_medium_create(janus_ice_handle *handle, janus_media_type type) {
@@ -1998,8 +1998,8 @@ static void janus_ice_peerconnection_medium_free(const janus_refcount *medium_re
 		janus_seq_list_free(&medium->last_seqs[1]);
 	if(medium->last_seqs[2])
 		janus_seq_list_free(&medium->last_seqs[2]);
+	janus_mutex_destroy(&medium->mutex);
 	g_free(medium);
-	//~ janus_mutex_unlock(&handle->mutex);
 }
 
 /* Call plugin slow_link callback if a minimum of lost packets are detected within a second */

--- a/src/janus.c
+++ b/src/janus.c
@@ -639,7 +639,7 @@ static janus_callbacks janus_handler_plugin =
 
 
 /* Core Sessions */
-static janus_mutex sessions_mutex;
+static janus_mutex sessions_mutex = JANUS_MUTEX_INITIALIZER;
 static GHashTable *sessions = NULL;
 static GMainContext *sessions_watchdog_context = NULL;
 
@@ -663,6 +663,7 @@ static void janus_session_free(const janus_refcount *session_ref) {
 		janus_request_destroy(session->source);
 		session->source = NULL;
 	}
+	janus_mutex_destroy(&session->mutex);
 	g_free(session);
 }
 
@@ -5472,7 +5473,6 @@ gint main(int argc, char *argv[]) {
 
 	/* Sessions */
 	sessions = g_hash_table_new_full(g_int64_hash, g_int64_equal, (GDestroyNotify)g_free, NULL);
-	janus_mutex_init(&sessions_mutex);
 	/* Start the sessions timeout watchdog */
 	sessions_watchdog_context = g_main_context_new();
 	GMainLoop *watchdog_loop = g_main_loop_new(sessions_watchdog_context, FALSE);

--- a/src/loggers/janus_jsonlog.c
+++ b/src/loggers/janus_jsonlog.c
@@ -16,7 +16,6 @@
 
 #include "../debug.h"
 #include "../config.h"
-#include "../mutex.h"
 #include "../utils.h"
 
 
@@ -69,9 +68,8 @@ janus_logger *create(void) {
 
 /* Useful stuff */
 static volatile gint initialized = 0, stopping = 0;
-static GThread *logger_thread;
+static GThread *logger_thread = NULL;
 static void *janus_jsonlog_thread(void *data);
-static janus_mutex logger_mutex;
 
 /* JSON serialization options */
 static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
@@ -186,7 +184,6 @@ int janus_jsonlog_init(const char *server_name, const char *config_path) {
 
 	/* Initialize the log queue */
 	loglines = g_async_queue_new_full((GDestroyNotify) janus_jsonlog_line_free);
-	janus_mutex_init(&logger_mutex);
 
 	g_atomic_int_set(&initialized, 1);
 

--- a/src/plugins/janus_audiobridge.c
+++ b/src/plugins/janus_audiobridge.c
@@ -1948,6 +1948,9 @@ static void janus_audiobridge_participant_free(const janus_refcount *participant
 	janus_mutex_lock(&participant->pmutex);
 	janus_audiobridge_plainrtp_media_cleanup(&participant->plainrtp_media);
 	janus_mutex_unlock(&participant->pmutex);
+	janus_mutex_destroy(&participant->pmutex);
+	janus_mutex_destroy(&participant->qmutex);
+	janus_mutex_destroy(&participant->rec_mutex);
 	g_free(participant);
 }
 
@@ -2003,6 +2006,8 @@ static void janus_audiobridge_room_free(const janus_refcount *audiobridge_ref) {
 		g_hash_table_destroy(audiobridge->groups);
 	if(audiobridge->groups_byid)
 		g_hash_table_destroy(audiobridge->groups_byid);
+	janus_mutex_destroy(&audiobridge->mutex);
+	janus_mutex_destroy(&audiobridge->rtp_mutex);
 	g_free(audiobridge);
 }
 

--- a/src/plugins/janus_nosip.c
+++ b/src/plugins/janus_nosip.c
@@ -393,6 +393,8 @@ static void janus_nosip_session_free(const janus_refcount *session_ref) {
 	session->media.remote_video_ip = NULL;
 	janus_nosip_srtp_cleanup(session);
 	session->handle = NULL;
+	janus_mutex_destroy(&session->mutex);
+	janus_mutex_destroy(&session->rec_mutex);
 	g_free(session);
 	session = NULL;
 }

--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -1222,6 +1222,7 @@ static void janus_sip_session_free(const janus_refcount *session_ref) {
 		su_home_deinit(session->stack->s_home);
 		su_home_unref(session->stack->s_home);
 		g_free(session->stack->contact_header);
+		janus_mutex_destroy(&session->stack->smutex);
 		g_free(session->stack);
 		session->stack = NULL;
 	}
@@ -1298,6 +1299,8 @@ static void janus_sip_session_free(const janus_refcount *session_ref) {
 		session->incoming_header_prefixes = NULL;
 	}
 	janus_sip_srtp_cleanup(session);
+	janus_mutex_destroy(&session->mutex);
+	janus_mutex_destroy(&session->rec_mutex);
 	g_free(session);
 }
 

--- a/src/plugins/janus_textroom.c
+++ b/src/plugins/janus_textroom.c
@@ -732,6 +732,7 @@ static void janus_textroom_room_free(const janus_refcount *textroom_ref) {
 	g_hash_table_destroy(textroom->allowed);
 	if(textroom->history)
 		g_queue_free_full(textroom->history, (GDestroyNotify)g_free);
+	janus_mutex_destroy(&textroom->mutex);
 	g_free(textroom);
 }
 
@@ -745,6 +746,7 @@ static void janus_textroom_session_free(const janus_refcount *session_ref) {
 	janus_refcount_decrease(&session->handle->ref);
 	/* This session can be destroyed, free all the resources */
 	g_hash_table_destroy(session->rooms);
+	janus_mutex_destroy(&session->mutex);
 	g_free(session);
 }
 
@@ -762,6 +764,7 @@ static void janus_textroom_participant_free(const janus_refcount *participant_re
 	/* This participant can be destroyed, free all the resources */
 	g_free(participant->username);
 	g_free(participant->display);
+	janus_mutex_destroy(&participant->mutex);
 	g_free(participant);
 }
 

--- a/src/plugins/janus_videocall.c
+++ b/src/plugins/janus_videocall.c
@@ -415,6 +415,7 @@ static void janus_videocall_session_free(const janus_refcount *session_ref) {
 	janus_refcount_decrease(&session->handle->ref);
 	/* This session can be destroyed, free all the resources */
 	g_free(session->username);
+	janus_mutex_destroy(&session->mutex);
 	janus_mutex_destroy(&session->rid_mutex);
 	janus_mutex_destroy(&session->rec_mutex);
 	janus_rtp_simulcasting_cleanup(NULL, NULL, session->rid, NULL);

--- a/src/rtpfwd.c
+++ b/src/rtpfwd.c
@@ -18,7 +18,7 @@
 #include "utils.h"
 
 /* Local resources */
-static janus_mutex rtpfwds_mutex;
+static janus_mutex rtpfwds_mutex = JANUS_MUTEX_INITIALIZER;
 static GHashTable *rtpfwds = NULL;
 static gboolean ipv6_disabled = FALSE;
 /* RTCP stuff */
@@ -45,7 +45,6 @@ int janus_rtp_forwarders_init(void) {
 	/* Initialize the forwarders table and muted */
 	rtpfwds = g_hash_table_new_full(g_str_hash, g_str_equal,
 		(GDestroyNotify)g_free, (GDestroyNotify)janus_rtp_forwarder_unref);
-	janus_mutex_init(&rtpfwds_mutex);
 	/* Let's check if IPv6 is disabled, as we may need to know for forwarders */
 	int fd = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
 	if(fd < 0) {

--- a/src/sctp.c
+++ b/src/sctp.c
@@ -123,7 +123,7 @@ void janus_sctp_handle_notification(janus_sctp_association *sctp, union sctp_not
 
 /* We need to keep a map of associations with random IDs, as usrsctp will
  * use the pointer to our structures in the actual messages instead */
-static janus_mutex sctp_mutex;
+static janus_mutex sctp_mutex = JANUS_MUTEX_INITIALIZER;
 static GHashTable *sctp_ids = NULL;
 static void janus_sctp_association_unref(janus_sctp_association *sctp);
 
@@ -142,7 +142,6 @@ int janus_sctp_init(void) {
 #endif
 
 	/* Create a map of local IDs too, to map them to our SCTP associations */
-	janus_mutex_init(&sctp_mutex);
 	sctp_ids = g_hash_table_new_full(NULL, NULL, NULL, (GDestroyNotify)janus_sctp_association_unref);
 
 	return 0;

--- a/src/text2pcap.c
+++ b/src/text2pcap.c
@@ -328,5 +328,6 @@ void janus_text2pcap_free(janus_text2pcap *instance) {
 		return;
 	janus_text2pcap_close(instance);
 	g_free(instance->filename);
+	janus_mutex_destroy(&instance->mutex);
 	g_free(instance);
 }

--- a/src/transports/janus_http.c
+++ b/src/transports/janus_http.c
@@ -214,6 +214,7 @@ static void janus_http_session_free(const janus_refcount *session_ref) {
 			json_decref(event);
 		g_async_queue_unref(session->events);
 	}
+	janus_mutex_destroy(&session->mutex);
 	g_free(session);
 }
 
@@ -306,7 +307,7 @@ static gboolean enforce_cors = FALSE;
 /* REST and Admin/Monitor ACL list */
 static GList *janus_http_access_list = NULL, *janus_http_admin_access_list = NULL;
 static gboolean janus_http_check_xff = FALSE, janus_http_admin_check_xff = FALSE;
-static janus_mutex access_list_mutex;
+static janus_mutex access_list_mutex = JANUS_MUTEX_INITIALIZER;
 static void janus_http_allow_address(const char *ip, gboolean admin) {
 	if(ip == NULL)
 		return;

--- a/src/transports/janus_nanomsg.c
+++ b/src/transports/janus_nanomsg.c
@@ -25,7 +25,6 @@
 #include "../debug.h"
 #include "../apierror.h"
 #include "../config.h"
-#include "../mutex.h"
 #include "../utils.h"
 
 

--- a/src/transports/janus_websockets.c
+++ b/src/transports/janus_websockets.c
@@ -113,7 +113,7 @@ static gboolean notify_events = TRUE;
 #if (LWS_LIBRARY_VERSION_MAJOR >= 3)
 static GHashTable *clients = NULL, *writable_clients = NULL;
 #endif
-static janus_mutex writable_mutex;
+static janus_mutex writable_mutex = JANUS_MUTEX_INITIALIZER;
 
 /* JSON serialization options */
 static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
@@ -773,7 +773,6 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 	clients = g_hash_table_new(NULL, NULL);
 	writable_clients = g_hash_table_new(NULL, NULL);
 #endif
-	janus_mutex_init(&writable_mutex);
 
 	g_atomic_int_set(&initialized, 1);
 

--- a/src/transports/transport.c
+++ b/src/transports/transport.c
@@ -6,7 +6,7 @@
  * the gateway and all the transports need too implement to interact with
  * each other. The structures to make the communication possible are
  * defined here as well.
- * 
+ *
  * \ingroup transportapi
  * \ref transportapi
  */
@@ -18,6 +18,7 @@ static void janus_transport_session_free(const janus_refcount *transport_ref) {
 	/* This session can be destroyed, free all the resources */
 	if(session->p_free)
 		session->p_free(session->transport_p);
+	janus_mutex_destroy(&session->mutex);
 	g_free(session);
 }
 


### PR DESCRIPTION
As the title says, this is simply a cleanup of how we use mutexes, since there were instances were we called `janus_mutex_init()` that didn't have a corresponding `janus_mutex_destroy()`. For static mutexes, this PR now also changes those to always use a static initialization via `JANUS_MUTEX_INITIALIZER`.

This is basically a continuation of what was started (and discussed) in #3128, and mentioned again in [this post](https://janus.discourse.group/t/memory-leak-in-transport-session/1617/1) on the group. It's worth mentioning that, since we use GMutex by default (which uses Futex), this is unneeded in most cases, and should only be relevant for those setups that enable pthread mutexes instead.

While I plan to merge this soon, it should also be thoroughly tested, as we want to ensure it won't result in regressions due to, e.g., crashes after trying to lock a cleared mutex. I'll do the same cleanup in `0.x` after this is merged.