### PR TITLE
Fix post-processor compile errors with FFmpeg 8

### DIFF
--- a/src/postprocessing/pp-g722.c
+++ b/src/postprocessing/pp-g722.c
@@ -239,9 +239,7 @@ int janus_pp_g722_process(FILE *file, janus_pp_frame_packet *list, int *working)
 
 void janus_pp_g722_close(void) {
 	/* Close decoder */
-	avcodec_close(dec_ctx);
-	av_free(dec_ctx);
-	dec_ctx = NULL;
+	avcodec_free_context(&dec_ctx);
 	/* Flush and close file */
 	if(wav_file != NULL) {
 		/* Update the header */

--- a/src/postprocessing/pp-h264.c
+++ b/src/postprocessing/pp-h264.c
@@ -549,10 +549,10 @@ void janus_pp_h264_close(void) {
 		av_write_trailer(fctx);
 #ifdef USE_CODECPAR
 	if(vEncoder != NULL)
-		avcodec_close(vEncoder);
+		avcodec_free_context(&vEncoder);
 #else
 	if(vStream != NULL && vStream->codec != NULL)
-		avcodec_close(vStream->codec);
+		avcodec_free_context(&(vStream->codec));
 #endif
 		avio_close(fctx->pb);
 		avformat_free_context(fctx);

--- a/src/postprocessing/pp-h265.c
+++ b/src/postprocessing/pp-h265.c
@@ -638,10 +638,10 @@ void janus_pp_h265_close(void) {
 		av_write_trailer(fctx);
 #ifdef USE_CODECPAR
 	if(vEncoder != NULL)
-		avcodec_close(vEncoder);
+		avcodec_free_context(&vEncoder);
 #else
 	if(vStream != NULL && vStream->codec != NULL)
-		avcodec_close(vStream->codec);
+		avcodec_free_context(&(vStream->codec));
 #endif
 		avio_close(fctx->pb);
 		avformat_free_context(fctx);


### PR DESCRIPTION
FFmpeg 8.0 removed the deprecated `avcodec_close` function. This change fixes the compile errors caused by that

`avcodec_free_context` was added in 2014 (https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff/68c05185e229b093bf5c2236c2883cbc296ea938?hp=ff17d8b56ec87fe1516ddd49b0bdea81f22904af). Instead of keeping the old code around and wrapping it in `#if LIBAVCODEC_VER_AT_LEAST(55, 63)`, I think we can assume people are using a new enough version of ffmpeg