### PR TITLE
Generate a pkg-config .pc file when installing Janus (fixes #3523)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ cmdline.c
 cmdline.h
 version.c
 docs/html/
+janus-gateway.pc
 
 janus
 janus-cfgconv

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,16 @@ CLEANFILES += conf/janus.jcfg.sample
 
 
 ##
+# pkg-config file
+##
+
+EXTRA_DIST = janus-gateway.pc.in
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = janus-gateway.pc
+DISTCLEANFILES = janus-gateway.pc
+
+
+##
 # Fuzzers checking
 ##
 

--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,9 @@ glib_version=2.34
 ssl_version=1.0.1
 jansson_version=2.5
 
+JANUS_PACKAGES_PUBLIC="glib-2.0 >= $glib_version, jansson >= $jansson_version"
+AC_SUBST(JANUS_PACKAGES_PUBLIC)
+
 ##
 # Janus
 ##
@@ -987,6 +990,7 @@ AC_CONFIG_FILES([
   src/Makefile
   html/Makefile
   docs/Makefile
+  janus-gateway.pc
 ])
 
 JANUS_MANUAL_LIBS+=" -pthread"

--- a/janus-gateway.pc.in
+++ b/janus-gateway.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: janus-gateway
+Description: Janus WebRTC Server
+Version: @JANUS_VERSION_STRING@
+Requires: @JANUS_PACKAGES_PUBLIC@
+Libs:
+Cflags: -I${includedir}


### PR DESCRIPTION
This is an attempt to address #3523. Currently WIP, as I'm not sure this contains everything it needs to contain.

Notice that, for `CFLAGS`, it lists the include path _without_ the `/janus` part, which means you need to specify that when including a Janus header in your plugin, e.g.

```
#include <janus/plugins/plugin.h>

#include <janus/debug.h>
```

At the moment, this only lists Glib and Jansson as dependencies, since those are the only ones that are typically always used by plugins.

With a `--prefix=/opt/janus --libdir=/opt/janus/lib64` passed to the `configure` script, this currently generates a `janus-gateway` file that looks like this:

```
prefix=/opt/janus
exec_prefix=${prefix}
libdir=/opt/janus/lib64
includedir=${prefix}/include

Name: janus-gateway
Description: Janus WebRTC Server
Version: 1.4.0
Requires: glib-2.0 >= 2.34, jansson >= 2.5
Libs:
Cflags: -I${includedir}
```

Using `pkg-config` to test it:

```
lminiero@lminiero pkgconfig-file $ PKG_CONFIG_PATH=`pwd` pkg-config --cflags --libs janus-gateway
-I/opt/janus/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-6 -pthread -lglib-2.0 -ljansson
```