### PR TITLE
Refactor keyframe buffering in Streaming plugin to store following deltas too

### DIFF
--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -1,3 +1,14 @@
+# You can configure static mountpoints that should be made available
+# when Janus starts in this configuration file. The syntax and the
+# available properties are listed below. Notice that, for the sake of
+# simplicity, only the global and legacy properties are listed in the
+# following text: you can use the new stream-based syntax as well (see
+# the 'multistream-test' example below for reference), but in that case
+# all properties whose names start with audio/video/data should be
+# renamed to have that prefix removed. Please refer to the Streaming
+# plugin documentation for more details, as the static configuration
+# in that case mirrors the dynamic API syntax.
+#
 # stream-name: {
 # type = rtp|live|ondemand|rtsp
 #        rtp = stream originated by an external tool (e.g., gstreamer or
@@ -36,8 +47,6 @@
 # videoiface = network interface or IP address to bind to, if any (binds to all otherwise)
 # videopt = <video RTP payload type> (e.g., 100)
 # videocodec = name of the video codec (e.g., vp8)
-# videobufferkf = true|false (whether the plugin should store the latest
-#		keyframe and send it immediately for new viewers, EXPERIMENTAL)
 # videosimulcast = true|false (do|don't enable video simulcasting)
 # videoport2 = second local port for receiving video frames (only for rtp, and simulcasting)
 # videoport3 = third local port for receiving video frames (only for rtp, and simulcasting)
@@ -58,6 +67,39 @@
 # threads = number of threads to assist with the relaying part, which can help
 #		if you expect a lot of viewers that may cause the RTP receiving part
 #		in the Streaming plugin to slow down and fail to catch up (default=0)
+#
+# Note: by default, the Streaming plugin only forwards the latest packets
+# it receives, never performing any buffering. This means that, for video
+# streams, new viewers may initially start receiving frames they cannot
+# decode right away, since they'd refer to keyframes that were sent before
+# they joined. In such scenarios, they'd have to wait until the next keyframe
+# arrives before video can be decoded and displayed, which could take a
+# while depending on the frequency of keyframes encoded by the source.
+# For forwarded streams (e.g., from the VideoRoom) this can be easily
+# addressed by using the RTCP support. For sources that can't or won't
+# honour dynamic keyframe requests, a partial and experimental solution
+# might be storing the latest keyframe and the following deltas, to send
+# to new viewers before new live packet are delivered. This feature can
+# be enabled in the Streaming plugin using the 'bufferkf_ms' and/or
+# the 'bufferkf_bytes' properties, which configure how many milliseconds
+# or how many bytes (in total) should be stored any time a keyframe is
+# received: data exceeding those limits won't be stored, until a new
+# keyframe arrives. The two properties are not mutually exclusive, and
+# can be configured at the same time: in that case, the first one that
+# hits the limit stops the buffering of the current keyframe. Notice
+# that, again, this feature should be considered highly experimental,
+# and that it comes with a few considerable drawbacks: the most obvious
+# one is that, depending on how many packets were stored, new viewers
+# may be hit with a considerable burst of data as soon as they connect,
+# which may negatively impact performance or even cause issues of its own.
+# Also notice that this is a global, and not per-stream, feature: this
+# means that if you create a mountpoint with two video streams, the
+# feature will impact both of them, and both streams will have a buffer
+# of their own. This also works for RTSP mountpoints.
+#	bufferkf_ms = how many milliseconds of packets to store, starting
+#					from a new keyframe (default=0)
+#	bufferkf_bytes = how many bytes of packets to store, starting
+#					from a new keyframe (default=0)
 #
 # In case you want to use SRTP for your RTP-based mountpoint, you'll need
 # to configure the SRTP-related properties as well, namely the suite to

--- a/src/plugins/janus_streaming.c
+++ b/src/plugins/janus_streaming.c
@@ -55,7 +55,14 @@ stream-name: {
 }
 \endverbatim
  *
- * with the allowed settings listed below:
+ * with the allowed settings listed below. Notice that, for the sake of
+ * simplicity, only the global and legacy properties are listed in the
+ * following text: you can use the new stream-based syntax as well (see
+ * the 'multistream-test' example below for reference), but in that case
+ * all properties whose names start with audio/video/data should be
+ * renamed to have that prefix removed. Please refer to the plugin API
+ * documentation for more details, as the static configuration in that
+ * case mirrors the dynamic API syntax.
  *
  * \verbatim
 type = rtp|live|ondemand|rtsp
