### PR TITLE
Adding support for HMAC-SHA256 for signed_tokens (see #3648)

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -63,10 +63,12 @@ general: {
 									# a valid token in all requests. Useful if
 									# you want to authenticate requests from web
 									# users.
-	#token_auth_secret = "janus"	# Use HMAC-SHA1 signed tokens (with token_auth). Note that
+	#token_auth_secret = "janus"	# Use HMAC signed tokens (with token_auth). Note that
 									# without this, the Admin API MUST
 									# be enabled, as tokens are added and removed
 									# through messages sent there.
+	#token_auth_hash = "sha1"		# Hash function used for signed-token authentication.
+									# Defaults to sha1. Supported values: sha1, sha256.
 	admin_secret = "janusoverlord"	# String that all Janus requests must contain
 									# to be accepted/authorized by the admin/monitor.
 									# only needed if you enabled the admin API

--- a/src/auth.c
+++ b/src/auth.c
@@ -38,13 +38,14 @@ static GHashTable *tokens = NULL, *allowed_plugins = NULL;
 static gboolean auth_enabled = FALSE;
 static janus_mutex mutex = JANUS_MUTEX_INITIALIZER;
 static char *auth_secret = NULL;
+static const EVP_MD *auth_hash = NULL;
 
 static void janus_auth_free_token(char *token) {
 	g_free(token);
 }
 
 /* Setup */
-void janus_auth_init(gboolean enabled, const char *secret) {
+int janus_auth_init(gboolean enabled, const char *secret, const char *hash) {
 	if(enabled) {
 		if(secret == NULL) {
 			JANUS_LOG(LOG_INFO, "Stored-Token based authentication enabled\n");
@@ -52,13 +53,23 @@ void janus_auth_init(gboolean enabled, const char *secret) {
 			allowed_plugins = g_hash_table_new_full(g_str_hash, g_str_equal, (GDestroyNotify)janus_auth_free_token, NULL);
 			auth_enabled = TRUE;
 		} else {
-			JANUS_LOG(LOG_INFO, "Signed-Token based authentication enabled\n");
+			if(hash == NULL || !strcasecmp(hash, "sha1")) {
+				auth_hash = EVP_sha1();
+			} else if(!strcasecmp(hash, "sha256")) {
+				auth_hash = EVP_sha256();
+			} else {
+				JANUS_LOG(LOG_ERR, "Unsupported token_auth_hash '%s' (supported values: sha1, sha256)\n", hash);
+				return -1;
+			}
+			JANUS_LOG(LOG_INFO, "Signed-Token based authentication enabled (HMAC-%s)\n",
+				auth_hash == EVP_sha256() ? "SHA256" : "SHA1");
 			auth_secret = g_strdup(secret);
 			auth_enabled = TRUE;
 		}
 	} else {
 		JANUS_LOG(LOG_INFO, "Token based authentication disabled\n");
 	}
+	return 0;
 }
 
 gboolean janus_auth_is_enabled(void) {
@@ -106,10 +117,10 @@ gboolean janus_auth_check_signature(const char *token, const char *realm) {
 	/* Verify realm */
 	if(strcmp(data[1], realm))
 		goto fail;
-	/* Verify HMAC-SHA1 */
+	/* Verify HMAC signature */
 	unsigned char signature[EVP_MAX_MD_SIZE] = "";
 	unsigned int len;
-	HMAC(EVP_sha1(), auth_secret, strlen(auth_secret), (const unsigned char*)parts[0], strlen(parts[0]), signature, &len);
+	HMAC(auth_hash, auth_secret, strlen(auth_secret), (const unsigned char*)parts[0], strlen(parts[0]), signature, &len);
 	gchar *base64 = g_base64_encode(signature, len);
 	gboolean result = janus_strcmp_const_time(parts[1], base64);
 	g_strfreev(data);
@@ -157,10 +168,10 @@ gboolean janus_auth_check_signature_contains(const char *token, const char *real
 	}
 	if (!result)
 		goto fail;
-	/* Verify HMAC-SHA1 */
+	/* Verify HMAC signature */
 	unsigned char signature[EVP_MAX_MD_SIZE] = "";
 	unsigned int len;
-	HMAC(EVP_sha1(), auth_secret, strlen(auth_secret), (const unsigned char*)parts[0], strlen(parts[0]), signature, &len);
+	HMAC(auth_hash, auth_secret, strlen(auth_secret), (const unsigned char*)parts[0], strlen(parts[0]), signature, &len);
 	gchar *base64 = g_base64_encode(signature, len);
 	result = janus_strcmp_const_time(parts[1], base64);
 	g_strfreev(data);

--- a/src/auth.h
+++ b/src/auth.h
@@ -24,8 +24,10 @@
 
 /*! \brief Method to initializing the token based authentication
  * @param[in] enabled Whether the authentication mechanism should be enabled or not
- * @param[in] secret the secret to validate signed tokens against, or NULL to use stored tokens */
-void janus_auth_init(gboolean enabled, const char *secret);
+ * @param[in] secret the secret to validate signed tokens against, or NULL to use stored tokens
+ * @param[in] hash the hash function to use for signed tokens (sha1 or sha256), or NULL for the default sha1;
+ * @returns 0 on success, or a negative integer otherwise */
+int janus_auth_init(gboolean enabled, const char *secret, const char *hash);
 /*! \brief Method to check whether the mechanism is enabled or not */
 gboolean janus_auth_is_enabled(void);
 /*! \brief Method to check whether the mechanism is in stored-token mode or not */

--- a/src/janus.c
+++ b/src/janus.c
@@ -5130,8 +5130,10 @@ gint main(int argc, char *argv[]) {
 	const char *auth_hash = NULL;
 	if (item && item->value)
 		auth_hash = item->value;
-	if(janus_auth_init(auth_enabled, auth_secret, auth_hash) < 0)
+	if(janus_auth_init(auth_enabled, auth_secret, auth_hash) < 0) {
+		janus_options_destroy();
 		exit(1);
+	}
 
 	/* Check if opaque IDs should be sent back in the Janus API too */
 	item = janus_config_get(config, config_general, janus_config_type_item, "opaqueid_in_api");

--- a/src/janus.c
+++ b/src/janus.c
@@ -5126,7 +5126,12 @@ gint main(int argc, char *argv[]) {
 	const char *auth_secret = NULL;
 	if (item && item->value)
 		auth_secret = item->value;
-	janus_auth_init(auth_enabled, auth_secret);
+	item = janus_config_get(config, config_general, janus_config_type_item, "token_auth_hash");
+	const char *auth_hash = NULL;
+	if (item && item->value)
+		auth_hash = item->value;
+	if(janus_auth_init(auth_enabled, auth_secret, auth_hash) < 0)
+		exit(1);
 
 	/* Check if opaque IDs should be sent back in the Janus API too */
 	item = janus_config_get(config, config_general, janus_config_type_item, "opaqueid_in_api");

--- a/src/mainpage.dox
+++ b/src/mainpage.dox
@@ -2183,8 +2183,12 @@ var websocket = new WebSocket('ws://1.2.3.4:8188', 'janus-protocol');
  * Where \c timestamp is a UNIX timestamp (seconds since 0:00 UTC, 1.1.1970)
  * that marks the point in time at which the token expires;
  * \c plugin1 etc. are the \c bundle names of plugins (such as \c janus.plugin.videoroom);
- * and \c signature is the base64-encoded HMAC-SHA1 signature of the expiry
+ * and \c signature is the base64-encoded HMAC signature of the expiry
  * timestamp in ASCII format, hashed using the \c --token-auth-secret as a key.
+ *
+ * Signed tokens use HMAC-SHA1 by default. The hash function can be changed
+ * with \c token_auth_hash in the \c general section of \c janus.jcfg;
+ * supported values are \c sha1 and \c sha256.
  *
  * The following function can be used to sign tokens using the node.js crypto library:
  *


### PR DESCRIPTION
* Users can configure which hash function is used for signed_tokens signature verification by setting `token_auth_hash` to `sha1` or `sha256`
* If token_auth_hash is not in the config, sha1 will be used to preserve backwards compatibility