### PR TITLE
[0.x] Fix memory leak in janus_sip.c

### DIFF
--- a/plugins/janus_sip.c
+++ b/plugins/janus_sip.c
@@ -1661,8 +1661,7 @@ static json_t *janus_sip_get_incoming_headers(const sip_t *sip, const janus_sip_
 			char *header_prefix = (char *)temp->data;
 			if(header_prefix != NULL && unknown_header->un_name != NULL) {
 				if(strncasecmp(unknown_header->un_name, header_prefix, strlen(header_prefix)) == 0) {
-					const char *header_name = g_strdup(unknown_header->un_name);
-					json_object_set(headers, header_name, json_string(unknown_header->un_value));
+					json_object_set(headers, unknown_header->un_name, json_string(unknown_header->un_value));
 					break;
 				}
 			}


### PR DESCRIPTION
Fixed memory leak in janus_sip_get_incoming_headers().
json_object_set() does not require a new memory allocation for the key.