### PR TITLE
Fix `TrackOption.capture` type to allow `MediaStreamTrack`

### DIFF
--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -286,7 +286,7 @@ declare namespace JanusJS {
 		remove?: boolean;
 		type: 'video' | 'screen' | 'audio' | 'data';
 		mid?: string;
-		capture: boolean | MediaTrackConstraints;
+		capture: boolean | MediaTrackConstraints | MediaStreamTrack;
 		recv?: boolean;
 		group?: 'default' | string;
 		gumGroup?: TrackOption['group'];


### PR DESCRIPTION
Updates the `TrackOption` type definition so that the `capture` property accepts `MediaStreamTrack` in addition to `boolean` and `MediaTrackConstraints`. This aligns the types with both the documentation and the actual implementation.

Closes [#3573](https://github.com/meetecho/janus-gateway/issues/3573)