### PR TITLE
Assign `handle->static_event_loop` when a handle is placed by loop index (fixes #3661)

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -1449,9 +1449,10 @@ gint janus_ice_handle_attach_plugin(void *core_session, janus_ice_handle *handle
 			} else {
 				janus_refcount_increase(&loop->ref);
 				automatic_selection = FALSE;
+				loop->handles++;
 				handle->mainctx = loop->mainctx;
 				handle->mainloop = loop->mainloop;
-				loop->handles++;
+				handle->static_event_loop = loop;
 				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Manually added handle to loop #%d\n", handle->handle_id, loop->id);
 			}
 		}
@@ -1534,7 +1535,7 @@ gint janus_ice_handle_destroy(void *core_session, janus_ice_handle *handle) {
 		janus_ice_static_event_loop *loop = (janus_ice_static_event_loop *)handle->static_event_loop;
 		loop->handles--;
 		janus_refcount_decrease(&loop->ref);
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Manually removed handle from loop #%d\n", handle->handle_id, loop->id);
+		JANUS_LOG(LOG_VERB, "[%"SCNu64"] Removed handle from loop #%d\n", handle->handle_id, loop->id);
 	}
 	janus_mutex_unlock(&event_loops_mutex);
 	janus_plugin *plugin_t = (janus_plugin *)handle->app;


### PR DESCRIPTION
Fixes #3661.

**Provenance:** as with the issue, the analysis behind this patch is [Claude Code](https://claude.com/claude-code)'s work; I have checked the code references and I am submitting it under my own name, so treat me as responsible for it. It is a static-analysis fix — see the verification note at the bottom for exactly what was and was not exercised.

With `static_event_loops > 0`, `janus_ice_handle_attach_plugin` can place a handle on a loop two ways. The automatic branch sets the back-pointer; the manual branch — taken when `allow_loop_indication` is on and the API supplies a valid `loop_index` — did everything except that. Since `janus_ice_handle_destroy` gates its cleanup on exactly that pointer, every manually-placed handle left `loop->handles` incremented forever and never released the loop's refcount.

The skew is not confined to the manual path: `loop->handles` is what the automatic branch scans to pick the least-loaded loop, so handles that never touched the manual API get placed against inflated counts. It is a `uint16_t`, so it wraps at 65536, and `loops_info` reports the inflated values as though they were real.

This patch assigns `handle->static_event_loop = loop;` in the manual branch and reorders the two adjacent lines so both branches read identically. The extra `janus_refcount_increase(&handle->ref)` taken earlier for the static-loop case is unaffected — it is released in `janus_ice_outgoing_traffic_finalize` under a global `static_event_loops > 0` check, so it balanced either way.

It also drops one word from the log line in `janus_ice_handle_destroy`, which read "Manually removed handle from loop #%d" — the one case it could never describe, since before this patch a manually-added handle was exactly what failed the condition. It now covers both kinds of placement, so "Removed handle from loop #%d" is what it should say. The attach-side "Manually added" / "Automatically added" messages are correct as they are and are left alone.

If you would rather remove the possibility of the two branches drifting again, the shared work (`janus_refcount_increase`, `loop->handles++`, `mainctx`, `mainloop`, `static_event_loop`) could be hoisted below the `if`/`else` with each branch only selecting the loop. I kept the diff minimal instead, but happy to rework it that way if you prefer.

**Verification:** the argument above is from reading the source. We run static event loops with `allow_loop_indication` off, so I have not exercised the manual path in production, and there is no runtime reproduction behind this. Compilation is covered by CI.