### PR TITLE
Change default JSON serialization to compact wherever applicable

### DIFF
--- a/conf/janus.eventhandler.mqttevh.jcfg.sample
+++ b/conf/janus.eventhandler.mqttevh.jcfg.sample
@@ -12,7 +12,7 @@ general: {
 							# in. Valid values are none, sessions, handles, jsep, webrtc,
 							# media, plugins, transports, core, external and all. By
 							# default we subscribe to everything (all)
-	json = "indented"		# Whether the JSON messages should be indented (default),
+	json = "compact"		# Whether the JSON messages should be indented (pretty),
 							# plain (no indentation) or compact (no indentation and no spaces)
 
 	url = "tcp://localhost:1883"	# The URL of the MQTT server. "tcp://" and "ssl://" protocols are supported.

--- a/conf/janus.eventhandler.nanomsgevh.jcfg.sample
+++ b/conf/janus.eventhandler.nanomsgevh.jcfg.sample
@@ -20,7 +20,7 @@ general: {
 						# requests with an application/json payload. In case
 						# authentication is required to contact the backend, set
 						# the credentials as well (basic authentication only).
-	json = "indented"	# Whether the JSON messages should be indented (default),
+	json = "compact"	# Whether the JSON messages should be indented (pretty),
 						# plain (no indentation) or compact (no indentation and no spaces)
 
 	#mode = "bind"						# Whether we should 'bind' to the specified

--- a/conf/janus.eventhandler.rabbitmqevh.jcfg.sample
+++ b/conf/janus.eventhandler.rabbitmqevh.jcfg.sample
@@ -9,7 +9,7 @@ general: {
 	grouping = true					# Whether events should be sent individually , or if it's ok
 									# to group them. The default is 'yes' to limit the number of
 									# messages
-	json = "indented"				# Whether the JSON messages should be indented (default),
+	json = "compact"				# Whether the JSON messages should be indented (pretty),
 									# plain (no indentation) or compact (no indentation and no spaces)
 
 	host = "localhost"				# The address of the RabbitMQ server

--- a/conf/janus.eventhandler.sampleevh.jcfg.sample
+++ b/conf/janus.eventhandler.sampleevh.jcfg.sample
@@ -13,7 +13,7 @@ general: {
 						# HTTP POST, JSON object), or if it's ok to group them
 						# (one or more per HTTP POST, JSON array with objects)
 						# The default is 'true' to limit the number of connections.
-	json = "indented"	# Whether the JSON messages should be indented (default),
+	json = "compact"	# Whether the JSON messages should be indented (pretty),
 						# plain (no indentation) or compact (no indentation and no spaces)
 
 	#compress = true	# Optionally, the JSON messages can be compressed using zlib

--- a/conf/janus.eventhandler.wsevh.jcfg.sample
+++ b/conf/janus.eventhandler.wsevh.jcfg.sample
@@ -14,7 +14,7 @@ general: {
 						# (one or more per HTTP POST, JSON array with objects)
 						# The default is 'yes' to limit the number of connections.
 
-	json = "indented"	# Whether the JSON messages should be indented (default),
+	json = "compact"	# Whether the JSON messages should be indented (pretty),
 						# plain (no indentation) or compact (no indentation and no spaces)
 
 						# Address the plugin will send all events to as WebSocket

--- a/conf/janus.logger.jsonlog.jcfg.sample
+++ b/conf/janus.logger.jsonlog.jcfg.sample
@@ -7,9 +7,9 @@
 general: {
 	enabled = false		# By default the module is not enabled
 
-	json = "indented"	# Since this logger simply writes each log line as
+	json = "compact"	# Since this logger simply writes each log line as
 						# a JSON object to a file, you can configure whether
-						# the JSON log lines should be indented (default),
+						# the JSON log lines should be indented (pretty),
 						# plain (no indentation) or compact (no indentation and no spaces)
 
 	filename = "/tmp/janus-log.json"	# Filename to save to

--- a/conf/janus.plugin.textroom.jcfg.sample
+++ b/conf/janus.plugin.textroom.jcfg.sample
@@ -10,7 +10,7 @@
 general: {
 	#admin_key = "supersecret"		# If set, rooms can be created via API only
 									# if this key is provided in the request
-	json = "indented"				# Whether the data channel JSON messages should be indented (default),
+	json = "compact"				# Whether the data channel JSON messages should be indented (pretty),
 									# plain (no indentation) or compact (no indentation and no spaces)
 	#events = false					# Whether events should be sent to event
 									# handlers (default=true)

--- a/conf/janus.transport.http.jcfg.sample
+++ b/conf/janus.transport.http.jcfg.sample
@@ -8,7 +8,7 @@
 # To see debug logs from the HTTP server library, set 'mhd_debug'.
 general: {
 	#events = true					# Whether to notify event handlers about transport events (default=true)
-	json = "indented"				# Whether the JSON messages should be indented (default),
+	json = "compact"				# Whether the JSON messages should be indented (pretty),
 									# plain (no indentation) or compact (no indentation and no spaces)
 	base_path = "/janus"			# Base path to bind to in the web server (plain HTTP only)
 	http = true						# Whether to enable the plain HTTP interface

--- a/conf/janus.transport.mqtt.jcfg.sample
+++ b/conf/janus.transport.mqtt.jcfg.sample
@@ -2,7 +2,7 @@
 general: {
 	enabled = false						# Whether the support must be enabled
 	#events = true						# Whether to notify event handlers about transport events (default=true)
-	json = "indented"						# Whether the JSON messages should be indented (default),
+	json = "compact"					# Whether the JSON messages should be indented (pretty),
 										# plain (no indentation) or compact (no indentation and no spaces)
 
 	url = "tcp://localhost:1883"		# The connection URL of the MQTT broker: if you want

--- a/conf/janus.transport.nanomsg.jcfg.sample
+++ b/conf/janus.transport.nanomsg.jcfg.sample
@@ -9,7 +9,7 @@ general: {
 	enabled = true						# Whether to enable the Nanomsg interface
 										# for Janus API clients
 	#events = true						# Whether to notify event handlers about transport events (default=true)
-	json = "indented"					# Whether the JSON messages should be indented (default),
+	json = "compact"					# Whether the JSON messages should be indented (pretty),
 										# plain (no indentation) or compact (no indentation and no spaces)
 	#mode = "bind"						# Whether we should 'bind' to the specified
 										# address (default), or connect to it if remote

--- a/conf/janus.transport.pfunix.jcfg.sample
+++ b/conf/janus.transport.pfunix.jcfg.sample
@@ -6,7 +6,7 @@ general: {
 	enabled = false					# Whether to enable the Unix Sockets interface
 									# for Janus API clients
 	#events = true					# Whether to notify event handlers about transport events (default=true)
-	json = "indented"				# Whether the JSON messages should be indented (default),
+	json = "compact"				# Whether the JSON messages should be indented (pretty),
 									# plain (no indentation) or compact (no indentation and no spaces)
 	#path = "/path/to/ux-janusapi"	# Path to bind to (Janus API)
 	#type = "SOCK_SEQPACKET"		# SOCK_SEQPACKET (default) or SOCK_DGRAM?

--- a/conf/janus.transport.rabbitmq.jcfg.sample
+++ b/conf/janus.transport.rabbitmq.jcfg.sample
@@ -17,7 +17,7 @@
 general: {
 	enabled = false						# Whether the support must be enabled
 	#events = true						# Whether to notify event handlers about transport events (default=true)
-	json = "indented"					# Whether the JSON messages should be indented (default),
+	json = "compact"					# Whether the JSON messages should be indented (pretty),
 										# plain (no indentation) or compact (no indentation and no spaces)
 	host = "localhost"					# The address of the RabbitMQ server
 	#port = 5672						# The port of the RabbitMQ server (5672 by default)

--- a/conf/janus.transport.websockets.jcfg.sample
+++ b/conf/janus.transport.websockets.jcfg.sample
@@ -2,7 +2,7 @@
 # should use, and so on.
 general: {
 	#events = true					# Whether to notify event handlers about transport events (default=true)
-	json = "indented"				# Whether the JSON messages should be indented (default),
+	json = "compact"				# Whether the JSON messages should be indented (pretty),
 									# plain (no indentation) or compact (no indentation and no spaces)
 	#pingpong_trigger = 30			# After how many seconds of idle, a PING should be sent
 	#pingpong_timeout = 10			# After how many seconds of not getting a PONG, a timeout should be detected

--- a/src/events/janus_gelfevh.c
+++ b/src/events/janus_gelfevh.c
@@ -94,7 +94,7 @@ static void *janus_gelfevh_handler(void *data);
 static janus_mutex evh_mutex = JANUS_MUTEX_INITIALIZER;
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 /* Queue of events to handle */
 static GAsyncQueue *events = NULL;

--- a/src/events/janus_mqttevh.c
+++ b/src/events/janus_mqttevh.c
@@ -107,7 +107,7 @@ static volatile gint initialized = 0, stopping = 0;
 #define JANUS_MQTTEVH_DEFAULT_WILL_QOS	 			0
 #define JANUS_MQTTEVH_DEFAULT_BASETOPIC	 			"/janus/events"
 #define JANUS_MQTTEVH_DEFAULT_MQTTURL				"tcp://localhost:1883"
-#define JANUS_MQTTEVH_DEFAULT_JSON_FORMAT			JSON_INDENT(3) | JSON_PRESERVE_ORDER
+#define JANUS_MQTTEVH_DEFAULT_JSON_FORMAT			JSON_COMPACT | JSON_PRESERVE_ORDER
 #define JANUS_MQTTEVH_DEFAULT_TLS_ENABLE			FALSE
 #define JANUS_MQTTEVH_DEFAULT_TLS_VERIFY_PEER		FALSE
 #define JANUS_MQTTEVH_DEFAULT_TLS_VERIFY_HOST		FALSE
@@ -790,7 +790,7 @@ static int janus_mqttevh_init(const char *config_path) {
 			/* Compact, so no spaces between separators */
 			json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 		} else {
-			JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", json_item->value);
+			JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (compact)\n", json_item->value);
 			json_format = JANUS_MQTTEVH_DEFAULT_JSON_FORMAT;
 		}
 	}

--- a/src/events/janus_nanomsgevh.c
+++ b/src/events/janus_nanomsgevh.c
@@ -90,7 +90,7 @@ static void janus_nanomsgevh_event_free(json_t *event) {
 }
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 /* Nanomsg stuff */
 static int nfd = -1, nfd_addr = -1, write_nfd[2];
@@ -157,8 +157,8 @@ int janus_nanomsgevh_init(const char *config_path) {
 			/* Compact, so no spaces between separators */
 			json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 		} else {
-			JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", item->value);
-			json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+			JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (compact)\n", item->value);
+			json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 		}
 	}
 

--- a/src/events/janus_rabbitmqevh.c
+++ b/src/events/janus_rabbitmqevh.c
@@ -100,7 +100,7 @@ static void janus_rabbitmqevh_event_free(json_t *event) {
 }
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 #define JANUS_RABBITMQEVH_EXCHANGE_TYPE "fanout"
 
@@ -185,8 +185,8 @@ int janus_rabbitmqevh_init(const char *config_path) {
 			/* Compact, so no spaces between separators */
 			json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 		} else {
-			JANUS_LOG(LOG_WARN, "RabbitMQEventHandler: Unsupported JSON format option '%s', using default (indented)\n", item->value);
-			json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+			JANUS_LOG(LOG_WARN, "RabbitMQEventHandler: Unsupported JSON format option '%s', using default (compact)\n", item->value);
+			json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 		}
 	}
 

--- a/src/events/janus_sampleevh.c
+++ b/src/events/janus_sampleevh.c
@@ -79,7 +79,7 @@ static void *janus_sampleevh_handler(void *data);
 static janus_mutex evh_mutex = JANUS_MUTEX_INITIALIZER;
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 /* Compression, if any */
 static gboolean compress = FALSE;
@@ -215,8 +215,8 @@ int janus_sampleevh_init(const char *config_path) {
 						/* Compact, so no spaces between separators */
 						json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 					} else {
-						JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", item->value);
-						json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+						JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (compact)\n", item->value);
+						json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 					}
 				}
 				/* Check if we need any compression */

--- a/src/events/janus_wsevh.c
+++ b/src/events/janus_wsevh.c
@@ -95,7 +95,7 @@ static void janus_wsevh_event_free(json_t *event) {
 }
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 
 /* Parameter validation (for tweaking via Admin API) */
@@ -291,8 +291,8 @@ int janus_wsevh_init(const char *config_path) {
 			/* Compact, so no spaces between separators */
 			json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 		} else {
-			JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", item->value);
-			json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+			JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (compact)\n", item->value);
+			json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 		}
 	}
 

--- a/src/loggers/janus_jsonlog.c
+++ b/src/loggers/janus_jsonlog.c
@@ -74,7 +74,7 @@ static GThread *logger_thread = NULL;
 static void *janus_jsonlog_thread(void *data);
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 /* Queue of log lines to handle */
 static GAsyncQueue *loglines = NULL;
@@ -168,8 +168,8 @@ int janus_jsonlog_init(const char *server_name, const char *config_path) {
 					/* Compact, so no spaces between separators */
 					json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 				} else {
-					JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", item->value);
-					json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+					JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (compact)\n", item->value);
+					json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 				}
 			}
 			/* Done */

--- a/src/plugins/janus_textroom.c
+++ b/src/plugins/janus_textroom.c
@@ -729,7 +729,7 @@ static void *janus_textroom_handler(void *data);
 static void janus_textroom_hangup_media_internal(janus_plugin_session *handle);
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 
 typedef struct janus_textroom_room {
@@ -960,8 +960,8 @@ int janus_textroom_init(janus_callbacks *callback, const char *config_path) {
 				/* Compact, so no spaces between separators */
 				json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 			} else {
-				JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", item->value);
-				json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+				JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (compact)\n", item->value);
+				json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 			}
 		}
 		/* Any admin key to limit who can "create"? */

--- a/src/transports/janus_http.c
+++ b/src/transports/janus_http.c
@@ -123,7 +123,7 @@ static gboolean notify_events = TRUE;
 static enum MHD_FLAG mhd_debug_flag = MHD_NO_FLAG;
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 /* Parameter validation (for tweaking and queries via Admin API) */
 static struct janus_json_parameter request_parameters[] = {
@@ -672,8 +672,8 @@ int janus_http_init(janus_transport_callbacks *callback, const char *config_path
 				/* Compact, so no spaces between separators */
 				json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 			} else {
-				JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", item->value);
-				json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+				JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (compact)\n", item->value);
+				json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 			}
 		}
 

--- a/src/transports/janus_mqtt.c
+++ b/src/transports/janus_mqtt.c
@@ -107,7 +107,7 @@ static gboolean janus_mqtt_admin_api_enabled_ = FALSE;
 static gboolean notify_events = TRUE;
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 /* Parameter validation (for tweaking and queries via Admin API) */
 static struct janus_json_parameter request_parameters[] = {
@@ -349,8 +349,8 @@ int janus_mqtt_init(janus_transport_callbacks *callback, const char *config_path
 			/* Compact, so no spaces between separators */
 			json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 		} else {
-			JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", json_item->value);
-			json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+			JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (compact)\n", json_item->value);
+			json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 		}
 	}
 

--- a/src/transports/janus_nanomsg.c
+++ b/src/transports/janus_nanomsg.c
@@ -94,7 +94,7 @@ static janus_transport_callbacks *gateway = NULL;
 static gboolean notify_events = TRUE;
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 #define BUFFER_SIZE		8192
 
@@ -176,8 +176,8 @@ int janus_nanomsg_init(janus_transport_callbacks *callback, const char *config_p
 				/* Compact, so no spaces between separators */
 				json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 			} else {
-				JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", item->value);
-				json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+				JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (compact)\n", item->value);
+				json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 			}
 		}
 

--- a/src/transports/janus_pfunix.c
+++ b/src/transports/janus_pfunix.c
@@ -110,7 +110,7 @@ static janus_transport_callbacks *gateway = NULL;
 static gboolean notify_events = TRUE;
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 #define BUFFER_SIZE		8192
 
@@ -260,8 +260,8 @@ int janus_pfunix_init(janus_transport_callbacks *callback, const char *config_pa
 				/* Compact, so no spaces between separators */
 				json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 			} else {
-				JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", item->value);
-				json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+				JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (compact)\n", item->value);
+				json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 			}
 		}
 

--- a/src/transports/janus_rabbitmq.c
+++ b/src/transports/janus_rabbitmq.c
@@ -128,7 +128,7 @@ static gfloat rmq_reconnect_backoff_multiplier = 1.5;
 #define JANUS_RABBITMQ_EXCHANGE_TYPE "fanout"
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 /* Parameter validation (for tweaking and queries via Admin API) */
 static struct janus_json_parameter request_parameters[] = {
@@ -234,8 +234,8 @@ int janus_rabbitmq_init(janus_transport_callbacks *callback, const char *config_
 			/* Compact, so no spaces between separators */
 			json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 		} else {
-			JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", item->value);
-			json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+			JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (compact)\n", item->value);
+			json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 		}
 	}
 

--- a/src/transports/janus_websockets.c
+++ b/src/transports/janus_websockets.c
@@ -116,7 +116,7 @@ static GHashTable *clients = NULL, *writable_clients = NULL;
 static janus_mutex writable_mutex = JANUS_MUTEX_INITIALIZER;
 
 /* JSON serialization options */
-static size_t json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+static size_t json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 
 /* Parameter validation (for tweaking and queries via Admin API) */
 static struct janus_json_parameter request_parameters[] = {
@@ -571,8 +571,8 @@ int janus_websockets_init(janus_transport_callbacks *callback, const char *confi
 				/* Compact, so no spaces between separators */
 				json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 			} else {
-				JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (indented)\n", item->value);
-				json_format = JSON_INDENT(3) | JSON_PRESERVE_ORDER;
+				JANUS_LOG(LOG_WARN, "Unsupported JSON format option '%s', using default (compact)\n", item->value);
+				json_format = JSON_COMPACT | JSON_PRESERVE_ORDER;
 			}
 		}
 


### PR DESCRIPTION
As the title says, this PR changes the default serialization we do of JSON objects to strings to compact, where before it was a pretty JSON with an indentation of 3. The discussion in https://github.com/OpenSIPS/opensips/pull/3840 made me realize it made little sense for the default being a pretty indentation, considering that it's almost always meant to just be for exchanging API messages, rather than something that needs to be consumed by a human (but even in that case, prettifying it after received is always an option). Compact messages also means less data on the wire, so this should be considered an optimization.

This shouldn't impact any existing application, so I plan to merge soon. If for any reason you need indented JSON, remember it's always possible to change the default in the associated configuration file.