### PR TITLE
Explicitly set the max DTLS MTU size

### DIFF
--- a/src/dtls.c
+++ b/src/dtls.c
@@ -598,7 +598,6 @@ janus_dtls_srtp *janus_dtls_srtp_create(void *ice_pc, janus_dtls_role role) {
 	DTLS_set_link_mtu(dtls->ssl, janus_dtls_bio_agent_get_mtu());
 #endif
 	SSL_set_info_callback(dtls->ssl, janus_dtls_callback);
-#endif
 	dtls->read_bio = BIO_new(BIO_s_mem());
 	if(!dtls->read_bio) {
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"]   Error creating read BIO! (%s)\n",


### PR DESCRIPTION
Adapted from: https://github.com/versatica/mediasoup/pull/1156

The Dtls bios may produce packet sizes larger than the standard 1500 MTU using the default configuration. This manually sets a maximum limit of 1350, which will avoid the error log of:

> The DTLS stack is trying to send a packet of %d bytes, this may be larger than the MTU and get dropped! 


When setting the maximum limit, the Dtls bios will internally fragment packets instead of having Janus outsource this task to the IP layer.

We observed cases where this error log would emit beyond 1500 and our MTU sizes presumably because as per this conversation: https://mta.openssl.org/pipermail/openssl-users/2015-June/001511.html a fallback MTU size was not provided BIO_CTRL_DGRAM_GET_FALLBACK_MTU. This solution is adapted from mediasoup's solution for handling dtls fragmentation.

This was tested with internal test cases and mtu sizes of 400/576/1200.