### PR TITLE
Key the subscriptions table with the string hash it is filled with

### DIFF
--- a/src/plugins/janus_sip.c
+++ b/src/plugins/janus_sip.c
@@ -4358,7 +4358,7 @@ static void *janus_sip_handler(void *data) {
 				}
 				if(session->stack->subscriptions == NULL) {
 					/* We still need a table for mapping these subscriptions as well */
-					session->stack->subscriptions = g_hash_table_new_full(g_int64_hash, g_int64_equal,
+					session->stack->subscriptions = g_hash_table_new_full(g_str_hash, g_str_equal,
 						(GDestroyNotify)g_free, (GDestroyNotify)nua_handle_destroy);
 				}
 				g_hash_table_insert(session->stack->subscriptions, g_strdup(event_type), nh);


### PR DESCRIPTION

The SIP plugin's `subscriptions` table is created with
`g_int64_hash`/`g_int64_equal`, while every key it is filled with is a
`g_strdup()` of the event package name, and every lookup passes that same
string. `g_int64_hash` hashes the eight bytes *pointed at* by the key rather
than the pointer, so for any event package name shorter than eight bytes
("dialog", for instance) it reads past the end of the allocation — valgrind
reports an uninitialised read of 8 bytes. Two names sharing their first eight
bytes would also collide onto one handle with no diagnostic.

In practice it lands benignly today: 200 000 alloc/lookup cycles under both
glibc and musl produced zero mismatches, because the byte after a short name's
NUL is reliably zero on both allocators. So this is a correctness fix rather
than a memory one — but the read is out of bounds, and it is one
malloc-fill-pattern change away from misbehaving.

`event` is `JANUS_JSON_PARAM_REQUIRED` in `subscribe_parameters` and both the
subscribe and unsubscribe branches validate against it, so the key is never
NULL and `g_str_hash` is safe here.

Reviewed against master; no rebase needed. Two further PRs against the SIP
plugin and the WebSockets event handler follow — this one is deliberately on
its own because it is one line and independent of them.
