### PR TITLE
fix(sip): fix one-way audio after long hold

### DIFF
--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -7179,6 +7179,10 @@ void janus_sip_save_reason(sip_t const *sip, janus_sip_session *session) {
 void janus_sip_sdp_process(janus_sip_session *session, janus_sdp *sdp, gboolean answer, gboolean update, gboolean *changed) {
 	if(!session || !sdp)
 		return;
+	/* Remember the previous media reception state, so we can detect a hold->resume
+	 * transition and reset the RTP switching context accordingly */
+	gboolean old_audio_recv = session->media.audio_recv;
+	gboolean old_video_recv = session->media.video_recv;
 	/* c= */
 	int opusred_pt = answer ? janus_sdp_get_opusred_pt(sdp, -1) : -1;
 	if(sdp->c_addr) {
@@ -7351,6 +7355,16 @@ void janus_sip_sdp_process(janus_sip_session *session, janus_sdp *sdp, gboolean 
 			} while(res == -1 && errno == EINTR);
 		}
 	}
+	/* If media reception transitioned from disabled (e.g. hold) to enabled
+	 * (e.g. unhold), reset the RTP switching context so the next outbound
+	 * sequence number is monotonic relative to the last one we sent. Without
+	 * this, after a long hold the peer's RTP seq may have wrapped uint16,
+	 * producing an output seq that is lower than what srtp_protect already
+	 * saw and causing it to fail with replay_old. */
+	if(!old_audio_recv && session->media.audio_recv)
+		session->media.acontext.seq_reset = TRUE;
+	if(!old_video_recv && session->media.video_recv)
+		session->media.vcontext.seq_reset = TRUE;
 }
 
 char *janus_sip_sdp_manipulate(janus_sip_session *session, janus_sdp *sdp, gboolean answer) {


### PR DESCRIPTION
## Summary

This PR fixes a one-way audio bug in the SIP plugin that occurs after a call is on hold for a long time (roughly 11+ minutes).

When the call resumes, the remote party can still hear the Janus side, but the Janus side no longer receives audio from the peer. The RTP packets arrive at Janus and the SIP relay thread forwards them, but `srtp_protect` rejects them with `srtp_err_status_replay_old` before they reach the WebRTC PeerConnection, so the browser's `packetsReceived` counter stays frozen while `packetsSent` keeps growing.

## Root cause

Two separate issues in `plugins/janus_sip.c`:

### 1. Relay thread not notified when only SDP direction changes

`janus_sip_sdp_process()` only sets `session->media.updated = TRUE` (and writes to the wake-up pipe) when the `changed` flag is set, which currently only happens on IP / port differences. When the peer answers a hold/unhold re-INVITE with the same IP and port but a changed `a=sendrecv` / `a=recvonly` direction, the relay thread is never woken up, so `session->media.audio_recv` stays out of date from the thread's point of view.

### 2. Outbound audio seq number can regress after a long hold

During hold, packets are dropped by the relay thread (`audio_recv == FALSE`) and never reach `janus_rtp_header_update`. The peer's RTP sequence number keeps advancing (~50 pps for G.711). After ~11 minutes of hold the peer's 16-bit `seq_number` wraps past 65535 and comes back to a lower value.

When the first packet after unhold is processed, `janus_rtp_header_update` maps the peer's (now wrapped) seq through `acontext` and produces an output seq that is lower than the last seq that was already successfully protected by `pc->dtls->srtp_out`. libsrtp's replay database treats the new index as "old" and `srtp_protect` returns `srtp_err_status_replay_old`; the encrypted packet is never sent to the browser.

The bug is intermittent because it only manifests when the combined active time + hold duration causes the peer's seq to wrap uint16 into a range 128–32768 below the last protected seq (SRTP's "dead zone" where ROC is not automatically adjusted).

## Fix

Two minimal changes in `plugins/janus_sip.c`:

1. In `janus_sip_sdp_process()`, remember the previous `audio_recv` / `audio_send` / `video_recv` / `video_send` values and force `*changed = TRUE` whenever any of them differs after processing the SDP. This guarantees the relay thread is woken up on every hold/unhold transition, even when IP and port are unchanged.

2. In `janus_sip_relay_thread()`, introduce a local `guint16 audio_out_seq` that is incremented once per relayed audio packet, and overwrite the RTP header seq number with it right after `janus_rtp_header_update`. The timestamp continues to come from `acontext` (so silence/gap handling is preserved). This makes the outbound audio seq strictly monotonic regardless of what the peer does during hold, so `srtp_protect` can never see a regression and libsrtp's natural 65535→0 wrap continues to be handled transparently via ROC.

Total change: 1 file, 38 insertions, 9 deletions. No public API change.

## Verification

Deployed in production on a NethVoice/Asterisk + Janus installation on 2026-04-17. Monitored for 7 days:

| Metric | Before fix | After fix (7 days) |
|---|---|---|
| Errors `srtp_err_status_replay_old` on SIP audio handles | ~100/s burst per occurrence | 0 |
| Unhold events after ≥11 min hold | each triggered the bug | 50+ handled cleanly |
| Unhold events after ≥22 min hold (single uint16 wrap) | systematic failure | 25+ handled cleanly |
| Unhold events after ≥44 min hold (double wrap) | — | 4+ handled cleanly (longest observed: 69 min) |

Across ~250+ unhold events we observed ~26 concrete cases where `audio_out_seq` produced a strictly monotonic value while the pre-fix code path (`acontext.last_seq`) would have produced a regressed value in SRTP's dead zone. All of these would have been silent audio on the browser side before the fix.
