### PR TITLE
Added option to disable manual injection of SPS/PPS for RTSP servers that put them in the SDP (see #3168)

### DIFF
--- a/conf/janus.plugin.streaming.jcfg.sample.in
+++ b/conf/janus.plugin.streaming.jcfg.sample.in
@@ -150,6 +150,9 @@
 # rtsp_conn_timeout = connection timeout for cURL (CURLOPT_CONNECTTIMEOUT) call gathering the RTSP information (default=5s)
 # rtsp_notify_changes = if set to true, will send an event to connected users when the RTSP session
 #		gets disconnected, and when it's reconnected (default=false)
+# rtsp_fmtp_sps = what the plugin should do it if finds SPS/PPS info in an SDP fmtp attribute sent by the RTSP server;
+#		the default value is "always", to manually inject them in RTP traffic, as that's what WebRTC endpoints need;
+#		to disable this behaviour (e.g., if the camera already sends SPS/PPS in-stream via RTP too) use "never"
 #
 # Notice that, for 'rtsp' mountpoints, normally the plugin uses the exact
 # SDP codec and fmtp attributes the remote camera or RTSP server sent.

--- a/src/plugins/janus_streaming.c
+++ b/src/plugins/janus_streaming.c
@@ -207,6 +207,9 @@ rtsp_timeout = communication timeout (CURLOPT_TIMEOUT) for cURL call gathering t
 rtsp_conn_timeout = connection timeout for cURL (CURLOPT_CONNECTTIMEOUT) call gathering the RTSP information (default=5s)
 rtsp_notify_changes = if set to true, will send an event to connected users when the RTSP session
 	gets disconnected, and when it's reconnected (default=false)
+rtsp_fmtp_sps = what the plugin should do it if finds SPS/PPS info in an SDP fmtp attribute sent by the RTSP server;
+	the default value is "always", to manually inject them in RTP traffic, as that's what WebRTC endpoints need;
+	to disable this behaviour (e.g., if the camera already sends SPS/PPS in-stream via RTP too) use "never"
 \endverbatim
  *
  * Notice that attributes like \c audioport or \c videopt only make sense
@@ -1143,6 +1146,7 @@ static struct janus_json_parameter rtsp_parameters[] = {
 	{"rtsp_timeout", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"rtsp_conn_timeout", JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
 	{"rtsp_notify_changes", JANUS_JSON_BOOL, 0},
+	{"rtsp_fmtp_sps", JSON_STRING, 0},
 	{"audiocodec", JSON_STRING, 0},
 	{"audiortpmap", JSON_STRING, 0},	/* Deprecated */
 	{"audiofmtp", JSON_STRING, 0},
@@ -1394,6 +1398,7 @@ typedef struct janus_streaming_rtp_source {
 	char *rtsp_stream_uri;
 	gboolean rtsp_quirk;
 	gboolean rtsp_notify_changes;
+	gboolean rtsp_fmtp_sps;
 	gint64 ka_timeout;
 	char *rtsp_ahost, *rtsp_vhost;
 	janus_streaming_codecs rtsp_acodecs, rtsp_vcodecs;
@@ -1580,7 +1585,7 @@ janus_streaming_mountpoint *janus_streaming_create_file_source(
 janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 		uint64_t id, char *id_str, char *name, char *desc, char *metadata,
 		char *url, char *username, char *password,
-		gboolean quirk, gboolean notify_changes,
+		gboolean quirk, gboolean notify_changes, gboolean fmtp_sps,
 		gboolean doaudio, int audiopt, char *acodec, char *afmtp,
 		gboolean dovideo, int videopt, char *vcodec, char *vfmtp,
 		uint16_t bufferkf_ms, uint32_t bufferkf_bytes,
@@ -2885,6 +2890,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				janus_config_item *rtsp_timeout = janus_config_get(config, cat, janus_config_type_item, "rtsp_timeout");
 				janus_config_item *rtsp_conn_timeout = janus_config_get(config, cat, janus_config_type_item, "rtsp_conn_timeout");
 				janus_config_item *rtsp_notify_changes = janus_config_get(config, cat, janus_config_type_item, "rtsp_notify_changes");
+				janus_config_item *rtsp_fmtp_sps = janus_config_get(config, cat, janus_config_type_item, "rtsp_fmtp_sps");
 				janus_network_address iface_value;
 				if(file == NULL || file->value == NULL) {
 					JANUS_LOG(LOG_ERR, "Can't add 'rtsp' mountpoint '%s', missing mandatory information...\n", cat->name);
@@ -2894,6 +2900,16 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 				gboolean is_private = priv && priv->value && janus_is_true(priv->value);
 				gboolean rtsp_quirk = quirk && quirk->value && janus_is_true(quirk->value);
 				gboolean notify_changes = rtsp_notify_changes && rtsp_notify_changes->value && janus_is_true(rtsp_notify_changes->value);
+				gboolean fmtp_sps = TRUE;
+				if(rtsp_fmtp_sps && rtsp_fmtp_sps->value) {
+					if(!strcasecmp(rtsp_fmtp_sps->value, "always")) {
+						fmtp_sps = TRUE;
+					} else if(!strcasecmp(rtsp_fmtp_sps->value, "never")) {
+						fmtp_sps = FALSE;
+					} else {
+						JANUS_LOG(LOG_WARN, "Unsupported value '%s' for rtsp_fmtp_sps\n", rtsp_fmtp_sps->value);
+					}
+				}
 				gboolean doaudio = audio && audio->value && janus_is_true(audio->value);
 				gboolean dovideo = video && video->value && janus_is_true(video->value);
 				if(video && vkf && vkf->value && janus_is_true(vkf->value)) {
@@ -2955,7 +2971,7 @@ int janus_streaming_init(janus_callbacks *callback, const char *config_path) {
 						(char *)file->value,
 						username ? (char *)username->value : NULL,
 						password ? (char *)password->value : NULL,
-						rtsp_quirk, notify_changes,
+						rtsp_quirk, notify_changes, fmtp_sps,
 						doaudio,
 						(apt && apt->value) ? atoi(apt->value) : -1,
 						(char *)audiocodec,
@@ -4352,12 +4368,23 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 			json_t *rtsp_timeout = json_object_get(root, "rtsp_timeout");
 			json_t *rtsp_conn_timeout = json_object_get(root, "rtsp_conn_timeout");
 			json_t *rtsp_notify_changes = json_object_get(root, "rtsp_notify_changes");
+			const char *rtsp_fmtp_sps = json_string_value(json_object_get(root, "rtsp_fmtp_sps"));
 			if(failerr == NULL)	/* For an old typo, we support the legacy syntax too */
 				failerr = json_object_get(root, "rtsp_check");
 			gboolean doaudio = audio ? json_is_true(audio) : FALSE;
 			gboolean dovideo = video ? json_is_true(video) : FALSE;
 			gboolean doquirk = quirk ? json_is_true(quirk) : FALSE;
 			gboolean notify_changes = rtsp_notify_changes ? json_is_true(rtsp_notify_changes) : FALSE;
+			gboolean fmtp_sps = TRUE;
+			if(rtsp_fmtp_sps) {
+				if(!strcasecmp(rtsp_fmtp_sps, "always")) {
+					fmtp_sps = TRUE;
+				} else if(!strcasecmp(rtsp_fmtp_sps, "never")) {
+					fmtp_sps = FALSE;
+				} else {
+					JANUS_LOG(LOG_WARN, "Unsupported value '%s' for rtsp_fmtp_sps\n", rtsp_fmtp_sps);
+				}
+			}
 			gboolean error_on_failure = failerr ? json_is_true(failerr) : TRUE;
 			if(json_is_true(vkf)) {
 				JANUS_LOG(LOG_WARN, "The videobufferkf property has been deprecated, please refer to bufferkf_ms and/or bufferkf_bytes\n");
@@ -4424,7 +4451,7 @@ static json_t *janus_streaming_process_synchronous_request(janus_streaming_sessi
 					(char *)json_string_value(url),
 					username ? (char *)json_string_value(username) : NULL,
 					password ? (char *)json_string_value(password) : NULL,
-					doquirk, notify_changes,
+					doquirk, notify_changes, fmtp_sps,
 					doaudio, (audiopt ? json_integer_value(audiopt) : -1), acodec, (char *)json_string_value(audiofmtp),
 					dovideo, (videopt ? json_integer_value(videopt) : -1), vcodec, (char *)json_string_value(videofmtp),
 					bufferkf_ms, bufferkf_bytes,
@@ -8968,9 +8995,13 @@ static int janus_streaming_rtsp_connect_to_server(janus_streaming_mountpoint *mp
 			g_free(stream->codecs.fmtp);
 			stream->codecs.fmtp = source->rtsp_vcodecs.fmtp ? g_strdup(source->rtsp_vcodecs.fmtp) : g_strdup(vfmtp);
 			g_free(stream->h264_spspps);
-			stream->h264_spspps = sps;
+			if(source->rtsp_fmtp_sps) {
+				stream->h264_spspps = sps;
+				stream->h264_spspps_len = spslen;
+			} else {
+				g_free(sps);
+			}
 			sps = NULL;
-			stream->h264_spspps_len = spslen;
 			spslen = 0;
 			g_free(source->rtsp_vhost);
 			source->rtsp_vhost = vsport > 0 ? g_strdup(vhost) : NULL;
@@ -9104,7 +9135,7 @@ static int janus_streaming_rtsp_play(janus_streaming_rtp_source *source) {
 janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 		uint64_t id, char *id_str, char *name, char *desc, char *metadata,
 		char *url, char *username, char *password,
-		gboolean quirk, gboolean notify_changes,
+		gboolean quirk, gboolean notify_changes, gboolean fmtp_sps,
 		gboolean doaudio, int apt, char *acodec, char *afmtp,
 		gboolean dovideo, int vpt, char *vcodec, char *vfmtp,
 		uint16_t bufferkf_ms, uint32_t bufferkf_bytes,
@@ -9184,6 +9215,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 	live_rtsp_source->rtsp_stream_uri = NULL;
 	live_rtsp_source->rtsp_quirk = quirk;
 	live_rtsp_source->rtsp_notify_changes = notify_changes;
+	live_rtsp_source->rtsp_fmtp_sps = fmtp_sps;
 	live_rtsp_source->media = NULL;		/* We'll prepare this later */
 	live_rtsp_source->media_byid = g_hash_table_new(NULL, NULL);
 	live_rtsp_source->media_byfd = g_hash_table_new(NULL, NULL);
@@ -9290,7 +9322,7 @@ janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 janus_streaming_mountpoint *janus_streaming_create_rtsp_source(
 		uint64_t id, char *id_str, char *name, char *desc, char *metadata,
 		char *url, char *username, char *password,
-		gboolean quirk, gboolean notify_changes,
+		gboolean quirk, gboolean notify_changes, gboolean fmtp_sps,
 		gboolean doaudio, int apt, char *audiocodec, char *audiofmtp,
 		gboolean dovideo, int vpt, char *videocodec, char *videofmtp,
 		uint16_t bufferkf_ms, uint32_t bufferkf_bytes,


### PR DESCRIPTION
In #3168 we added a way for the Janus Streaming plugin to manually inject SPS/PPS NALs in the RTP stream, in case RTSP servers advertised them in the SDP via fmtp attributes. This helped address scenarios where the RTSP server would _only_ put SPS/PPS in a `sprop-parameter-sets`: WebRTC endoints never look at that, and expect them to be part of the RTP stream, so this manual injection ensured video could be decoded.

This seems to not always work as expected with RTSP cameras that do advertise SPS/PPS via the SDP, but then _also_ send SPS/PPS in the RTP stream. The end result is that, on the WebRTC side, SPS/PPS are duplicated, since there is the one sent by the camera itself, and then the one we add ourselves, which apparently confuses browsers and causes broken video.

This PR is a first attempt to fix this. It adds a new configuration property you can add when creating an RTSP mountpoint (statically or dynamically) called `rtsp_fmtp_sps`: if the value of that property is `"always"` (default), then it behaves as it does now, and so if it finds SPS/PPS data in the SDP, it will inject it manually in RTP; if the value is `"never"`, instead, we ignore fmtp data sent in the RTSP SDP.

The property is a string and not a boolean as I want to keep doors open for more flexibility. In the future, for instance, it might be helpful to have something like an `"auto"` setting, where the plugin stores the SPS/PPS found in the fmtp, but only uses it if it never sees an SPS on the wire. This would allow the code to handle more dynamically scenarios where you don't know in advance what a camera will do. That said, this automatic mode would require more code than I wanted to add now: the existing setting should already help address the main issue in scenarios where the behaviour of the cameras is known.

I haven't tested this yet, so feedback is welcome. In case it works fine and with no regressions, I plan to merge soon and backport to `0.x`.