### PR TITLE
core: add disable_info_api option to restrict janus=info endpoint

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -156,6 +156,15 @@ general: {
 									# application in the related Janus API responses
 									# or events; in case you need them to be in the
 									# Janus API too, set this property to 'true'.
+	#disable_info_api = true		# By default, the "info" endpoint is unauthenticated,
+									# allowing any caller to discover loaded plugins and
+									# server details. Setting this to 'true' restricts
+									# the endpoint so that a valid api_secret or token
+									# is required to access it, e.g., when Janus runs
+									# behind a reverse proxy and you want to reduce
+									# server fingerprinting. Note that this option has
+									# no effect unless api_secret or token_auth is
+									# also configured.
 	#hide_dependencies = true		# By default, a call to the "info" endpoint of
 									# either the Janus or Admin API now also returns
 									# the versions of the main dependencies (e.g.,

--- a/src/janus.c
+++ b/src/janus.c
@@ -310,6 +310,10 @@ static uint candidates_timeout = DEFAULT_CANDIDATES_TIMEOUT;
 /* By default we list dependencies details, but some may prefer not to */
 static gboolean hide_dependencies = FALSE;
 
+/* By default the "info" endpoint is unauthenticated, but operators who want
+ * to reduce server fingerprinting can require auth to access it */
+static gboolean disable_info_api = FALSE;
+
 /* By default we do not exit if a shared library cannot be loaded or is missing an expected symbol */
 static gboolean exit_on_dl_error = FALSE;
 
@@ -1108,6 +1112,14 @@ int janus_process_incoming_request(janus_request *request) {
 	if(session_id == 0 && handle_id == 0) {
 		/* Can only be a 'Create new session', a 'Get info' or a 'Ping/Pong' request */
 		if(!strcasecmp(message_text, "info")) {
+			if(disable_info_api) {
+				/* Info endpoint is restricted: require a valid secret or token */
+				ret = janus_request_check_secret(request, session_id, transaction_text);
+				if(ret != 0) {
+					ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_UNAUTHORIZED, NULL);
+					goto jsondone;
+				}
+			}
 			ret = janus_process_success(request, janus_info(transaction_text));
 			goto jsondone;
 		}
@@ -4882,6 +4894,8 @@ gint main(int argc, char *argv[]) {
 		janus_config_add(config, config_general, janus_config_item_create("token_auth", "true"));
 	if(options.token_auth_secret)
 		janus_config_add(config, config_general, janus_config_item_create("token_auth_secret", options.token_auth_secret));
+	if(options.disable_info_api)
+		janus_config_add(config, config_general, janus_config_item_create("disable_info_api", "true"));
 	if(options.no_webrtc_encryption)
 		janus_config_add(config, config_general, janus_config_item_create("no_webrtc_encryption", "true"));
 	if(options.cert_pem)
@@ -5118,6 +5132,14 @@ gint main(int argc, char *argv[]) {
 	item = janus_config_get(config, config_general, janus_config_type_item, "hide_dependencies");
 	if(item && item->value && janus_is_true(item->value))
 		hide_dependencies = TRUE;
+	/* Check if the "info" endpoint should require authentication */
+	item = janus_config_get(config, config_general, janus_config_type_item, "disable_info_api");
+	if(item && item->value && janus_is_true(item->value)) {
+		disable_info_api = TRUE;
+		if(api_secret == NULL && !janus_auth_is_enabled()) {
+			JANUS_LOG(LOG_WARN, "disable_info_api is enabled, but neither api_secret nor token_auth is configured: the \"info\" endpoint will remain accessible to all\n");
+		}
+	}
 
 	/* Setup ICE stuff (e.g., checking if the provided STUN server is correct) */
 	char *stun_server = NULL, *turn_server = NULL;

--- a/src/mainpage.dox
+++ b/src/mainpage.dox
@@ -1241,6 +1241,18 @@ export const initialiseJanusLibrary = () => Janus.init({dependencies: setupDeps(
  * in your application according to what's available in the Janus instance
  * you're trying to contact.
  *
+ * Note that the \c info endpoint is intentionally unauthenticated, to allow
+ * clients to auto-negotiate capabilities before establishing a session.
+ * If you want to restrict access to this endpoint (e.g., to reduce server
+ * fingerprinting when Janus is behind a reverse proxy), you can require
+ * authentication for it via the \c disable_info_api option in the \c general
+ * section of \c janus.jcfg, or via the \c --disable-info-api command line
+ * argument. When enabled, unauthenticated \c info requests will be rejected
+ * with a \c 403 Unauthorized error, while requests carrying a valid
+ * \c api_secret or token will still be served normally. Note that this
+ * option has no effect unless \c api_secret or \c token_auth is also
+ * configured; a warning will be logged at startup if that is the case.
+ *
  *
  * \section root The server root
  * The server root is \c /janus by default but, as anticipated, it is

--- a/src/options.c
+++ b/src/options.c
@@ -56,6 +56,7 @@ gboolean janus_options_parse(janus_options *options, int argc, char *argv[]) {
 		{ "apisecret", 'a', 0, G_OPTION_ARG_STRING, &options->apisecret, "API secret all requests need to pass in order to be accepted by Janus (useful when wrapping Janus API requests in a server, none by default)", "randomstring" },
 		{ "token-auth", 'A', 0, G_OPTION_ARG_NONE, &options->token_auth, "Enable token-based authentication for all requests", NULL },
 		{ "token-auth-secret", 0, 0, G_OPTION_ARG_STRING, &options->token_auth_secret, "Secret to verify HMAC-signed tokens with, to be used with -A", "randomstring" },
+		{ "disable-info-api", 0, 0, G_OPTION_ARG_NONE, &options->disable_info_api, "Restrict the \"info\" endpoint to authenticated requests only (requires api_secret or token)", NULL },
 		{ "event-handlers", 'e', 0, G_OPTION_ARG_NONE, &options->event_handlers, "Enable event handlers", NULL },
 		{ "no-webrtc-encryption", 'w', 0, G_OPTION_ARG_NONE, &options->no_webrtc_encryption, "Disable WebRTC encryption, so no DTLS or SRTP (only for debugging!)", NULL },
 		{ "version", 'V', 0, G_OPTION_ARG_NONE, &options->print_version, "Print version and exit", NULL },

--- a/src/options.h
+++ b/src/options.h
@@ -55,6 +55,7 @@ typedef struct janus_options {
 	const char *apisecret;
 	gboolean token_auth;
 	const char *token_auth_secret;
+	gboolean disable_info_api;
 	gboolean event_handlers;
 	gboolean no_webrtc_encryption;
 	gboolean print_version;


### PR DESCRIPTION
The janus=info request is handled before auth checks, allowing any caller to enumerate loaded plugins and server details without credentials. Add a disable_info_api config option (default: false) for operators who want to restrict this endpoint, e.g., when Janus is behind a reverse proxy and client auto-discovery is not needed.