### PR TITLE
Listen for an optional signal handler for log rotation

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -14,6 +14,10 @@ general: {
 	#log_to_stdout = false					# Whether the Janus output should be written
 											# to stdout or not (default=true)
 	#log_to_file = "/path/to/janus.log"		# Whether to use a log file or not
+	#log_rotate_sig = "SIGUSR1"				# Signal to handle for log rotation, valid values
+											# are "SIGUSR1" and "SIGHUP".
+											# Default is no setting, which disables the
+											# signal handler for log rotation.
 	debug_level = 4							# Debug/logging level, valid values are 0-7
 	#debug_timestamps = true				# Whether to show a timestamp for each log line
 	#debug_colors = false					# Whether colors should be disabled in the log

--- a/src/janus.c
+++ b/src/janus.c
@@ -509,6 +509,7 @@ int janus_log_level = LOG_INFO;
 gboolean janus_log_timestamps = FALSE;
 gboolean janus_log_colors = FALSE;
 char *janus_log_global_prefix = NULL;
+int janus_log_rotate_sig = 0;
 int lock_debug = 0;
 #ifdef REFCOUNT_DEBUG
 int refcount_debug = 1;
@@ -517,8 +518,16 @@ int refcount_debug = 0;
 #endif
 
 
-/*! \brief Signal handler (just used to intercept CTRL+C and SIGTERM) */
+/*! \brief Signal handler (just used to intercept CTRL+C, SIGTERM and SIGUSR1) */
 static void janus_handle_signal(int signum) {
+	if(signum == janus_log_rotate_sig && janus_log_rotate_sig > 0) {
+		if(stop_signal > 0)
+			/* Skip log rotation while stopping */
+			return;
+		janus_log_reload();
+		return;
+	}
+	/* If we got here it's either a SIGINT or a SIGTERM */
 	stop_signal = signum;
 	switch(g_atomic_int_get(&stop)) {
 		case 0:
@@ -2194,6 +2203,7 @@ int janus_process_incoming_admin_request(janus_request *request) {
 			json_object_set_new(status, "log_level", json_integer(janus_log_level));
 			json_object_set_new(status, "log_timestamps", janus_log_timestamps ? json_true() : json_false());
 			json_object_set_new(status, "log_colors", janus_log_colors ? json_true() : json_false());
+			json_object_set_new(status, "log_rotate_sig", json_integer(janus_log_rotate_sig));
 			json_object_set_new(status, "locking_debug", lock_debug ? json_true() : json_false());
 			json_object_set_new(status, "refcount_debug", refcount_debug ? json_true() : json_false());
 			json_object_set_new(status, "libnice_debug", janus_ice_is_ice_debugging_enabled() ? json_true() : json_false());
@@ -4548,6 +4558,30 @@ gint main(int argc, char *argv[]) {
 		janus_config_item *item = janus_config_get(config, config_general, janus_config_type_item, "log_to_file");
 		if(item && item->value)
 			logfile = item->value;
+	}
+
+	/* Set an optional signal handler for log rotation */
+	const char *log_rotate_sig = NULL;
+	if(options.log_rotate_sig) {
+		log_rotate_sig = options.log_rotate_sig;
+		janus_config_add(config, config_general, janus_config_item_create("log_rotate_sig", log_rotate_sig));
+	} else {
+		janus_config_item *item = janus_config_get(config, config_general, janus_config_type_item, "log_rotate_sig");
+		if(item && item->value)
+			log_rotate_sig = item->value;
+	}
+	if(log_rotate_sig != NULL) {
+		if(!strcasecmp(log_rotate_sig, "SIGUSR1")) {
+			janus_log_rotate_sig = SIGUSR1;
+		} else if(!strcasecmp(log_rotate_sig, "SIGHUP")) {
+			janus_log_rotate_sig = SIGHUP;
+		} else {
+			JANUS_LOG(LOG_WARN, "Unsupported signal for log rotation: %s\n", log_rotate_sig);
+		}
+		if(janus_log_rotate_sig > 0) {
+			JANUS_LOG(LOG_INFO, "Setting signal for log rotation: %s (%d)\n", log_rotate_sig, janus_log_rotate_sig);
+			signal(janus_log_rotate_sig, janus_handle_signal);
+		}
 	}
 
 	/* Check if we're going to daemonize Janus */

--- a/src/log.h
+++ b/src/log.h
@@ -33,6 +33,8 @@ void janus_vprintf(const char *format, ...) G_GNUC_PRINTF(1, 2);
 * @param loggers Hash table of external loggers registered in the core, if any
 * @returns 0 in case of success, a negative integer otherwise */
 int janus_log_init(gboolean daemon, gboolean console, const char *logfile, GHashTable *loggers);
+/*! \brief Reopen log file (log rotation) */
+void janus_log_reload(void);
 /*! \brief Log destruction */
 void janus_log_destroy(void);
 

--- a/src/options.c
+++ b/src/options.c
@@ -21,6 +21,7 @@ gboolean janus_options_parse(janus_options *options, int argc, char *argv[]) {
 		{ "disable-stdout", 'N', 0, G_OPTION_ARG_NONE, &options->disable_stdout, "Disable stdout based logging", NULL },
 		{ "log-stdout", 0, 0, G_OPTION_ARG_NONE, &options->log_stdout, "Log to stdout, even when the process is daemonized", NULL },
 		{ "log-file", 'L', 0, G_OPTION_ARG_STRING, &options->log_file, "Log to the specified file (default=stdout only)", "path" },
+		{ "log-rotate-sig", 'R', 0, G_OPTION_ARG_STRING, &options->log_rotate_sig, "Signal to trigger log reloading (e.g. SIGUSR1) (default=none)", "signal" },
 		{ "cwd-path", 'H', 0, G_OPTION_ARG_STRING, &options->cwd_path, "Working directory for Janus daemon process (default=/)", "path" },
 		{ "interface", 'i', 0, G_OPTION_ARG_STRING, &options->interface, "Interface to use (will be the public IP)", "ipaddress" },
 		{ "plugins-folder", 'P', 0, G_OPTION_ARG_STRING, &options->plugins_folder, "Plugins folder (default=./plugins)", "path" },

--- a/src/options.h
+++ b/src/options.h
@@ -20,6 +20,7 @@ typedef struct janus_options {
 	gboolean disable_stdout;
 	gboolean log_stdout;
 	const char *log_file;
+	const char *log_rotate_sig;
 	const char *cwd_path;
 	const char *interface;
 	const char *plugins_folder;


### PR DESCRIPTION
See #3548 for context.

Add a CLI parameter "--log-rotate-sig" / "-R" and a jcfg option "log_rotate_sig" to setup a signal handler used for log rotation.
The only supported values are "SIGUSR1" and "SIGHUP" for now.
The handler will reload (flush, close, open) the log file when receiving the signal.
By default the option is unset, which disables the signal handler for log rotation.