### PR TITLE
fix: sip subscription renew to wrong host

### DIFF
--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -3567,7 +3567,7 @@ static void *janus_sip_handler(void *data) {
 			char *contact_header = janus_sip_session_contact_header_retrieve(session);
 			/* Retrieve the outbound proxy */
 			char *proxy = session->helper && session->master ?
-					session->master->account.outbound_proxy : session->account.outbound_proxy;
+				session->master->account.outbound_proxy : session->account.outbound_proxy;
 			/* Send the SUBSCRIBE */
 			nua_subscribe(nh,
 				SIPTAG_TO_STR(to),


### PR DESCRIPTION
This is the fix for the issue https://github.com/meetecho/janus-gateway/issues/3562
Problem happened if the SIP server stays behind proxy and Janus sends subscription renew request to wrong destination(ignores proxy from dialog), this happened because NUTAG_PROXY(NULL) have such side-effect.

Here is a pcap dumps before and after [dumps.zip](https://github.com/user-attachments/files/23415176/dumps.zip)
