### PR TITLE
Fix for SIP plugin not offering SRTP in response to offerless INVITEs

### DIFF
--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -4163,7 +4163,7 @@ static void *janus_sip_handler(void *data) {
 			session->media.has_srtp_local_video = answer_srtp && (session->media.has_srtp_remote_video || !answer);
 			if(answer_srtp) {
 				JANUS_LOG(LOG_VERB, "Going to negotiate SDES-SRTP (%s)...\n", session->media.require_srtp ? "mandatory" : "optional");
-				if(!answer && session->media.srtp_profile == NULL) {
+				if(!answer && !session->media.srtp_profile) {
 					/* We got an offerless-INVITE, any SRTP profile different from the default? */
 					srtp_profile = JANUS_SRTP_AES128_CM_SHA1_80;
 					const char *profile = json_string_value(json_object_get(root, "srtp_profile"));


### PR DESCRIPTION
A post on our [Discourse group](https://janus.discourse.group/t/in-response-to-a-secure-offerless-sip-invite-the-janus-webrtc-server-is-missing-sdes-in-the-offer-sip-200ok-with-sdp/1757) pointed out a bug in the SIP plugin: specifically, when receiving an offerless INVITE and sending an `accept` with a `srtp: "sdes_mandatory"`, still results in a plain SDP being sent, while it should contain crypto attributes.

Checking the code, this was because normally an `accept` expects that an SDP to refer to exists (the offer) when deciding whether or not to add some properties at the time of manipulating the WebRTC SDP to an SDP one. For SRTP, it was indeed checking the current status of the `session->media` object, which in case of offerless INVITEs is wrong, though, as the state is still "clean". This patch tries to address that, and make sure that SRTP attributes are correctly generated in that case.

I don't have a quick or easy way to test this, so please let me know if that works for you, and more importantly if you notice any regression that this may introduce. If this works as expected, I'll backport it to `0.x` as well.