### PR TITLE
WebSockets event handler: bound the outgoing queue, and keep the cap armed

### DIFF
--- a/conf/janus.eventhandler.wsevh.jcfg.sample
+++ b/conf/janus.eventhandler.wsevh.jcfg.sample
@@ -45,6 +45,16 @@ general: {
 						# events when a reconnection actually ends up taking place.
 	# events_cap_on_reconnect = 10
 
+						# 'events_cap_on_reconnect' only applies while we are actually
+						# reconnecting. A backend that completes the WebSocket handshake
+						# and then stops reading never puts us in that state, so nothing
+						# pops the queue and it grows until libwebsockets itself gives up
+						# on the connection minutes later. 'events_max_queue' is an
+						# absolute ceiling that applies whatever the connection state is:
+						# when both are set the smaller one wins. As above, 0 disables it
+						# (the default), so the minimum useful value is 1.
+	# events_max_queue = 20000
+
 						# In case you need to debug connection issues, you can configure
 						# the libwebsockets debugging level as a comma separated list of things
 						# to debug, supported values: err, warn, notice, info, debug, parser,

--- a/src/events/janus_wsevh.c
+++ b/src/events/janus_wsevh.c
@@ -896,7 +896,12 @@ static void janus_wsevh_connect_attempt(lws_sorted_usec_list_t *sul) {
 		JANUS_LOG(LOG_ERR, "WebSocketsEventHandler: Connecting to backend websocket server %s:%d failed\n", address, port);
 		return;
 	}
+#if !((LWS_LIBRARY_VERSION_MAJOR == 3 && LWS_LIBRARY_VERSION_MINOR >= 2) || LWS_LIBRARY_VERSION_MAJOR >= 4)
+	/* On lws < 3.2 the service loop keys off this flag to decide whether to
+	 * reconnect, so it must be cleared when the attempt starts. On newer lws
+	 * LWS_CALLBACK_CLIENT_ESTABLISHED clears it once the connection exists. */
 	g_atomic_int_set(&reconnect, 0);
+#endif
 }
 
 /* Adopts the reconnect_delay value in case of an error

--- a/src/events/janus_wsevh.c
+++ b/src/events/janus_wsevh.c
@@ -89,7 +89,7 @@ static void janus_wsevh_connect_attempt(lws_sorted_usec_list_t *sul);
 static GQueue *events = NULL;
 static janus_mutex events_mutex = JANUS_MUTEX_INITIALIZER;
 static gboolean group_events = TRUE;
-static volatile gint events_cap_on_reconnect = 0, dropped = 0;
+static volatile gint events_cap_on_reconnect = 0, events_max_queue = 0, dropped = 0;
 static void janus_wsevh_event_free(json_t *event) {
 	json_decref(event);
 }
@@ -105,7 +105,8 @@ static struct janus_json_parameter request_parameters[] = {
 static struct janus_json_parameter tweak_parameters[] = {
 	{"events", JSON_STRING, 0},
 	{"grouping", JANUS_JSON_BOOL, 0},
-	{"events_cap_on_reconnect", JANUS_JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE}
+	{"events_cap_on_reconnect", JANUS_JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE},
+	{"events_max_queue", JANUS_JSON_INTEGER, JANUS_JSON_PARAM_POSITIVE}
 };
 /* Error codes (for the tweaking via Admin API */
 #define JANUS_WSEVH_ERROR_INVALID_REQUEST		411
