### PR TITLE
Gracefully handle `m=text` (T.140 RTT) instead of rejecting the entire SDP

### DIFF
--- a/src/sdp-utils.c
+++ b/src/sdp-utils.c
@@ -203,6 +203,8 @@ janus_sdp_mtype janus_sdp_parse_mtype(const char *type) {
 		return JANUS_SDP_VIDEO;
 	if(!strcasecmp(type, "application"))
 		return JANUS_SDP_APPLICATION;
+	if(!strcasecmp(type, "text"))
+		return JANUS_SDP_TEXT;
 	return JANUS_SDP_OTHER;
 }
 
@@ -214,6 +216,8 @@ const char *janus_sdp_mtype_str(janus_sdp_mtype type) {
 			return "video";
 		case JANUS_SDP_APPLICATION:
 			return "application";
+		case JANUS_SDP_TEXT:
+			return "text";
 		case JANUS_SDP_OTHER:
 		default:
 			break;

--- a/src/sdp-utils.h
+++ b/src/sdp-utils.h
@@ -64,6 +64,8 @@ typedef enum janus_sdp_mtype {
 	JANUS_SDP_VIDEO,
 	/*! \brief m=application */
 	JANUS_SDP_APPLICATION,
+	/*! \brief m=text */
+	JANUS_SDP_TEXT,
 	/*! \brief m=whatever (we don't care, unsupported) */
 	JANUS_SDP_OTHER
 } janus_sdp_mtype;

--- a/src/sdp.c
+++ b/src/sdp.c
@@ -1639,6 +1639,13 @@ char *janus_sdp_merge(void *ice_handle, janus_sdp *anon, gboolean offer) {
 			JANUS_LOG(LOG_WARN, "[%"SCNu64"] Skipping disabled/unsupported media line...\n", handle->handle_id);
 			m->port = 0;
 			m->direction = JANUS_SDP_INACTIVE;
+			/* RFC 8843 (BUNDLE): rejected m-lines are not included in the
+			* BUNDLE group. If a rejected m-line retains a real connection address,
+			* browsers may attempt to establish a separate ICE
+			* transport for it, which fails since it's not bundled. Remove c_addr to
+			* prevent this (e.g., for unsupported media types like text/T.140). */
+			g_free(m->c_addr);
+			m->c_addr = NULL;
 			temp = temp->next;
 			continue;
 		}


### PR DESCRIPTION
# Summary
This PR adds graceful handling of `m=text` media lines (T.140 Real-Time Text, [RFC 4103](https://www.rfc-editor.org/rfc/rfc4103)) in SDP processing. I know, that Janus does not implement RTT yet, at least its not [merged](github.com/meetecho/janus-gateway/pull/3231), but i think `m=text` line in an incoming SDP offer should not cause the entire session to be rejected. Instead, Janus now recognizes the `m=text` type, accepts it at the SDP parsing level, and just disables it by setting port to zero - allowing call with compatible media (e.g., m=audio) to proceed normally.

# Problem
Many SIP clients (e.g., PJSIP lib) include `m=text` in their SDP to advertise T.140 Real-Time Text support. When such an SDP reaches Janus, Janus currently treats `m=text` as an unknown media type, causing the SDP to be treated as invalid and returning a `488 Not Acceptable Here`, even though the offer contains perfectly compatible audio/video streams.

Per [RFC 3264 Section 6.1](https://www.rfc-editor.org/rfc/rfc3264#section-6.1), unsupported media streams should be handled gracefully:

_If the answerer has no media formats in common for a particular offered stream, the answerer MUST reject that media stream by setting the port to zero._

_If there are no media formats in common for all streams, the entire offered session is rejected._

So, i think, Janus should reject only the unsupported `m=text` stream (with port 0), not the entire SDP session

# Changes
## 1. Recognize m=text as a known media type
[sdp-utils.h](https://github.com/yakimenko73/janus-gateway/commit/7c850c823a7f5db56a30a2c42f2d09ac55cf48d0#diff-f0ce4a6d67eaa71ae8db6a849e2d8a4c4ec8ce71334d3683a366abc0c51317b3), [sdp-utils.c](https://github.com/yakimenko73/janus-gateway/commit/7c850c823a7f5db56a30a2c42f2d09ac55cf48d0#diff-4e2249a57b167a9647ebe1b04a79041cc7eb93445ede89abbfc7da32b6b4a65e)
Added `JANUS_SDP_TEXT` to the `janus_sdp_mtype` enum and the corresponding parsing/serialization logic. 
Previously, `m=text` was parsed as `JANUS_SDP_OTHER`, which triggered an error. Now it is recognized as a known (but unsupported) media type.

## 2. Remove connection address for rejected unsupported media
[sdp.c](https://github.com/yakimenko73/janus-gateway/commit/7c850c823a7f5db56a30a2c42f2d09ac55cf48d0#diff-4e2249a57b167a9647ebe1b04a79041cc7eb93445ede89abbfc7da32b6b4a65e)
In `janus_sdp_merge`, the code path for unsupported media types already sets `port=0` and `direction=inactive`. This PR additionally removes the connection address `c=` for such lines.

This is necessary because Janus uses BUNDLE ([RFC 8843](https://www.rfc-editor.org/rfc/rfc8843)) for WebRTC, and rejected m-lines are not included in `a=group:BUNDLE`. 

If a rejected m-line retains a real connection address while not being in the BUNDLE group, WebRTC browsers attempt to establish a separate ICE transport for it, which fails. The [RFC 8843 Section 18.5](https://www.rfc-editor.org/rfc/rfc8843#section-18.5) example confirms that disabled/rejected m-lines omit the `c=` line entirely

# Use Case
SIP-to-WebRTC bridging via the Janus SIP plugin, where SIP endpoints include `m=text` for `T.140` accessibility support alongside `m=audio`. Without this fix, the call fails entirely despite audio being fully compatible.