### PR TITLE
Make participant encoder/decoder access thread-safe

### DIFF
--- a/src/plugins/janus_audiobridge.c
+++ b/src/plugins/janus_audiobridge.c
@@ -9313,7 +9313,6 @@ static void *janus_audiobridge_participant_thread(void *data) {
 		if(mixedpkt != NULL && g_atomic_int_get(&session->destroyed) == 0 && g_atomic_int_get(&session->started)) {
 			if(g_atomic_int_get(&participant->active) && (participant->codec == JANUS_AUDIOCODEC_PCMA ||
 					participant->codec == JANUS_AUDIOCODEC_PCMU)) {
-				janus_mutex_lock(&participant->encoding_mutex);
 				/* Encode using G.711 */
 				if(mixedpkt->length != 320) {
 					/* TODO Resample */
@@ -9329,7 +9328,6 @@ static void *janus_audiobridge_participant_thread(void *data) {
 					for(i=0; i<160; i++)
 						*(payload+12+i) = janus_audiobridge_g711_ulaw_encode(outBuffer[i]);
 				}
-				janus_mutex_unlock(&participant->encoding_mutex);
 				outpkt->length = 172;	/* Take the RTP header into consideration */
 				/* Update RTP header */
 				outpkt->data->version = 2;

--- a/src/plugins/janus_audiobridge.c
+++ b/src/plugins/janus_audiobridge.c
@@ -9184,8 +9184,9 @@ static void *janus_audiobridge_participant_thread(void *data) {
 						pkt->seq_number = participant->last_seq + 1;
 						/* This is a redundant packet, so we can't parse any extension info */
 						pkt->silence = FALSE;
-						janus_audiobridge_participant_istalking(session, participant, NULL, NULL);
 						pkt->length = opus_decode(participant->decoder, NULL, 0, (opus_int16 *)pkt->data, output_samples, 0);
+						janus_mutex_unlock(&participant->decoding_mutex);
+						janus_audiobridge_participant_istalking(session, participant, NULL, NULL);
 #ifdef HAVE_RNNOISE
 						/* Check if we need to denoise this packet */
 						if(participant->denoise)
@@ -9194,7 +9195,6 @@ static void *janus_audiobridge_participant_thread(void *data) {
 						/* Update the details */
 						participant->last_seq = pkt->seq_number;
 						participant->last_timestamp = pkt->timestamp;
-						janus_mutex_unlock(&participant->decoding_mutex);
 						if(pkt->length < 0) {
 							JANUS_LOG(LOG_ERR, "[Opus] Ops! got an error decoding the Opus frame: %d (%s)\n", pkt->length, opus_strerror(pkt->length));
 							g_free(pkt->data);


### PR DESCRIPTION
Replaces gbooleans used for encoding/decoding status with mutexes to ensure all access to the participant encoder and decoder is thread-safe. Additionally, the reset status gboolean is now accessed atomically.

Currently only tested with participants using Opus encoder/decoder.

This needs to be carefully reviewed for performance issues and logic errors.

See also #3587