### PR TITLE
Implemented compound rtcp reports rfc3550

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -4378,7 +4378,9 @@ static gboolean janus_ice_outgoing_rtcp_handle(gpointer user_data) {
 	if(offset > 0) {
 		/* We've got a batch of RTCP messages to send that we didn't
 		 * send as of yet: enqueue the buffer, we'll send it later */
-		janus_ice_send_compound_rtcp(handle, medium, rtcpbuf, rtcpbuf_size, &offset);
+		janus_plugin_rtcp rtcp = { .mindex = medium->mindex,
+			.video = (medium->type == JANUS_MEDIA_VIDEO), .buffer = rtcpbuf, .length = offset };
+		janus_ice_relay_rtcp_internal(handle, medium, &rtcp, FALSE);
 	}
 
 	if(twcc_period == 1000) {


### PR DESCRIPTION
Discovered performance issues for client/server while performance testing with stream counts > 1 relating to high RTCP packet traffic.

Implementation of https://datatracker.ietf.org/doc/html/rfc3550#section-6.1

Coalesced compound RTCP reports in janus_ice_outgoing_rtcp_handle to combine ~30 reports into a single packet instead of single report per packet.

A value of 1324 was selected for the buffer meaning at most the size will be 1400. Open to adjusting this value.

Also, get time once instead of inside the loop as a minor performance optimization.