@@ -96,8 +103,6 @@ videoiface = network interface or IP address to bind to, if any (binds to all ot
 videopt = <video RTP payload type> (e.g., 100)
 videocodec = name of the video codec (vp8)
 videofmtp = Codec specific parameters, if any
-videobufferkf = true|false (whether the plugin should store the latest
-	keyframe and send it immediately for new viewers, EXPERIMENTAL)
 videosimulcast = true|false (do|don't enable video simulcasting)
 videoport2 = second local port for receiving video frames (only for rtp, and simulcasting)
 videoport3 = third local port for receiving video frames (only for rtp, and simulcasting)
@@ -119,6 +124,39 @@ databuffermsg = true|false (whether the plugin should store the latest
 threads = number of threads to assist with the relaying part, which can help
 	if you expect a lot of viewers that may cause the RTP receiving part
 	in the Streaming plugin to slow down and fail to catch up (default=0)
+
+Note: by default, the Streaming plugin only forwards the latest packets
+it receives, never performing any buffering. This means that, for video
+streams, new viewers may initially start receiving frames they cannot
+decode right away, since they'd refer to keyframes that were sent before
+they joined. In such scenarios, they'd have to wait until the next keyframe
+arrives before video can be decoded and displayed, which could take a
+while depending on the frequency of keyframes encoded by the source.
+For forwarded streams (e.g., from the VideoRoom) this can be easily
+addressed by using the RTCP support. For sources that can't or won't
+honour dynamic keyframe requests, a partial and experimental solution
+might be storing the latest keyframe and the following deltas, to send
+to new viewers before new live packet are delivered. This feature can
+be enabled in the Streaming plugin using the 'bufferkf_ms' and/or
+the 'bufferkf_bytes' properties, which configure how many milliseconds
+or how many bytes (in total) should be stored any time a keyframe is
+received: data exceeding those limits won't be stored, until a new
+keyframe arrives. The two properties are not mutually exclusive, and
+can be configured at the same time: in that case, the first one that
+hits the limit stops the buffering of the current keyframe. Notice
+that, again, this feature should be considered highly experimental,
+and that it comes with a few considerable drawbacks: the most obvious
+one is that, depending on how many packets were stored, new viewers
+may be hit with a considerable burst of data as soon as they connect,
+which may negatively impact performance or even cause issues of its own.
+Also notice that this is a global, and not per-stream, feature: this
+means that if you create a mountpoint with two video streams, the
+feature will impact both of them, and both streams will have a buffer
+of their own. This also works for RTSP mountpoints.
+	bufferkf_ms = how many milliseconds of packets to store, starting
+		from a new keyframe (default=0)
+	bufferkf_bytes = how many bytes of packets to store, starting
+		from a new keyframe (default=0)
 
 In case you want to use SRTP for your RTP-based mountpoint, you'll need
 to configure the SRTP-related properties as well, namely the suite to
@@ -1067,6 +1105,8 @@ static struct janus_json_parameter create_parameters[] = {
 };
 static struct janus_json_parameter rtp_parameters[] = {
 	{"collision", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"bufferkf_ms", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"bufferkf_bytes", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"threads", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"srtpsuite", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"srtpcrypto", JSON_STRING, 0},
@@ -1105,7 +1145,9 @@ static struct janus_json_parameter rtsp_parameters[] = {
 	{"videortpmap", JSON_STRING, 0},	/* Deprecated */
 	{"videofmtp", JSON_STRING, 0},
 	{"videopt", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
-	{"videobufferkf", JANUS_JSON_BOOL, 0},
+	{"videobufferkf", JANUS_JSON_BOOL, 0},	/* Deprecated for the properties below */
+	{"bufferkf_ms", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"bufferkf_bytes", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"threads", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"rtspiface", JSON_STRING, 0},
 	{"rtsp_failcheck", JANUS_JSON_BOOL, 0}
@@ -1126,7 +1168,7 @@ static struct janus_json_parameter rtp_media_parameters[] = {
 	{"fmtp", JANUS_JSON_STRING, 0},
 	{"skew", JANUS_JSON_BOOL, 0},
 	/* Video only */
-	{"bufferkf", JANUS_JSON_BOOL, 0},
+	{"bufferkf", JANUS_JSON_BOOL, 0},	/* Deprecated: see global bufferkf_ms and bufferkf_bytes */
 	{"simulcast", JANUS_JSON_BOOL, 0},
 	{"port2", JANUS_JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"port3", JANUS_JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
@@ -1158,7 +1200,7 @@ static struct janus_json_parameter rtp_video_parameters[] = {
 	{"videocodec", JSON_STRING, 0},
 	{"videortpmap", JSON_STRING, 0},	/* Deprecated */
 	{"videofmtp", JSON_STRING, 0},
-	{"videobufferkf", JANUS_JSON_BOOL, 0},
+	{"videobufferkf", JANUS_JSON_BOOL, 0},	/* Deprecated: see global bufferkf_ms and bufferkf_bytes */
 	{"videoiface", JSON_STRING, 0},
 	{"videosimulcast", JANUS_JSON_BOOL, 0},
 	{"videoport2", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
@@ -1273,11 +1315,15 @@ typedef enum janus_streaming_source {
 
 typedef struct janus_streaming_rtp_keyframe {
 	gboolean enabled;
-	/* If enabled, we store the packets of the last keyframe, to immediately send them for new viewers */
+	uint16_t bufferkf_ms;
+	uint32_t bufferkf_bytes;
+	/* If enabled, we store the packets of the last keyframe plus the
+	 * following deltas (assuming they are within the ms/bytes limits),
+	 * so that we can send them as a burst for new viewers */
 	GList *latest_keyframe;
-	/* This is where we store packets while we're still collecting the whole keyframe */
-	GList *temp_keyframe;
-	guint32 temp_ts;
+	uint32_t kf_ssrc, kf_ts, kf_bytes;
+	int64_t kf_start;
+	gboolean first_ts;
 	janus_mutex mutex;
 } janus_streaming_rtp_keyframe;
 
@@ -1288,7 +1334,7 @@ typedef struct janus_streaming_rtp_relay_packet {
 	gboolean is_rtp;	/* This may be a data packet and not RTP */
 	gboolean is_data;
 	gboolean is_video;
-	gboolean is_keyframe;
+	gboolean is_kfburst;
 	gboolean simulcast;
 	uint32_t ssrc[3];
 	janus_videocodec codec;
@@ -1346,7 +1392,7 @@ typedef struct janus_streaming_rtp_source {
 	gint64 ka_timeout;
 	char *rtsp_ahost, *rtsp_vhost;
 	janus_streaming_codecs rtsp_acodecs, rtsp_vcodecs;
-	gboolean rtsp_bufferkf, reconnecting;
+	gboolean reconnecting;
 	gint64 reconnect_timer;
 	gint64 reconnect_delay;
 	gint64 session_timeout;
@@ -1354,6 +1400,9 @@ typedef struct janus_streaming_rtp_source {
 	int rtsp_conn_timeout;
 	janus_mutex rtsp_mutex;
 #endif
+	/* Optional keyframe (and deltas) buffering */
+	uint16_t bufferkf_ms;
+	uint32_t bufferkf_bytes;
 	/* Only needed for SRTP support */
 	gboolean is_srtp;
 	int srtpsuite;
@@ -1511,11 +1560,12 @@ janus_streaming_rtp_source_stream *janus_streaming_create_rtp_source_stream(
 		char *mcast, char *miface, const janus_network_address *iface,
 		uint16_t port, uint16_t port2, uint16_t port3, gboolean dortcp, uint16_t rtcpport,
 		uint8_t pt, char *codec, char *fmtp, char *sprop,
-		gboolean doskew, gboolean bufferkf, gboolean simulcast, gboolean svc,
+		gboolean doskew, uint16_t bufferkf_ms, uint32_t bufferkf_bytes, gboolean simulcast, gboolean svc,
 		gboolean textdata, gboolean buffermsg);
 janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 		uint64_t id, char *id_str, char *name, char *desc, char *metadata,
 		GList *media, int srtpsuite, char *srtpcrypto, int threads, int rtp_collision,
+		uint16_t bufferkf_ms, uint32_t bufferkf_bytes,
 		gboolean e2ee, gboolean playoutdelay_ext, int abscapturetime_src_ext_id);
 /* Helper to create a file/ondemand live source */
 janus_streaming_mountpoint *janus_streaming_create_file_source(
@@ -1526,7 +1576,8 @@ janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 		uint64_t id, char *id_str, char *name, char *desc, char *metadata,
 		char *url, char *username, char *password,
 		gboolean quirk, gboolean doaudio, int audiopt, char *acodec, char *afmtp,
-		gboolean dovideo, int videopt, char *vcodec, char *vfmtp, gboolean bufferkf,
+		gboolean dovideo, int videopt, char *vcodec, char *vfmtp,
+		uint16_t bufferkf_ms, uint32_t bufferkf_bytes,
 		const janus_network_address *iface, int threads,
 		gint64 reconnect_delay, gint64 session_timeout, int rtsp_timeout, int rtsp_conn_timeout,
 		gboolean error_on_failure);
@@ -2133,6 +2184,8 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				janus_config_item *pin = janus_config_get(config, cat, janus_config_type_item, "pin");
 				janus_config_item *media = janus_config_get(config, cat, janus_config_type_array, "media");
 				janus_config_item *rtpcollision = janus_config_get(config, cat, janus_config_type_item, "collision");
+				janus_config_item *vkf_ms = janus_config_get(config, cat, janus_config_type_item, "bufferkf_ms");
+				janus_config_item *vkf_bytes = janus_config_get(config, cat, janus_config_type_item, "bufferkf_bytes");
 				janus_config_item *threads = janus_config_get(config, cat, janus_config_type_item, "threads");
 				janus_config_item *ssuite = janus_config_get(config, cat, janus_config_type_item, "srtpsuite");
 				janus_config_item *scrypto = janus_config_get(config, cat, janus_config_type_item, "srtpcrypto");
@@ -2147,6 +2200,18 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				}
 				if(rtpcollision && rtpcollision->value && atoi(rtpcollision->value) < 0) {
 					JANUS_LOG(LOG_ERR, "Can't add 'rtp' mountpoint '%s', invalid collision configuration...\n", cat->name);
+					cl = cl->next;
+					continue;
+				}
+				uint16_t bufferkf_ms = 0;
+				if(vkf_ms && vkf_ms->value && janus_string_to_uint16(vkf_ms->value, &bufferkf_ms) < 0) {
+					JANUS_LOG(LOG_ERR, "Can't add 'rtp' mountpoint '%s', invalid bufferkf_ms configuration...\n", cat->name);
+					cl = cl->next;
+					continue;
+				}
+				uint32_t bufferkf_bytes = 0;
+				if(vkf_bytes && vkf_bytes->value && janus_string_to_uint32(vkf_bytes->value, &bufferkf_bytes) < 0) {
+					JANUS_LOG(LOG_ERR, "Can't add 'rtp' mountpoint '%s', invalid bufferkf_bytes configuration...\n", cat->name);
 					cl = cl->next;
 					continue;
 				}
@@ -2168,6 +2233,8 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				if(media != NULL) {
 					/* We're using the new media-based configuration, iterate on all media objects */
 					gboolean failed = FALSE;
+					uint16_t s_bufferkf_ms = 0;
+					uint32_t s_bufferkf_bytes = 0;
 					GList *ml = media->list;
 					while(ml) {
 						janus_config_item *m = (janus_config_item *)ml->data;
@@ -2220,12 +2287,17 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 						janus_config_item *skew = janus_config_get(config, m, janus_config_type_item, "skew");
 						gboolean doskew = skew && skew->value && janus_is_true(skew->value);
 						gboolean dosvc = video && vsvc && vsvc->value && janus_is_true(vsvc->value);
-						gboolean bufferkf = video && vkf && vkf->value && janus_is_true(vkf->value);
+						if(video && vkf && vkf->value && janus_is_true(vkf->value)) {
+							JANUS_LOG(LOG_WARN, "The bufferkf property has been deprecated, please refer to bufferkf_ms and/or bufferkf_bytes\n");
+						}
+						s_bufferkf_ms = video ? bufferkf_ms : 0;
+						s_bufferkf_bytes = video ? bufferkf_bytes : 0;
 						gboolean simulcast = video && vsc && vsc->value && janus_is_true(vsc->value);
-						if(simulcast && bufferkf) {
+						if(simulcast && (s_bufferkf_ms || s_bufferkf_bytes)) {
 							/* FIXME We'll need to take care of this */
-							JANUS_LOG(LOG_WARN, "Simulcasting enabled, so disabling buffering of keyframes\n");
-							bufferkf = FALSE;
+							JANUS_LOG(LOG_WARN, "Simulcasting enabled, so disabling buffering of keyframes for this stream\n");
+							s_bufferkf_ms = 0;
+							s_bufferkf_bytes = 0;
 						}
 						gboolean buffermsg = data && dbm && dbm->value && janus_is_true(dbm->value);
 						gboolean textdata = TRUE;
@@ -2286,7 +2358,8 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 							(char *)streamcodec,
 							fmtp ? (char *)fmtp->value : NULL,
 							vsps ? (char *)vsps->value : NULL,
-							doskew, bufferkf, simulcast, dosvc, textdata, buffermsg);
+							doskew, s_bufferkf_ms, s_bufferkf_bytes,
+							simulcast, dosvc, textdata, buffermsg);
 						if(stream == NULL) {
 							JANUS_LOG(LOG_ERR, "Can't add '%s' stream '%s', error creating source stream...\n", type->value, cat->name);
 							failed = TRUE;
@@ -2343,12 +2416,15 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					gboolean dovskew = video && vskew && vskew->value && janus_is_true(vskew->value);
 					gboolean dosvc = video && vsvc && vsvc->value && janus_is_true(vsvc->value);
 					gboolean dodata = data && data->value && janus_is_true(data->value);
-					gboolean bufferkf = video && vkf && vkf->value && janus_is_true(vkf->value);
+					if(video && vkf && vkf->value && janus_is_true(vkf->value)) {
+						JANUS_LOG(LOG_WARN, "The videobufferkf property has been deprecated, please refer to bufferkf_ms and/or bufferkf_bytes\n");
+					}
 					gboolean simulcast = video && vsc && vsc->value && janus_is_true(vsc->value);
-					if(simulcast && bufferkf) {
+					if(simulcast && (bufferkf_ms > 0 || bufferkf_bytes > 0)) {
 						/* FIXME We'll need to take care of this */
-						JANUS_LOG(LOG_WARN, "Simulcasting enabled, so disabling buffering of keyframes\n");
-						bufferkf = FALSE;
+						JANUS_LOG(LOG_WARN, "Simulcasting enabled, so disabling buffering of keyframes for this stream\n");
+						bufferkf_ms = 0;
+						bufferkf_bytes = 0;
 					}
 					gboolean buffermsg = data && dbm && dbm->value && janus_is_true(dbm->value);
 					gboolean textdata = TRUE;
@@ -2488,7 +2564,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 							(apt && apt->value) ? atoi(apt->value) : 0,
 							(char *)audiocodec,
 							afmtp ? (char *)afmtp->value : NULL, NULL,
-							doaskew, FALSE, FALSE, FALSE, FALSE, FALSE);
+							doaskew, 0, 0, FALSE, FALSE, FALSE, FALSE);
 						if(stream == NULL) {
 							JANUS_LOG(LOG_ERR, "Skipping 'audio' stream '%s', error creating source stream...\n", cat->name);
 							g_list_free_full(streams, (GDestroyNotify)(janus_streaming_rtp_source_stream_unref));
@@ -2514,7 +2590,8 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 							(char *)videocodec,
 							vfmtp ? (char *)vfmtp->value : NULL,
 							vsps ? (char *)vsps->value : NULL,
-							dovskew, bufferkf, simulcast, dosvc, FALSE, FALSE);
+							dovskew, bufferkf_ms, bufferkf_bytes,
+							simulcast, dosvc, FALSE, FALSE);
 						if(stream == NULL) {
 							JANUS_LOG(LOG_ERR, "Skipping 'video' stream '%s', error creating source stream...\n", cat->name);
 							g_list_free_full(streams, (GDestroyNotify)(janus_streaming_rtp_source_stream_unref));
@@ -2535,7 +2612,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 							(dport && dport->value) ? atoi(dport->value) : 0,
 							0, 0, FALSE, 0,
 							0, NULL, NULL, NULL,
-							FALSE, FALSE, FALSE, FALSE, textdata, buffermsg);
+							FALSE, 0, 0, FALSE, FALSE, textdata, buffermsg);
 						if(stream == NULL) {
 							JANUS_LOG(LOG_ERR, "Skipping 'data' stream '%s', error creating source stream...\n", cat->name);
 							g_list_free_full(streams, (GDestroyNotify)(janus_streaming_rtp_source_stream_unref));
@@ -2558,6 +2635,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 						scrypto && scrypto->value ? (char *)scrypto->value : NULL,
 						(threads && threads->value) ? atoi(threads->value) : 0,
 						(rtpcollision && rtpcollision->value) ?  atoi(rtpcollision->value) : 0,
+						bufferkf_ms, bufferkf_bytes,
 						(e2ee && e2ee->value) ? janus_is_true(e2ee->value) : FALSE,
 						(pd && pd->value) ? janus_is_true(pd->value) : FALSE,
 						abscaptime_src_id_int)) == NULL) {
@@ -2744,6 +2822,8 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				janus_config_item *vrtpmap = janus_config_get(config, cat, janus_config_type_item, "videortpmap");
 				janus_config_item *vfmtp = janus_config_get(config, cat, janus_config_type_item, "videofmtp");
 				janus_config_item *vkf = janus_config_get(config, cat, janus_config_type_item, "videobufferkf");
+				janus_config_item *vkf_ms = janus_config_get(config, cat, janus_config_type_item, "bufferkf_ms");
+				janus_config_item *vkf_bytes = janus_config_get(config, cat, janus_config_type_item, "bufferkf_bytes");
 				janus_config_item *iface = janus_config_get(config, cat, janus_config_type_item, "rtspiface");
 				janus_config_item *failerr = janus_config_get(config, cat, janus_config_type_item, "rtsp_failcheck");
 				janus_config_item *threads = janus_config_get(config, cat, janus_config_type_item, "threads");
@@ -2761,7 +2841,21 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				gboolean rtsp_quirk = quirk && quirk->value && janus_is_true(quirk->value);
 				gboolean doaudio = audio && audio->value && janus_is_true(audio->value);
 				gboolean dovideo = video && video->value && janus_is_true(video->value);
-				gboolean bufferkf = video && vkf && vkf->value && janus_is_true(vkf->value);
+				if(video && vkf && vkf->value && janus_is_true(vkf->value)) {
+					JANUS_LOG(LOG_WARN, "The videobufferkf property has been deprecated, please refer to bufferkf_ms and/or bufferkf_bytes\n");
+				}
+				uint16_t bufferkf_ms = 0;
+				if(vkf_ms && vkf_ms->value && janus_string_to_uint16(vkf_ms->value, &bufferkf_ms) < 0) {
+					JANUS_LOG(LOG_ERR, "Can't add 'rtsp' mountpoint '%s', invalid bufferkf_ms configuration...\n", cat->name);
+					cl = cl->next;
+					continue;
+				}
+				uint32_t bufferkf_bytes = 0;
+				if(vkf_bytes && vkf_bytes->value && janus_string_to_uint32(vkf_bytes->value, &bufferkf_bytes) < 0) {
+					JANUS_LOG(LOG_ERR, "Can't add 'rtsp' mountpoint '%s', invalid bufferkf_bytes configuration...\n", cat->name);
+					cl = cl->next;
+					continue;
+				}
 				gboolean error_on_failure = TRUE;
 				if(failerr && failerr->value)
 					error_on_failure = janus_is_true(failerr->value);
@@ -2815,7 +2909,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 						(vpt && vpt->value) ? atoi(vpt->value) : -1,
 						(char *)videocodec,
 						vfmtp ? (char *)vfmtp->value : NULL,
-						bufferkf,
+						bufferkf_ms, bufferkf_bytes,
 						iface && iface->value ? &iface_value : NULL,
 						(threads && threads->value) ? atoi(threads->value) : 0,
 						((reconnect_delay && reconnect_delay->value) ? atoi(reconnect_delay->value) : JANUS_STREAMING_DEFAULT_RECONNECT_DELAY) * G_USEC_PER_SEC,
@@ -3266,6 +3360,12 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 			}
 			if(source->rtp_collision > 0)
 				json_object_set_new(ml, "collision", json_integer(source->rtp_collision));
+			if(source->bufferkf_ms > 0) {
+				json_object_set_new(ml, "bufferkf_ms", json_integer(source->bufferkf_ms));
+			}
+			if(source->bufferkf_bytes > 0) {
+				json_object_set_new(ml, "bufferkf_bytes", json_integer(source->bufferkf_bytes));
+			}
 			if(mp->helper_threads > 0)
 				json_object_set_new(ml, "threads", json_integer(mp->helper_threads));
 			/* Iterate on media now */
@@ -3300,9 +3400,6 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 				}
 				if(stream->codecs.fmtp)
 					json_object_set_new(info, "fmtp", json_string(stream->codecs.fmtp));
-				if(stream->keyframe.enabled) {
-					json_object_set_new(info, "videobufferkf", json_true());
-				}
 				if(stream->simulcast) {
 					json_object_set_new(info, "videosimulcast", json_true());
 				}
@@ -3450,6 +3547,8 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 			json_t *md = json_object_get(root, "metadata");
 			json_t *is_private = json_object_get(root, "is_private");
 			json_t *rtpcollision = json_object_get(root, "collision");
+			json_t *vkf_ms = json_object_get(root, "bufferkf_ms");
+			json_t *vkf_bytes = json_object_get(root, "bufferkf_bytes");
 			json_t *threads = json_object_get(root, "threads");
 			json_t *ssuite = json_object_get(root, "srtpsuite");
 			json_t *scrypto = json_object_get(root, "srtpcrypto");
@@ -3465,6 +3564,26 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 				janus_mutex_unlock(&mountpoints_mutex);
 				goto prepare_response;
 			}
+			if(vkf_ms && json_integer_value(vkf_ms) > UINT16_MAX) {
+				JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream, invalid bufferkf_ms value...\n");
+				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
+				g_snprintf(error_cause, 512, "Can't add 'rtp' stream, invalid bufferkf_ms value...");
+				janus_mutex_lock(&mountpoints_mutex);
+				g_hash_table_remove(mountpoints_temp, string_ids ? (gpointer)mpid_str : (gpointer)&mpid);
+				janus_mutex_unlock(&mountpoints_mutex);
+				goto prepare_response;
+			}
+			uint16_t bufferkf_ms = vkf_ms ? json_integer_value(vkf_ms) : 0;
+			if(vkf_bytes && json_integer_value(vkf_bytes) > UINT32_MAX) {
+				JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream, invalid bufferkf_bytes value...\n");
+				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
+				g_snprintf(error_cause, 512, "Can't add 'rtp' stream, invalid bufferkf_bytes value...");
+				janus_mutex_lock(&mountpoints_mutex);
+				g_hash_table_remove(mountpoints_temp, string_ids ? (gpointer)mpid_str : (gpointer)&mpid);
+				janus_mutex_unlock(&mountpoints_mutex);
+				goto prepare_response;
+			}
+			uint32_t bufferkf_bytes = vkf_bytes ? json_integer_value(vkf_bytes) : 0;
 			if(ssuite && json_integer_value(ssuite) != 32 && json_integer_value(ssuite) != 80) {
 				JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream, invalid SRTP suite...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
@@ -3478,6 +3597,8 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 			GList *streams = NULL;
 			/* How are we adding media? */
 			if(media != NULL) {
+				uint16_t s_bufferkf_ms = 0;
+				uint32_t s_bufferkf_bytes = 0;
 				/* We're using the new media-based configuration, iterate on all media objects */
 				if(json_array_size(media) == 0) {
 					JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream, no audio, video or data have to be streamed...\n");
@@ -3505,7 +3626,7 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 					uint16_t rtcpport = 0;
 					uint8_t pt = 0;
 					char *mtype = NULL, *mid = NULL, *label = NULL, *msid = NULL, *codec = NULL, *fmtp = NULL, *sps = NULL, *mcast = NULL, *miface = NULL;
-					gboolean doskew = FALSE, bufferkf = FALSE, simulcast = FALSE, dosvc = FALSE, textdata = TRUE, buffermsg = FALSE;
+					gboolean doskew = FALSE, simulcast = FALSE, dosvc = FALSE, textdata = TRUE, buffermsg = FALSE;
 					json_t *jmtype = json_object_get(m, "type");
 					mtype = (char *)json_string_value(jmtype);
 					if(strcasecmp(mtype, "audio") && strcasecmp(mtype, "video") && strcasecmp(mtype, "data")) {
@@ -3564,15 +3685,22 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 					}
 					json_t *jskew = json_object_get(m, "skew");
 					doskew = jskew ? json_is_true(jskew) : FALSE;
+					s_bufferkf_ms = 0;
+					s_bufferkf_bytes = 0;
 					if(!strcasecmp(mtype, "video")) {
 						json_t *vkf = json_object_get(m, "bufferkf");
-						bufferkf = vkf ? json_is_true(vkf) : FALSE;
+						if(json_is_true(vkf)) {
+							JANUS_LOG(LOG_WARN, "The bufferkf property has been deprecated, please refer to bufferkf_ms and/or bufferkf_bytes\n");
+						}
+						s_bufferkf_ms = bufferkf_ms;
+						s_bufferkf_bytes = bufferkf_bytes;
 						json_t *vsc = json_object_get(m, "simulcast");
 						simulcast = vsc ? json_is_true(vsc) : FALSE;
-						if(simulcast && bufferkf) {
+						if(simulcast && (s_bufferkf_ms > 0 || s_bufferkf_bytes > 0)) {
 							/* FIXME We'll need to take care of this */
-							JANUS_LOG(LOG_WARN, "Simulcasting enabled, so disabling buffering of keyframes\n");
-							bufferkf = FALSE;
+							JANUS_LOG(LOG_WARN, "Simulcasting enabled, so disabling buffering of keyframes for this stream\n");
+							s_bufferkf_ms = 0;
+							s_bufferkf_bytes = 0;
 						}
 						json_t *videoport2 = json_object_get(m, "port2");
 						port2 = json_integer_value(videoport2);
@@ -3602,12 +3730,13 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 							}
 						}
 					}
-					/* Create the data source stream */
+					/* Create the source stream */
 					janus_streaming_rtp_source_stream *stream = janus_streaming_create_rtp_source_stream(
 						name ? (char *)json_string_value(name) : NULL, g_list_length(streams),
 						mtype, mid, label ? label : mtype, msid, mcast, miface, &iface,
 						port, port2, port3, jrtcpport != NULL, rtcpport,
-						pt, codec, fmtp, sps, doskew, bufferkf, simulcast, dosvc, textdata, buffermsg);
+						pt, codec, fmtp, sps,
+						doskew, bufferkf_ms, bufferkf_bytes, simulcast, dosvc, textdata, buffermsg);
 					if(stream == NULL) {
 						JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream '%s', error creating data source stream...\n", (const char *)json_string_value(name));
 						error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
@@ -3699,7 +3828,7 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 						"audio", "a", "audio", NULL,
 						amcast, amiface, &audio_iface,
 						aport, 0, 0, audiortcpport != NULL, artcpport,
-						apt, acodec, afmtp, NULL, doaskew, FALSE, FALSE, FALSE, FALSE, FALSE);
+						apt, acodec, afmtp, NULL, doaskew, 0, 0, FALSE, FALSE, FALSE, FALSE);
 					if(stream == NULL) {
 						JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream '%s', error creating audio source stream...\n", (const char *)json_string_value(name));
 						error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
@@ -3717,7 +3846,7 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 				uint16_t vrtcpport = 0;
 				uint8_t vpt = 0;
 				char *vcodec = NULL, *vfmtp = NULL, *vsps = NULL, *vmcast = NULL, *vmiface = NULL;
-				gboolean bufferkf = FALSE, simulcast = FALSE;
+				gboolean simulcast = FALSE;
 				if(dovideo) {
 					JANUS_VALIDATE_JSON_OBJECT(root, rtp_video_parameters,
 						error_code, error_cause, TRUE,
@@ -3751,13 +3880,16 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 					json_t *h264sps = json_object_get(root, "h264sps");
 					vsps = (char *)json_string_value(h264sps);
 					json_t *vkf = json_object_get(root, "videobufferkf");
-					bufferkf = vkf ? json_is_true(vkf) : FALSE;
+					if(json_is_true(vkf)) {
+						JANUS_LOG(LOG_WARN, "The videobufferkf property has been deprecated, please refer to bufferkf_ms and/or bufferkf_bytes\n");
+					}
 					json_t *vsc = json_object_get(root, "videosimulcast");
 					simulcast = vsc ? json_is_true(vsc) : FALSE;
-					if(simulcast && bufferkf) {
+					if(simulcast && (bufferkf_ms > 0 || bufferkf_bytes > 0)) {
 						/* FIXME We'll need to take care of this */
-						JANUS_LOG(LOG_WARN, "Simulcasting enabled, so disabling buffering of keyframes\n");
-						bufferkf = FALSE;
+						JANUS_LOG(LOG_WARN, "Simulcasting enabled, so disabling buffering of keyframes for this stream\n");
+						bufferkf_ms = 0;
+						bufferkf_bytes = 0;
 					}
 					json_t *videoport2 = json_object_get(root, "videoport2");
 					vport2 = json_integer_value(videoport2);
@@ -3789,7 +3921,8 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 						"video", "v", "video", NULL,
 						vmcast, vmiface, &video_iface,
 						vport, vport2, vport3, videortcpport != NULL, vrtcpport,
-						vpt, vcodec, vfmtp, vsps, dovskew, bufferkf, simulcast, dosvc, FALSE, FALSE);
+						vpt, vcodec, vfmtp, vsps,
+						dovskew, bufferkf_ms, bufferkf_bytes, simulcast, dosvc, FALSE, FALSE);
 					if(stream == NULL) {
 						JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream '%s', error creating video source stream...\n", (const char *)json_string_value(name));
 						error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
@@ -3863,7 +3996,7 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 						"data", "d", "data", NULL,
 						dmcast, dmiface, &data_iface,
 						dport, 0, 0, FALSE, 0,
-						0, NULL, NULL, NULL, FALSE, FALSE, FALSE, FALSE, textdata, buffermsg);
+						0, NULL, NULL, NULL, FALSE, 0, 0, FALSE, FALSE, textdata, buffermsg);
 					if(stream == NULL) {
 						JANUS_LOG(LOG_ERR, "Can't add 'rtp' stream '%s', error creating data source stream...\n", (const char *)json_string_value(name));
 						error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
@@ -3898,6 +4031,7 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 					scrypto ? (char *)json_string_value(scrypto) : NULL,
 					threads ? json_integer_value(threads) : 0,
 					rtpcollision ? json_integer_value(rtpcollision) : 0,
+					bufferkf_ms, bufferkf_bytes,
 					e2ee ? json_is_true(e2ee) : FALSE,
 					pd ? json_is_true(pd) : FALSE,
 					abscaptime_src_id ? json_integer_value(abscaptime_src_id) : 0);
@@ -4124,7 +4258,9 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 			json_t *videocodec = json_object_get(root, "videocodec");
 			json_t *videortpmap = json_object_get(root, "videortpmap");
 			json_t *videofmtp = json_object_get(root, "videofmtp");
-			json_t *videobufferkf = json_object_get(root, "videobufferkf");
+			json_t *vkf = json_object_get(root, "videobufferkf");
+			json_t *vkf_ms = json_object_get(root, "bufferkf_ms");
+			json_t *vkf_bytes = json_object_get(root, "bufferkf_bytes");
 			json_t *url = json_object_get(root, "url");
 			json_t *username = json_object_get(root, "rtsp_user");
 			json_t *password = json_object_get(root, "rtsp_pwd");
@@ -4142,6 +4278,29 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 			gboolean dovideo = video ? json_is_true(video) : FALSE;
 			gboolean doquirk = quirk ? json_is_true(quirk) : FALSE;
 			gboolean error_on_failure = failerr ? json_is_true(failerr) : TRUE;
+			if(json_is_true(vkf)) {
+				JANUS_LOG(LOG_WARN, "The videobufferkf property has been deprecated, please refer to bufferkf_ms and/or bufferkf_bytes\n");
+			}
+			if(vkf_ms && json_integer_value(vkf_ms) > UINT16_MAX) {
+				JANUS_LOG(LOG_ERR, "Can't add 'rtsp' stream, invalid bufferkf_ms value...\n");
+				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
+				g_snprintf(error_cause, 512, "Can't add 'rtsp' stream, invalid bufferkf_ms value...");
+				janus_mutex_lock(&mountpoints_mutex);
+				g_hash_table_remove(mountpoints_temp, string_ids ? (gpointer)mpid_str : (gpointer)&mpid);
+				janus_mutex_unlock(&mountpoints_mutex);
+				goto prepare_response;
+			}
+			uint16_t bufferkf_ms = vkf_ms ? json_integer_value(vkf_ms) : 0;
+			if(vkf_bytes && json_integer_value(vkf_bytes) > UINT32_MAX) {
+				JANUS_LOG(LOG_ERR, "Can't add 'rtsp' stream, invalid bufferkf_bytes value...\n");
+				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
+				g_snprintf(error_cause, 512, "Can't add 'rtsp' stream, invalid bufferkf_bytes value...");
+				janus_mutex_lock(&mountpoints_mutex);
+				g_hash_table_remove(mountpoints_temp, string_ids ? (gpointer)mpid_str : (gpointer)&mpid);
+				janus_mutex_unlock(&mountpoints_mutex);
+				goto prepare_response;
+			}
+			uint32_t bufferkf_bytes = vkf_bytes ? json_integer_value(vkf_bytes) : 0;
 			if(!doaudio && !dovideo) {
 				JANUS_LOG(LOG_ERR, "Can't add 'rtsp' stream, no audio or video have to be streamed...\n");
 				error_code = JANUS_STREAMING_ERROR_CANT_CREATE;
@@ -4187,7 +4346,7 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 					doquirk,
 					doaudio, (audiopt ? json_integer_value(audiopt) : -1), acodec, (char *)json_string_value(audiofmtp),
 					dovideo, (videopt ? json_integer_value(videopt) : -1), vcodec, (char *)json_string_value(videofmtp),
-						videobufferkf ? json_is_true(videobufferkf) : FALSE,
+					bufferkf_ms, bufferkf_bytes,
 					&multicast_iface, (threads ? json_integer_value(threads) : 0),
 					((reconnect_delay ? json_integer_value(reconnect_delay) : JANUS_STREAMING_DEFAULT_RECONNECT_DELAY) * G_USEC_PER_SEC),
 					((session_timeout ? json_integer_value(session_timeout) : JANUS_STREAMING_DEFAULT_SESSION_TIMEOUT) * G_USEC_PER_SEC),
@@ -4245,6 +4404,14 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 					g_snprintf(value, BUFSIZ, "%d", source->rtp_collision);
 					janus_config_add(config, c, janus_config_item_create("collision", value));
 				}
+				if(source->bufferkf_ms > 0) {
+					g_snprintf(value, BUFSIZ, "%"SCNu16, source->bufferkf_ms);
+					janus_config_add(config, c, janus_config_item_create("bufferkf_ms", value));
+				}
+				if(source->bufferkf_bytes > 0) {
+					g_snprintf(value, BUFSIZ, "%"SCNu32, source->bufferkf_bytes);
+					janus_config_add(config, c, janus_config_item_create("bufferkf_bytes", value));
+				}
 				if(source->srtpsuite > 0 && source->srtpcrypto) {
 					g_snprintf(value, BUFSIZ, "%d", source->srtpsuite);
 					janus_config_add(config, c, janus_config_item_create("srtpsuite", value));
@@ -4300,8 +4467,6 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 						if(stream->skew)
 							janus_config_add(config, m, janus_config_item_create("skew", "true"));
 					}
-					if(stream->keyframe.enabled)
-						janus_config_add(config, m, janus_config_item_create("videobufferkf", "true"));
 					if(stream->simulcast) {
 						janus_config_add(config, m, janus_config_item_create("videosimulcast", "true"));
 						if(stream->port[1]) {
@@ -4343,6 +4508,14 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 				if(source->rtsp_quirk)
 					janus_config_add(config, c, janus_config_item_create("rtsp_quirk", "true"));
 #endif
+				if(source->bufferkf_ms > 0) {
+					g_snprintf(value, BUFSIZ, "%"SCNu16, source->bufferkf_ms);
+					janus_config_add(config, c, janus_config_item_create("bufferkf_ms", value));
+				}
+				if(source->bufferkf_bytes > 0) {
+					g_snprintf(value, BUFSIZ, "%"SCNu32, source->bufferkf_bytes);
+					janus_config_add(config, c, janus_config_item_create("bufferkf_bytes", value));
+				}
 				GList *temp = source->media;
 				while(temp) {
 					janus_streaming_rtp_source_stream *stream = (janus_streaming_rtp_source_stream *)temp->data;
@@ -4594,148 +4767,151 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 			if(mp->pin)
 				janus_config_add(config, c, janus_config_item_create("pin", mp->pin));
 			/* Per type values */
-			if(mp->streaming_source == janus_streaming_source_rtp) {
-				gboolean rtsp = FALSE;
-#ifdef HAVE_LIBCURL
+			if(mp->streaming_source == janus_streaming_source_rtp && !((janus_streaming_rtp_source *)mp->source)->rtsp) {
+				/* We save using the new format, not the old deprecated one */
 				janus_streaming_rtp_source *source = mp->source;
-				if(source->rtsp)
-						rtsp = TRUE;
-#endif
-				if(rtsp) {
-					janus_streaming_rtp_source *source = mp->source;
-#ifdef HAVE_LIBCURL
-					janus_config_add(config, c, janus_config_item_create("type", "rtsp"));
-					if(source->rtsp_url)
-						janus_config_add(config, c, janus_config_item_create("url", source->rtsp_url));
-					if(source->rtsp_username)
-						janus_config_add(config, c, janus_config_item_create("rtsp_user", source->rtsp_username));
-					if(source->rtsp_password)
-						janus_config_add(config, c, janus_config_item_create("rtsp_pwd", source->rtsp_password));
-					if(source->rtsp_quirk)
-						janus_config_add(config, c, janus_config_item_create("rtsp_quirk", "true"));
-#endif
-					GList *temp = source->media;
-					while(temp) {
-						janus_streaming_rtp_source_stream *stream = (janus_streaming_rtp_source_stream *)temp->data;
-						/* FIXME Should we support RTSP streams with multiple media? */
-						if(stream->type == JANUS_STREAMING_MEDIA_AUDIO) {
-							janus_config_add(config, c, janus_config_item_create("audio", "true"));
-							if(stream->codecs.audio_codec != JANUS_AUDIOCODEC_NONE)
-								janus_config_add(config, c, janus_config_item_create("audiocodec", janus_audiocodec_name(stream->codecs.audio_codec)));
-							if(stream->codecs.fmtp)
-								janus_config_add(config, c, janus_config_item_create("audiofmtp", stream->codecs.fmtp));
-						} else if(stream->type == JANUS_STREAMING_MEDIA_VIDEO) {
-							janus_config_add(config, c, janus_config_item_create("video", "true"));
-							if(stream->codecs.video_codec != JANUS_VIDEOCODEC_NONE)
-								janus_config_add(config, c, janus_config_item_create("videocodec", janus_videocodec_name(stream->codecs.video_codec)));
-							if(stream->codecs.fmtp)
-								janus_config_add(config, c, janus_config_item_create("videofmtp", stream->codecs.fmtp));
-						}
-						temp = temp->next;
+				if(source->rtp_collision > 0) {
+					g_snprintf(value, BUFSIZ, "%d", source->rtp_collision);
+					janus_config_add(config, c, janus_config_item_create("collision", value));
+				}
+				if(source->bufferkf_ms > 0) {
+					g_snprintf(value, BUFSIZ, "%"SCNu16, source->bufferkf_ms);
+					janus_config_add(config, c, janus_config_item_create("bufferkf_ms", value));
+				}
+				if(source->bufferkf_bytes > 0) {
+					g_snprintf(value, BUFSIZ, "%"SCNu32, source->bufferkf_bytes);
+					janus_config_add(config, c, janus_config_item_create("bufferkf_bytes", value));
+				}
+				if(source->srtpsuite > 0 && source->srtpcrypto) {
+					g_snprintf(value, BUFSIZ, "%d", source->srtpsuite);
+					janus_config_add(config, c, janus_config_item_create("srtpsuite", value));
+					janus_config_add(config, c, janus_config_item_create("srtpcrypto", source->srtpcrypto));
+				}
+				if(mp->helper_threads > 0) {
+					g_snprintf(value, BUFSIZ, "%d", mp->helper_threads);
+					janus_config_add(config, c, janus_config_item_create("threads", value));
+				}
+				if(source->e2ee)
+					janus_config_add(config, c, janus_config_item_create("e2ee", "true"));
+				if(source->playoutdelay_ext)
+					janus_config_add(config, c, janus_config_item_create("playoutdelay_ext", "true"));
+				if(source->abscapturetime_src_ext_id > 0) {
+					g_snprintf(value, BUFSIZ, "%d", source->abscapturetime_src_ext_id);
+					janus_config_add(config, c, janus_config_item_create("abscapturetime_src_ext_id", value));
+				}
+				/* Iterate on all media streams */
+				janus_config_array *media = janus_config_array_create("media");
+				janus_config_add(config, c, media);
+				GList *temp = source->media;
+				while(temp) {
+					janus_streaming_rtp_source_stream *stream = (janus_streaming_rtp_source_stream *)temp->data;
+					janus_config_category *m = janus_config_category_create(NULL);
+					janus_config_add(config, media, m);
+					janus_config_add(config, m, janus_config_item_create("type", janus_streaming_media_str(stream->type)));
+					janus_config_add(config, m, janus_config_item_create("mid", stream->mid));
+					janus_config_add(config, m, janus_config_item_create("label", stream->label));
+					if(stream->msid && stream->mstid) {
+						char msid[150];
+						g_snprintf(msid, sizeof(msid), "%s %s", stream->msid, stream->mstid);
+						janus_config_add(config, m, janus_config_item_create("msid", msid));
 					}
-					json_t *iface = json_object_get(root, "rtspiface");
-					if(iface)
-						janus_config_add(config, c, janus_config_item_create("rtspiface", json_string_value(iface)));
-					if(mp->helper_threads > 0) {
-						g_snprintf(value, BUFSIZ, "%d", mp->helper_threads);
-						janus_config_add(config, c, janus_config_item_create("threads", value));
+					if(stream->port[0] > 0) {
+						g_snprintf(value, BUFSIZ, "%d", stream->port[0]);
+						janus_config_add(config, m, janus_config_item_create("port", value));
 					}
-				} else {
-					janus_config_add(config, c, janus_config_item_create("type", "rtp"));
-					/* We save using the new format, not the old deprecated one */
-					janus_streaming_rtp_source *source = mp->source;
-					if(source->rtp_collision > 0) {
-						g_snprintf(value, BUFSIZ, "%d", source->rtp_collision);
-						janus_config_add(config, c, janus_config_item_create("collision", value));
+					if(stream->rtcp_port > 0) {
+						g_snprintf(value, BUFSIZ, "%d", stream->rtcp_port);
+						janus_config_add(config, m, janus_config_item_create("rtcpport", value));
 					}
-					if(source->srtpsuite > 0 && source->srtpcrypto) {
-						g_snprintf(value, BUFSIZ, "%d", source->srtpsuite);
-						janus_config_add(config, c, janus_config_item_create("srtpsuite", value));
-						janus_config_add(config, c, janus_config_item_create("srtpcrypto", source->srtpcrypto));
+					if(stream->codecs.pt >= 0) {
+						g_snprintf(value, BUFSIZ, "%d", stream->codecs.pt);
+						janus_config_add(config, m, janus_config_item_create("pt", value));
 					}
-					if(mp->helper_threads > 0) {
-						g_snprintf(value, BUFSIZ, "%d", mp->helper_threads);
-						janus_config_add(config, c, janus_config_item_create("threads", value));
-					}
-					if(source->e2ee)
-						janus_config_add(config, c, janus_config_item_create("e2ee", "true"));
-					if(source->playoutdelay_ext)
-						janus_config_add(config, c, janus_config_item_create("playoutdelay_ext", "true"));
-					if(source->abscapturetime_src_ext_id > 0) {
-						g_snprintf(value, BUFSIZ, "%d", source->abscapturetime_src_ext_id);
-						janus_config_add(config, c, janus_config_item_create("abscapturetime_src_ext_id", value));
-					}
-					/* Iterate on all media streams */
-					janus_config_array *media = janus_config_array_create("media");
-					janus_config_add(config, c, media);
-					GList *temp = source->media;
-					while(temp) {
-						janus_streaming_rtp_source_stream *stream = (janus_streaming_rtp_source_stream *)temp->data;
-						janus_config_category *m = janus_config_category_create(NULL);
-						janus_config_add(config, media, m);
-						janus_config_add(config, m, janus_config_item_create("type", janus_streaming_media_str(stream->type)));
-						janus_config_add(config, m, janus_config_item_create("mid", stream->mid));
-						janus_config_add(config, m, janus_config_item_create("label", stream->label));
-						if(stream->msid && stream->mstid) {
-							char msid[150];
-							g_snprintf(msid, sizeof(msid), "%s %s", stream->msid, stream->mstid);
-							janus_config_add(config, m, janus_config_item_create("msid", msid));
-						}
-						if(stream->port[0] > 0) {
-							g_snprintf(value, BUFSIZ, "%d", stream->port[0]);
-							janus_config_add(config, m, janus_config_item_create("port", value));
-						}
-						if(stream->rtcp_port > 0) {
-							g_snprintf(value, BUFSIZ, "%d", stream->rtcp_port);
-							janus_config_add(config, m, janus_config_item_create("rtcpport", value));
-						}
-						if(stream->codecs.pt >= 0) {
-							g_snprintf(value, BUFSIZ, "%d", stream->codecs.pt);
-							janus_config_add(config, m, janus_config_item_create("pt", value));
-						}
-						if(stream->codecs.audio_codec != JANUS_AUDIOCODEC_NONE || stream->codecs.video_codec != JANUS_VIDEOCODEC_NONE) {
-							if(stream->codecs.audio_codec != JANUS_AUDIOCODEC_NONE)
-								janus_config_add(config, m, janus_config_item_create("codec", janus_audiocodec_name(stream->codecs.audio_codec)));
-							else if(stream->codecs.video_codec != JANUS_VIDEOCODEC_NONE)
-								janus_config_add(config, m, janus_config_item_create("codec", janus_videocodec_name(stream->codecs.video_codec)));
-							if(stream->codecs.fmtp)
-								janus_config_add(config, m, janus_config_item_create("fmtp", stream->codecs.fmtp));
-							if(stream->skew)
-								janus_config_add(config, m, janus_config_item_create("skew", "true"));
-						}
-						if(stream->keyframe.enabled)
-							janus_config_add(config, m, janus_config_item_create("videobufferkf", "true"));
-						if(stream->simulcast) {
-							janus_config_add(config, m, janus_config_item_create("videosimulcast", "true"));
-							if(stream->port[1]) {
-								g_snprintf(value, BUFSIZ, "%d", stream->port[1]);
-								janus_config_add(config, m, janus_config_item_create("port2", value));
-							}
-							if(stream->port[2]) {
-								g_snprintf(value, BUFSIZ, "%d", stream->port[2]);
-								janus_config_add(config, m, janus_config_item_create("port3", value));
-							}
-						}
-						if(stream->svc)
-							janus_config_add(config, m, janus_config_item_create("videosvc", "true"));
+					if(stream->codecs.audio_codec != JANUS_AUDIOCODEC_NONE || stream->codecs.video_codec != JANUS_VIDEOCODEC_NONE) {
+						if(stream->codecs.audio_codec != JANUS_AUDIOCODEC_NONE)
+							janus_config_add(config, m, janus_config_item_create("codec", janus_audiocodec_name(stream->codecs.audio_codec)));
+						else if(stream->codecs.video_codec != JANUS_VIDEOCODEC_NONE)
+							janus_config_add(config, m, janus_config_item_create("codec", janus_videocodec_name(stream->codecs.video_codec)));
+						if(stream->codecs.fmtp)
+							janus_config_add(config, m, janus_config_item_create("fmtp", stream->codecs.fmtp));
 						if(stream->skew)
 							janus_config_add(config, m, janus_config_item_create("skew", "true"));
-						if(stream->mcast_str)
-							janus_config_add(config, m, janus_config_item_create("mcast", stream->mcast_str));
-						if(stream->iface_str)
-							janus_config_add(config, m, janus_config_item_create("iface", stream->iface_str));
-						if(stream->type == JANUS_STREAMING_MEDIA_DATA)
-							janus_config_add(config, m, janus_config_item_create("datatype", stream->textdata ? "text" : "binary"));
-						if(stream->buffermsg)
-							janus_config_add(config, m, janus_config_item_create("buffermsg", "true"));
-						temp = temp->next;
 					}
+					if(stream->simulcast) {
+						janus_config_add(config, m, janus_config_item_create("videosimulcast", "true"));
+						if(stream->port[1]) {
+							g_snprintf(value, BUFSIZ, "%d", stream->port[1]);
+							janus_config_add(config, m, janus_config_item_create("port2", value));
+						}
+						if(stream->port[2]) {
+							g_snprintf(value, BUFSIZ, "%d", stream->port[2]);
+							janus_config_add(config, m, janus_config_item_create("port3", value));
+						}
+					}
+					if(stream->svc)
+						janus_config_add(config, m, janus_config_item_create("videosvc", "true"));
+					if(stream->skew)
+						janus_config_add(config, m, janus_config_item_create("skew", "true"));
+					if(stream->mcast_str)
+						janus_config_add(config, m, janus_config_item_create("mcast", stream->mcast_str));
+					if(stream->iface_str)
+						janus_config_add(config, m, janus_config_item_create("iface", stream->iface_str));
+					if(stream->type == JANUS_STREAMING_MEDIA_DATA)
+						janus_config_add(config, m, janus_config_item_create("datatype", stream->textdata ? "text" : "binary"));
+					if(stream->buffermsg)
+						janus_config_add(config, m, janus_config_item_create("databuffermsg", "true"));
+					temp = temp->next;
 				}
-			} else {
-				janus_config_add(config, c, janus_config_item_create("type", (mp->streaming_type == janus_streaming_type_live) ? "live" : "ondemand"));
+			} else if(mp->streaming_source == janus_streaming_source_file) {
 				janus_streaming_file_source *source = mp->source;
 				janus_config_add(config, c, janus_config_item_create("filename", source->filename));
 				janus_config_add(config, c, janus_config_item_create("audio", "true"));
+			} else if(mp->streaming_source == janus_streaming_source_rtp && ((janus_streaming_rtp_source *)mp->source)->rtsp) {
+				janus_streaming_rtp_source *source = mp->source;
+#ifdef HAVE_LIBCURL
+				if(source->rtsp_url)
+					janus_config_add(config, c, janus_config_item_create("url", source->rtsp_url));
+				if(source->rtsp_username)
+					janus_config_add(config, c, janus_config_item_create("rtsp_user", source->rtsp_username));
+				if(source->rtsp_password)
+					janus_config_add(config, c, janus_config_item_create("rtsp_pwd", source->rtsp_password));
+				if(source->rtsp_quirk)
+					janus_config_add(config, c, janus_config_item_create("rtsp_quirk", "true"));
+#endif
+				if(source->bufferkf_ms > 0) {
+					g_snprintf(value, BUFSIZ, "%"SCNu16, source->bufferkf_ms);
+					janus_config_add(config, c, janus_config_item_create("bufferkf_ms", value));
+				}
+				if(source->bufferkf_bytes > 0) {
+					g_snprintf(value, BUFSIZ, "%"SCNu32, source->bufferkf_bytes);
+					janus_config_add(config, c, janus_config_item_create("bufferkf_bytes", value));
+				}
+				GList *temp = source->media;
+				while(temp) {
+					janus_streaming_rtp_source_stream *stream = (janus_streaming_rtp_source_stream *)temp->data;
+					/* FIXME Should we support RTSP streams with multiple media? */
+					if(stream->type == JANUS_STREAMING_MEDIA_AUDIO) {
+						janus_config_add(config, c, janus_config_item_create("audio", "true"));
+						if(stream->codecs.audio_codec != JANUS_AUDIOCODEC_NONE)
+							janus_config_add(config, c, janus_config_item_create("audiocodec", janus_audiocodec_name(stream->codecs.audio_codec)));
+						if(stream->codecs.fmtp)
+							janus_config_add(config, c, janus_config_item_create("audiofmtp", stream->codecs.fmtp));
+					} else if(stream->type == JANUS_STREAMING_MEDIA_VIDEO) {
+						janus_config_add(config, c, janus_config_item_create("video", "true"));
+						if(stream->codecs.video_codec != JANUS_VIDEOCODEC_NONE)
+							janus_config_add(config, c, janus_config_item_create("videocodec", janus_videocodec_name(stream->codecs.video_codec)));
+						if(stream->codecs.fmtp)
+							janus_config_add(config, c, janus_config_item_create("videofmtp", stream->codecs.fmtp));
+					}
+					temp = temp->next;
+				}
+				json_t *iface = json_object_get(root, "rtspiface");
+				if(iface)
+					janus_config_add(config, c, janus_config_item_create("rtspiface", json_string_value(iface)));
+				if(mp->helper_threads > 0) {
+					g_snprintf(value, BUFSIZ, "%d", mp->helper_threads);
+					janus_config_add(config, c, janus_config_item_create("threads", value));
+				}
 			}
 			/* Save modified configuration */
 			if(janus_config_save(config, config_folder, JANUS_STREAMING_PACKAGE) < 0)
@@ -5624,11 +5800,12 @@ void janus_streaming_setup_media(janus_plugin_session *handle) {
 				janus_mutex_lock(&stream->keyframe.mutex);
 				if(stream->keyframe.latest_keyframe != NULL) {
 					JANUS_LOG(LOG_HUGE, "Yep! %d packets\n", g_list_length(stream->keyframe.latest_keyframe));
-					GList *temp = stream->keyframe.latest_keyframe;
+					GList *packets = g_list_reverse(g_list_copy(stream->keyframe.latest_keyframe)), *temp = packets;
 					while(temp) {
 						janus_streaming_relay_rtp_packet(session, temp->data);
 						temp = temp->next;
 					}
+					g_list_free(packets);
 				}
 				janus_mutex_unlock(&stream->keyframe.mutex);
 			}
@@ -7450,7 +7627,6 @@ static void janus_streaming_rtp_source_stream_free(const janus_refcount *st_ref)
 	janus_mutex_lock(&stream->keyframe.mutex);
 	if(stream->keyframe.latest_keyframe != NULL)
 		g_list_free_full(stream->keyframe.latest_keyframe, (GDestroyNotify)janus_streaming_rtp_relay_packet_free);
-	stream->keyframe.latest_keyframe = NULL;
 	janus_mutex_unlock(&stream->keyframe.mutex);
 	janus_mutex_lock(&stream->buffermsg_mutex);
 	if(stream->last_msg != NULL)
@@ -7530,7 +7706,7 @@ janus_streaming_rtp_source_stream *janus_streaming_create_rtp_source_stream(
 		char *mcast, char *miface, const janus_network_address *iface,
 		uint16_t port, uint16_t port2, uint16_t port3, gboolean dortcp, uint16_t rtcpport,
 		uint8_t pt, char *codec, char *fmtp, char *sprop,
-		gboolean doskew, gboolean bufferkf, gboolean simulcast, gboolean svc,
+		gboolean doskew, uint16_t bufferkf_ms, uint32_t bufferkf_bytes, gboolean simulcast, gboolean svc,
 		gboolean textdata, gboolean buffermsg) {
 	if(type == NULL || mid == NULL || label == NULL) {
 		JANUS_LOG(LOG_ERR, "[%s] Can't add 'rtp' stream, missing media type, mid or label...\n", name);
@@ -7673,10 +7849,15 @@ janus_streaming_rtp_source_stream *janus_streaming_create_rtp_source_stream(
 	stream->last_received[1] = stream->last_received[0];
 	stream->last_received[2] = stream->last_received[0];
 	if(mtype == JANUS_STREAMING_MEDIA_VIDEO) {
-		stream->keyframe.enabled = bufferkf;
+		stream->keyframe.enabled = (bufferkf_ms > 0 || bufferkf_bytes > 0);
+		stream->keyframe.bufferkf_ms = bufferkf_ms;
+		stream->keyframe.bufferkf_bytes = bufferkf_bytes;
 		stream->keyframe.latest_keyframe = NULL;
-		stream->keyframe.temp_keyframe = NULL;
-		stream->keyframe.temp_ts = 0;
+		stream->keyframe.kf_ssrc = 0;
+		stream->keyframe.kf_ts = 0;
+		stream->keyframe.kf_bytes = 0;
+		stream->keyframe.kf_start = 0;
+		stream->keyframe.first_ts = FALSE;
 		janus_mutex_init(&stream->keyframe.mutex);
 	} else if(mtype == JANUS_STREAMING_MEDIA_DATA) {
 		stream->textdata = textdata;
@@ -7691,6 +7872,7 @@ janus_streaming_rtp_source_stream *janus_streaming_create_rtp_source_stream(
 janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 		uint64_t id, char *id_str, char *name, char *desc, char *metadata,
 		GList *media, int srtpsuite, char *srtpcrypto, int threads, int rtp_collision,
+		uint16_t bufferkf_ms, uint32_t bufferkf_bytes,
 		gboolean e2ee, gboolean playoutdelay_ext, int abscapturetime_src_ext_id) {
 	char id_num[30];
 	if(!string_ids) {
@@ -7811,6 +7993,8 @@ janus_streaming_mountpoint *janus_streaming_create_rtp_source(
 	pipe(live_rtp_source->pipefd);
 	janus_mutex_init(&live_rtp_source->rec_mutex);
 	live_rtp_source->rtp_collision = rtp_collision;
+	live_rtp_source->bufferkf_ms = bufferkf_ms;
+	live_rtp_source->bufferkf_bytes = bufferkf_bytes;
 	live_rtp_source->e2ee = e2ee;
 	live_rtp_source->playoutdelay_ext = playoutdelay_ext;
 	live_rtp_source->abscapturetime_src_ext_id = abscapturetime_src_ext_id;
@@ -8725,11 +8909,16 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 				g_hash_table_insert(source->media_byfd, GINT_TO_POINTER(stream->fd[0]), stream);
 			if(stream->rtcp_fd != -1)
 				g_hash_table_insert(source->media_byfd, GINT_TO_POINTER(stream->rtcp_fd), stream);
-			if(source->rtsp_bufferkf) {
+			if(source->bufferkf_ms > 0 || source->bufferkf_bytes > 0) {
 				stream->keyframe.enabled = TRUE;
+				stream->keyframe.bufferkf_ms = source->bufferkf_ms;
+				stream->keyframe.bufferkf_bytes = source->bufferkf_bytes;
 				stream->keyframe.latest_keyframe = NULL;
-				stream->keyframe.temp_keyframe = NULL;
-				stream->keyframe.temp_ts = 0;
+				stream->keyframe.kf_ssrc = 0;
+				stream->keyframe.kf_ts = 0;
+				stream->keyframe.kf_bytes = 0;
+				stream->keyframe.kf_start = 0;
+				stream->keyframe.first_ts = FALSE;
 				janus_mutex_init(&stream->keyframe.mutex);
 			}
 		}
@@ -8840,7 +9029,8 @@ janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 		uint64_t id, char *id_str, char *name, char *desc, char *metadata,
 		char *url, char *username, char *password,
 		gboolean quirk, gboolean doaudio, int apt, char *acodec, char *afmtp,
-		gboolean dovideo, int vpt, char *vcodec, char *vfmtp, gboolean bufferkf,
+		gboolean dovideo, int vpt, char *vcodec, char *vfmtp,
+		uint16_t bufferkf_ms, uint32_t bufferkf_bytes,
 		const janus_network_address *iface, int threads,
 		gint64 reconnect_delay, gint64 session_timeout, int rtsp_timeout, int rtsp_conn_timeout,
 		gboolean error_on_failure) {
@@ -8922,7 +9112,8 @@ janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 	live_rtsp_source->pipefd[0] = -1;
 	live_rtsp_source->pipefd[1] = -1;
 	pipe(live_rtsp_source->pipefd);
-	live_rtsp_source->rtsp_bufferkf = bufferkf;
+	live_rtsp_source->bufferkf_ms = bufferkf_ms;
+	live_rtsp_source->bufferkf_bytes = bufferkf_bytes;
 	live_rtsp_source->ka_timeout = session_timeout;
 	live_rtsp_source->reconnect_delay = reconnect_delay;
 	live_rtsp_source->session_timeout = session_timeout;
@@ -9173,7 +9364,7 @@ static void *janus_streaming_ondemand_thread(void *data) {
 		packet.length = RTP_HEADER_SIZE + read;
 		packet.is_rtp = TRUE;
 		packet.is_video = FALSE;
-		packet.is_keyframe = FALSE;
+		packet.is_kfburst = FALSE;
 		/* Backup the actual payload type, timestamp and sequence number */
 		packet.ptype = packet.data->type;
 		packet.timestamp = ntohl(packet.data->timestamp);
@@ -9324,7 +9515,7 @@ static void *janus_streaming_filesource_thread(void *data) {
 		packet.length = RTP_HEADER_SIZE + read;
 		packet.is_rtp = TRUE;
 		packet.is_video = FALSE;
-		packet.is_keyframe = FALSE;
+		packet.is_kfburst = FALSE;
 		/* Backup the actual payload type, timestamp and sequence number */
 		packet.ptype = packet.data->type;
 		packet.timestamp = ntohl(packet.data->timestamp);
@@ -9349,6 +9540,44 @@ static void *janus_streaming_filesource_thread(void *data) {
 	fclose(audio);
 	janus_refcount_decrease(&mountpoint->ref);
 	return NULL;
+}
+
+/* Helper method to buffer keyframes + deltas, if needed (and if allowed) */
+static void janus_streaming_buffer_keyframe_data(janus_streaming_rtp_source_stream *stream, char *buffer, int bytes) {
+	if(!stream || !stream->keyframe.enabled || !buffer || bytes < 12)
+		return;
+	/* Check if this exceeds ms and/or bytes (the keyframe itself is never impacted) */
+	if(!stream->keyframe.first_ts && stream->keyframe.bufferkf_ms > 0) {
+		/* TODO Check if this exceeds the duration limit */
+		int64_t now = janus_get_monotonic_time() / 1000;
+		if((now - stream->keyframe.kf_start) > (int64_t)stream->keyframe.bufferkf_ms) {
+			JANUS_LOG(LOG_WARN, "[kf] Not buffering keyframe data (exceeds ms limit)\n");
+			return;
+		}
+	}
+	if(!stream->keyframe.first_ts && stream->keyframe.bufferkf_bytes > 0) {
+		/* Check if this exceeds the bytes limit */
+		if((stream->keyframe.kf_bytes + bytes) > stream->keyframe.bufferkf_bytes) {
+			JANUS_LOG(LOG_WARN, "[kf] Not buffering keyframe data (exceeds bytes limit)\n");
+			return;
+		}
+	}
+	janus_rtp_header *rtp = (janus_rtp_header *)buffer;
+	janus_streaming_rtp_relay_packet *pkt = g_malloc0(sizeof(janus_streaming_rtp_relay_packet));
+	pkt->mindex = stream->mindex;
+	pkt->data = g_malloc(bytes);
+	memcpy(pkt->data, buffer, bytes);
+	pkt->data->ssrc = stream->keyframe.kf_ssrc;
+	pkt->data->type = stream->codecs.pt;
+	pkt->is_rtp = TRUE;
+	pkt->is_video = TRUE;
+	pkt->is_kfburst = TRUE;
+	pkt->length = bytes;
+	pkt->ptype = rtp->type;
+	pkt->timestamp = ntohl(rtp->timestamp);
+	pkt->seq_number = ntohs(rtp->seq_number);
+	stream->keyframe.latest_keyframe = g_list_prepend(stream->keyframe.latest_keyframe, pkt);
+	stream->keyframe.kf_bytes += bytes;
 }
 
 /* Thread to relay RTP frames coming from gstreamer/ffmpeg/others */
@@ -9688,7 +9917,7 @@ static void *janus_streaming_relay_thread(void *data) {
 					packet.length = bytes;
 					packet.is_rtp = TRUE;
 					packet.is_video = FALSE;
-					packet.is_keyframe = FALSE;
+					packet.is_kfburst = FALSE;
 					packet.data->type = stream->codecs.pt;
 					/* Is there a recorder? */
 					janus_rtp_header_update(packet.data, &stream->context[0], FALSE, 0);
@@ -9775,89 +10004,50 @@ static void *janus_streaming_relay_thread(void *data) {
 					}
 					/* First of all, let's check if this is (part of) a keyframe that we may need to save it for future reference */
 					if(index == 0 && stream->keyframe.enabled) {
-						if(stream->keyframe.temp_ts > 0 && ntohl(rtp->timestamp) != stream->keyframe.temp_ts) {
-							/* We received the last part of the keyframe, get rid of the old one and use this from now on */
-							JANUS_LOG(LOG_HUGE, "[%s] ... ... last part of keyframe received! ts=%"SCNu32", %d packets\n",
-								name, stream->keyframe.temp_ts, g_list_length(stream->keyframe.temp_keyframe));
-							stream->keyframe.temp_ts = 0;
-							janus_mutex_lock(&stream->keyframe.mutex);
-							if(stream->keyframe.latest_keyframe != NULL)
-								g_list_free_full(stream->keyframe.latest_keyframe, (GDestroyNotify)janus_streaming_rtp_relay_packet_free);
-							stream->keyframe.latest_keyframe = stream->keyframe.temp_keyframe;
-							stream->keyframe.temp_keyframe = NULL;
-							janus_mutex_unlock(&stream->keyframe.mutex);
-						} else if(ntohl(rtp->timestamp) == stream->keyframe.temp_ts) {
-							/* Part of the keyframe we're currently saving, store */
-							janus_mutex_lock(&stream->keyframe.mutex);
-							JANUS_LOG(LOG_HUGE, "[%s] ... other part of keyframe received! ts=%"SCNu32"\n", name, stream->keyframe.temp_ts);
-							janus_streaming_rtp_relay_packet *pkt = g_malloc0(sizeof(janus_streaming_rtp_relay_packet));
-							pkt->mindex = stream->mindex;
-							pkt->data = g_malloc(bytes);
-							memcpy(pkt->data, buffer, bytes);
-							pkt->data->ssrc = htons(1);
-							pkt->data->type = stream->codecs.pt;
-							pkt->is_rtp = TRUE;
-							pkt->is_video = TRUE;
-							pkt->is_keyframe = TRUE;
-							pkt->length = bytes;
-							pkt->ptype = rtp->type;
-							pkt->timestamp = stream->keyframe.temp_ts;
-							pkt->seq_number = ntohs(rtp->seq_number);
-							stream->keyframe.temp_keyframe = g_list_append(stream->keyframe.temp_keyframe, pkt);
-							janus_mutex_unlock(&stream->keyframe.mutex);
+						/* Check how we should process this packet */
+						janus_mutex_lock(&stream->keyframe.mutex);
+						if(stream->keyframe.latest_keyframe != NULL && ntohl(rtp->timestamp) == stream->keyframe.kf_ts) {
+							/* New fragment of the latest frame we received (keyframe or not),
+							 * re-use the same SSRC we allocated before for this specific frame */
+							JANUS_LOG(LOG_INFO, "[kf]   -- Updating frame (ts=%"SCNu32", ssrc=%"SCNu32")\n",
+								stream->keyframe.kf_ts, stream->keyframe.kf_ssrc);
+							janus_streaming_buffer_keyframe_data(stream, buffer, bytes);
 						} else {
-							gboolean kf = FALSE;
-							/* Parse RTP header first */
-							janus_rtp_header *header = (janus_rtp_header *)buffer;
-							guint32 timestamp = ntohl(header->timestamp);
-							guint16 seq = ntohs(header->seq_number);
-							JANUS_LOG(LOG_HUGE, "Checking if packet (size=%d, seq=%"SCNu16", ts=%"SCNu32") is a key frame...\n",
-								bytes, seq, timestamp);
+							/* New frame: check if it's a delta or a keyframe. If it's a
+							 * keyframe, it means we can start a new list and get rid of the
+							 * previous (and now old) one, if we had one; if it's a delta,
+							 * we append it to the list if it exists, and drop it if it
+							 * doesn't (as it makes no sense to start from a delta) */
 							int plen = 0;
 							char *payload = janus_rtp_payload(buffer, bytes, &plen);
-							if(payload) {
-								switch(stream->codecs.video_codec) {
-									case JANUS_VIDEOCODEC_VP8:
-										kf = janus_vp8_is_keyframe(payload, plen);
-										break;
-									case JANUS_VIDEOCODEC_VP9:
-										kf = janus_vp9_is_keyframe(payload, plen);
-										break;
-									case JANUS_VIDEOCODEC_H264:
-										kf = janus_h264_is_keyframe(payload, plen);
-										break;
-									case JANUS_VIDEOCODEC_AV1:
-										kf = janus_av1_is_keyframe(payload, plen);
-										break;
-									case JANUS_VIDEOCODEC_H265:
-										kf = janus_h265_is_keyframe(payload, plen);
-										break;
-									default:
-										break;
-								}
-								if(kf) {
-									/* New keyframe, start saving it */
-									stream->keyframe.temp_ts = ntohl(rtp->timestamp);
-									JANUS_LOG(LOG_HUGE, "[%s] New keyframe received! ts=%"SCNu32"\n", name, stream->keyframe.temp_ts);
-									janus_mutex_lock(&stream->keyframe.mutex);
-									janus_streaming_rtp_relay_packet *pkt = g_malloc0(sizeof(janus_streaming_rtp_relay_packet));
-									pkt->mindex = stream->mindex;
-									pkt->data = g_malloc(bytes);
-									memcpy(pkt->data, buffer, bytes);
-									pkt->data->ssrc = htons(1);
-									pkt->data->type = stream->codecs.pt;
-									pkt->is_rtp = TRUE;
-									pkt->is_video = TRUE;
-									pkt->is_keyframe = TRUE;
-									pkt->length = bytes;
-									pkt->ptype = rtp->type;
-									pkt->timestamp = stream->keyframe.temp_ts;
-									pkt->seq_number = ntohs(rtp->seq_number);
-									stream->keyframe.temp_keyframe = g_list_append(stream->keyframe.temp_keyframe, pkt);
-									janus_mutex_unlock(&stream->keyframe.mutex);
-								}
+							if(janus_is_keyframe(stream->codecs.video_codec, payload, plen)) {
+								/* This is a keyframe: remove the old list, if
+								 * we had one, and start a new one from scratch */
+								if(stream->keyframe.latest_keyframe != NULL)
+									g_list_free_full(stream->keyframe.latest_keyframe, (GDestroyNotify)janus_streaming_rtp_relay_packet_free);
+								stream->keyframe.latest_keyframe = NULL;
+								stream->keyframe.kf_ssrc = janus_random_uint32();
+								stream->keyframe.kf_ts = ntohl(rtp->timestamp);
+								stream->keyframe.kf_bytes = 0;
+								stream->keyframe.kf_start = janus_get_monotonic_time() / 1000;
+								stream->keyframe.first_ts = TRUE;
+								JANUS_LOG(LOG_INFO, "[kf] New keyframe (ts=%"SCNu32", ssrc=%"SCNu32")\n",
+									stream->keyframe.kf_ts, stream->keyframe.kf_ssrc);
+								janus_streaming_buffer_keyframe_data(stream, buffer, bytes);
+							} else if(stream->keyframe.latest_keyframe != NULL) {
+								/* This is a new delta: track the timestamp, allocate
+								 * a new SSRC, and add the packet to our existing list */
+								stream->keyframe.kf_ssrc = janus_random_uint32();
+								stream->keyframe.kf_ts = ntohl(rtp->timestamp);
+								stream->keyframe.first_ts = FALSE;
+								JANUS_LOG(LOG_INFO, "[kf] New delta (ts=%"SCNu32", ssrc=%"SCNu32")\n",
+									stream->keyframe.kf_ts, stream->keyframe.kf_ssrc);
+								janus_streaming_buffer_keyframe_data(stream, buffer, bytes);
+							} else {
+								JANUS_LOG(LOG_WARN, "[kf] Dropping initial delta on empty list\n");
 							}
 						}
+						janus_mutex_unlock(&stream->keyframe.mutex);
 					}
 					/* If paused, ignore this packet */
 					if(!mountpoint->enabled && !stream->rc)
@@ -9868,7 +10058,7 @@ static void *janus_streaming_relay_thread(void *data) {
 					packet.length = bytes;
 					packet.is_rtp = TRUE;
 					packet.is_video = TRUE;
-					packet.is_keyframe = FALSE;
+					packet.is_kfburst = FALSE;
 					packet.simulcast = stream->simulcast;
 					packet.substream = index;
 					packet.codec = stream->codecs.video_codec;
@@ -9922,7 +10112,7 @@ static void *janus_streaming_relay_thread(void *data) {
 							spspkt.length = stream->h264_spspps_len;
 							spspkt.is_rtp = TRUE;
 							spspkt.is_video = TRUE;
-							spspkt.is_keyframe = FALSE;
+							spspkt.is_kfburst = FALSE;
 							spspkt.simulcast = FALSE;
 							spspkt.codec = stream->codecs.video_codec;
 							spspkt.svc = FALSE;
@@ -10137,7 +10327,7 @@ static void janus_streaming_relay_rtp_packet(gpointer data, gpointer user_data) 
 	if(!session || !session->handle) {
 		return;
 	}
-	if(!packet->is_keyframe && (!g_atomic_int_get(&session->started) || g_atomic_int_get(&session->paused))) {
+	if(!packet->is_kfburst && (!g_atomic_int_get(&session->started) || g_atomic_int_get(&session->paused))) {
 		return;
 	}
 	janus_streaming_session_stream *s = g_hash_table_lookup(session->streams_byid, GINT_TO_POINTER(packet->mindex));
@@ -10505,7 +10695,7 @@ static void janus_streaming_helper_rtprtcp_packet(gpointer data, gpointer user_d
 	copy->is_data = packet->is_data;
 	copy->textdata = packet->textdata;
 	copy->is_video = packet->is_video;
-	copy->is_keyframe = packet->is_keyframe;
+	copy->is_kfburst = packet->is_kfburst;
 	copy->simulcast = packet->simulcast;
 	copy->ssrc[0] = packet->ssrc[0];
 	copy->ssrc[1] = packet->ssrc[1];

--- a/src/utils.c
+++ b/src/utils.c
@@ -24,6 +24,7 @@
 #include <openssl/rand.h>
 
 #include "utils.h"
+#include "rtp.h"
 #include "debug.h"
 #include "mutex.h"
 
@@ -931,6 +932,24 @@ gboolean janus_h265_is_keyframe(const char *buffer, int len) {
 		/* FIXME We return TRUE for more than just VPS and SPS, as
 		 * suggested in https://github.com/meetecho/janus-gateway/issues/2323 */
 		return TRUE;
+	}
+	return FALSE;
+}
+
+gboolean janus_is_keyframe(int codec, const char *buffer, int len) {
+	switch(codec) {
+		case JANUS_VIDEOCODEC_VP8:
+			return janus_vp8_is_keyframe(buffer, len);
+		case JANUS_VIDEOCODEC_VP9:
+			return janus_vp9_is_keyframe(buffer, len);
+		case JANUS_VIDEOCODEC_H264:
+			return janus_h264_is_keyframe(buffer, len);
+		case JANUS_VIDEOCODEC_AV1:
+			return janus_av1_is_keyframe(buffer, len);
+		case JANUS_VIDEOCODEC_H265:
+			return janus_h265_is_keyframe(buffer, len);
+		default:
+			break;
 	}
 	return FALSE;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -375,6 +375,14 @@ gboolean janus_av1_is_keyframe(const char *buffer, int len);
  * @returns TRUE if it's a keyframe, FALSE otherwise */
 gboolean janus_h265_is_keyframe(const char *buffer, int len);
 
+/*! \brief Helper method to check if keyframe or not, using one of the
+ * codec specific helper methods according to the provided codec type
+ * @param[in] codec The \ref janus_videocodec used for this RTP payload
+ * @param[in] buffer The RTP payload to process
+ * @param[in] len The length of the RTP payload
+ * @returns TRUE if it's a keyframe, FALSE otherwise */
+gboolean janus_is_keyframe(int codec, const char *buffer, int len);
+
 /*! \brief VP8 simulcasting context, in order to make sure SSRC changes result in coherent picid/temporal level increases */
 typedef struct janus_vp8_simulcast_context {
 	uint16_t last_picid, base_picid, base_picid_prev;


### PR DESCRIPTION
Hi all,

this pull request is a sponsored development effort funded by our friends at [Byborg](https://www.byborgenterprises.com/), so thank you, guys!

To provide some context on the changes this PR introduces, it's a good idea to first make a step backward, and describe what was there originally, what is was trying to solve and why that wasn't enough.

## Motivation

The main problem is that, when using the Streaming plugin, new viewers may join a mountpoint at any time. With video having keyframes at more or less specific intervals, this means that new viewers may jump in a few seconds after a keyframe was received, and so wouldn't be able to decode/display any video until the subsequent keyframe is received, which could take a while depending on the keyframe frequency of the video. The usual way subscribers handle that with WebRTC is by sending a PLI message, to ask the source for a new keyframe right away, but that only works if the source can actually handle it: for Streaming plugin subscribers, this definitely works if the mountpoint source is, e.g., a VideoRoom publisher using RTP forwarders with RTCP support, but that would not work if the source is completely external (e.g., a generic external script feeding RTP packets to the mountpoint, or an RTSP server), as either there's no way to relay the PLI to that generic source, or they wouldn't support it anyway.

## Existing (faulty) solution

A few years ago we added a tentative way to address that, where we basically would optionally store in the Streaming plugin the latest keyframe we received from the source, which means storing in memory all the RTP packets composing the latest keyframe: then, for new viewers, we'd send those RTP packets first, and then start serving the "fresh" packets from the source. This helped, but introduced other problems:

1. Since we were only storing a single frame (the latest keyframe), a new viewer would indeed be able to decode that, but then that decoded image would often be displayed as frozen until the next keyframe, since fresh deltas would not apply to that, and the decoder would not know how to deal with them.
2. When not frozen, the video would actually show a lot of artifacts, for the same reason: fresh deltas would refer to previous deltas the viewer never received, rather than the base keyframe, causing the decoder to get confused and as such generate ghosting effects and artifacts.

While some people are ok with that effect while waiting for a keyframe, there are others that aren't, mostly because it suggests something's wrong with the stream when there really isn't anything wrong: it's just a matter of waiting for a proper sync point. We personally preferred never to use that feature, although available in Janus, as I'm of those that think that a frozen image for a few seconds does indeed give the wrong impression: better not to show anything at all (or a spinning wheel), rather than to show something that suggests technical issues.

## New approach

Which now brings us to this PR. Our friends at [Byborg](https://www.byborgenterprises.com/) contacted us to try and come up with an alternative solution to just storing the keyframe, and the idea was to not only store the keyframe itself, but also following deltas, and then shoot all those RTP packets to new viewers before fresh ones, in order to give recipients all the context they need to kickstart a new Streaming plugin session without waiting and without freezes/artifacts. This sounded like a doable idea, even though with a couple of important drawbacks to take into account:

1. Sending the latest keyframe + deltas to a new viewer as soon as they connect may cause a huge burst of data to be sent: this may cause trouble, depending on how many packets need to be sent and the available bandwidth the recipient has.
2. Sending those RTP packets without rewriting timestamps would cause an unrecoverable delay in the video displayed by the recipient, as the starting reference time would be the one from the keyframe itself, which may have originally been received many seconds ago.

We addressed those drawbacks by adding some options to configure the behaviour:

* As far as timestamps are concerned, the idea was to basically rewrite them so that all stored packets would be sent as if they came right one after the other, so with a small (1) gap between them; this is supposed to trick the recipient into thinking that, for a little while, framerate was really high, and so cause a fast decode through keyframe and deltas to catchup with fresh frames ASAP (which is what video players internally do as well, when seeking).
* To limit the impact of bursts, we added a couple of options to configure this new behaviour, where when enabling the feature you can choose how many seconds of data you want to store at max (starting from the keyframe) and/or enforce a cap on the overall bytes you want to store (again starting from the keyframe). This effectively moves the problem to who creates the mountpoint, but since they know the application space this would be used in, it at least gives them control on how much "bursting" they may considered acceptable.

## Enabling the feature

Enabling the feature is relatively easy, since it only requires you to set a new global feature when creating an RTP or RTSP mountpoint. Specifically, when you create a new mountpoint (statically, in the config file, or dynamically, via API) there are two new mountpoint-level properties you can configure:

* `bufferkf_ms`
* `bufferkf_bytes`

The Streaming plugin configuration file has a new extensive documentation section about them, so I encourage you to refer to that. In a nutshell, as the names suggest, `bufferkf_ms` imposes a temporal limit (only store RTP packets up to X milliseconds), while `bufferkf_bytes` imposes a size limit (only store RTP packets as long as the sum of their size does not exceed X bytes). Both are disabled by default (value 0). The two properties are not mutually exclusive: if both are set, the first one that is triggered causes following RTP packets not to be stored. Limits are reset any time a new keyframe is received, since the previous list is pruned and we start from scratch again: the RTP packets belonging to the keyframe itself are not impacted, which means that if a keyframe exceeds the value set in `bufferkf_bytes`, those RTP packets will be saved nevertheless, but the following deltas won't (as they would cross the already exceeded configured limit).

Since they're mountpoint level, this means they automatically apply to all video streams configured in that specific mountpoint: each video stream would have their own, separate, keyframe+deltas buffer. This also makes it work for RTSP streams, where we don't know the video profile in advance.

## Backwards compatibilty

The refactoring of the feature was conceived to still allow people to use the previous "only save the keyframe" behaviour, if they liked that. While the old `videobufferkf` is deprecated and ignored (a warning is displayed if you try to use it), you can still get the same behaviour if the set `bufferkf_ms` or `bufferkf_bytes` to `1`: both will only give the code enough "room" to only save the keyframe itself (which is always excluded by those limits), while dropping the following deltas.

## Testing the feature

I tested the feature briefly, and it seems to be working as expected in both Firefox and Chrome. That said, more extensive testing should be performed, especially to analyse the impact of bursting in networks other than the local setup I was using. If you are interested in the future, please do test this PR and let us know, taking into account that, due to the drawbacks we mentioned, this isn't supposed to be a magical solution that will work in all situations (especially in case keyframe intervals are very long).

Please notice that, to facilitate debugging, at the moment the code prints quite verbose logging for all packets as they're stored, in order to have an explicit indication of what an incoming packet is (keyframe vs delta) and how it's handled (e.g., whether it's being stored, or ignored because of exceeded limits). That logging will of course disappear when I merge this PR, and be moved to much lower debug levels than `LOG_INFO` and `LOG_WARN`.

Also notice that the code does make some assumptions, in particular on the order of incoming packets. It currently expects incoming RTP packets to be ordered, as implementing reordering would have made the code way more complex than that: this may have an impact on how we store packets, since we currently store different frames with different SSRCs to trigger the automatic "timestamp+1" mechanism to simulate the fast decode functionality, and out of order packets may incorrectly be marked as frames of their own. Implementing reordering, if needed, can be delegated to other efforts in the future: the idea is that, when WebRTC publishers are not involved (for which as mentioned we already have RTCP support in RTP forwarders todeal with keyframes automatically), generic sources are supposed to be close enough to Janus instances that this shouldn't be a big deal.

## Feedback welcome

I've talked enough: now go and test this :grimacing: 