@@ -362,6 +363,15 @@ int janus_wsevh_init(const char *config_path) {
 	if(events_cap_on_reconnect < 0)
 		events_cap_on_reconnect = 0;
 
+	/* Do we need an absolute cap on the queue, connected or not? A backend that
+	 * accepts the connection and then stops reading it never puts us in the
+	 * reconnect state, so events_cap_on_reconnect would never apply. */
+	item = janus_config_get(config, config_general, janus_config_type_item, "events_max_queue");
+	if(item && item->value)
+		events_max_queue = atoi(item->value);
+	if(events_max_queue < 0)
+		events_max_queue = 0;
+
 	/* Handle the rest of the configuration, starting from the server details */
 	item = janus_config_get(config, config_general, janus_config_type_item, "backend");
 	if(item && item->value)
@@ -512,17 +522,21 @@ void janus_wsevh_incoming_event(json_t *event) {
 	json_incref(event);
 	janus_mutex_lock(&events_mutex);
 	g_queue_push_tail(events, event);
-	if(g_atomic_int_get(&reconnect)) {
-		/* We're reconnecting: check if there's a cap to how many events to keep in the buffer */
-		guint cap = g_atomic_int_get(&events_cap_on_reconnect);
-		if(cap > 0 && g_queue_get_length(events) > cap) {
-			/* Get rid of older events, we won't need them anymore */
-			json_t *drop = NULL;
-			while(g_queue_get_length(events) > cap) {
-				drop = g_queue_pop_head(events);
-				json_decref(drop);
-				g_atomic_int_inc(&dropped);
-			}
+	/* While reconnecting we only keep events_cap_on_reconnect events; events_max_queue,
+	 * when set, applies at all times, including while the backend is connected but is
+	 * not reading what we write to it. */
+	guint cap = g_atomic_int_get(&reconnect) ?
+		(guint)g_atomic_int_get(&events_cap_on_reconnect) : 0;
+	guint hard = (guint)g_atomic_int_get(&events_max_queue);
+	if(hard > 0 && (cap == 0 || hard < cap))
+		cap = hard;
+	if(cap > 0 && g_queue_get_length(events) > cap) {
+		/* Get rid of older events, we won't need them anymore */
+		json_t *drop = NULL;
+		while(g_queue_get_length(events) > cap) {
+			drop = g_queue_pop_head(events);
+			json_decref(drop);
+			g_atomic_int_inc(&dropped);
 		}
 	}
 	janus_mutex_unlock(&events_mutex);
@@ -569,6 +583,9 @@ json_t *janus_wsevh_handle_request(json_t *request) {
 		/* Whether we should put a cap on queued events when reconnecting */
 		if(json_object_get(request, "events_cap_on_reconnect"))
 			g_atomic_int_set(&events_cap_on_reconnect, json_integer_value(json_object_get(request, "events_cap_on_reconnect")));
+		/* Whether we should put an absolute cap on queued events */
+		if(json_object_get(request, "events_max_queue"))
+			g_atomic_int_set(&events_max_queue, json_integer_value(json_object_get(request, "events_max_queue")));
 	} else {
 		JANUS_LOG(LOG_VERB, "Unknown request '%s'\n", request_text);
 		error_code = JANUS_WSEVH_ERROR_INVALID_REQUEST;


### PR DESCRIPTION

Two fixes for the same failure: the outgoing event queue growing without limit
while the handler believes it is connected.

**`events_cap_on_reconnect` is consulted only in the `reconnect` state.** A
backend that completes the WebSocket handshake and then stops reading never
puts the handler into that state — lws cannot drain the socket, nothing pops
the queue, and events accumulate until lws itself gives up on the connection
minutes later. Measured with `events = "all"`, grouping and broadcast at only
~20 events/s: RSS grew 25.4 kB/s (about 91 MB/h) for three and a half minutes,
then the stalled connection was dropped and 3 002 queued events were discarded
in one go. The cycle repeated with the same amplitude and RSS never came back.
One caveat on those bytes, since the run was done on a downstream build: it
serialised events with `JSON_INDENT(3)`, while master has defaulted to
`JSON_COMPACT` since #3633. The event count is unaffected — the queue is
unbounded either way — but on master the same stall holds fewer bytes for the
same number of events.

The first commit adds `events_max_queue`, a ceiling that applies whatever the
connection state is; when both caps are set the smaller wins, and it defaults
to 0, which keeps today's behaviour for anyone who does not set it.

**The cap is also disarmed while a connect attempt is in flight.**
`janus_wsevh_connect_attempt()` clears `reconnect` as soon as
`lws_client_connect_via_info()` returns a wsi, but that only *starts* an
asynchronous connect: with `connect_timeout_secs = 5` the failure arrives up to
five seconds later, and for that whole window the cap does not apply. A backend
down long enough for the retry delay to reach its 8 s maximum leaves the queue
uncapped for roughly a third of the outage. `LWS_CALLBACK_CLIENT_ESTABLISHED`
already clears the flag where the connection really exists, so on lws >= 3.2 the
premature clear can simply go; the pre-3.2 service loop keys off the same flag
to decide whether to reconnect, so it keeps the old behaviour. The version guard
is the one already used at the top of this file.

The new setting is documented in `janus.eventhandler.wsevh.jcfg.sample` and can
be changed at runtime through the existing `tweak` request.
