### PR TITLE
ice: don't dispose the current agent in the async close callback

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -1612,9 +1612,10 @@ static void janus_ice_cb_agent_closed(GObject *src, GAsyncResult *result, gpoint
 	janus_ice_outgoing_traffic *t = (janus_ice_outgoing_traffic *)data;
 	janus_ice_handle *handle = t->handle;
 
-	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Disposing nice agent %p\n", handle->handle_id, handle->agent);
-	g_object_unref(handle->agent);
-	handle->agent = NULL;
+	JANUS_LOG(LOG_VERB, "[%"SCNu64"] Disposing nice agent %p\n", handle->handle_id, src);
+	if(handle->agent == (NiceAgent *)src)
+		handle->agent = NULL;
+	g_object_unref(src);
 	g_source_unref((GSource *)t);
 	janus_refcount_decrease(&handle->ref);
 }


### PR DESCRIPTION
### Summary
`janus_ice_cb_agent_closed()` ignores its `src` argument — the agent whose
async close just completed — and instead operates on the current
`handle->agent`. Under a reproducible race this unrefs and NULLs a
*different, freshly-created* agent, deadlocking the handle; because the
handle thread dies holding `handle->mutex`, the instance stops answering
its API on every transport.

### The race
1. A PeerConnection takes a hangup (e.g. DTLS alert). On the handle's
   mainloop, `janus_ice_webrtc_free()` calls
   `nice_agent_close_async(handle->agent, janus_ice_cb_agent_closed, ...)`
   and then, **before that async close completes**, clears
   `JANUS_ICE_HANDLE_WEBRTC_CLEANING` and `..._HAS_AGENT`. `handle->agent`
   still points at the closing agent (it is only NULLed later, in the callback).
2. A re-offer for the same handle, parked in the `CLEANING` wait in
   `janus_process_incoming_request()`, sees `CLEANING` clear, proceeds, and
   takes `handle->mutex`.
3. `janus_ice_setup_local()` finds `HAS_AGENT` clear, so the
   "Agent already exists?" guard doesn't fire, and it creates a new agent,
   overwriting `handle->agent`.
4. The original agent's close completes and `janus_ice_cb_agent_closed()`
   runs, reads `handle->agent` — now the **new** agent — and unrefs + NULLs
   it while the requests thread holds `handle->mutex` inside `setup_local()`.
   The handle thread dies there, the mutex is never released, and every
   later request on the handle blocks behind it.

Log signature: `Creating ICE agent` immediately followed by
`Disposing nice agent`, then silence — no `Handle thread ended!`.

### The fix
Act on the agent the callback was handed (`src`) instead of re-reading
`handle->agent`, and only clear `handle->agent` if it still points at the
agent being closed. `src` is the agent: libnice's `nice_agent_close_async()`
builds its task with `g_task_new(agent, ...)`, so the callback's source
object is the closing agent.

### Affected versions
Present on current `master` (4602fcc) and the latest release `v1.4.1`
(identical code, shifted a few lines). I couldn't find an existing issue
covering it.
