### PR TITLE
Initialize and destroy mutexes and conditions to be consistent with the rest of the codebase

### DIFF
--- a/src/plugins/janus_audiobridge.c
+++ b/src/plugins/janus_audiobridge.c
@@ -1953,6 +1953,8 @@ static void janus_audiobridge_participant_free(const janus_refcount *participant
 	janus_mutex_destroy(&participant->pmutex);
 	janus_mutex_destroy(&participant->qmutex);
 	janus_mutex_destroy(&participant->rec_mutex);
+	janus_mutex_destroy(&participant->suspend_cond_mutex);
+	janus_condition_destroy(&participant->suspend_cond);
 	g_free(participant);
 }
 
@@ -6903,6 +6905,8 @@ static void *janus_audiobridge_handler(void *data) {
 				janus_audiobridge_plainrtp_media_cleanup(&participant->plainrtp_media);
 				janus_mutex_init(&participant->pmutex);
 				janus_mutex_init(&participant->rec_mutex);
+				janus_mutex_init(&participant->suspend_cond_mutex);
+				janus_condition_init(&participant->suspend_cond);
 			}
 			participant->session = session;
 			participant->room = audiobridge;


### PR DESCRIPTION
* `suspend_cond_mutex` the same as every other mutex in `janus_audiobridge.c` (and elsewhere)
* `suspend_cond` the same as in `src/transports/janus_mqtt.c`

https://github.com/meetecho/janus-gateway/blob/fcfd0c5f31285b2fa3898ebb665739a200664a0b/src/transports/janus_mqtt.c#L564-L565

https://github.com/meetecho/janus-gateway/blob/fcfd0c5f31285b2fa3898ebb665739a200664a0b/src/transports/janus_mqtt.c#L1682-L1683