### PR TITLE
Fix build error when using older OpenSSL API

### DIFF
--- a/src/dtls.c
+++ b/src/dtls.c
@@ -560,8 +560,9 @@ void janus_dtls_srtp_cleanup(void) {
 		ssl_ctx = NULL;
 	}
 #if JANUS_USE_OPENSSL_PRE_1_1_API && !defined(HAVE_BORINGSSL)
-	for(l = 0; l < CRYPTO_num_locks(); l++) {
+	for(int l = 0; l < CRYPTO_num_locks(); l++) {
 		pthread_mutex_destroy(&janus_dtls_locks[l]);
+	}
 	g_free(janus_dtls_locks);
 #endif
 }


### PR DESCRIPTION
This fixes issue #3622. Changes made in commit fd24309 were missing a variable declaration and closing brace. These have been added.