### PR TITLE
[0.x] streaming: fix extension check

### DIFF
--- a/plugins/janus_streaming.c
+++ b/plugins/janus_streaming.c
@@ -2200,7 +2200,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 					JANUS_LOG(LOG_ERR, "Can't add 'live' mountpoint '%s', unsupported format (we only support Opus and raw mu-Law/a-Law files right now)\n", cat->name);
 #else
 				if(!janus_streaming_check_extension(file->value, ".alaw") &&
-						!strstr(file->janus_streaming_check_extension, ".mulaw")) {
+						!janus_streaming_check_extension(file->value, ".mulaw")) {
 					JANUS_LOG(LOG_ERR, "Can't add 'live' mountpoint '%s', unsupported format (we only support raw mu-Law and a-Law files right now)\n", cat->name);
 #endif
 					cl = cl->next;


### PR DESCRIPTION
This was breaking compilation for builds with ogg disabled.

Regression from 0b6ddadb9c4f86e07dc6b3e663d76f6f06d6383b

`master` is not impacted but v0.16.1 is.