### PR TITLE
Add optional per-handle ICE port range (`min_port` / `max_port` on `attach`)

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -274,6 +274,17 @@ media: {
 	# https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18#page-6
 	# That said, DON'T TOUCH THIS IF YOU DON'T KNOW WHAT IT MEANS!
 	#dscp = 46
+
+	# By default the 'rtp_port_range' configured above (if any) is shared by all
+	# PeerConnections. If you want to let clients confine a single handle to a
+	# narrower sub-range, you can set the 'rtp_port_range_perhandle_override'
+	# property to true: when enabled, an 'attach' request may provide optional
+	# 'min_port' and 'max_port' properties to restrict that handle's RTP/RTCP
+	# ports. The requested range is confined within the global 'rtp_port_range'
+	# above: a range that falls outside it is ignored and the global range is
+	# used instead. When this is disabled (the default), the 'min_port' and
+	# 'max_port' properties are ignored, so the existing behavior is preserved.
+	#rtp_port_range_perhandle_override = false
 }
 
 # NAT-related stuff: specifically, you can configure the STUN/TURN

--- a/html/demos/janus.js
+++ b/html/demos/janus.js
@@ -1313,9 +1313,11 @@ var Janus = (function (factory) {
 			}
 			let opaqueId = callbacks.opaqueId;
 			let loopIndex = callbacks.loopIndex;
+			let minPort = callbacks.minPort;
+			let maxPort = callbacks.maxPort;
 			let handleToken = callbacks.token ? callbacks.token : token;
 			let transaction = Janus.randomString(12);
-			let request = { "janus": "attach", "plugin": plugin, "opaque_id": opaqueId, "loop_index": loopIndex, "transaction": transaction };
+			let request = { "janus": "attach", "plugin": plugin, "opaque_id": opaqueId, "loop_index": loopIndex, "min_port": minPort, "max_port": maxPort, "transaction": transaction };
 			if(handleToken)
 				request["token"] = handleToken;
 			if(apisecret)

--- a/npm/janus.d.ts
+++ b/npm/janus.d.ts
@@ -56,6 +56,8 @@ declare namespace JanusJS {
 		handle_id?: number,
 		opaque_id?: string,
 		loop_index?: number,
+		min_port?: number,
+		max_port?: number,
 		janus: string,
 		transaction: string,
 		body?: any,
@@ -168,6 +170,8 @@ declare namespace JanusJS {
 		opaqueId?: string;
 		token?: string;
 		loopIndex?: number;
+		minPort?: number;
+		maxPort?: number;
 	}
 
 	interface OfferParams {

--- a/src/ice.c
+++ b/src/ice.c
@@ -3803,7 +3803,9 @@ int janus_ice_setup_local(janus_ice_handle *handle, gboolean offer, gboolean tri
 	pc->media_bytype = g_hash_table_new_full(NULL, NULL, NULL, (GDestroyNotify)janus_ice_peerconnection_medium_dereference);
 #ifdef HAVE_PORTRANGE
 	/* FIXME: libnice supports this since 0.1.0, but the 0.1.3 on Fedora fails with an undefined reference! */
-	nice_agent_set_port_range(handle->agent, handle->stream_id, 1, rtp_range_min, rtp_range_max);
+	uint16_t pc_range_min = handle->rtp_range_min ? handle->rtp_range_min : rtp_range_min;
+	uint16_t pc_range_max = handle->rtp_range_max ? handle->rtp_range_max : rtp_range_max;
+	nice_agent_set_port_range(handle->agent, handle->stream_id, 1, pc_range_min, pc_range_max);
 #endif
 	/* Gather now only if we're doing hanf-trickle */
 	if(!janus_full_trickle_enabled && !nice_agent_gather_candidates(handle->agent, handle->stream_id)) {

--- a/src/ice.c
+++ b/src/ice.c
@@ -416,6 +416,12 @@ int janus_ice_get_peerconnection_num(void) {
 /* RTP/RTCP port range */
 static uint16_t rtp_range_min = 0;
 static uint16_t rtp_range_max = 0;
+uint16_t janus_ice_get_rtp_range_min(void) {
+	return rtp_range_min;
+}
+uint16_t janus_ice_get_rtp_range_max(void) {
+	return rtp_range_max;
+}
 
 
 #define JANUS_ICE_PACKET_AUDIO	0

--- a/src/ice.h
+++ b/src/ice.h
@@ -353,6 +353,10 @@ struct janus_ice_handle {
 	char *opaque_id;
 	/*! \brief Token that was used to attach the handle, if required */
 	char *token;
+	/*! \brief Per-handle ICE port range min (0 = use global) */
+	uint16_t rtp_range_min;
+	/*! \brief Per-handle ICE port range max (0 = use global) */
+	uint16_t rtp_range_max;
 	/*! \brief Monotonic time of when the handle has been created */
 	gint64 created;
 	/*! \brief Opaque application (plugin) pointer */

--- a/src/ice.h
+++ b/src/ice.h
@@ -133,6 +133,12 @@ gboolean janus_ice_is_ice_tcp_enabled(void);
 /*! \brief Method to check whether full-trickle support is enabled or not
  * @returns true if full-trickle support is enabled, false otherwise */
 gboolean janus_ice_is_full_trickle_enabled(void);
+/*! \brief Method to get the minimum of the configured RTP/RTCP port range
+ * @returns The configured minimum port, or 0 if no range was set */
+uint16_t janus_ice_get_rtp_range_min(void);
+/*! \brief Method to get the maximum of the configured RTP/RTCP port range
+ * @returns The configured maximum port, or 0 if no range was set */
+uint16_t janus_ice_get_rtp_range_max(void);
 /*! \brief Method to check whether mDNS resolution is enabled or not
  * @returns true if mDNS resolution is enabled, false otherwise */
 gboolean janus_ice_is_mdns_enabled(void);

--- a/src/janus.c
+++ b/src/janus.c
@@ -311,6 +311,9 @@ static uint candidates_timeout = DEFAULT_CANDIDATES_TIMEOUT;
 
 /* By default we list dependencies details, but some may prefer not to */
 static gboolean hide_dependencies = FALSE;
+/* Cached config: the configured RTP/RTCP port range, and whether handles may request a sub-range on attach */
+static uint16_t rtp_port_range_min = 0, rtp_port_range_max = 0;
+static gboolean rtp_port_range_perhandle_override = FALSE;
 
 /* By default we do not exit if a shared library cannot be loaded or is missing an expected symbol */
 static gboolean exit_on_dl_error = FALSE;
@@ -1270,18 +1273,24 @@ int janus_process_incoming_request(janus_request *request) {
 			ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_UNKNOWN, "Memory error");
 			goto jsondone;
 		}
-		/* Optional per-handle ICE port range (falls back to global) */
+		/* Optional per-handle ICE port range, confined within the global rtp_port_range */
 		json_t *min_port = json_object_get(root, "min_port");
 		json_t *max_port = json_object_get(root, "max_port");
 		if(min_port || max_port) {
-			json_int_t mn = min_port ? json_integer_value(min_port) : 0;
-			json_int_t mx = max_port ? json_integer_value(max_port) : 0;
-			if(mn > 0 && mx >= mn && mx <= 65535) {
-				handle->rtp_range_min = (uint16_t)mn;
-				handle->rtp_range_max = (uint16_t)mx;
+			if(!rtp_port_range_perhandle_override) {
+				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Ignoring min_port/max_port: per-handle RTP port range override is disabled (rtp_port_range_perhandle_override)\n",
+					handle->handle_id);
 			} else {
-				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Ignoring invalid attach port range %"JSON_INTEGER_FORMAT"-%"JSON_INTEGER_FORMAT" (using global rtp_port_range)\n",
-					handle->handle_id, mn, mx);
+				json_int_t mn = min_port ? json_integer_value(min_port) : 0;
+				json_int_t mx = max_port ? json_integer_value(max_port) : 0;
+				uint16_t lo = rtp_port_range_min ? rtp_port_range_min : 1, hi = rtp_port_range_max ? rtp_port_range_max : 65535;
+				if(mn >= lo && mx >= mn && mx <= hi) {
+					handle->rtp_range_min = (uint16_t)mn;
+					handle->rtp_range_max = (uint16_t)mx;
+				} else {
+					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Ignoring attach port range %"JSON_INTEGER_FORMAT"-%"JSON_INTEGER_FORMAT" outside the configured rtp_port_range %"SCNu16"-%"SCNu16"\n",
+						handle->handle_id, mn, mx, lo, hi);
+				}
 			}
 		}
 		handle_id = handle->handle_id;
@@ -5176,6 +5185,11 @@ gint main(int argc, char *argv[]) {
 			rtp_max_port = 65535;
 		JANUS_LOG(LOG_INFO, "RTP port range: %u -- %u\n", rtp_min_port, rtp_max_port);
 	}
+	/* Remember the configured range + the per-handle override switch for use at attach time */
+	rtp_port_range_min = rtp_min_port;
+	rtp_port_range_max = rtp_max_port;
+	item = janus_config_get(config, config_media, janus_config_type_item, "rtp_port_range_perhandle_override");
+	rtp_port_range_perhandle_override = (item && item->value) ? janus_is_true(item->value) : FALSE;
 	/* Check if we need to enable the ICE Lite mode */
 	item = janus_config_get(config, config_nat, janus_config_type_item, "ice_lite");
 	ice_lite = (item && item->value) ? janus_is_true(item->value) : FALSE;

--- a/src/janus.c
+++ b/src/janus.c
@@ -104,6 +104,8 @@ static struct janus_json_parameter attach_parameters[] = {
 	{"plugin", JSON_STRING, JANUS_JSON_PARAM_REQUIRED},
 	{"opaque_id", JSON_STRING, 0},
 	{"loop_index", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"min_port", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"max_port", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 };
 static struct janus_json_parameter body_parameters[] = {
 	{"body", JSON_OBJECT, JANUS_JSON_PARAM_REQUIRED}
@@ -1267,6 +1269,20 @@ int janus_process_incoming_request(janus_request *request) {
 		if(handle == NULL) {
 			ret = janus_process_error(request, session_id, transaction_text, JANUS_ERROR_UNKNOWN, "Memory error");
 			goto jsondone;
+		}
+		/* Optional per-handle ICE port range (falls back to global) */
+		json_t *min_port = json_object_get(root, "min_port");
+		json_t *max_port = json_object_get(root, "max_port");
+		if(min_port || max_port) {
+			json_int_t mn = min_port ? json_integer_value(min_port) : 0;
+			json_int_t mx = max_port ? json_integer_value(max_port) : 0;
+			if(mn > 0 && mx >= mn && mx <= 65535) {
+				handle->rtp_range_min = (uint16_t)mn;
+				handle->rtp_range_max = (uint16_t)mx;
+			} else {
+				JANUS_LOG(LOG_WARN, "[%"SCNu64"] Ignoring invalid attach port range %"JSON_INTEGER_FORMAT"-%"JSON_INTEGER_FORMAT" (using global rtp_port_range)\n",
+					handle->handle_id, mn, mx);
+			}
 		}
 		handle_id = handle->handle_id;
 		/* We increase the counter as this request is using the handle */

--- a/src/janus.c
+++ b/src/janus.c
@@ -311,8 +311,7 @@ static uint candidates_timeout = DEFAULT_CANDIDATES_TIMEOUT;
 
 /* By default we list dependencies details, but some may prefer not to */
 static gboolean hide_dependencies = FALSE;
-/* Cached config: the configured RTP/RTCP port range, and whether handles may request a sub-range on attach */
-static uint16_t rtp_port_range_min = 0, rtp_port_range_max = 0;
+/* Whether handles may request a custom RTP port sub-range on attach (default off) */
 static gboolean rtp_port_range_perhandle_override = FALSE;
 
 /* By default we do not exit if a shared library cannot be loaded or is missing an expected symbol */
@@ -1283,11 +1282,14 @@ int janus_process_incoming_request(janus_request *request) {
 			} else {
 				json_int_t mn = min_port ? json_integer_value(min_port) : 0;
 				json_int_t mx = max_port ? json_integer_value(max_port) : 0;
-				uint16_t lo = rtp_port_range_min ? rtp_port_range_min : 1, hi = rtp_port_range_max ? rtp_port_range_max : 65535;
+				uint16_t gmin = janus_ice_get_rtp_range_min(), gmax = janus_ice_get_rtp_range_max();
+				uint16_t lo = gmin ? gmin : 1, hi = gmax ? gmax : 65535;
 				if(mn >= lo && mx >= mn && mx <= hi) {
 					handle->rtp_range_min = (uint16_t)mn;
 					handle->rtp_range_max = (uint16_t)mx;
 				} else {
+					handle->rtp_range_min = 0;
+					handle->rtp_range_max = 0;
 					JANUS_LOG(LOG_WARN, "[%"SCNu64"] Ignoring attach port range %"JSON_INTEGER_FORMAT"-%"JSON_INTEGER_FORMAT" outside the configured rtp_port_range %"SCNu16"-%"SCNu16"\n",
 						handle->handle_id, mn, mx, lo, hi);
 				}
@@ -5185,9 +5187,7 @@ gint main(int argc, char *argv[]) {
 			rtp_max_port = 65535;
 		JANUS_LOG(LOG_INFO, "RTP port range: %u -- %u\n", rtp_min_port, rtp_max_port);
 	}
-	/* Remember the configured range + the per-handle override switch for use at attach time */
-	rtp_port_range_min = rtp_min_port;
-	rtp_port_range_max = rtp_max_port;
+	/* Remember whether handles may request a custom RTP port sub-range on attach */
 	item = janus_config_get(config, config_media, janus_config_type_item, "rtp_port_range_perhandle_override");
 	rtp_port_range_perhandle_override = (item && item->value) ? janus_is_true(item->value) : FALSE;
 	/* Check if we need to enable the ICE Lite mode */

--- a/src/mainpage.dox
+++ b/src/mainpage.dox
@@ -1402,6 +1402,10 @@ GET http://host:port/janus/<sessionid>?maxev=5
  * Optional \c min_port and \c max_port integer properties can be provided too,
  * to confine this handle's ICE host candidates to a specific UDP port range;
  * when omitted, the global \c rtp_port_range from the configuration is used.
+ * These properties are only honored when \c rtp_port_range_perhandle_override
+ * is enabled in the \c media configuration (otherwise they are ignored). The
+ * requested range is confined within the global \c rtp_port_range: a range that
+ * falls outside it is ignored, and the global range is used instead.
  * If the request is successful, you'll receive the unique plugin handle
  * identifier in a response formatted the same way as the session create
  * one, that is like this:

--- a/src/mainpage.dox
+++ b/src/mainpage.dox
@@ -1399,6 +1399,9 @@ GET http://host:port/janus/<sessionid>?maxev=5
  * Notice that you can also provide an optional \c opaque_id string
  * identifier (for more details on why this might be useful, read more
  * <a href="https://github.com/meetecho/janus-gateway/pull/748">here</a>).
+ * Optional \c min_port and \c max_port integer properties can be provided too,
+ * to confine this handle's ICE host candidates to a specific UDP port range;
+ * when omitted, the global \c rtp_port_range from the configuration is used.
  * If the request is successful, you'll receive the unique plugin handle
  * identifier in a response formatted the same way as the session create
  * one, that is like this:


### PR DESCRIPTION
## Summary

Two optional `attach` parameters, `min_port` and `max_port`, that confine a handle's ICE host-candidate UDP ports to the given range. When absent, behavior is byte-identical to today and the handle uses the global static config `rtp_port_range`. Core-only, plugin-agnostic, opt-in, and in the spirit of the existing optional per-handle attributes `opaque_id` and
`loop_index`.

```
attach { "plugin": "...", "opaque_id": "...", "loop_index": N,
         "min_port": 20000, "max_port": 29999 }   // min_port/max_port optional
```

## Motivation

The global `rtp_port_range` sets the total UDP surface Janus may use, but gives no control over which connection lands where. Every PeerConnection draws from one pool with no per-connection input, yet the range a connection should use is often a function of what it is (its media, tenant, room, or priority). That is runtime knowledge the application has at
`attach`, not config-time knowledge in `janus.jcfg`.

A per-handle optional override makes port placement a per-connection decision, with no restart and for any plugin, since it is just a property of the handle's ICE agent.

Our motivating case is QoS by port. On a managed network, media is classified by UDP port at the network edge to apply DiffServ/DSCP, because endpoint-set DSCP is untrusted and bleached across administrative boundaries.

This needs media on deterministic, classifiable port bands, which a per-handle range provides and a single global pool cannot.

The same primitive fits other needs, such as isolating each tenant's or room's media in its own band, segmenting firewalls and ACLs into narrow predictable sub-ranges, or steering a subset of connections onto canary or A/B network paths.

I may well have missed something here. Feedback and corrections are very welcome, Thank you.